### PR TITLE
Add database-per-microservice support (multiple named databases per engine)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -733,6 +733,18 @@ dotnet_diagnostic.MA0025.severity = none
 dotnet_diagnostic.MA0001.severity = none
 dotnet_diagnostic.MA0006.severity = none
 
+# Collection-expression style suggestions are noise in test setup (explicit
+# constructors read more clearly in arrange blocks) and the analyzer flags them
+# inconsistently across SDK/analyzer versions — e.g. it reports IDE0028 on one
+# `new Dictionary<,>(StringComparer.Ordinal)` but not an identical sibling line.
+dotnet_diagnostic.IDE0028.severity = none
+dotnet_diagnostic.IDE0300.severity = none
+dotnet_diagnostic.IDE0301.severity = none
+dotnet_diagnostic.IDE0302.severity = none
+dotnet_diagnostic.IDE0303.severity = none
+dotnet_diagnostic.IDE0304.severity = none
+dotnet_diagnostic.IDE0305.severity = none
+
 ###############################################################################
 # Razor/Blazor files
 ###############################################################################

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,15 +146,22 @@ BaseEntity<TId> → AuditableBaseEntity<TId> → AuditableAggregateRootEntity<TI
 
 A shared `global using UserIdentifierType = int;` in `Source/Core/MMCA.Common.Domain/GlobalUsings.IdentifierType.cs` is linked into all MMCA.Common projects via `Directory.Build.props`. A second alias file, `GlobalUsings.NotificationIdentifierType.cs` (in `MMCA.Common.Shared`), is linked the same way. To add a solution-wide identifier alias, create the `GlobalUsings.*.cs` file and add a matching `<Compile Include ... Link=... />` block in `Directory.Build.props`.
 
-### Multi-Database Strategy
+### Multi-Database Strategy (database per microservice)
 
-`DbContextFactory` (scoped) routes repositories to the correct `ApplicationDbContext` subclass based on `DataSource` enum (`CosmosDB`, `SQLite`, `SQLServer`). Per-scope caching ensures repositories in the same request share the same change tracker. Transactions coordinate across SQL Server + SQLite (Cosmos has no multi-document transactions).
+Every entity resolves to a **physical data source** — a `DataSourceKey(Engine, Name)` pair, where the engine comes from the configuration base class (`EntityTypeConfigurationSQLServer/Cosmos/Sqlite`, via `[UseDataSource]`) and the database name resolves as: `[UseDatabase("X")]` attribute on the concrete configuration → module name derived from the entity namespace (segment before `Domain`, same rule as SQL schema derivation) → `"Default"`.
+
+- **Logical → physical collapse** (`DataSourceResolver`, singleton): the `DataSources` appsettings section maps logical names to connection strings (`DataSources:Conference:SQLServerConnectionString`, optional per-source `SQLServerMigrationsAssembly`, `CosmosDatabaseName`). Logical names without an entry, or whose connection string equals the top-level `ConnectionStrings` value, collapse onto the `Default` source — so a host with no `DataSources` config behaves exactly like a single-database monolith (one context, one change tracker, FK constraints intact). Names sharing a connection string collapse to one physical source. Conflicting `SQLServerMigrationsAssembly` declarations on a collapsed source fail at startup.
+- **Eager entity registry** (`EntityDataSourceRegistry`, singleton): scans configuration assemblies up front and maps every entity to its physical source — routing no longer depends on a model having been built. `DataSourceService` is a facade over it.
+- **One context class per engine, one instance per database**: `PhysicalDbContextFactory` (singleton, NEVER pooled — per-instance `PhysicalDataSource` state) creates raw contexts; `DbContextFactory` (scoped) caches one per `DataSourceKey` and coordinates saves/transactions/disposal. `DataSourceModelCacheKeyFactory` keys EF's model cache by (context type, source name) so each database gets its own model containing only its own entities.
+- **Cross-source relationships auto-degrade** (`CrossDataSourceDegradeConvention`, model-finalizing): when a relationship's ends live in different physical sources, the FK constraint and navigations are removed from the model (scalar FK columns + a compensating index survive, foreign entity types are dropped). Runtime navigation flows through `INavigationPopulator` batch loading; consistency across sources is the outbox's job.
+- **Transactions are per-source, best-effort sequential** — there is no two-phase commit. The outbox pattern is the cross-source consistency mechanism.
+- **Design time**: `DesignTimeDbContextHelper.CreateSqlServer(args, options => ...)` builds a per-source context for `dotnet ef ... -- --datasource <Name>`, enabling one migrations project per database.
 
 **SaveChanges flow**: stamp audit fields → capture domain events from aggregates → serialize to `OutboxMessage` entries → `base.SaveChangesAsync()` (data + outbox in same transaction) → dispatch events in-process → mark outbox processed.
 
 ### Outbox Pattern
 
-`OutboxMessage` entries are persisted atomically with aggregate changes. `OutboxProcessor` (background service) polls every 10 seconds for unprocessed messages, processes in batches of 50, retries up to 5 times. Provides at-least-once delivery guarantee with OpenTelemetry metrics for dead-letter tracking.
+`OutboxMessage` entries are persisted atomically with aggregate changes, in the **same database as the aggregate** (every relational physical source has its own `OutboxMessages` table). `OutboxProcessor` (background service) drains the outbox of every relational source the host uses — a host never races for another service's outbox rows. Polls on signal or interval, processes in batches of 50, retries up to 5 times. Integration events published via `IEventBus` target the source named by `Outbox:DataSource` + `Outbox:DatabaseName` (default: SQL Server / Default). Provides at-least-once delivery guarantee with OpenTelemetry metrics for dead-letter tracking.
 
 ### Microservices Extraction Seams
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,13 +26,14 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <!-- Messaging (MassTransit) -->
-    <!-- Pinned to v8 (free). v9.x introduced a commercial license requirement; the health-check
-         pipeline materializes IBusControl during MapDefaultEndpoints which fails the license
-         check at startup. Revisit with SetLicense/SetCommunityLicense or MT_LICENSE env var
-         before bumping back. -->
-    <PackageVersion Include="MassTransit" Version="9.1.2" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="9.1.2" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.2" />
+    <!-- Pinned to v8 (free). v9.x introduced a commercial license requirement; the bus fails the
+         license check at startup ("License must be specified with SetLicense/SetLicenseLocation
+         or by setting the MT_LICENSE/MT_LICENSE_PATH environment variables") and every broker-
+         enabled service host crashes. A blanket package-update bumped this to 9.1.2 once before
+         and reintroduced the crash — do NOT bump past v8 without configuring a license. -->
+    <PackageVersion Include="MassTransit" Version="8.5.5" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.5.5" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.5" />
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.31.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/DataSourceKey.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/DataSourceKey.cs
@@ -1,0 +1,27 @@
+namespace MMCA.Common.Application.Interfaces.Infrastructure;
+
+/// <summary>
+/// Identifies a physical data source: a database <see cref="Engine"/> plus a <see cref="Name"/>
+/// distinguishing multiple databases on the same engine ("database per microservice").
+/// <para>
+/// The <see cref="Name"/> is the <b>physical</b> source name produced by the Infrastructure-layer
+/// resolver after collapsing logical names that share a connection string. Application code only
+/// ever compares physical keys — two entities support EF Core <c>.Include()</c> between them only
+/// when their physical keys are equal (and the engine is relational).
+/// </para>
+/// </summary>
+/// <param name="Engine">The database engine backing this source.</param>
+/// <param name="Name">The physical source name; <see cref="DefaultName"/> for the top-level connection strings.</param>
+public readonly record struct DataSourceKey(DataSource Engine, string Name)
+{
+    /// <summary>The reserved name of the default physical source (top-level <c>ConnectionStrings</c> section).</summary>
+    public const string DefaultName = "Default";
+
+    /// <summary>Creates the default physical key for the given engine.</summary>
+    /// <param name="engine">The database engine.</param>
+    /// <returns>The default <see cref="DataSourceKey"/> for the engine.</returns>
+    public static DataSourceKey Default(DataSource engine) => new(engine, DefaultName);
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Engine}/{Name}";
+}

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IDataSourceService.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IDataSourceService.cs
@@ -1,5 +1,3 @@
-using MMCA.Common.Domain.Entities;
-
 namespace MMCA.Common.Application.Interfaces.Infrastructure;
 
 /// <summary>
@@ -18,51 +16,46 @@ public enum DataSource
 }
 
 /// <summary>
-/// Resolves which <see cref="DataSource"/> backs a given entity type and determines
-/// whether two entity types share a data source that supports EF Core <c>.Include()</c>.
-/// Used by <see cref="Services.Query.NavigationMetadataProvider"/> to classify navigation
-/// properties as supported or unsupported includes.
+/// Resolves which physical data source (<see cref="DataSourceKey"/>: engine + database) backs a
+/// given entity type and determines whether two entity types share a data source that supports
+/// EF Core <c>.Include()</c>. Used by <see cref="Services.Query.NavigationMetadataProvider"/> to
+/// classify navigation properties as supported or unsupported includes.
 /// </summary>
 public interface IDataSourceService
 {
-    /// <summary>Gets the data source for an entity based on its type and EF configuration type.</summary>
+    /// <summary>Gets the physical data source key for an entity by its CLR type.</summary>
     /// <param name="entityType">The entity CLR type.</param>
-    /// <param name="configurationType">The EF entity type configuration CLR type.</param>
-    /// <returns>The data source backing this entity.</returns>
-    DataSource GetDataSource(Type entityType, Type configurationType);
+    /// <returns>The physical data source backing this entity.</returns>
+    DataSourceKey GetDataSourceKey(Type entityType);
 
-    /// <summary>Gets the data source for an entity using generic type parameters.</summary>
-    /// <typeparam name="TEntity">The entity type.</typeparam>
-    /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
-    /// <typeparam name="TEntityTypeConfiguration">The EF entity type configuration.</typeparam>
-    /// <returns>The data source backing this entity.</returns>
-    DataSource GetDataSource<TEntity, TIdentifierType, TEntityTypeConfiguration>()
-        where TEntity : AuditableBaseEntity<TIdentifierType>
-        where TEntityTypeConfiguration : class
-        where TIdentifierType : notnull;
-
-    /// <summary>Gets the data source for an entity by its full type name.</summary>
+    /// <summary>Gets the physical data source key for an entity by its full type name.</summary>
     /// <param name="entityFullName">The entity's full CLR type name.</param>
-    /// <returns>The data source backing this entity.</returns>
+    /// <returns>The physical data source backing this entity.</returns>
+    DataSourceKey GetDataSourceKey(string entityFullName);
+
+    /// <summary>Gets the database engine for an entity by its full type name.</summary>
+    /// <param name="entityFullName">The entity's full CLR type name.</param>
+    /// <returns>The engine backing this entity.</returns>
     DataSource GetDataSource(string entityFullName);
 
-    /// <summary>Gets the data source for an entity by its CLR type.</summary>
+    /// <summary>Gets the database engine for an entity by its CLR type.</summary>
     /// <param name="entityType">The entity CLR type.</param>
-    /// <returns>The data source backing this entity.</returns>
+    /// <returns>The engine backing this entity.</returns>
     DataSource GetDataSource(Type entityType);
 
     /// <summary>
-    /// Determines whether two data sources support EF Core <c>.Include()</c> between them.
-    /// Returns <see langword="true"/> when both use the same relational provider (e.g. both SQL Server).
+    /// Determines whether two physical data sources support EF Core <c>.Include()</c> between them.
+    /// Returns <see langword="true"/> only when both keys identify the same physical database
+    /// and the engine is relational (Cosmos DB does not support cross-document JOINs).
     /// </summary>
-    /// <param name="first">The first data source.</param>
-    /// <param name="second">The second data source.</param>
+    /// <param name="first">The first physical data source.</param>
+    /// <param name="second">The second physical data source.</param>
     /// <returns><see langword="true"/> if JOINs/includes are supported between the two sources.</returns>
-    bool HaveIncludeSupport(DataSource first, DataSource second);
+    bool HaveIncludeSupport(DataSourceKey first, DataSourceKey second);
 
     /// <summary>
     /// Determines whether two entity types support EF Core <c>.Include()</c> between them
-    /// by resolving their data sources.
+    /// by resolving their physical data sources.
     /// </summary>
     /// <param name="firstEntityFullName">Full type name of the first entity.</param>
     /// <param name="secondEntityFullName">Full type name of the second entity.</param>

--- a/Source/Core/MMCA.Common.Application/Services/Query/NavigationMetadataProvider.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Query/NavigationMetadataProvider.cs
@@ -21,9 +21,11 @@ public sealed class NavigationMetadataProvider(IDataSourceService dataSourceServ
 {
     /// <summary>
     /// Caches navigation metadata per entity type and navigation kind (FK vs child collection).
-    /// Since entity type metadata is immutable, this cache never needs invalidation.
+    /// Instance-level (not static): classification depends on the host's data-source configuration
+    /// via <see cref="IDataSourceService"/>, so a process hosting multiple service configurations
+    /// (e.g. integration tests) must not share classification results across hosts.
     /// </summary>
-    private static readonly ConcurrentDictionary<(Type EntityType, NavigationType NavType), NavigationMetadata> Cache = new();
+    private readonly ConcurrentDictionary<(Type EntityType, NavigationType NavType), NavigationMetadata> _cache = new();
 
     /// <inheritdoc />
     public NavigationMetadata BuildIncludes<TEntity>(bool includeFKs, bool includeChildren)
@@ -48,7 +50,7 @@ public sealed class NavigationMetadataProvider(IDataSourceService dataSourceServ
     }
 
     private NavigationMetadata GetNavigationProperties(Type entityType, NavigationType navigationType) =>
-        Cache.GetOrAdd((entityType, navigationType), key => BuildNavigationMetadata(key.EntityType, key.NavType));
+        _cache.GetOrAdd((entityType, navigationType), key => BuildNavigationMetadata(key.EntityType, key.NavType));
 
     /// <summary>
     /// Reflects over the entity's public properties looking for <see cref="NavigationAttribute"/>,

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -19,6 +19,7 @@ using MMCA.Common.Infrastructure.Http;
 using MMCA.Common.Infrastructure.Hubs;
 using MMCA.Common.Infrastructure.Persistence;
 using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
@@ -62,18 +63,33 @@ public static class DependencyInjection
                 .ValidateOnStart();
             services.TryAddSingleton<IConnectionStringSettings>(sp => sp.GetRequiredService<IOptions<ConnectionStringSettings>>().Value);
 
+            // Named data sources for database-per-microservice routing. A root-level dictionary
+            // section does not bind through the options pipeline — build the settings directly.
+            services.TryAddSingleton(new DataSourcesSettings(
+                configuration.GetSection(DataSourcesSettings.SectionName)
+                    .Get<Dictionary<string, DataSourceEntrySettings>>()));
+            services.TryAddSingleton<IDataSourceResolver, DataSourceResolver>();
+            services.TryAddSingleton<IEntityDataSourceRegistry, EntityDataSourceRegistry>();
+
             services.AddOptions<SmtpSettings>()
                 .Bind(configuration.GetSection(SmtpSettings.SectionName))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
             services.TryAddSingleton<ISmtpSettings>(sp => sp.GetRequiredService<IOptions<SmtpSettings>>().Value);
 
-            // Register our custom IDbContextFactory (scoped — one per request) and EF Core's
-            // IDbContextFactory<T> for each provider (these are the pooled factories that create raw contexts).
+            // Register our custom IDbContextFactory (scoped — one per request) and the singleton
+            // physical factory that creates raw contexts per physical data source.
+            // NEVER convert the physical factory to EF context pooling (AddPooledDbContextFactory):
+            // each context instance carries per-source constructor state (PhysicalDataSource) that
+            // pooling would silently reuse across databases.
             services.TryAddScoped<IDbContextFactory, DbContextFactory>();
-            services.AddDbContextFactory<CosmosDbContext>();
-            services.AddDbContextFactory<SqliteDbContext>();
-            services.AddDbContextFactory<SQLServerDbContext>();
+            services.TryAddSingleton<IPhysicalDbContextFactory, PhysicalDbContextFactory>();
+
+            // EF-style IDbContextFactory<T> adapters bound to each engine's Default physical
+            // source — preserves the DI surface for ApplicationDbContextEFFactory and tests.
+            services.TryAddSingleton<Microsoft.EntityFrameworkCore.IDbContextFactory<CosmosDbContext>, DefaultCosmosDbContextFactory>();
+            services.TryAddSingleton<Microsoft.EntityFrameworkCore.IDbContextFactory<SqliteDbContext>, DefaultSqliteDbContextFactory>();
+            services.TryAddSingleton<Microsoft.EntityFrameworkCore.IDbContextFactory<SQLServerDbContext>, DefaultSqlServerDbContextFactory>();
 
             // Dual factory: our IDbContextFactory manages multi-DB routing, while this adapter satisfies
             // consumers that require EF Core's standard IDbContextFactory<ApplicationDbContext>.

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationBase.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationBase.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Domain.Interfaces;
 
@@ -7,13 +6,17 @@ namespace MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfigu
 
 /// <summary>
 /// Base class for all entity type configurations. Handles cross-cutting concerns:
-/// registering the entity's data source in the cache, and excluding the
-/// <see cref="AuditableAggregateRootEntity{TId}.DomainEvents"/> collection from EF mapping.
+/// excluding the <see cref="AuditableAggregateRootEntity{TId}.DomainEvents"/> collection from EF mapping.
+/// <para>
+/// The entity-to-data-source mapping is no longer registered here as a model-building side effect —
+/// <see cref="DataSources.EntityDataSourceRegistry"/> derives it eagerly from the configuration
+/// class's attributes (<see cref="UseDataSourceAttribute"/> for the engine,
+/// <see cref="UseDatabaseAttribute"/>/module namespace for the database).
+/// </para>
 /// </summary>
 /// <typeparam name="TEntity">The entity type being configured.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
-/// <param name="dataSourceService">Used to register which data source backs this entity.</param>
-public abstract class EntityTypeConfigurationBase<TEntity, TIdentifierType>(IDataSourceService dataSourceService)
+public abstract class EntityTypeConfigurationBase<TEntity, TIdentifierType>
     : IEntityTypeConfigurationBase<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull
@@ -21,10 +24,6 @@ public abstract class EntityTypeConfigurationBase<TEntity, TIdentifierType>(IDat
     /// <inheritdoc />
     public virtual void Configure(EntityTypeBuilder<TEntity> builder)
     {
-        // Side effect: registers the entity-to-DataSource mapping in the cache so
-        // UnitOfWork can later resolve the correct DbContext for this entity type.
-        _ = dataSourceService.GetDataSource(typeof(TEntity), GetType());
-
         // DomainEvents is an in-memory-only collection used for event dispatch;
         // it has no database column and must be excluded from EF mapping.
         if (typeof(IAggregateRoot).IsAssignableFrom(typeof(TEntity)))

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationCosmos.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationCosmos.cs
@@ -16,10 +16,9 @@ namespace MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfigu
 /// </summary>
 /// <typeparam name="TEntity">The entity type being configured.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
-/// <param name="dataSourceService">Used to register which data source backs this entity.</param>
 [UseDataSource(DataSource.CosmosDB)]
-public abstract class EntityTypeConfigurationCosmos<TEntity, TIdentifierType>(IDataSourceService dataSourceService)
-    : EntityTypeConfigurationBase<TEntity, TIdentifierType>(dataSourceService),
+public abstract class EntityTypeConfigurationCosmos<TEntity, TIdentifierType>
+    : EntityTypeConfigurationBase<TEntity, TIdentifierType>,
       IEntityTypeConfigurationCosmos<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationSQLServer.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationSQLServer.cs
@@ -14,10 +14,9 @@ namespace MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfigu
 /// </summary>
 /// <typeparam name="TEntity">The entity type being configured.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
-/// <param name="dataSourceService">Used to register which data source backs this entity.</param>
 [UseDataSource(DataSource.SQLServer)]
-public abstract class EntityTypeConfigurationSQLServer<TEntity, TIdentifierType>(IDataSourceService dataSourceService)
-    : EntityTypeConfigurationBase<TEntity, TIdentifierType>(dataSourceService),
+public abstract class EntityTypeConfigurationSQLServer<TEntity, TIdentifierType>
+    : EntityTypeConfigurationBase<TEntity, TIdentifierType>,
       IEntityTypeConfigurationSQLServer<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull
@@ -29,13 +28,9 @@ public abstract class EntityTypeConfigurationSQLServer<TEntity, TIdentifierType>
 
         // Derive the SQL schema from the module namespace segment preceding "Domain".
         // E.g., "MMCA.Store.Sales.Domain.Orders" -> schema "Sales", table "Order".
-        // Also handles legacy "MMCA.Modules.Catalog.Domain" layout.
-        var segments = typeof(TEntity).Namespace?.Split('.') ?? [];
-        var domainIndex = Array.FindIndex(segments,
-            s => s.Equals("Domain", StringComparison.OrdinalIgnoreCase));
-        var schema = domainIndex >= 1
-            ? segments[domainIndex - 1]
-            : "dbo";
+        // Also handles legacy "MMCA.Modules.Catalog.Domain" layout. The same derivation
+        // feeds the default logical database name, so schema and database can never drift.
+        var schema = NamespaceConventions.GetModuleName(typeof(TEntity)) ?? "dbo";
 
         builder.ToTable(typeof(TEntity).Name, schema);
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationSqlite.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/EntityTypeConfigurationSqlite.cs
@@ -13,10 +13,9 @@ namespace MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfigu
 /// </summary>
 /// <typeparam name="TEntity">The entity type being configured.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
-/// <param name="dataSourceService">Used to register which data source backs this entity.</param>
 [UseDataSource(DataSource.Sqlite)]
-public abstract class EntityTypeConfigurationSqlite<TEntity, TIdentifierType>(IDataSourceService dataSourceService)
-    : EntityTypeConfigurationBase<TEntity, TIdentifierType>(dataSourceService),
+public abstract class EntityTypeConfigurationSqlite<TEntity, TIdentifierType>
+    : EntityTypeConfigurationBase<TEntity, TIdentifierType>,
       IEntityTypeConfigurationSqlite<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
@@ -1,17 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Notifications.PushNotifications;
 
 namespace MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration.Notifications;
 
 /// <summary>
 /// EF Core configuration for the <see cref="PushNotification"/> entity.
-/// Explicitly sets the "Notification" schema because the base class derives schema from the
-/// namespace segment before "Domain", which would resolve to "Common" for Common.Domain entities.
+/// Explicitly sets the "Notification" schema (and logical database name via
+/// <see cref="UseDatabaseAttribute"/>) because the base class derives both from the namespace
+/// segment before "Domain", which would resolve to "Common" for Common.Domain entities.
+/// Hosts without a <c>DataSources:Notification</c> entry keep these tables in the default database.
 /// </summary>
-internal sealed class PushNotificationConfiguration(IDataSourceService dataSourceService)
-    : EntityTypeConfigurationSQLServer<PushNotification, PushNotificationIdentifierType>(dataSourceService)
+[UseDatabase("Notification")]
+internal sealed class PushNotificationConfiguration
+    : EntityTypeConfigurationSQLServer<PushNotification, PushNotificationIdentifierType>
 {
     /// <inheritdoc />
     public override void Configure(EntityTypeBuilder<PushNotification> builder)

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/UserNotificationConfiguration.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/UserNotificationConfiguration.cs
@@ -1,17 +1,19 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Notifications.UserNotifications;
 
 namespace MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration.Notifications;
 
 /// <summary>
 /// EF Core configuration for the <see cref="UserNotification"/> entity.
-/// Explicitly sets the "Notification" schema because the base class derives schema from the
-/// namespace segment before "Domain", which would resolve to "Common" for Common.Domain entities.
+/// Explicitly sets the "Notification" schema (and logical database name via
+/// <see cref="UseDatabaseAttribute"/>) because the base class derives both from the namespace
+/// segment before "Domain", which would resolve to "Common" for Common.Domain entities.
+/// Hosts without a <c>DataSources:Notification</c> entry keep these tables in the default database.
 /// </summary>
-internal sealed class UserNotificationConfiguration(IDataSourceService dataSourceService)
-    : EntityTypeConfigurationSQLServer<UserNotification, UserNotificationIdentifierType>(dataSourceService)
+[UseDatabase("Notification")]
+internal sealed class UserNotificationConfiguration
+    : EntityTypeConfigurationSQLServer<UserNotification, UserNotificationIdentifierType>
 {
     /// <inheritdoc />
     public override void Configure(EntityTypeBuilder<UserNotification> builder)

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Conventions/CrossDataSourceDegradeConvention.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Conventions/CrossDataSourceDegradeConvention.cs
@@ -1,0 +1,166 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+
+namespace MMCA.Common.Infrastructure.Persistence.Conventions;
+
+/// <summary>
+/// Model-finalizing convention that automatically degrades relationships whose two ends live in
+/// different physical data sources ("database per microservice"):
+/// <list type="bullet">
+///   <item>The EF relationship and FK constraint are removed — a database cannot enforce an FK
+///   into another database. Declared scalar FK columns survive, with a compensating index.</item>
+///   <item>CLR navigation members targeting foreign entities are ignored; runtime navigation flows
+///   through the existing <c>INavigationPopulator</c> batch-loading machinery instead, and
+///   consistency is maintained via integration events.</item>
+///   <item>Entity types belonging to another physical source (pulled into the model by EF's
+///   relationship discovery, or promoted to explicit by cross-cutting configuration like the
+///   soft-delete filters) are removed from this model entirely.</item>
+/// </list>
+/// Mutations go through the <b>mutable</b> model API rather than convention builders:
+/// cross-cutting helpers (soft-delete filters, concurrency tokens) promote every entity type to
+/// the Explicit configuration source, which convention-sourced builder calls cannot override.
+/// <para>
+/// When every entity resolves to the same physical source (the monolith collapse case) nothing is
+/// foreign and this convention is a structural no-op — the model is identical to the
+/// single-database model.
+/// </para>
+/// </summary>
+/// <param name="contextKey">The physical data source of the context whose model is being built.</param>
+/// <param name="registry">Registry mapping entity types to their physical data sources.</param>
+public sealed class CrossDataSourceDegradeConvention(
+    DataSourceKey contextKey,
+    IEntityDataSourceRegistry registry) : IModelFinalizingConvention
+{
+    /// <inheritdoc />
+    public void ProcessModelFinalizing(
+        IConventionModelBuilder modelBuilder,
+        IConventionContext<IConventionModelBuilder> context)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        // The runtime Model class implements both IConventionModel and IMutableModel; the mutable
+        // surface applies changes with explicit precedence, which convention builders cannot.
+        var model = (IMutableModel)modelBuilder.Metadata;
+
+        var foreignEntityTypes = model.GetEntityTypes()
+            .Where(et => !et.IsOwned() && IsForeign(et.ClrType))
+            .ToList();
+
+        if (foreignEntityTypes.Count == 0)
+        {
+            return;
+        }
+
+        var foreignClrTypes = foreignEntityTypes.Select(et => et.ClrType).ToHashSet();
+        var localEntityTypes = model.GetEntityTypes()
+            .Where(et => !foreignClrTypes.Contains(et.ClrType))
+            .ToList();
+
+        // 1) Degrade FKs declared on LOCAL dependents that point at foreign principals
+        //    (keep declared scalar FK columns + a compensating index). FKs declared on foreign
+        //    dependents disappear together with the foreign entity type in step 3.
+        foreach (var entityType in localEntityTypes)
+        {
+            foreach (var foreignKey in entityType.GetDeclaredForeignKeys()
+                .Where(fk => foreignClrTypes.Contains(fk.PrincipalEntityType.ClrType))
+                .ToList())
+            {
+                DegradeForeignKey(entityType, foreignKey);
+            }
+        }
+
+        // 2) Ignore every CLR member on local entities whose (unwrapped) type is foreign —
+        //    removed navigations leave unmapped CLR properties of entity type behind, which
+        //    model validation would otherwise reject.
+        foreach (var entityType in localEntityTypes)
+        {
+            IgnoreForeignMembers(entityType, foreignClrTypes);
+        }
+
+        // 3) Remove the foreign entity types from this model.
+        foreach (var foreignEntityType in foreignEntityTypes)
+        {
+            model.RemoveEntityType(foreignEntityType);
+        }
+    }
+
+    private bool IsForeign(Type clrType) =>
+        clrType.FullName is not null
+        && registry.TryGetDataSourceKey(clrType.FullName, out var key)
+        && key != contextKey;
+
+    /// <summary>
+    /// Removes a cross-source FK (and both its navigations), then re-adds a plain index over the
+    /// surviving declared scalar FK columns unless an existing index already covers them as a prefix
+    /// (the conventional FK index disappears with the relationship).
+    /// </summary>
+    private static void DegradeForeignKey(IMutableEntityType dependent, IMutableForeignKey foreignKey)
+    {
+        var scalarProperties = foreignKey.Properties
+            .Where(p => !p.IsShadowProperty())
+            .ToList();
+
+        dependent.RemoveForeignKey(foreignKey);
+
+        if (scalarProperties.Count == 0)
+        {
+            return;
+        }
+
+        // Eagerly drop the index ForeignKeyIndexConvention created for the removed FK — its
+        // deferred event processing would otherwise remove it AFTER our coverage check, leaving
+        // the column unindexed.
+        if (dependent.FindIndex(scalarProperties) is { } autoIndex
+            && ((IConventionIndex)autoIndex).GetConfigurationSource() == ConfigurationSource.Convention)
+        {
+            dependent.RemoveIndex(autoIndex);
+        }
+
+        if (HasCoveringIndex(dependent, scalarProperties))
+        {
+            return;
+        }
+
+        dependent.AddIndex(scalarProperties);
+    }
+
+    private static bool HasCoveringIndex(IMutableEntityType entityType, List<IMutableProperty> properties) =>
+        entityType.GetIndexes().Any(index =>
+            index.Properties.Count >= properties.Count
+            && properties.Select(p => p.Name)
+                .SequenceEqual(index.Properties.Take(properties.Count).Select(p => p.Name), StringComparer.Ordinal));
+
+    /// <summary>
+    /// Ignores skip navigations and unmapped CLR properties whose target type is a foreign entity
+    /// (covers single references and collections of foreign entities). Regular navigations were
+    /// already removed together with their FKs.
+    /// </summary>
+    private static void IgnoreForeignMembers(IMutableEntityType entityType, HashSet<Type> foreignClrTypes)
+    {
+        foreach (var skipNavigation in entityType.GetDeclaredSkipNavigations()
+            .Where(n => foreignClrTypes.Contains(n.TargetEntityType.ClrType))
+            .ToList())
+        {
+            entityType.RemoveSkipNavigation(skipNavigation);
+        }
+
+        foreach (var property in entityType.ClrType.GetProperties()
+            .Where(p => foreignClrTypes.Contains(UnwrapCollectionElementType(p.PropertyType))))
+        {
+            entityType.AddIgnored(property.Name);
+        }
+    }
+
+    /// <summary>
+    /// Unwraps generic single-argument collection types (e.g. <c>List&lt;T&gt;</c>,
+    /// <c>ICollection&lt;T&gt;</c>) to the element type for foreign-entity detection.
+    /// </summary>
+    private static Type UnwrapCollectionElementType(Type propertyType) =>
+        propertyType.IsGenericType && propertyType.GenericTypeArguments.Length == 1
+            ? propertyType.GenericTypeArguments[0]
+            : propertyType;
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/DataSourceResolver.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/DataSourceResolver.cs
@@ -1,0 +1,280 @@
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Persistence.DataSources;
+
+/// <summary>
+/// Singleton implementation of <see cref="IDataSourceResolver"/>. Builds the logical→physical map
+/// once from <see cref="IConnectionStringSettings"/> (the <c>Default</c> source) and
+/// <see cref="DataSourcesSettings"/> (named sources), validating that no two logical names that
+/// collapse to the same database declare conflicting migrations assemblies.
+/// </summary>
+public sealed partial class DataSourceResolver : IDataSourceResolver
+{
+    private static readonly DataSource[] AllEngines = [DataSource.CosmosDB, DataSource.Sqlite, DataSource.SQLServer];
+
+    /// <summary>Per-engine map of logical name → physical key (collapse already applied).</summary>
+    private readonly Dictionary<(DataSource Engine, string LogicalName), DataSourceKey> _logicalToPhysical = [];
+
+    /// <summary>Resolved connection information per physical key (Default keys always present).</summary>
+    private readonly Dictionary<DataSourceKey, PhysicalDataSource> _physicalSources = [];
+
+    /// <summary>
+    /// Initializes the resolver, eagerly building and validating the logical→physical map.
+    /// </summary>
+    /// <param name="connectionStrings">The top-level connection strings (the Default source).</param>
+    /// <param name="dataSources">The named data source entries.</param>
+    /// <param name="logger">Logger for configuration warnings.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Two logical names collapse to the same physical database but declare different
+    /// <c>SQLServerMigrationsAssembly</c> values.
+    /// </exception>
+    public DataSourceResolver(
+        IConnectionStringSettings connectionStrings,
+        DataSourcesSettings dataSources,
+        ILogger<DataSourceResolver> logger)
+    {
+        ArgumentNullException.ThrowIfNull(connectionStrings);
+        ArgumentNullException.ThrowIfNull(dataSources);
+
+        foreach (var engine in AllEngines)
+        {
+            BuildEngineMap(engine, connectionStrings, dataSources, logger);
+        }
+    }
+
+    /// <inheritdoc />
+    public DataSourceKey ResolveLogical(DataSource engine, string logicalName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
+        if (string.Equals(logicalName, DataSourceKey.DefaultName, StringComparison.OrdinalIgnoreCase))
+        {
+            return DataSourceKey.Default(engine);
+        }
+
+        return _logicalToPhysical.TryGetValue((engine, logicalName), out var key)
+            ? key
+            : DataSourceKey.Default(engine);
+    }
+
+    /// <inheritdoc />
+    public PhysicalDataSource GetPhysical(DataSourceKey key) =>
+        _physicalSources.TryGetValue(key, out var physical)
+            ? physical
+            : throw new InvalidOperationException(
+                $"No physical data source is configured for \"{key}\". " +
+                "Physical keys must be obtained via IDataSourceResolver.ResolveLogical.");
+
+    /// <summary>
+    /// Builds the logical→physical map and physical source registry for one engine:
+    /// collapses entries onto Default (no/equal connection string), groups entries sharing a
+    /// connection onto one canonical physical source, and validates migrations assemblies.
+    /// </summary>
+    private void BuildEngineMap(
+        DataSource engine,
+        IConnectionStringSettings connectionStrings,
+        DataSourcesSettings dataSources,
+        ILogger<DataSourceResolver> logger)
+    {
+        var (defaultCollapsed, groups) = ClassifyEntries(engine, connectionStrings, dataSources);
+        RegisterDefaultSource(engine, connectionStrings, defaultCollapsed);
+
+        foreach (var members in groups.Values)
+        {
+            RegisterNamedSource(engine, connectionStrings, members, logger);
+        }
+    }
+
+    /// <summary>
+    /// Classifies each named entry for the engine: collapsed onto Default (no connection string,
+    /// or connection identity equal to the top-level one) versus grouped by connection identity.
+    /// </summary>
+    private static (List<(string LogicalName, DataSourceEntrySettings Entry)> DefaultCollapsed,
+        Dictionary<string, List<(string LogicalName, DataSourceEntrySettings Entry)>> Groups) ClassifyEntries(
+        DataSource engine,
+        IConnectionStringSettings connectionStrings,
+        DataSourcesSettings dataSources)
+    {
+        var defaultIdentity = GetIdentity(engine, GetConnectionString(engine, connectionStrings), connectionStrings.CosmosDatabaseName);
+        var defaultCollapsed = new List<(string LogicalName, DataSourceEntrySettings Entry)>();
+        var groups = new Dictionary<string, List<(string LogicalName, DataSourceEntrySettings Entry)>>(StringComparer.Ordinal);
+
+        foreach (var (logicalName, entry) in dataSources.Sources)
+        {
+            var entryConnection = GetConnectionString(engine, entry);
+            if (string.IsNullOrEmpty(entryConnection))
+            {
+                // No connection string for this engine — falls back to Default. No mapping entry
+                // needed: ResolveLogical already defaults on a map miss.
+                continue;
+            }
+
+            var entryCosmosDb = string.IsNullOrEmpty(entry.CosmosDatabaseName)
+                ? connectionStrings.CosmosDatabaseName
+                : entry.CosmosDatabaseName;
+            var identity = GetIdentity(engine, entryConnection, entryCosmosDb);
+
+            if (string.Equals(identity, defaultIdentity, StringComparison.Ordinal))
+            {
+                defaultCollapsed.Add((logicalName, entry));
+                continue;
+            }
+
+            if (!groups.TryGetValue(identity, out var members))
+            {
+                members = [];
+                groups[identity] = members;
+            }
+
+            members.Add((logicalName, entry));
+        }
+
+        return (defaultCollapsed, groups);
+    }
+
+    /// <summary>
+    /// Registers the Default physical source for the engine. Entries collapsed onto it may
+    /// contribute an explicit migrations assembly; conflicting explicit values throw.
+    /// </summary>
+    private void RegisterDefaultSource(
+        DataSource engine,
+        IConnectionStringSettings connectionStrings,
+        List<(string LogicalName, DataSourceEntrySettings Entry)> defaultCollapsed)
+    {
+        var defaultKey = DataSourceKey.Default(engine);
+
+        var explicitValues = new List<(string LogicalName, string Assembly)>();
+        if (!string.IsNullOrEmpty(connectionStrings.SQLServerMigrationsAssembly))
+        {
+            explicitValues.Add((DataSourceKey.DefaultName, connectionStrings.SQLServerMigrationsAssembly));
+        }
+
+        AddExplicitMigrationsAssemblies(explicitValues, defaultCollapsed);
+
+        _physicalSources[defaultKey] = new PhysicalDataSource(
+            defaultKey,
+            GetConnectionString(engine, connectionStrings),
+            ResolveMigrationsAssembly(engine, defaultKey, explicitValues),
+            connectionStrings.CosmosDatabaseName);
+
+        foreach (var (logicalName, _) in defaultCollapsed)
+        {
+            _logicalToPhysical[(engine, logicalName)] = defaultKey;
+        }
+    }
+
+    /// <summary>
+    /// Registers one named physical source for a group of entries sharing a connection identity,
+    /// named after the alphabetically-first member for determinism.
+    /// </summary>
+    private void RegisterNamedSource(
+        DataSource engine,
+        IConnectionStringSettings connectionStrings,
+        List<(string LogicalName, DataSourceEntrySettings Entry)> members,
+        ILogger<DataSourceResolver> logger)
+    {
+        var canonicalName = members.Select(m => m.LogicalName).Order(StringComparer.Ordinal).First();
+        var key = new DataSourceKey(engine, canonicalName);
+
+        var explicitValues = new List<(string LogicalName, string Assembly)>();
+        AddExplicitMigrationsAssemblies(explicitValues, members);
+
+        var migrationsAssembly = ResolveMigrationsAssembly(engine, key, explicitValues);
+        if (engine == DataSource.SQLServer && migrationsAssembly is null)
+        {
+            // Falling back to the Default migrations assembly is almost always a mistake for a
+            // separate database (its snapshot describes a different schema) — surface it.
+            migrationsAssembly = string.IsNullOrEmpty(connectionStrings.SQLServerMigrationsAssembly)
+                ? null
+                : connectionStrings.SQLServerMigrationsAssembly;
+            LogMigrationsAssemblyFallback(logger, key.Name, migrationsAssembly ?? "<context assembly>");
+        }
+
+        var canonicalEntry = members.First(m => string.Equals(m.LogicalName, canonicalName, StringComparison.Ordinal)).Entry;
+        var cosmosDatabaseName = string.IsNullOrEmpty(canonicalEntry.CosmosDatabaseName)
+            ? connectionStrings.CosmosDatabaseName
+            : canonicalEntry.CosmosDatabaseName;
+
+        _physicalSources[key] = new PhysicalDataSource(
+            key,
+            GetConnectionString(engine, canonicalEntry),
+            migrationsAssembly,
+            cosmosDatabaseName);
+
+        foreach (var (logicalName, _) in members)
+        {
+            _logicalToPhysical[(engine, logicalName)] = key;
+        }
+    }
+
+    private static void AddExplicitMigrationsAssemblies(
+        List<(string LogicalName, string Assembly)> explicitValues,
+        List<(string LogicalName, DataSourceEntrySettings Entry)> members)
+    {
+        foreach (var (logicalName, entry) in members)
+        {
+            if (!string.IsNullOrEmpty(entry.SQLServerMigrationsAssembly))
+            {
+                explicitValues.Add((logicalName, entry.SQLServerMigrationsAssembly));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Picks the single explicit migrations assembly for a physical source, throwing when logical
+    /// names sharing the database declare conflicting values. Non-SQL-Server engines have none.
+    /// </summary>
+    private static string? ResolveMigrationsAssembly(
+        DataSource engine,
+        DataSourceKey key,
+        List<(string LogicalName, string Assembly)> explicitValues)
+    {
+        if (engine != DataSource.SQLServer || explicitValues.Count == 0)
+        {
+            return null;
+        }
+
+        var distinct = explicitValues.Select(v => v.Assembly).Distinct(StringComparer.Ordinal).ToList();
+        if (distinct.Count > 1)
+        {
+            var declarations = string.Join("; ", explicitValues.Select(v => $"\"{v.LogicalName}\" → \"{v.Assembly}\""));
+            throw new InvalidOperationException(
+                $"Data sources collapsing to the same physical database \"{key}\" declare conflicting " +
+                $"SQLServerMigrationsAssembly values: {declarations}. Align them on a single assembly.");
+        }
+
+        return distinct[0];
+    }
+
+    /// <summary>
+    /// Computes the physical-identity string for a connection. Cosmos identities include the
+    /// database name because one Cosmos account hosts many databases; relational engines use the
+    /// connection string alone. Comparison is ordinal — semantically-equal-but-textually-different
+    /// connection strings deliberately do not collapse.
+    /// </summary>
+    private static string GetIdentity(DataSource engine, string connectionString, string cosmosDatabaseName) =>
+        engine == DataSource.CosmosDB
+            ? string.Concat(connectionString, "\n", cosmosDatabaseName)
+            : connectionString;
+
+    private static string GetConnectionString(DataSource engine, IConnectionStringSettings settings) => engine switch
+    {
+        DataSource.CosmosDB => settings.CosmosConnectionString,
+        DataSource.Sqlite => settings.SqliteConnectionString,
+        DataSource.SQLServer => settings.SQLServerConnectionString,
+        _ => throw new InvalidOperationException($"DataSource \"{engine}\" not implemented."),
+    };
+
+    private static string GetConnectionString(DataSource engine, DataSourceEntrySettings entry) => engine switch
+    {
+        DataSource.CosmosDB => entry.CosmosConnectionString,
+        DataSource.Sqlite => entry.SqliteConnectionString,
+        DataSource.SQLServer => entry.SQLServerConnectionString,
+        _ => throw new InvalidOperationException($"DataSource \"{engine}\" not implemented."),
+    };
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SQL Server data source \"{DataSourceName}\" has no dedicated SQLServerMigrationsAssembly; falling back to {Fallback}. Applying another database's migrations to a separate database is almost always a mistake — declare a per-source migrations assembly.")]
+    private static partial void LogMigrationsAssemblyFallback(ILogger logger, string dataSourceName, string fallback);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/EntityDataSourceRegistry.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/EntityDataSourceRegistry.cs
@@ -1,0 +1,193 @@
+using System.Collections.Frozen;
+using System.Reflection;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
+
+namespace MMCA.Common.Infrastructure.Persistence.DataSources;
+
+/// <summary>
+/// Singleton implementation of <see cref="IEntityDataSourceRegistry"/>. Reflects over the
+/// configuration assemblies from <see cref="IEntityConfigurationAssemblyProvider"/>, derives each
+/// entity's physical data source from its configuration class
+/// (engine via <see cref="UseDataSourceAttribute"/>, logical name via
+/// <see cref="UseDatabaseAttribute"/> → module namespace → <c>Default</c>), and resolves the
+/// logical name through <see cref="IDataSourceResolver"/>.
+/// <para>
+/// Built lazily on first access and rescanned once on a lookup miss to pick up module assemblies
+/// loaded after the first access. Duplicate registrations of one entity are tolerated when they
+/// agree on the physical source and rejected (fail-fast) when they conflict.
+/// </para>
+/// </summary>
+public sealed class EntityDataSourceRegistry(
+    IEntityConfigurationAssemblyProvider assemblyProvider,
+    IDataSourceResolver resolver) : IEntityDataSourceRegistry
+{
+    private sealed record Snapshot(
+        FrozenDictionary<string, (DataSourceKey Key, Type ConfigurationType)> Entities,
+        FrozenSet<Assembly> ScannedAssemblies);
+
+    private readonly Lock _rebuildLock = new();
+    private volatile Snapshot? _snapshot;
+
+    /// <inheritdoc />
+    public DataSourceKey GetDataSourceKey(Type entityType)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+        return GetDataSourceKey(entityType.FullName!);
+    }
+
+    /// <inheritdoc />
+    public DataSourceKey GetDataSourceKey(string entityFullName) =>
+        TryGetDataSourceKey(entityFullName, out var key)
+            ? key
+            : throw new InvalidOperationException(
+                $"DataSource not defined for {entityFullName}. " +
+                "Ensure an entity type configuration (EntityTypeConfigurationSQLServer/Cosmos/Sqlite) exists " +
+                "for the entity in a discovered configuration assembly.");
+
+    /// <inheritdoc />
+    public bool TryGetDataSourceKey(string entityFullName, out DataSourceKey key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityFullName);
+
+        var snapshot = GetOrBuildSnapshot();
+        if (snapshot.Entities.TryGetValue(entityFullName, out var registration))
+        {
+            key = registration.Key;
+            return true;
+        }
+
+        // Miss: a module assembly may have been loaded after the first scan. Rescan once when the
+        // assembly set changed, then retry.
+        snapshot = RescanIfAssembliesChanged(snapshot);
+        if (snapshot.Entities.TryGetValue(entityFullName, out registration))
+        {
+            key = registration.Key;
+            return true;
+        }
+
+        key = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse() =>
+        [.. GetOrBuildSnapshot().Entities.Values.Select(r => r.Key).Distinct()];
+
+    private Snapshot GetOrBuildSnapshot()
+    {
+        var snapshot = _snapshot;
+        if (snapshot is not null)
+        {
+            return snapshot;
+        }
+
+        lock (_rebuildLock)
+        {
+            return _snapshot ??= BuildSnapshot();
+        }
+    }
+
+    private Snapshot RescanIfAssembliesChanged(Snapshot current)
+    {
+        lock (_rebuildLock)
+        {
+            var snapshot = _snapshot ?? current;
+            var assemblies = assemblyProvider.GetConfigurationAssemblies();
+            if (assemblies.All(snapshot.ScannedAssemblies.Contains))
+            {
+                return snapshot;
+            }
+
+            snapshot = BuildSnapshot();
+            _snapshot = snapshot;
+            return snapshot;
+        }
+    }
+
+    private Snapshot BuildSnapshot()
+    {
+        var assemblies = assemblyProvider.GetConfigurationAssemblies().Distinct().ToList();
+        var entities = new Dictionary<string, (DataSourceKey Key, Type ConfigurationType)>(StringComparer.Ordinal);
+
+        foreach (var configurationType in assemblies.SelectMany(GetLoadableTypes))
+        {
+            if (configurationType.IsAbstract || configurationType.IsGenericTypeDefinition)
+            {
+                continue;
+            }
+
+            var baseInterface = configurationType.GetInterfaces().FirstOrDefault(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEntityTypeConfigurationBase<,>));
+            if (baseInterface is null)
+            {
+                continue;
+            }
+
+            var entityType = baseInterface.GenericTypeArguments[0];
+            var key = DeriveDataSourceKey(configurationType, entityType);
+            if (key is null)
+            {
+                continue;
+            }
+
+            if (entities.TryGetValue(entityType.FullName!, out var existing))
+            {
+                if (existing.Key != key.Value)
+                {
+                    throw new InvalidOperationException(
+                        $"Entity \"{entityType.FullName}\" is registered by multiple configurations targeting " +
+                        $"different data sources: \"{existing.ConfigurationType.FullName}\" → {existing.Key}, " +
+                        $"\"{configurationType.FullName}\" → {key}. An entity must live in exactly one database.");
+                }
+
+                continue;
+            }
+
+            entities[entityType.FullName!] = (key.Value, configurationType);
+        }
+
+        return new Snapshot(
+            entities.ToFrozenDictionary(StringComparer.Ordinal),
+            assemblies.ToFrozenSet());
+    }
+
+    /// <summary>
+    /// Derives the physical data source for a configuration class:
+    /// engine from <see cref="UseDataSourceAttribute"/> (declared on the provider-specific base class),
+    /// logical name from <see cref="UseDatabaseAttribute"/> → entity module namespace → Default,
+    /// then collapsed to a physical key by the resolver.
+    /// Configurations without <see cref="UseDataSourceAttribute"/> (implementing a provider
+    /// interface directly instead of deriving from the attributed base classes) are skipped —
+    /// their entities are not routable through the unit of work, matching legacy behavior.
+    /// </summary>
+    private DataSourceKey? DeriveDataSourceKey(Type configurationType, Type entityType)
+    {
+        var engine = configurationType.GetCustomAttribute<UseDataSourceAttribute>()?.DataSource;
+        if (engine is null)
+        {
+            return null;
+        }
+
+        var logicalName = configurationType.GetCustomAttribute<UseDatabaseAttribute>()?.Name
+            ?? NamespaceConventions.GetModuleName(entityType)
+            ?? DataSourceKey.DefaultName;
+
+        return resolver.ResolveLogical(engine.Value, logicalName);
+    }
+
+    /// <summary>
+    /// Gets the types of an assembly, tolerating partial load failures (mirrors module discovery).
+    /// </summary>
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t is not null)!;
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/IDataSourceResolver.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/IDataSourceResolver.cs
@@ -1,0 +1,36 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.DataSources;
+
+/// <summary>
+/// Maps <b>logical</b> data source names (from <c>[UseDatabase]</c> attributes, module namespaces,
+/// or settings like <c>Outbox:DatabaseName</c>) to <b>physical</b> data sources, collapsing logical
+/// names that point at the same database onto one <see cref="DataSourceKey"/>.
+/// <para>
+/// The collapse is the backward-compatibility guarantee: in a host with no <c>DataSources</c>
+/// configuration, every logical name resolves to <c>Default</c>, yielding a single DbContext per
+/// engine — identical change tracker, FK constraints, transactions, and EF model as before.
+/// </para>
+/// </summary>
+public interface IDataSourceResolver
+{
+    /// <summary>
+    /// Resolves a logical name to its physical data source key for the given engine.
+    /// Logical names without a <c>DataSources</c> entry, without a connection string for the
+    /// engine, or whose connection equals the top-level one collapse to
+    /// <see cref="DataSourceKey.Default(DataSource)"/>. Entries sharing a connection with each
+    /// other collapse to one physical source named after the alphabetically-first logical name.
+    /// </summary>
+    /// <param name="engine">The database engine.</param>
+    /// <param name="logicalName">The logical data source name.</param>
+    /// <returns>The physical data source key.</returns>
+    DataSourceKey ResolveLogical(DataSource engine, string logicalName);
+
+    /// <summary>
+    /// Gets the resolved connection information for a physical data source key.
+    /// </summary>
+    /// <param name="key">The physical key (must come from <see cref="ResolveLogical"/> or be a Default key).</param>
+    /// <returns>The physical data source connection information.</returns>
+    /// <exception cref="InvalidOperationException">The key does not identify a configured physical source.</exception>
+    PhysicalDataSource GetPhysical(DataSourceKey key);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/IEntityDataSourceRegistry.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/IEntityDataSourceRegistry.cs
@@ -1,0 +1,36 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.DataSources;
+
+/// <summary>
+/// Eagerly-built registry mapping every configured entity type to its physical data source.
+/// Replaces the legacy lazy cache that was populated as a side effect of EF model building —
+/// routing decisions (UnitOfWork, navigation classification, outbox enumeration) no longer
+/// depend on a model having been built first.
+/// </summary>
+public interface IEntityDataSourceRegistry
+{
+    /// <summary>Gets the physical data source key for an entity type.</summary>
+    /// <param name="entityType">The entity CLR type.</param>
+    /// <returns>The physical data source backing the entity.</returns>
+    /// <exception cref="InvalidOperationException">No entity type configuration registers the entity.</exception>
+    DataSourceKey GetDataSourceKey(Type entityType);
+
+    /// <summary>Gets the physical data source key for an entity by its full CLR type name.</summary>
+    /// <param name="entityFullName">The entity's full CLR type name.</param>
+    /// <returns>The physical data source backing the entity.</returns>
+    /// <exception cref="InvalidOperationException">No entity type configuration registers the entity.</exception>
+    DataSourceKey GetDataSourceKey(string entityFullName);
+
+    /// <summary>Attempts to get the physical data source key for an entity by its full CLR type name.</summary>
+    /// <param name="entityFullName">The entity's full CLR type name.</param>
+    /// <param name="key">The physical data source key when registered.</param>
+    /// <returns><see langword="true"/> when the entity is registered.</returns>
+    bool TryGetDataSourceKey(string entityFullName, out DataSourceKey key);
+
+    /// <summary>
+    /// Gets the distinct physical data sources used by the registered entities of this host.
+    /// Used to enumerate databases for migrations, EnsureCreated, and outbox processing.
+    /// </summary>
+    IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse();
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/PhysicalDataSource.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/PhysicalDataSource.cs
@@ -1,0 +1,21 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.DataSources;
+
+/// <summary>
+/// Fully resolved connection information for one physical data source (one database).
+/// Produced by <see cref="IDataSourceResolver"/> from the top-level <c>ConnectionStrings</c>
+/// section (the <c>Default</c> source) and the named <c>DataSources</c> entries.
+/// </summary>
+/// <param name="Key">The physical identity (engine + name) of this source.</param>
+/// <param name="ConnectionString">The engine-specific connection string.</param>
+/// <param name="SqlServerMigrationsAssembly">
+/// The EF Core migrations assembly for SQL Server sources; <see langword="null"/> when EF should
+/// default to the context assembly. Ignored for non-SQL-Server engines.
+/// </param>
+/// <param name="CosmosDatabaseName">The Cosmos DB database name. Ignored for relational engines.</param>
+public sealed record PhysicalDataSource(
+    DataSourceKey Key,
+    string ConnectionString,
+    string? SqlServerMigrationsAssembly,
+    string CosmosDatabaseName);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -1,10 +1,13 @@
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Domain.Interfaces;
 using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
+using MMCA.Common.Infrastructure.Persistence.Conventions;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using StackExchange.Profiling;
@@ -16,16 +19,30 @@ namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 /// Cross-cutting concerns (audit stamping, domain event capture/dispatch) are handled by
 /// <see cref="AuditSaveChangesInterceptor"/> and <see cref="DomainEventSaveChangesInterceptor"/>.
 /// This class provides global soft-delete query filters and model configuration.
+/// <para>
+/// One instance exists per <b>physical data source</b> (database): the same context class is
+/// instantiated multiple times with different <see cref="PhysicalDataSource"/> values, each
+/// building a model containing only its own database's entities
+/// (see <see cref="DataSourceModelCacheKeyFactory"/>).
+/// </para>
 /// </summary>
 /// <param name="options">EF Core options forwarded to <see cref="DbContext"/>.</param>
 /// <param name="serviceProvider">Service provider used when applying entity configurations and resolving interceptors.</param>
 /// <param name="assemblyProvider">Provides module assemblies containing entity configurations.</param>
+/// <param name="physicalDataSource">The physical data source (database) this context instance targets.</param>
 public abstract class ApplicationDbContext(
     DbContextOptions options,
     IServiceProvider serviceProvider,
-    IEntityConfigurationAssemblyProvider assemblyProvider)
+    IEntityConfigurationAssemblyProvider assemblyProvider,
+    PhysicalDataSource physicalDataSource)
     : DbContext(options)
 {
+    /// <summary>Gets the physical data source key (engine + database name) this context targets.</summary>
+    public DataSourceKey DataSourceKey => physicalDataSource.Key;
+
+    /// <summary>Gets the resolved connection information for this context's physical data source.</summary>
+    internal PhysicalDataSource PhysicalSource => physicalDataSource;
+
     /// <summary>
     /// Keyless entity used to map scalar SQL results (e.g. from raw queries) without a backing table.
     /// </summary>
@@ -77,7 +94,25 @@ public abstract class ApplicationDbContext(
         var domainEventInterceptor = serviceProvider.GetRequiredService<DomainEventSaveChangesInterceptor>();
         optionsBuilder.AddInterceptors(auditInterceptor, domainEventInterceptor);
 
+        // Key EF's model cache by (context type, physical source name): the same context class is
+        // instantiated once per database, each with a different model. Without this, the first
+        // built model would silently be reused for every database.
+        optionsBuilder.ReplaceService<IModelCacheKeyFactory, DataSourceModelCacheKeyFactory>();
+
         base.OnConfiguring(optionsBuilder);
+    }
+
+    /// <inheritdoc />
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(configurationBuilder);
+        base.ConfigureConventions(configurationBuilder);
+
+        // Degrade relationships that cross physical data sources (runs at model finalization,
+        // after EF's relationship-discovery conventions). A structural no-op when every entity
+        // collapses onto one database (the monolith case).
+        var registry = serviceProvider.GetRequiredService<IEntityDataSourceRegistry>();
+        configurationBuilder.Conventions.Add(_ => new CrossDataSourceDegradeConvention(DataSourceKey, registry));
     }
 
     public override DbSet<TEntity> Set<TEntity>()
@@ -126,19 +161,33 @@ public abstract class ApplicationDbContext(
     /// <summary>
     /// Configures the <c>RowVersion</c> property as an optimistic concurrency token on every
     /// non-owned entity type that inherits from <see cref="AuditableBaseEntity{TId}"/>.
-    /// SQL Server maps this to <c>rowversion</c> (auto-incremented by the database);
-    /// SQLite maps it to a <c>BLOB</c> column (application-managed).
+    /// SQL Server maps this to <c>rowversion</c> (auto-incremented by the database, so the
+    /// property is database-generated); other relational providers (SQLite) have no equivalent
+    /// server-generated type — the property is mapped as a plain application-managed concurrency
+    /// token there, so EF includes the entity's value in INSERTs instead of expecting the
+    /// database to generate one.
     /// EF Core automatically includes the token in UPDATE/DELETE WHERE clauses and throws
     /// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/> on conflicts.
     /// </summary>
-    protected static void ConfigureConcurrencyTokens(ModelBuilder modelBuilder)
+    protected void ConfigureConcurrencyTokens(ModelBuilder modelBuilder)
     {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+        var isSqlServer = Database.ProviderName?.Contains("SqlServer", StringComparison.OrdinalIgnoreCase) == true;
+
         foreach (var entityType in modelBuilder.Model.GetEntityTypes()
             .Where(et => typeof(IAuditableEntity).IsAssignableFrom(et.ClrType) && !et.IsOwned()))
         {
-            modelBuilder.Entity(entityType.ClrType)
-                .Property(nameof(AuditableBaseEntity<>.RowVersion))
-                .IsRowVersion();
+            var property = modelBuilder.Entity(entityType.ClrType)
+                .Property(nameof(AuditableBaseEntity<>.RowVersion));
+
+            if (isSqlServer)
+            {
+                property.IsRowVersion();
+            }
+            else
+            {
+                property.IsConcurrencyToken();
+            }
         }
     }
 
@@ -163,9 +212,11 @@ public abstract class ApplicationDbContext(
         });
 
     /// <summary>
-    /// Discovers and applies all EF entity configurations for the given data source from module Infrastructure assemblies.
+    /// Discovers and applies the EF entity configurations for the given engine from module
+    /// Infrastructure assemblies, filtered to entities whose physical data source matches this
+    /// context instance (so each database's model contains only its own entities).
     /// </summary>
-    /// <param name="dataSource">The target data source whose configuration interface to match.</param>
+    /// <param name="dataSource">The target engine whose configuration interface to match.</param>
     /// <param name="modelBuilder">The model builder to apply configurations to.</param>
     protected void ApplyConfigurationsForEntitiesInContext(DataSource dataSource, ModelBuilder modelBuilder)
     {
@@ -177,9 +228,22 @@ public abstract class ApplicationDbContext(
             _ => throw new InvalidOperationException($"DataSource \"{dataSource}\" not implemented."),
         };
 
+        // The registry derives keys from the same attributes/namespaces as the configurations
+        // themselves, so model contents and runtime routing agree by construction. Entities whose
+        // configuration is not registered (e.g. one implementing the provider interface directly
+        // without the attributed base classes) fall back to the engine's Default source — they are
+        // included in the Default model but are not routable via the unit of work (legacy behavior).
+        var registry = serviceProvider.GetRequiredService<IEntityDataSourceRegistry>();
+
         foreach (var assembly in assemblyProvider.GetConfigurationAssemblies())
         {
-            modelBuilder.ApplyAllConfigurations(serviceProvider, assembly, configType);
+            modelBuilder.ApplyAllConfigurations(
+                serviceProvider,
+                assembly,
+                configType,
+                entityType => registry.TryGetDataSourceKey(entityType.FullName!, out var key)
+                    ? key == DataSourceKey
+                    : DataSourceKey.Name == DataSourceKey.DefaultName);
         }
     }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/CosmosDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/CosmosDbContext.cs
@@ -1,28 +1,30 @@
 using Microsoft.EntityFrameworkCore;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
-using MMCA.Common.Infrastructure.Settings;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 
 /// <summary>
-/// DbContext targeting Azure Cosmos DB. Automatically detects the local emulator
+/// DbContext targeting Azure Cosmos DB. One instance exists per physical Cosmos data source
+/// (account + database); connection string and database name come from the resolved
+/// <see cref="PhysicalDataSource"/>. Automatically detects the local emulator
 /// and adjusts connection mode and SSL settings accordingly.
 /// </summary>
 public sealed class CosmosDbContext(
     DbContextOptions<CosmosDbContext> options,
     IServiceProvider serviceProvider,
-    IConnectionStringSettings connectionStringSettings,
-    IEntityConfigurationAssemblyProvider assemblyProvider)
-    : ApplicationDbContext(options, serviceProvider, assemblyProvider)
+    IEntityConfigurationAssemblyProvider assemblyProvider,
+    PhysicalDataSource physicalDataSource)
+    : ApplicationDbContext(options, serviceProvider, assemblyProvider, physicalDataSource)
 {
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         ArgumentNullException.ThrowIfNull(optionsBuilder);
 
-        var connectionString = connectionStringSettings.CosmosConnectionString;
+        var connectionString = PhysicalSource.ConnectionString;
 
         // "C2y6yDjf5" is the well-known prefix of the Cosmos DB Emulator's default account key.
         var isEmulator = connectionString.Contains("C2y6yDjf5", StringComparison.Ordinal);
@@ -30,7 +32,7 @@ public sealed class CosmosDbContext(
         optionsBuilder
             .UseCosmos(
                 connectionString: connectionString,
-                databaseName: "AtlDevCon",
+                databaseName: PhysicalSource.CosmosDatabaseName,
                 cosmosOptionsAction: options =>
                 {
                     if (isEmulator)

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/DataSourceModelCacheKeyFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/DataSourceModelCacheKeyFactory.cs
@@ -19,5 +19,5 @@ public sealed class DataSourceModelCacheKeyFactory : IModelCacheKeyFactory
     public object Create(DbContext context, bool designTime) =>
         context is ApplicationDbContext applicationDbContext
             ? (context.GetType(), applicationDbContext.DataSourceKey.Name, designTime)
-            : (object)(context.GetType(), designTime);
+            : (context.GetType(), designTime);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/DataSourceModelCacheKeyFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/DataSourceModelCacheKeyFactory.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
+
+/// <summary>
+/// Model cache key factory that keys EF's model cache by (context type, physical data source name)
+/// instead of context type alone. Required because one context class per engine
+/// (e.g. <see cref="SQLServerDbContext"/>) is instantiated once per physical database, each with a
+/// different EF model containing only that database's entities.
+/// <para>
+/// Without this, the first-built model would silently be reused for every physical source —
+/// queries would target tables that don't exist in the other databases.
+/// </para>
+/// </summary>
+public sealed class DataSourceModelCacheKeyFactory : IModelCacheKeyFactory
+{
+    /// <inheritdoc />
+    public object Create(DbContext context, bool designTime) =>
+        context is ApplicationDbContext applicationDbContext
+            ? (context.GetType(), applicationDbContext.DataSourceKey.Name, designTime)
+            : (object)(context.GetType(), designTime);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
@@ -1,0 +1,116 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Design;
+
+/// <summary>
+/// Builds <see cref="SQLServerDbContext"/> instances for <c>dotnet ef</c> design-time commands
+/// without the application's DI container. A downstream migrations project implements EF's
+/// <c>IDesignTimeDbContextFactory&lt;SQLServerDbContext&gt;</c> in a few lines:
+/// <code language="csharp">
+/// public sealed class ConferenceDbContextFactory : IDesignTimeDbContextFactory&lt;SQLServerDbContext&gt;
+/// {
+///     public SQLServerDbContext CreateDbContext(string[] args) =>
+///         DesignTimeDbContextHelper.CreateSqlServer(args, options =>
+///         {
+///             options.ConnectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "...", SQLServerMigrationsAssembly = "..." };
+///             options.AddConfigurationAssembly(typeof(ConferenceAssemblyReference).Assembly);
+///         });
+/// }
+/// </code>
+/// Invoked as <c>dotnet ef migrations add X --project ... -- --datasource Conference</c>
+/// (EF forwards the arguments after <c>--</c> to the factory).
+/// </summary>
+public static class DesignTimeDbContextHelper
+{
+    /// <summary>
+    /// Creates a <see cref="SQLServerDbContext"/> for the data source selected by
+    /// <see cref="DesignTimeDbContextOptions.DataSourceName"/> or the <c>--datasource</c> argument.
+    /// </summary>
+    /// <param name="args">The design-time arguments forwarded by <c>dotnet ef</c> (after <c>--</c>).</param>
+    /// <param name="configure">Callback configuring connection settings and configuration assemblies.</param>
+    /// <returns>A context whose model contains only the selected data source's entities.</returns>
+    public static SQLServerDbContext CreateSqlServer(string[] args, Action<DesignTimeDbContextOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var designOptions = new DesignTimeDbContextOptions();
+        configure(designOptions);
+
+        var logicalName = designOptions.DataSourceName
+            ?? ParseDataSourceName(args)
+            ?? DataSourceKey.DefaultName;
+
+        var assemblyProvider = new ExplicitAssemblyProvider([.. designOptions.ConfigurationAssemblies]);
+        var resolver = new DataSourceResolver(
+            designOptions.ConnectionStrings,
+            new DataSourcesSettings(designOptions.DataSources),
+            NullLogger<DataSourceResolver>.Instance);
+        var registry = new EntityDataSourceRegistry(assemblyProvider, resolver);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<IDomainEventDispatcher, NullDomainEventDispatcher>();
+        services.AddSingleton<IOutboxSignal, OutboxSignal>();
+        services.AddSingleton<AuditSaveChangesInterceptor>();
+        services.AddSingleton<DomainEventSaveChangesInterceptor>();
+        services.AddSingleton<IEntityConfigurationAssemblyProvider>(assemblyProvider);
+        services.AddSingleton<IDataSourceResolver>(resolver);
+        services.AddSingleton<IEntityDataSourceRegistry>(registry);
+
+        var physical = resolver.GetPhysical(resolver.ResolveLogical(DataSource.SQLServer, logicalName));
+
+        return new SQLServerDbContext(
+            new DbContextOptionsBuilder<SQLServerDbContext>().Options,
+            services.BuildServiceProvider(),
+            assemblyProvider,
+            physical);
+    }
+
+    /// <summary>
+    /// Parses <c>--datasource &lt;Name&gt;</c> or <c>--datasource=Name</c> from the design-time arguments.
+    /// </summary>
+    internal static string? ParseDataSourceName(string[] args)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--datasource", StringComparison.OrdinalIgnoreCase))
+            {
+                return i + 1 < args.Length
+                    ? args[i + 1]
+                    : throw new InvalidOperationException("--datasource requires a value (e.g. -- --datasource Conference).");
+            }
+
+            if (args[i].StartsWith("--datasource=", StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i]["--datasource=".Length..];
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class ExplicitAssemblyProvider(IReadOnlyList<Assembly> assemblies) : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => assemblies;
+    }
+
+    private sealed class NullDomainEventDispatcher : IDomainEventDispatcher
+    {
+        public Task DispatchAsync(IEnumerable<IDomainEvent> domainEvents, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Design;
+
+/// <summary>
+/// Options for <see cref="DesignTimeDbContextHelper"/>. A downstream migrations project supplies
+/// its module's configuration assemblies and connection settings; the data source name normally
+/// comes from the <c>dotnet ef ... -- --datasource &lt;Name&gt;</c> argument.
+/// </summary>
+public sealed class DesignTimeDbContextOptions
+{
+    /// <summary>
+    /// Gets or sets the logical data source name to build the context for. When
+    /// <see langword="null"/>, the name is parsed from the <c>--datasource</c> design-time
+    /// argument, falling back to <c>Default</c>.
+    /// </summary>
+    public string? DataSourceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the top-level connection strings (the <c>Default</c> source), including
+    /// <c>SQLServerMigrationsAssembly</c>.
+    /// </summary>
+    public ConnectionStringSettings ConnectionStrings { get; set; } = new();
+
+    /// <summary>Gets the named data source entries (mirrors the <c>DataSources</c> configuration section).</summary>
+    public Dictionary<string, DataSourceEntrySettings> DataSources { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the assemblies containing the entity type configurations to include in the model.
+    /// Must be listed explicitly — the AppDomain scan used at runtime sees nothing at design time.
+    /// </summary>
+    public IList<Assembly> ConfigurationAssemblies { get; } = [];
+
+    /// <summary>Adds an assembly containing entity type configurations.</summary>
+    /// <param name="assembly">The configuration assembly.</param>
+    /// <returns>These options, for chaining.</returns>
+    public DesignTimeDbContextOptions AddConfigurationAssembly(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        if (!ConfigurationAssemblies.Contains(assembly))
+        {
+            ConfigurationAssemblies.Add(assembly);
+        }
+
+        return this;
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
@@ -24,7 +24,7 @@ public sealed class DesignTimeDbContextOptions
     public ConnectionStringSettings ConnectionStrings { get; set; } = new();
 
     /// <summary>Gets the named data source entries (mirrors the <c>DataSources</c> configuration section).</summary>
-    public Dictionary<string, DataSourceEntrySettings> DataSources { get; } = new(StringComparer.Ordinal);
+    public Dictionary<string, DataSourceEntrySettings> DataSources { get; } = [];
 
     /// <summary>
     /// Gets the assemblies containing the entity type configurations to include in the model.

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -5,35 +5,33 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 
 /// <summary>
-/// Creates and caches <see cref="ApplicationDbContext"/> instances per <see cref="DataSource"/>.
-/// Each data source yields at most one context per scope; subsequent calls return the cached instance.
+/// Creates and caches <see cref="ApplicationDbContext"/> instances per physical
+/// <see cref="DataSourceKey"/> (engine + database). Each physical source yields at most one
+/// context per scope; subsequent calls return the cached instance.
 /// Coordinates save, transaction, and disposal across all active contexts.
 /// </summary>
 public sealed class DbContextFactory(
-    IDbContextFactory<CosmosDbContext> dbContextFactoryCosmos,
-    IDbContextFactory<SqliteDbContext> dbContextFactorySqlite,
-    IDbContextFactory<SQLServerDbContext> dbContextFactorySQLServer,
+    IPhysicalDbContextFactory physicalDbContextFactory,
+    IEntityDataSourceRegistry entityDataSourceRegistry,
+    IDataSourceResolver dataSourceResolver,
     ICurrentUserService currentUserService
 ) : IDbContextFactory
 {
+    private readonly IPhysicalDbContextFactory _physicalDbContextFactory = physicalDbContextFactory ?? throw new ArgumentNullException(nameof(physicalDbContextFactory));
+    private readonly IEntityDataSourceRegistry _entityDataSourceRegistry = entityDataSourceRegistry ?? throw new ArgumentNullException(nameof(entityDataSourceRegistry));
+    private readonly IDataSourceResolver _dataSourceResolver = dataSourceResolver ?? throw new ArgumentNullException(nameof(dataSourceResolver));
     private readonly ICurrentUserService _currentUserService = currentUserService ?? throw new ArgumentNullException(nameof(currentUserService));
 
     /// <summary>
-    /// Caches one context per DataSource so all repositories within a scope share the same change tracker.
+    /// Caches one context per physical data source so all repositories within a scope share the same change tracker.
     /// </summary>
-    private readonly Dictionary<DataSource, ApplicationDbContext> _dbContexts = [];
-
-    private readonly Dictionary<DataSource, Func<ApplicationDbContext>> _contextFactoryRegistry = new()
-    {
-        [DataSource.CosmosDB] = () => (dbContextFactoryCosmos ?? throw new ArgumentNullException(nameof(dbContextFactoryCosmos))).CreateDbContext(),
-        [DataSource.Sqlite] = () => (dbContextFactorySqlite ?? throw new ArgumentNullException(nameof(dbContextFactorySqlite))).CreateDbContext(),
-        [DataSource.SQLServer] = () => (dbContextFactorySQLServer ?? throw new ArgumentNullException(nameof(dbContextFactorySQLServer))).CreateDbContext(),
-    };
+    private readonly Dictionary<DataSourceKey, ApplicationDbContext> _dbContexts = [];
 
     /// <summary>
     /// Tracks whether a transaction is active so that contexts created lazily (after
@@ -51,14 +49,14 @@ public sealed class DbContextFactory(
     private volatile bool _disposed;
 
     /// <inheritdoc />
-    public ApplicationDbContext GetDbContext(DataSource dataSource)
+    public ApplicationDbContext GetDbContext(DataSourceKey dataSourceKey)
     {
         ObjectDisposedException.ThrowIf(_disposed, nameof(DbContextFactory));
 
-        if (!_dbContexts.TryGetValue(dataSource, out var context) || context is null)
+        if (!_dbContexts.TryGetValue(dataSourceKey, out var context) || context is null)
         {
-            context = CreateDbContext(dataSource);
-            _dbContexts[dataSource] = context;
+            context = _physicalDbContextFactory.Create(dataSourceKey);
+            _dbContexts[dataSourceKey] = context;
 
             // Enlist late-created contexts in the active transaction so that all
             // persistence within a transactional command shares the same boundary.
@@ -68,17 +66,30 @@ public sealed class DbContextFactory(
         return context;
     }
 
-    private ApplicationDbContext CreateDbContext(DataSource dataSource) =>
-        _contextFactoryRegistry.TryGetValue(dataSource, out var factory)
-            ? factory()
-            : throw new InvalidOperationException($"Invalid DataSource \"{dataSource}\"");
+    /// <inheritdoc />
+    public ApplicationDbContext GetDbContext(DataSource dataSource) =>
+        GetDbContext(DataSourceKey.Default(dataSource));
 
     /// <inheritdoc />
     public async Task EnsureCreatedAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var context in _dbContexts.Values)
-            await context.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var key in GetSourcesInUse())
+        {
+            // Sources without a configured connection string are skipped (e.g. Cosmos is
+            // optional in integration tests that omit its connection string).
+            if (string.IsNullOrEmpty(_dataSourceResolver.GetPhysical(key).ConnectionString))
+                continue;
+
+            await GetDbContext(key).Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
+
+    /// <summary>
+    /// The physical sources this host actually uses: every source backing a registered entity,
+    /// plus any already-materialized contexts (e.g. the outbox publish target).
+    /// </summary>
+    private List<DataSourceKey> GetSourcesInUse() =>
+        [.. _entityDataSourceRegistry.GetPhysicalSourcesInUse().Union(_dbContexts.Keys)];
 
     /// <inheritdoc />
     /// <remarks>
@@ -245,6 +256,10 @@ public sealed class DbContextFactory(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// With multiple physical sources, each gets its own transaction; commits are sequential and
+    /// best-effort (no two-phase commit). The outbox is the cross-source consistency mechanism.
+    /// </remarks>
     public async Task<TResult> ExecuteInTransactionAsync<TResult>(
         Func<CancellationToken, Task<TResult>> operation,
         CancellationToken cancellationToken = default)
@@ -291,16 +306,16 @@ public sealed class DbContextFactory(
     /// <inheritdoc />
     public async Task MigrateAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var context in _dbContexts.Values.Where(SupportsRelationalMigrations))
-            await context.Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var key in GetSourcesInUse().Where(k => k.Engine == DataSource.SQLServer))
+            await GetDbContext(key).Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var context in _dbContexts.Values.Where(SupportsRelationalMigrations))
+        foreach (var key in GetSourcesInUse().Where(k => k.Engine == DataSource.SQLServer))
         {
-            var pending = await context.Database.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
+            var pending = await GetDbContext(key).Database.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
             if (pending.Any())
                 return true;
         }
@@ -316,13 +331,6 @@ public sealed class DbContextFactory(
 
     private static bool HasActiveTransaction(ApplicationDbContext context) =>
         context.Database.CurrentTransaction is not null;
-
-    /// <summary>
-    /// Only relational contexts that have a migrations assembly configured support EF Core migrations.
-    /// Cosmos and SQLite contexts are excluded.
-    /// </summary>
-    private static bool SupportsRelationalMigrations(ApplicationDbContext context) =>
-        context is SQLServerDbContext;
 
     private void Dispose(bool disposing)
     {

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DefaultEngineDbContextFactories.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DefaultEngineDbContextFactories.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+
+/// <summary>
+/// Adapters preserving EF Core's <see cref="IDbContextFactory{TContext}"/> DI surface for the
+/// three engine context types after the move to per-physical-source instantiation. Each returns
+/// a context for the engine's <b>Default</b> physical source (the top-level connection strings),
+/// matching the pre-multi-database behavior for consumers such as
+/// <see cref="ApplicationDbContextEFFactory"/> and health checks.
+/// </summary>
+internal sealed class DefaultSqlServerDbContextFactory(IPhysicalDbContextFactory physicalFactory)
+    : IDbContextFactory<SQLServerDbContext>
+{
+    /// <inheritdoc />
+    public SQLServerDbContext CreateDbContext() =>
+        (SQLServerDbContext)physicalFactory.Create(DataSourceKey.Default(DataSource.SQLServer));
+}
+
+/// <summary>Default-source factory adapter for <see cref="SqliteDbContext"/>.</summary>
+internal sealed class DefaultSqliteDbContextFactory(IPhysicalDbContextFactory physicalFactory)
+    : IDbContextFactory<SqliteDbContext>
+{
+    /// <inheritdoc />
+    public SqliteDbContext CreateDbContext() =>
+        (SqliteDbContext)physicalFactory.Create(DataSourceKey.Default(DataSource.Sqlite));
+}
+
+/// <summary>Default-source factory adapter for <see cref="CosmosDbContext"/>.</summary>
+internal sealed class DefaultCosmosDbContextFactory(IPhysicalDbContextFactory physicalFactory)
+    : IDbContextFactory<CosmosDbContext>
+{
+    /// <inheritdoc />
+    public CosmosDbContext CreateDbContext() =>
+        (CosmosDbContext)physicalFactory.Create(DataSourceKey.Default(DataSource.CosmosDB));
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IDbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IDbContextFactory.cs
@@ -5,18 +5,27 @@ namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 
 /// <summary>
 /// Abstracts the creation and lifecycle management of <see cref="ApplicationDbContext"/> instances
-/// across multiple data sources. Caches contexts per <see cref="DataSource"/> within a scope and
-/// coordinates saves, transactions, and disposal across all active contexts.
+/// across multiple data sources. Caches contexts per physical <see cref="DataSourceKey"/> within a
+/// scope and coordinates saves, transactions, and disposal across all active contexts.
 /// </summary>
 public interface IDbContextFactory : IDisposable, IAsyncDisposable
 {
     /// <summary>
-    /// Returns the <see cref="ApplicationDbContext"/> for the specified data source, creating one if it doesn't exist in this scope.
+    /// Returns the <see cref="ApplicationDbContext"/> for the specified physical data source,
+    /// creating one if it doesn't exist in this scope.
+    /// </summary>
+    ApplicationDbContext GetDbContext(DataSourceKey dataSourceKey);
+
+    /// <summary>
+    /// Returns the <see cref="ApplicationDbContext"/> for the engine's <b>Default</b> physical
+    /// source (the top-level connection strings). Convenience overload preserving the
+    /// single-database call sites.
     /// </summary>
     ApplicationDbContext GetDbContext(DataSource dataSource);
 
     /// <summary>
-    /// Ensures the underlying databases for all active contexts have been created.
+    /// Ensures the databases of every physical data source in use by this host have been created
+    /// (sources without a configured connection string are skipped).
     /// </summary>
     Task EnsureCreatedAsync(CancellationToken cancellationToken = default);
 
@@ -56,6 +65,12 @@ public interface IDbContextFactory : IDisposable, IAsyncDisposable
     /// <summary>
     /// Executes <paramref name="operation"/> inside a database transaction, wrapped by the
     /// active execution strategy so that retrying strategies can retry the entire unit.
+    /// <para>
+    /// When the operation touches multiple physical data sources, each source gets its own
+    /// transaction and the commits are sequential and best-effort — there is <b>no</b> distributed
+    /// (two-phase) commit. A failure mid-commit leaves earlier sources committed. The outbox
+    /// pattern is the cross-source consistency mechanism; design multi-source work accordingly.
+    /// </para>
     /// </summary>
     /// <typeparam name="TResult">The type returned by the operation.</typeparam>
     /// <param name="operation">The work to execute inside the transaction.</param>
@@ -65,13 +80,14 @@ public interface IDbContextFactory : IDisposable, IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Applies pending EF Core migrations for all active relational contexts.
-    /// Cosmos contexts are skipped (document DB — no schema migrations).
+    /// Applies pending EF Core migrations for every SQL Server physical data source in use by this
+    /// host (each with its own migrations assembly). Cosmos and SQLite sources are skipped.
     /// </summary>
     Task MigrateAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns <see langword="true"/> if any active relational context has pending migrations that have not been applied.
+    /// Returns <see langword="true"/> if any SQL Server physical data source in use has pending
+    /// migrations that have not been applied.
     /// </summary>
     Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken = default);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IPhysicalDbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IPhysicalDbContextFactory.cs
@@ -1,0 +1,22 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+
+/// <summary>
+/// Creates raw <see cref="ApplicationDbContext"/> instances for a specific physical data source.
+/// The engine selects the context class (SQL Server / Cosmos / SQLite); the source name selects
+/// the database (connection string, migrations assembly, EF model).
+/// <para>
+/// Contexts created here are not scoped or cached — <see cref="IDbContextFactory"/> layers
+/// per-scope caching, save coordination, and transactions on top.
+/// </para>
+/// </summary>
+public interface IPhysicalDbContextFactory
+{
+    /// <summary>
+    /// Creates a new context instance for the given physical data source.
+    /// </summary>
+    /// <param name="key">The physical data source key.</param>
+    /// <returns>A new context targeting that database.</returns>
+    ApplicationDbContext Create(DataSourceKey key);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/PhysicalDbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/PhysicalDbContextFactory.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+
+/// <summary>
+/// Singleton <see cref="IPhysicalDbContextFactory"/> that constructs context instances directly,
+/// resolving connection information through <see cref="IDataSourceResolver"/>.
+/// <para>
+/// IMPORTANT: these contexts must never be pooled (<c>AddPooledDbContextFactory</c>) — each
+/// instance carries per-source constructor state (<see cref="PhysicalDataSource"/>), which pooling
+/// would reuse across sources, silently pointing repositories at the wrong database.
+/// </para>
+/// </summary>
+public sealed class PhysicalDbContextFactory(
+    IServiceProvider serviceProvider,
+    IDataSourceResolver resolver,
+    IEntityConfigurationAssemblyProvider assemblyProvider) : IPhysicalDbContextFactory
+{
+    // Options are intentionally empty — all configuration (provider, connection, interceptors,
+    // model cache key) happens in each context's OnConfiguring. Matches the empty options the
+    // previous AddDbContextFactory<T>() registrations produced.
+    private static readonly DbContextOptions<SQLServerDbContext> SqlServerOptions =
+        new DbContextOptionsBuilder<SQLServerDbContext>().Options;
+
+    private static readonly DbContextOptions<SqliteDbContext> SqliteOptions =
+        new DbContextOptionsBuilder<SqliteDbContext>().Options;
+
+    private static readonly DbContextOptions<CosmosDbContext> CosmosOptions =
+        new DbContextOptionsBuilder<CosmosDbContext>().Options;
+
+    /// <inheritdoc />
+    public ApplicationDbContext Create(DataSourceKey key)
+    {
+        var physical = resolver.GetPhysical(key);
+
+        return key.Engine switch
+        {
+            DataSource.SQLServer => new SQLServerDbContext(SqlServerOptions, serviceProvider, assemblyProvider, physical),
+            DataSource.Sqlite => new SqliteDbContext(SqliteOptions, serviceProvider, assemblyProvider, physical),
+            DataSource.CosmosDB => new CosmosDbContext(CosmosOptions, serviceProvider, assemblyProvider, physical),
+            _ => throw new InvalidOperationException($"Invalid DataSource \"{key.Engine}\""),
+        };
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ModelBuilderExtensions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ModelBuilderExtensions.cs
@@ -12,17 +12,21 @@ internal static class ModelBuilderExtensions
     /// <summary>
     /// Scans the given assembly for concrete classes implementing <paramref name="interfaceType"/>
     /// (a provider-specific configuration interface like <c>IEntityTypeConfigurationSQLServer&lt;,&gt;</c>),
-    /// instantiates each via DI, and applies it to the model builder.
+    /// instantiates each via DI, and applies it to the model builder. An optional
+    /// <paramref name="entityFilter"/> restricts application to entities belonging to the
+    /// context's physical data source.
     /// </summary>
     /// <param name="modelBuilder">The model builder to apply configurations to.</param>
     /// <param name="serviceProvider">Service provider for resolving configuration constructor dependencies.</param>
     /// <param name="assembly">The assembly to scan for configuration classes.</param>
     /// <param name="interfaceType">The open generic interface type to match (e.g., <c>IEntityTypeConfigurationSQLServer&lt;,&gt;</c>).</param>
+    /// <param name="entityFilter">Optional predicate over the entity CLR type; configurations whose entity fails the predicate are skipped.</param>
     internal static void ApplyAllConfigurations(
         this ModelBuilder modelBuilder,
         IServiceProvider serviceProvider,
         Assembly assembly,
-        Type interfaceType)
+        Type interfaceType,
+        Func<Type, bool>? entityFilter = null)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         ArgumentNullException.ThrowIfNull(serviceProvider);
@@ -50,6 +54,11 @@ internal static class ModelBuilderExtensions
         {
             // First generic argument is the entity type (TEntity).
             var entityType = config.Interface!.GenericTypeArguments[0];
+            if (entityFilter is not null && !entityFilter(entityType))
+            {
+                continue;
+            }
+
             var configInstance = ActivatorUtilities.CreateInstance(serviceProvider, config.Type);
             var genericMethod = applyConfigMethod.MakeGenericMethod(entityType);
             genericMethod.Invoke(modelBuilder, [configInstance]);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/SQLServerDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/SQLServerDbContext.cs
@@ -2,19 +2,21 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure;
-using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 
 /// <summary>
-/// DbContext targeting SQL Server. Configured via connection string from <see cref="IConnectionStringSettings"/>.
+/// DbContext targeting SQL Server. One instance exists per physical SQL Server data source
+/// (database); the connection string and migrations assembly come from the resolved
+/// <see cref="PhysicalDataSource"/>.
 /// </summary>
 public sealed class SQLServerDbContext(
     DbContextOptions<SQLServerDbContext> options,
     IServiceProvider serviceProvider,
-    IConnectionStringSettings connectionStringSettings,
-    IEntityConfigurationAssemblyProvider assemblyProvider)
-    : ApplicationDbContext(options, serviceProvider, assemblyProvider)
+    IEntityConfigurationAssemblyProvider assemblyProvider,
+    PhysicalDataSource physicalDataSource)
+    : ApplicationDbContext(options, serviceProvider, assemblyProvider, physicalDataSource)
 {
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -23,12 +25,12 @@ public sealed class SQLServerDbContext(
 
         optionsBuilder
             .UseSqlServer(
-                connectionStringSettings.SQLServerConnectionString,
+                PhysicalSource.ConnectionString,
                 sql =>
                 {
-                    if (!string.IsNullOrEmpty(connectionStringSettings.SQLServerMigrationsAssembly))
+                    if (!string.IsNullOrEmpty(PhysicalSource.SqlServerMigrationsAssembly))
                     {
-                        sql.MigrationsAssembly(connectionStringSettings.SQLServerMigrationsAssembly);
+                        sql.MigrationsAssembly(PhysicalSource.SqlServerMigrationsAssembly);
                     }
 
                     // Retry transient SQL Server failures (timeouts, transient network drops,

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/SqliteDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/SqliteDbContext.cs
@@ -1,27 +1,28 @@
 using Microsoft.EntityFrameworkCore;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure;
-using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 
 /// <summary>
-/// DbContext targeting SQLite. Configured via connection string from <see cref="IConnectionStringSettings"/>.
+/// DbContext targeting SQLite. One instance exists per physical SQLite data source (database file);
+/// the connection string comes from the resolved <see cref="PhysicalDataSource"/>.
 /// Useful for lightweight local development or testing without a full SQL Server instance.
 /// </summary>
 public sealed class SqliteDbContext(
     DbContextOptions<SqliteDbContext> options,
     IServiceProvider serviceProvider,
-    IConnectionStringSettings connectionStringSettings,
-    IEntityConfigurationAssemblyProvider assemblyProvider)
-    : ApplicationDbContext(options, serviceProvider, assemblyProvider)
+    IEntityConfigurationAssemblyProvider assemblyProvider,
+    PhysicalDataSource physicalDataSource)
+    : ApplicationDbContext(options, serviceProvider, assemblyProvider, physicalDataSource)
 {
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         ArgumentNullException.ThrowIfNull(optionsBuilder);
 
         optionsBuilder
-            .UseSqlite(connectionStringSettings.SqliteConnectionString);
+            .UseSqlite(PhysicalSource.ConnectionString);
 
         base.OnConfiguring(optionsBuilder);
     }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/DomainEventSaveChangesInterceptor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/DomainEventSaveChangesInterceptor.cs
@@ -121,6 +121,11 @@ public sealed partial class DomainEventSaveChangesInterceptor(
         {
             await domainEventDispatcher.DispatchAsync(state.DomainEvents, cancellationToken).ConfigureAwait(false);
 
+            // Clear BEFORE the nested SaveChanges in MarkOutboxAsProcessed: that save re-enters
+            // this interceptor synchronously, and any events still on the aggregates would be
+            // captured a second time, writing duplicate outbox rows.
+            ClearDomainEvents(state);
+
             MarkOutboxAsProcessed(context, state.OutboxEntries);
         }
         catch (Exception ex)
@@ -134,9 +139,15 @@ public sealed partial class DomainEventSaveChangesInterceptor(
         }
         finally
         {
-            foreach (var aggregateRootEntity in state.AggregateRootEntities)
-                aggregateRootEntity.Entity.ClearDomainEvents();
+            // Idempotent — covers the dispatch-failure path.
+            ClearDomainEvents(state);
         }
+    }
+
+    private static void ClearDomainEvents(CapturedState state)
+    {
+        foreach (var aggregateRootEntity in state.AggregateRootEntities)
+            aggregateRootEntity.Entity.ClearDomainEvents();
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/NamespaceConventions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/NamespaceConventions.cs
@@ -1,0 +1,23 @@
+namespace MMCA.Common.Infrastructure.Persistence;
+
+/// <summary>
+/// Shared namespace-derivation conventions used for both SQL schema names and logical data
+/// source (database) names, so the two can never drift apart.
+/// </summary>
+internal static class NamespaceConventions
+{
+    /// <summary>
+    /// Derives the module name from an entity's namespace: the segment preceding <c>Domain</c>.
+    /// E.g. <c>MMCA.Store.Sales.Domain.Orders</c> → <c>"Sales"</c>;
+    /// <c>MMCA.Modules.Catalog.Domain</c> → <c>"Catalog"</c>.
+    /// </summary>
+    /// <param name="entityType">The entity CLR type.</param>
+    /// <returns>The module name, or <see langword="null"/> when the namespace has no <c>Domain</c> segment.</returns>
+    internal static string? GetModuleName(Type entityType)
+    {
+        var segments = entityType.Namespace?.Split('.') ?? [];
+        var domainIndex = Array.FindIndex(segments,
+            s => s.Equals("Domain", StringComparison.OrdinalIgnoreCase));
+        return domainIndex >= 1 ? segments[domainIndex - 1] : null;
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -6,8 +6,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Messaging;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 using MMCA.Common.Infrastructure.Settings;
@@ -15,20 +17,30 @@ using MMCA.Common.Infrastructure.Settings;
 namespace MMCA.Common.Infrastructure.Persistence.Outbox;
 
 /// <summary>
-/// Background service that polls the outbox table for unprocessed domain events and
+/// Background service that polls the outbox tables for unprocessed domain events and
 /// dispatches them via <see cref="IDomainEventDispatcher"/>. Acts as a safety net:
 /// events are normally dispatched in-process immediately after persistence, but if
 /// that dispatch fails (e.g. process crash), this processor retries them.
+/// <para>
+/// Every relational physical data source in use by this host has its own
+/// <c>OutboxMessages</c> table; each polling cycle drains them all. A host therefore only
+/// processes the outboxes of its own databases — services with separate databases never race
+/// for each other's messages.
+/// </para>
 /// </summary>
 /// <param name="scopeFactory">Factory for creating DI scopes per processing cycle.</param>
 /// <param name="logger">Logger for processing diagnostics.</param>
 /// <param name="outboxOptions">Configurable outbox processing settings.</param>
 /// <param name="outboxSignal">Signal to wait on between polling cycles for immediate wakeup.</param>
+/// <param name="entityDataSourceRegistry">Registry enumerating the physical data sources in use.</param>
+/// <param name="dataSourceResolver">Resolver for the configured outbox publish target.</param>
 public sealed partial class OutboxProcessor(
     IServiceScopeFactory scopeFactory,
     ILogger<OutboxProcessor> logger,
     IOptions<OutboxSettings> outboxOptions,
-    IOutboxSignal outboxSignal) : BackgroundService
+    IOutboxSignal outboxSignal,
+    IEntityDataSourceRegistry entityDataSourceRegistry,
+    IDataSourceResolver dataSourceResolver) : BackgroundService
 {
     private readonly OutboxSettings _settings = outboxOptions.Value;
 
@@ -42,14 +54,14 @@ public sealed partial class OutboxProcessor(
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (_settings.DataSource == Application.Interfaces.Infrastructure.DataSource.CosmosDB)
-        {
-            LogOutboxDisabled(logger, _settings.DataSource);
-            return;
-        }
-
         // Brief startup delay so the application finishes initializing before we start polling.
         await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
+
+        if (GetOutboxSources().Count == 0)
+        {
+            LogOutboxDisabled(logger);
+            return;
+        }
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -72,11 +84,50 @@ public sealed partial class OutboxProcessor(
         }
     }
 
+    /// <summary>
+    /// The relational physical sources whose outbox tables this host owns: every source backing a
+    /// registered entity plus the configured publish target (Cosmos has no outbox table).
+    /// Recomputed per cycle — cheap, and tolerant of module assemblies loading after startup.
+    /// </summary>
+    private List<DataSourceKey> GetOutboxSources()
+    {
+        IEnumerable<DataSourceKey> sources = entityDataSourceRegistry.GetPhysicalSourcesInUse()
+            .Where(k => k.Engine != DataSource.CosmosDB);
+
+        if (_settings.DataSource != DataSource.CosmosDB)
+        {
+            sources = sources.Append(dataSourceResolver.ResolveLogical(_settings.DataSource, _settings.DatabaseName));
+        }
+
+        return [.. sources.Distinct()];
+    }
+
     private async Task ProcessPendingMessagesAsync(CancellationToken cancellationToken)
     {
+        foreach (var source in GetOutboxSources())
+        {
+            try
+            {
+                await ProcessSourceAsync(source, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // One unreachable database must not starve the other sources' outboxes.
+                LogSourceProcessingError(logger, source.ToString(), ex);
+            }
+        }
+    }
+
+    private async Task ProcessSourceAsync(DataSourceKey source, CancellationToken cancellationToken)
+    {
+        var sourceName = source.ToString();
         using var scope = scopeFactory.CreateScope();
         var dbContextFactory = scope.ServiceProvider.GetRequiredService<DbContexts.Factory.IDbContextFactory>();
-        var context = dbContextFactory.GetDbContext(_settings.DataSource);
+        var context = dbContextFactory.GetDbContext(source);
         var dispatcher = scope.ServiceProvider.GetRequiredService<IDomainEventDispatcher>();
         var messageBus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
 
@@ -94,11 +145,11 @@ public sealed partial class OutboxProcessor(
             return;
         }
 
-        LogProcessingBatch(logger, messages.Count);
+        LogProcessingBatch(logger, messages.Count, sourceName);
 
         foreach (var message in messages)
         {
-            using var activity = StartOutboxActivity(message);
+            using var activity = StartOutboxActivity(message, source);
             try
             {
                 var domainEvent = message.DeserializeEvent();
@@ -144,7 +195,7 @@ public sealed partial class OutboxProcessor(
     /// stored in the outbox message. Returns <see langword="null"/> when no trace context
     /// was captured (e.g., messages written before this feature was added).
     /// </summary>
-    private static Activity? StartOutboxActivity(OutboxMessage message)
+    private static Activity? StartOutboxActivity(OutboxMessage message, DataSourceKey source)
     {
         if (string.IsNullOrEmpty(message.TraceId) || string.IsNullOrEmpty(message.SpanId))
         {
@@ -163,18 +214,22 @@ public sealed partial class OutboxProcessor(
 
         activity?.SetTag("messaging.outbox.message_id", message.Id.ToString());
         activity?.SetTag("messaging.outbox.event_type", message.EventType);
+        activity?.SetTag("messaging.outbox.data_source", source.ToString());
 
         return activity;
     }
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Outbox processor disabled: {DataSource} does not support the outbox table")]
-    private static partial void LogOutboxDisabled(ILogger logger, Application.Interfaces.Infrastructure.DataSource dataSource);
+    [LoggerMessage(Level = LogLevel.Information, Message = "Outbox processor disabled: no relational data sources in use (Cosmos DB does not support the outbox table)")]
+    private static partial void LogOutboxDisabled(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Outbox processor encountered an error")]
     private static partial void LogProcessingError(ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Processing {Count} pending outbox messages")]
-    private static partial void LogProcessingBatch(ILogger logger, int count);
+    [LoggerMessage(Level = LogLevel.Error, Message = "Outbox processing failed for data source {DataSourceName}")]
+    private static partial void LogSourceProcessingError(ILogger logger, string dataSourceName, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Processing {Count} pending outbox messages from {DataSourceName}")]
+    private static partial void LogProcessingBatch(ILogger logger, int count, string dataSourceName);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Outbox message {MessageId} ({EventType}) dispatched successfully")]
     private static partial void LogMessageProcessed(ILogger logger, Guid messageId, string eventType);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/UnitOfWork.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/UnitOfWork.cs
@@ -26,7 +26,7 @@ internal sealed class UnitOfWork(IDbContextFactory dbContextFactory, IDataSource
 
     /// <inheritdoc />
     /// <remarks>
-    /// Resolves the correct <see cref="DataSource"/> for the entity via <see cref="IDataSourceService"/>,
+    /// Resolves the entity's physical data source (engine + database) via <see cref="IDataSourceService"/>,
     /// obtains the matching DbContext, and creates a repository bound to it.
     /// The repository is cached so subsequent calls for the same entity type reuse the same instance.
     /// </remarks>
@@ -37,8 +37,8 @@ internal sealed class UnitOfWork(IDbContextFactory dbContextFactory, IDataSource
         var key = typeof(IRepository<TEntity, TIdentifierType>);
         if (!_repositories.TryGetValue(key, out var repository))
         {
-            var dataSource = dataSourceService.GetDataSource(typeof(TEntity));
-            var dbContext = _dbContextFactory.GetDbContext(dataSource);
+            var dataSourceKey = dataSourceService.GetDataSourceKey(typeof(TEntity));
+            var dbContext = _dbContextFactory.GetDbContext(dataSourceKey);
             repository = _repositoryFactory.Create<TEntity, TIdentifierType>(dbContext);
             _repositories[key] = repository;
         }
@@ -57,8 +57,8 @@ internal sealed class UnitOfWork(IDbContextFactory dbContextFactory, IDataSource
         var key = typeof(IReadRepository<TEntity, TIdentifierType>);
         if (!_repositories.TryGetValue(key, out var repository))
         {
-            var dataSource = dataSourceService.GetDataSource(typeof(TEntity));
-            var dbContext = _dbContextFactory.GetDbContext(dataSource);
+            var dataSourceKey = dataSourceService.GetDataSourceKey(typeof(TEntity));
+            var dbContext = _dbContextFactory.GetDbContext(dataSourceKey);
             repository = _repositoryFactory.CreateReadOnly<TEntity, TIdentifierType>(dbContext);
             _repositories[key] = repository;
         }

--- a/Source/Core/MMCA.Common.Infrastructure/Services/BrokerEventBus.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/BrokerEventBus.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using MMCA.Common.Infrastructure.Settings;
 using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
@@ -29,6 +30,7 @@ namespace MMCA.Common.Infrastructure.Services;
 public sealed class BrokerEventBus(
     IDbContextFactory dbContextFactory,
     IOutboxSignal outboxSignal,
+    IDataSourceResolver dataSourceResolver,
     IOptions<OutboxSettings> outboxOptions) : IEventBus
 {
     /// <inheritdoc />
@@ -36,7 +38,8 @@ public sealed class BrokerEventBus(
     {
         ArgumentNullException.ThrowIfNull(integrationEvent);
 
-        var context = dbContextFactory.GetDbContext(outboxOptions.Value.DataSource);
+        var target = dataSourceResolver.ResolveLogical(outboxOptions.Value.DataSource, outboxOptions.Value.DatabaseName);
+        var context = dbContextFactory.GetDbContext(target);
 
         if (!context.SupportsOutbox)
         {
@@ -44,7 +47,7 @@ public sealed class BrokerEventBus(
             // datasource. Throwing here surfaces the misconfiguration loudly rather than
             // silently dropping events.
             throw new InvalidOperationException(
-                $"BrokerEventBus requires an outbox-enabled DataSource. Current DataSource '{outboxOptions.Value.DataSource}' does not support OutboxMessage. Configure SQL Server or SQLite, or fall back to InProcessEventBus.");
+                $"BrokerEventBus requires an outbox-enabled data source. The configured outbox target '{target}' (Outbox:DataSource='{outboxOptions.Value.DataSource}', Outbox:DatabaseName='{outboxOptions.Value.DatabaseName}') does not support OutboxMessage. Configure SQL Server or SQLite, or fall back to InProcessEventBus.");
         }
 
         var outboxEntry = OutboxMessage.FromDomainEvent(integrationEvent);

--- a/Source/Core/MMCA.Common.Infrastructure/Services/DataSourceService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/DataSourceService.cs
@@ -1,53 +1,39 @@
-using System.Collections.Concurrent;
-using System.Reflection;
 using MMCA.Common.Application.Interfaces.Infrastructure;
-using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 
 namespace MMCA.Common.Infrastructure.Services;
 
 /// <summary>
-/// Maintains a singleton cache mapping entity type names to their <see cref="DataSource"/>.
-/// Populated lazily during EF model configuration via <see cref="UseDataSourceAttribute"/> on configuration classes.
+/// Application-facing facade over <see cref="IEntityDataSourceRegistry"/>. Resolves each entity's
+/// physical data source (engine + database) and answers include-support questions for navigation
+/// classification. The registry is built eagerly from configuration assemblies, so resolution no
+/// longer depends on an EF model having been built first.
 /// </summary>
-public sealed class DataSourceService : IDataSourceService
+public sealed class DataSourceService(IEntityDataSourceRegistry registry) : IDataSourceService
 {
-    private readonly ConcurrentDictionary<string, DataSource> _dataSourceCache = new();
+    /// <inheritdoc />
+    public DataSourceKey GetDataSourceKey(Type entityType) => registry.GetDataSourceKey(entityType);
 
     /// <inheritdoc />
-    public DataSource GetDataSource(Type entityType, Type configurationType)
-        => _dataSourceCache.GetOrAdd(
-                entityType.FullName!,
-                _ => configurationType.GetCustomAttribute<UseDataSourceAttribute>()?.DataSource
-                    ?? throw new InvalidOperationException($"DataSource not defined for {entityType.FullName}"));
+    public DataSourceKey GetDataSourceKey(string entityFullName) => registry.GetDataSourceKey(entityFullName);
 
     /// <inheritdoc />
-    public DataSource GetDataSource<TEntity, TIdentifierType, TEntityTypeConfiguration>()
-        where TEntity : AuditableBaseEntity<TIdentifierType>
-        where TEntityTypeConfiguration : class
-        where TIdentifierType : notnull
-        => GetDataSource(typeof(TEntity), typeof(TEntityTypeConfiguration));
+    public DataSource GetDataSource(string entityFullName) => registry.GetDataSourceKey(entityFullName).Engine;
 
     /// <inheritdoc />
-    public DataSource GetDataSource(string entityFullName)
-        => _dataSourceCache.TryGetValue(entityFullName, out DataSource dataSource)
-            ? dataSource
-            : throw new InvalidOperationException($"DataSource not defined for {entityFullName}");
-
-    /// <inheritdoc />
-    public DataSource GetDataSource(Type entityType)
-        => GetDataSource(entityType.FullName!);
+    public DataSource GetDataSource(Type entityType) => registry.GetDataSourceKey(entityType).Engine;
 
     /// <inheritdoc />
     /// <remarks>
-    /// EF Include (eager loading) only works when both entities share the same relational data source.
-    /// Cosmos DB does not support cross-document includes — it models relationships differently.
+    /// EF Include (eager loading) only works when both entities live in the same physical database
+    /// on a relational engine. Cosmos DB does not support cross-document includes.
     /// </remarks>
-    public bool HaveIncludeSupport(DataSource first, DataSource second)
-        => first == second && first != DataSource.CosmosDB;
+    public bool HaveIncludeSupport(DataSourceKey first, DataSourceKey second)
+        => first == second && first.Engine != DataSource.CosmosDB;
 
     /// <inheritdoc />
     public bool HaveIncludeSupport(string firstEntityFullName, string secondEntityFullName)
-        => _dataSourceCache.TryGetValue(firstEntityFullName, out var first)
-            && _dataSourceCache.TryGetValue(secondEntityFullName, out var second)
+        => registry.TryGetDataSourceKey(firstEntityFullName, out var first)
+            && registry.TryGetDataSourceKey(secondEntityFullName, out var second)
             && HaveIncludeSupport(first, second);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Services/InProcessEventBus.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/InProcessEventBus.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using MMCA.Common.Infrastructure.Settings;
 using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
@@ -22,6 +23,7 @@ namespace MMCA.Common.Infrastructure.Services;
 public sealed class InProcessEventBus(
     IDbContextFactory dbContextFactory,
     IDomainEventDispatcher domainEventDispatcher,
+    IDataSourceResolver dataSourceResolver,
     IOptions<OutboxSettings> outboxOptions) : IEventBus
 {
     /// <inheritdoc />
@@ -29,7 +31,8 @@ public sealed class InProcessEventBus(
     {
         ArgumentNullException.ThrowIfNull(integrationEvent);
 
-        var context = dbContextFactory.GetDbContext(outboxOptions.Value.DataSource);
+        var target = dataSourceResolver.ResolveLogical(outboxOptions.Value.DataSource, outboxOptions.Value.DatabaseName);
+        var context = dbContextFactory.GetDbContext(target);
 
         if (context.SupportsOutbox)
         {

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/ConnectionStringSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/ConnectionStringSettings.cs
@@ -15,6 +15,9 @@ public sealed class ConnectionStringSettings : IConnectionStringSettings
     public string CosmosConnectionString { get; init; } = string.Empty;
 
     /// <inheritdoc />
+    public string CosmosDatabaseName { get; init; } = "AtlDevCon";
+
+    /// <inheritdoc />
     public string SqliteConnectionString { get; init; } = string.Empty;
 
     /// <inheritdoc />

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/DataSourceEntrySettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/DataSourceEntrySettings.cs
@@ -1,0 +1,38 @@
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// Connection settings for one named (logical) data source under the <c>DataSources</c>
+/// configuration section. All properties are optional — any value left empty falls back to the
+/// corresponding top-level <c>ConnectionStrings</c> value, which collapses the logical name onto
+/// the <c>Default</c> physical source (preserving single-database behavior).
+/// </summary>
+/// <example>
+/// <code language="json">
+/// "DataSources": {
+///   "Conference": {
+///     "SQLServerConnectionString": "Server=localhost;Database=ADC_Conference;...",
+///     "SQLServerMigrationsAssembly": "MMCA.ADC.Migrations.SqlServer.Conference"
+///   }
+/// }
+/// </code>
+/// </example>
+public sealed class DataSourceEntrySettings
+{
+    /// <summary>Gets the Azure Cosmos DB connection string for this source.</summary>
+    public string CosmosConnectionString { get; init; } = string.Empty;
+
+    /// <summary>Gets the Cosmos DB database name for this source. Falls back to the top-level name.</summary>
+    public string CosmosDatabaseName { get; init; } = string.Empty;
+
+    /// <summary>Gets the SQLite connection string for this source.</summary>
+    public string SqliteConnectionString { get; init; } = string.Empty;
+
+    /// <summary>Gets the SQL Server connection string for this source.</summary>
+    public string SQLServerConnectionString { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the assembly containing EF Core migrations for this source's SQL Server database.
+    /// Falls back to the top-level <c>SQLServerMigrationsAssembly</c> when empty.
+    /// </summary>
+    public string SQLServerMigrationsAssembly { get; init; } = string.Empty;
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/DataSourcesSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/DataSourcesSettings.cs
@@ -1,0 +1,45 @@
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// Named data sources bound from the <c>DataSources</c> configuration section, keyed by
+/// <b>logical</b> source name (e.g. a module name like <c>"Conference"</c>). Enables
+/// "database per microservice": each logical name maps to its own connection strings while
+/// unmapped names fall back to the top-level <c>ConnectionStrings</c> (the <c>Default</c> source).
+/// <para>
+/// Built directly from configuration in <c>AddInfrastructure</c> (root-level dictionary sections
+/// do not bind through the options pipeline) and registered as a singleton.
+/// </para>
+/// </summary>
+public sealed class DataSourcesSettings
+{
+    /// <summary>Configuration section name.</summary>
+    public static readonly string SectionName = "DataSources";
+
+    /// <summary>
+    /// Initializes the settings from the bound dictionary.
+    /// </summary>
+    /// <param name="sources">Named source entries keyed by logical name; may be empty.</param>
+    /// <exception cref="InvalidOperationException">A reserved or empty logical name is used.</exception>
+    public DataSourcesSettings(IReadOnlyDictionary<string, DataSourceEntrySettings>? sources = null)
+    {
+        Sources = sources ?? new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal);
+
+        foreach (var name in Sources.Keys)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new InvalidOperationException("DataSources entry names must be non-empty.");
+            }
+
+            if (string.Equals(name, Application.Interfaces.Infrastructure.DataSourceKey.DefaultName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"The DataSources entry name \"{name}\" is reserved. The Default source is configured " +
+                    "via the top-level ConnectionStrings section; remove the entry or rename it.");
+            }
+        }
+    }
+
+    /// <summary>Gets the named source entries keyed by logical name.</summary>
+    public IReadOnlyDictionary<string, DataSourceEntrySettings> Sources { get; }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/IConnectionStringSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/IConnectionStringSettings.cs
@@ -8,6 +8,9 @@ public interface IConnectionStringSettings
     /// <summary>Gets the Azure Cosmos DB connection string.</summary>
     string CosmosConnectionString { get; init; }
 
+    /// <summary>Gets the Cosmos DB database name for the default source.</summary>
+    string CosmosDatabaseName { get; init; }
+
     /// <summary>Gets the SQLite connection string (typically a file path).</summary>
     string SqliteConnectionString { get; init; }
 

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
@@ -32,9 +32,19 @@ public sealed class OutboxSettings
     public int ProcessingDelaySeconds { get; init; } = 30;
 
     /// <summary>
-    /// Gets the data source used by the outbox processor to poll for pending messages.
-    /// Must be a relational provider that supports the outbox table (SQL Server or SQLite).
+    /// Gets the engine of the data source where integration events published via
+    /// <c>IEventBus</c> are written to the outbox. Must be a relational provider that
+    /// supports the outbox table (SQL Server or SQLite).
     /// Defaults to <see cref="DataSource.SQLServer"/>.
     /// </summary>
     public DataSource DataSource { get; init; } = DataSource.SQLServer;
+
+    /// <summary>
+    /// Gets the <b>logical</b> data source name (paired with <see cref="DataSource"/>) where
+    /// integration events published via <c>IEventBus</c> are written to the outbox.
+    /// Defaults to <see cref="DataSourceKey.DefaultName"/> (the top-level connection strings),
+    /// preserving single-database behavior. The outbox <em>processor</em> is not limited to this
+    /// source — it drains the outbox table of every relational physical source in use.
+    /// </summary>
+    public string DatabaseName { get; init; } = DataSourceKey.DefaultName;
 }

--- a/Source/Core/MMCA.Common.Infrastructure/UseDatabaseAttribute.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/UseDatabaseAttribute.cs
@@ -1,0 +1,26 @@
+namespace MMCA.Common.Infrastructure;
+
+/// <summary>
+/// Declares the <b>logical data source name</b> (database) an entity type configuration targets,
+/// enabling "database per microservice" routing. Distinct from <see cref="UseDataSourceAttribute"/>,
+/// which declares the database <em>engine</em> (SQL Server / Cosmos / SQLite) on the provider-specific
+/// configuration base classes — this attribute selects <em>which database on that engine</em>.
+/// <para>
+/// Resolution order for an entity's logical name:
+/// <list type="number">
+///   <item>This attribute on the concrete configuration class (inherited).</item>
+///   <item>The module name derived from the entity namespace (segment before <c>Domain</c>).</item>
+///   <item><c>"Default"</c> — the top-level <c>ConnectionStrings</c> section.</item>
+/// </list>
+/// The logical name maps to connection strings via the <c>DataSources</c> configuration section;
+/// names without an entry (or whose connection string equals the top-level one) collapse onto the
+/// <c>Default</c> physical source, preserving single-database behavior.
+/// </para>
+/// </summary>
+/// <param name="name">The logical data source name (e.g. <c>"Conference"</c>).</param>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class UseDatabaseAttribute(string name) : Attribute
+{
+    /// <summary>Gets the logical data source name.</summary>
+    public string Name { get; } = name;
+}

--- a/Source/Hosting/MMCA.Common.Testing/IIntegrationTestFixture.cs
+++ b/Source/Hosting/MMCA.Common.Testing/IIntegrationTestFixture.cs
@@ -10,6 +10,11 @@ public interface IIntegrationTestFixture
     /// <summary>Creates a new <see cref="HttpClient"/> configured for the test server.</summary>
     HttpClient CreateClient();
 
-    /// <summary>Resets the database to a clean state between tests (e.g., via Respawn).</summary>
+    /// <summary>
+    /// Resets the database to a clean state between tests (e.g., via Respawn).
+    /// Hosts using multiple physical data sources ("database per microservice") must reset
+    /// <b>every</b> relational source — fixtures can resolve <c>IEntityDataSourceRegistry</c> and
+    /// <c>IDataSourceResolver</c> from the host's services to enumerate the connection strings.
+    /// </summary>
     Task ResetDatabaseAsync();
 }

--- a/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
@@ -3,15 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Modules;
 using MMCA.Common.Application.Settings;
-using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
-using MMCA.Common.Infrastructure.Settings;
 
 namespace MMCA.Common.API.Startup;
 
 /// <summary>
 /// Database initialization pipeline shared by all downstream MMCA applications.
 /// Creates DbContexts, applies schema changes, and seeds data for enabled modules.
+/// Operates per <b>physical data source</b>: every database in use by the host's registered
+/// entities is initialized (migrated/created) independently.
 /// </summary>
 public static class DatabaseInitializationExtensions
 {
@@ -35,24 +36,32 @@ public static class DatabaseInitializationExtensions
 
         using var scope = services.CreateScope();
 
-        // Eagerly resolve each DbContext to populate the DataSourceService cache;
-        // subsequent repository calls can then retrieve the correct context by DataSource key.
-        var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
-        _ = (SQLServerDbContext)dbContextFactory.GetDbContext(DataSource.SQLServer);
+        // Warm the entity data-source registry: this scans configuration assemblies once and makes
+        // entity-to-database routing deterministic before the first repository call (replacing the
+        // legacy model-building side effect that populated the lazy DataSourceService cache).
+        var registry = scope.ServiceProvider.GetRequiredService<IEntityDataSourceRegistry>();
+        var resolver = scope.ServiceProvider.GetRequiredService<IDataSourceResolver>();
+        var sourcesInUse = registry.GetPhysicalSourcesInUse();
 
-        // Cosmos is optional — integration tests may omit its connection string.
+        var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
+
+        // Cosmos sources are optional — integration tests may omit their connection strings.
         // Cosmos is a document DB with no schema migrations; always use EnsureCreated.
-        var connectionStrings = scope.ServiceProvider.GetRequiredService<IConnectionStringSettings>();
-        if (!string.IsNullOrEmpty(connectionStrings.CosmosConnectionString))
+        foreach (var cosmosKey in sourcesInUse.Where(k => k.Engine == DataSource.CosmosDB))
         {
-            var cosmosContext = (CosmosDbContext)dbContextFactory.GetDbContext(DataSource.CosmosDB);
-            await cosmosContext.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(resolver.GetPhysical(cosmosKey).ConnectionString))
+            {
+                continue;
+            }
+
+            await dbContextFactory.GetDbContext(cosmosKey).Database
+                .EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
         }
 
         // Apply schema initialisation based on the configured strategy:
-        //   "Migrate"       — auto-apply pending EF Core migrations (development/testing).
-        //   "EnsureCreated" — legacy EnsureCreated behavior.
-        //   "None"          — production: validate no pending migrations, throw if behind.
+        //   "Migrate"       — auto-apply pending EF Core migrations per SQL Server source (development/testing).
+        //   "EnsureCreated" — legacy EnsureCreated behavior for every source in use.
+        //   "None"          — production: validate no pending migrations on any source, throw if behind.
         switch (applicationSettings.DatabaseInitStrategy)
         {
             case "Migrate":
@@ -62,15 +71,7 @@ public static class DatabaseInitializationExtensions
                 await dbContextFactory.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
                 break;
             case "None":
-                if (await dbContextFactory.HasPendingMigrationsAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    var pending = await dbContextFactory.GetDbContext(DataSource.SQLServer)
-                        .Database.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
-                    throw new InvalidOperationException(
-                        $"Database has pending migrations that must be applied before starting: {string.Join(", ", pending)}. " +
-                        "Run 'dotnet ef database update' or apply the migration SQL script.");
-                }
-
+                await ThrowIfPendingMigrationsAsync(dbContextFactory, sourcesInUse, cancellationToken).ConfigureAwait(false);
                 break;
             default:
                 throw new InvalidOperationException(
@@ -79,5 +80,35 @@ public static class DatabaseInitializationExtensions
         }
 
         await moduleLoader.SeedAllAsync(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Production guard for the <c>"None"</c> strategy: throws with a per-source breakdown when
+    /// any SQL Server data source in use has migrations that have not been applied.
+    /// </summary>
+    private static async Task ThrowIfPendingMigrationsAsync(
+        IDbContextFactory dbContextFactory,
+        IReadOnlyCollection<DataSourceKey> sourcesInUse,
+        CancellationToken cancellationToken)
+    {
+        if (!await dbContextFactory.HasPendingMigrationsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        var pendingPerSource = new List<string>();
+        foreach (var sqlKey in sourcesInUse.Where(k => k.Engine == DataSource.SQLServer))
+        {
+            var pending = await dbContextFactory.GetDbContext(sqlKey).Database
+                .GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
+            if (pending.Any())
+            {
+                pendingPerSource.Add($"{sqlKey}: {string.Join(", ", pending)}");
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Database has pending migrations that must be applied before starting: {string.Join("; ", pendingPerSource)}. " +
+            "Run 'dotnet ef database update' or apply the migration SQL script.");
     }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/ApplicationDbContextTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/ApplicationDbContextTests.cs
@@ -4,8 +4,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
@@ -96,7 +98,7 @@ public sealed class ApplicationDbContextTests : IDisposable
             DbContextOptions<TestApplicationDbContext> options,
             IServiceProvider serviceProvider,
             IEntityConfigurationAssemblyProvider assemblyProvider)
-            : base(options, serviceProvider, assemblyProvider)
+            : base(options, serviceProvider, assemblyProvider, TestPhysicalDataSources.Sqlite())
         {
         }
 
@@ -112,6 +114,7 @@ public sealed class ApplicationDbContextTests : IDisposable
                 var outboxSignal = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
                 return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
             });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
             IServiceProvider sp = services.BuildServiceProvider();
 
             var assemblyProvider = Mock.Of<IEntityConfigurationAssemblyProvider>(

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditSaveChangesInterceptorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditSaveChangesInterceptorTests.cs
@@ -2,8 +2,10 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
@@ -140,7 +142,7 @@ public sealed class AuditSaveChangesInterceptorTests : IDisposable
         internal override bool SupportsOutbox => false;
 
         private TestAuditDbContext(DbContextOptions<TestAuditDbContext> options, IServiceProvider serviceProvider)
-            : base(options, serviceProvider, new NullAssemblyProvider())
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
         {
         }
 
@@ -160,6 +162,7 @@ public sealed class AuditSaveChangesInterceptorTests : IDisposable
                 var outboxSignal = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
                 return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
             });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
             IServiceProvider sp = services.BuildServiceProvider();
 
             var options = new DbContextOptionsBuilder<TestAuditDbContext>()

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/CrossDataSourceDegradeConventionTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/CrossDataSourceDegradeConventionTests.cs
@@ -1,0 +1,243 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.DataSources;
+
+/// <summary>
+/// Covers <see cref="MMCA.Common.Infrastructure.Persistence.Conventions.CrossDataSourceDegradeConvention"/>
+/// (auto-degrade of relationships crossing physical data sources), the monolith-collapse
+/// equivalence guarantee, and per-source EF model isolation via
+/// <see cref="DataSourceModelCacheKeyFactory"/>.
+/// </summary>
+public sealed class CrossDataSourceDegradeConventionTests
+{
+    // ── Cross-source: FK + navigation removed, scalar column + index kept, foreign type gone ──
+    [Fact]
+    public void CrossSourceRelationship_IsDegraded()
+    {
+        var registry = new MapRegistry(new Dictionary<string, DataSourceKey>(StringComparer.Ordinal)
+        {
+            [typeof(DegradeOrder).FullName!] = new(DataSource.Sqlite, "CrossA"),
+            [typeof(DegradeCustomer).FullName!] = new(DataSource.Sqlite, "CrossB"),
+        });
+        using var serviceProvider = BuildServiceProvider(registry);
+        using var context = CreateContext(serviceProvider, "CrossA");
+
+        var model = context.Model;
+
+        // The foreign entity type is removed from this source's model entirely.
+        model.FindEntityType(typeof(DegradeCustomer)).Should().BeNull();
+
+        var order = model.FindEntityType(typeof(DegradeOrder))!;
+        order.Should().NotBeNull();
+
+        // The relationship and navigation are gone…
+        order.GetForeignKeys().Should().BeEmpty();
+        order.FindNavigation(nameof(DegradeOrder.Customer)).Should().BeNull();
+
+        // …but the declared scalar FK column survives, with a compensating index.
+        order.FindProperty(nameof(DegradeOrder.CustomerId)).Should().NotBeNull();
+        order.GetIndexes().Should().Contain(index =>
+            index.Properties.Count == 1 && index.Properties[0].Name == nameof(DegradeOrder.CustomerId));
+    }
+
+    // ── Monolith collapse: same source for everything → structural no-op ──
+    [Fact]
+    public void SameSourceRelationship_IsPreserved()
+    {
+        var registry = new MapRegistry(new Dictionary<string, DataSourceKey>(StringComparer.Ordinal)
+        {
+            [typeof(DegradeOrder).FullName!] = new(DataSource.Sqlite, "MonoA"),
+            [typeof(DegradeCustomer).FullName!] = new(DataSource.Sqlite, "MonoA"),
+        });
+        using var serviceProvider = BuildServiceProvider(registry);
+        using var context = CreateContext(serviceProvider, "MonoA");
+
+        var model = context.Model;
+
+        model.FindEntityType(typeof(DegradeCustomer)).Should().NotBeNull();
+
+        var order = model.FindEntityType(typeof(DegradeOrder))!;
+        order.GetForeignKeys().Should().ContainSingle(fk => fk.PrincipalEntityType.ClrType == typeof(DegradeCustomer));
+        order.FindNavigation(nameof(DegradeOrder.Customer)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SameSourceModel_IsStructurallyEquivalentToUnregisteredBaseline()
+    {
+        // Baseline: nothing registered in the registry — the convention must treat every entity
+        // as local and leave the model untouched (the pre-multi-database shape).
+        using var baselineProvider = BuildServiceProvider(new MapRegistry(new Dictionary<string, DataSourceKey>(StringComparer.Ordinal)));
+        using var baselineContext = CreateContext(baselineProvider, "MonoBaseline");
+
+        var registry = new MapRegistry(new Dictionary<string, DataSourceKey>(StringComparer.Ordinal)
+        {
+            [typeof(DegradeOrder).FullName!] = new(DataSource.Sqlite, "MonoEquiv"),
+            [typeof(DegradeCustomer).FullName!] = new(DataSource.Sqlite, "MonoEquiv"),
+        });
+        using var collapsedProvider = BuildServiceProvider(registry);
+        using var collapsedContext = CreateContext(collapsedProvider, "MonoEquiv");
+
+        var baseline = baselineContext.Model;
+        var collapsed = collapsedContext.Model;
+
+        collapsed.GetEntityTypes().Select(e => e.Name).Order(StringComparer.Ordinal)
+            .Should().Equal(baseline.GetEntityTypes().Select(e => e.Name).Order(StringComparer.Ordinal));
+
+        foreach (var baselineEntity in baseline.GetEntityTypes())
+        {
+            var collapsedEntity = collapsed.FindEntityType(baselineEntity.Name)!;
+            collapsedEntity.GetForeignKeys().Count().Should().Be(baselineEntity.GetForeignKeys().Count());
+            collapsedEntity.GetNavigations().Select(n => n.Name).Order(StringComparer.Ordinal)
+                .Should().Equal(baselineEntity.GetNavigations().Select(n => n.Name).Order(StringComparer.Ordinal));
+        }
+    }
+
+    // ── Model isolation: same context class, different physical sources → different models ──
+    [Fact]
+    public void SameContextClass_DifferentSources_BuildIsolatedModels()
+    {
+        var registry = new MapRegistry(new Dictionary<string, DataSourceKey>(StringComparer.Ordinal)
+        {
+            [typeof(DegradeOrder).FullName!] = new(DataSource.Sqlite, "IsoA"),
+            [typeof(DegradeCustomer).FullName!] = new(DataSource.Sqlite, "IsoB"),
+        });
+        using var serviceProvider = BuildServiceProvider(registry);
+        using var contextA = CreateContext(serviceProvider, "IsoA");
+        using var contextB = CreateContext(serviceProvider, "IsoB");
+
+        ReferenceEquals(contextA.Model, contextB.Model).Should().BeFalse(
+            "each physical source must get its own EF model (DataSourceModelCacheKeyFactory)");
+
+        contextA.Model.FindEntityType(typeof(DegradeOrder)).Should().NotBeNull();
+        contextA.Model.FindEntityType(typeof(DegradeCustomer)).Should().BeNull();
+
+        contextB.Model.FindEntityType(typeof(DegradeCustomer)).Should().NotBeNull();
+        contextB.Model.FindEntityType(typeof(DegradeOrder)).Should().BeNull();
+    }
+
+    // ── DataSourceModelCacheKeyFactory unit behavior ──
+    [Fact]
+    public void ModelCacheKey_DiffersByPhysicalSourceName()
+    {
+        var registry = new MapRegistry(new Dictionary<string, DataSourceKey>(StringComparer.Ordinal));
+        using var serviceProvider = BuildServiceProvider(registry);
+        using var contextA = CreateContext(serviceProvider, "KeyA");
+        using var contextB = CreateContext(serviceProvider, "KeyB");
+        using var contextA2 = CreateContext(serviceProvider, "KeyA");
+
+        var factory = new DataSourceModelCacheKeyFactory();
+
+        factory.Create(contextA, designTime: false).Should().NotBe(factory.Create(contextB, designTime: false));
+        factory.Create(contextA, designTime: false).Should().Be(factory.Create(contextA2, designTime: false));
+        factory.Create(contextA, designTime: true).Should().NotBe(factory.Create(contextA, designTime: false));
+    }
+
+    // ── Helpers ──
+    private static DegradeTestContext CreateContext(IServiceProvider serviceProvider, string sourceName)
+    {
+        var physical = new PhysicalDataSource(
+            new DataSourceKey(DataSource.Sqlite, sourceName), "DataSource=:memory:", null, "AtlDevCon");
+
+        var options = new DbContextOptionsBuilder<DegradeTestContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        return new DegradeTestContext(options, serviceProvider, physical);
+    }
+
+    private static ServiceProvider BuildServiceProvider(IEntityDataSourceRegistry registry) =>
+        new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<ILoggerFactory, NullLoggerFactory>()
+            .AddSingleton(typeof(ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<IDomainEventDispatcher>())
+            .AddSingleton<IOutboxSignal, OutboxSignal>()
+            .AddSingleton<AuditSaveChangesInterceptor>()
+            .AddSingleton<DomainEventSaveChangesInterceptor>()
+            .AddSingleton(registry)
+            .BuildServiceProvider();
+
+    private sealed class MapRegistry(Dictionary<string, DataSourceKey> map) : IEntityDataSourceRegistry
+    {
+        public DataSourceKey GetDataSourceKey(Type entityType) => map[entityType.FullName!];
+
+        public DataSourceKey GetDataSourceKey(string entityFullName) => map[entityFullName];
+
+        public bool TryGetDataSourceKey(string entityFullName, out DataSourceKey key) =>
+            map.TryGetValue(entityFullName, out key);
+
+        public IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse() => [.. map.Values.Distinct()];
+    }
+
+    private sealed class EmptyAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+
+    public sealed class DegradeOrder : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int CustomerId { get; set; }
+
+        public DegradeCustomer? Customer { get; set; }
+    }
+
+    public sealed class DegradeCustomer : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public List<DegradeOrder> Orders { get; } = [];
+    }
+
+    /// <summary>
+    /// Mirrors <c>ApplyConfigurationsForEntitiesInContext</c>: only entities belonging to this
+    /// context's physical source are registered explicitly; foreign entities enter the model
+    /// solely via EF's relationship-discovery conventions (Order→Customer / Customer.Orders),
+    /// which the finalizing convention then degrades when the ends' sources differ.
+    /// </summary>
+    public sealed class DegradeTestContext : ApplicationDbContext
+    {
+        private readonly IServiceProvider _testServiceProvider;
+
+        public DegradeTestContext(
+            DbContextOptions<DegradeTestContext> options,
+            IServiceProvider serviceProvider,
+            PhysicalDataSource physicalDataSource)
+            : base(options, serviceProvider, new EmptyAssemblyProvider(), physicalDataSource) =>
+            _testServiceProvider = serviceProvider;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var registry = _testServiceProvider.GetRequiredService<IEntityDataSourceRegistry>();
+
+            if (IsLocal(registry, typeof(DegradeOrder)))
+            {
+                modelBuilder.Entity<DegradeOrder>();
+            }
+
+            if (IsLocal(registry, typeof(DegradeCustomer)))
+            {
+                modelBuilder.Entity<DegradeCustomer>();
+            }
+
+            base.OnModelCreating(modelBuilder);
+        }
+
+        private bool IsLocal(IEntityDataSourceRegistry registry, Type entityType) =>
+            !registry.TryGetDataSourceKey(entityType.FullName!, out var key) || key == DataSourceKey;
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/DataSourceResolverTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/DataSourceResolverTests.cs
@@ -1,0 +1,244 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.DataSources;
+
+public sealed class DataSourceResolverTests
+{
+    private const string DefaultSql = "Server=localhost;Database=Main;";
+    private const string OtherSql = "Server=localhost;Database=Other;";
+
+    // ── Collapse rules ──
+    [Fact]
+    public void ResolveLogical_NameWithoutEntry_CollapsesToDefault()
+    {
+        var sut = CreateSut();
+
+        var key = sut.ResolveLogical(DataSource.SQLServer, "Conference");
+
+        key.Should().Be(DataSourceKey.Default(DataSource.SQLServer));
+    }
+
+    [Theory]
+    [InlineData("Default")]
+    [InlineData("default")]
+    [InlineData("DEFAULT")]
+    public void ResolveLogical_DefaultName_AnyCase_ReturnsDefault(string name)
+    {
+        var sut = CreateSut();
+
+        sut.ResolveLogical(DataSource.Sqlite, name).Should().Be(DataSourceKey.Default(DataSource.Sqlite));
+    }
+
+    [Fact]
+    public void ResolveLogical_EntryWithoutConnectionStringForEngine_CollapsesToDefault()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Conference"] = new() { SqliteConnectionString = "Data Source=conference.db" },
+        });
+
+        // The entry only configures Sqlite — SQL Server resolution falls back to Default.
+        sut.ResolveLogical(DataSource.SQLServer, "Conference").Should().Be(DataSourceKey.Default(DataSource.SQLServer));
+        sut.ResolveLogical(DataSource.Sqlite, "Conference").Should().Be(new DataSourceKey(DataSource.Sqlite, "Conference"));
+    }
+
+    [Fact]
+    public void ResolveLogical_EntryEqualToTopLevelConnection_CollapsesToDefault()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Conference"] = new() { SQLServerConnectionString = DefaultSql },
+        });
+
+        sut.ResolveLogical(DataSource.SQLServer, "Conference").Should().Be(DataSourceKey.Default(DataSource.SQLServer));
+    }
+
+    [Fact]
+    public void ResolveLogical_EntryWithDistinctConnection_YieldsNamedKey()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Conference"] = new() { SQLServerConnectionString = OtherSql },
+        });
+
+        sut.ResolveLogical(DataSource.SQLServer, "Conference").Should().Be(new DataSourceKey(DataSource.SQLServer, "Conference"));
+    }
+
+    [Fact]
+    public void ResolveLogical_EntriesSharingConnection_CollapseToAlphabeticallyFirstName()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Zebra"] = new() { SQLServerConnectionString = OtherSql },
+            ["Alpha"] = new() { SQLServerConnectionString = OtherSql },
+        });
+
+        var expected = new DataSourceKey(DataSource.SQLServer, "Alpha");
+        sut.ResolveLogical(DataSource.SQLServer, "Zebra").Should().Be(expected);
+        sut.ResolveLogical(DataSource.SQLServer, "Alpha").Should().Be(expected);
+    }
+
+    // ── Cosmos identity includes the database name ──
+    [Fact]
+    public void ResolveLogical_Cosmos_SameAccountDifferentDatabase_AreDistinctSources()
+    {
+        var sut = CreateSut(
+            new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["Conference"] = new() { CosmosConnectionString = "AccountEndpoint=https://acc;", CosmosDatabaseName = "ConfDb" },
+                ["Identity"] = new() { CosmosConnectionString = "AccountEndpoint=https://acc;", CosmosDatabaseName = "IdDb" },
+            },
+            new ConnectionStringSettings { SQLServerConnectionString = DefaultSql, CosmosConnectionString = "AccountEndpoint=https://other;" });
+
+        var conference = sut.ResolveLogical(DataSource.CosmosDB, "Conference");
+        var identity = sut.ResolveLogical(DataSource.CosmosDB, "Identity");
+
+        conference.Should().NotBe(identity);
+        sut.GetPhysical(conference).CosmosDatabaseName.Should().Be("ConfDb");
+        sut.GetPhysical(identity).CosmosDatabaseName.Should().Be("IdDb");
+    }
+
+    [Fact]
+    public void ResolveLogical_Cosmos_SameAccountSameDatabase_Collapse()
+    {
+        var sut = CreateSut(
+            new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["Conference"] = new() { CosmosConnectionString = "AccountEndpoint=https://acc;", CosmosDatabaseName = "Shared" },
+                ["Identity"] = new() { CosmosConnectionString = "AccountEndpoint=https://acc;", CosmosDatabaseName = "Shared" },
+            },
+            new ConnectionStringSettings { SQLServerConnectionString = DefaultSql, CosmosConnectionString = "AccountEndpoint=https://other;" });
+
+        sut.ResolveLogical(DataSource.CosmosDB, "Conference")
+            .Should().Be(sut.ResolveLogical(DataSource.CosmosDB, "Identity"));
+    }
+
+    // ── Reserved name ──
+    [Theory]
+    [InlineData("Default")]
+    [InlineData("default")]
+    public void DataSourcesSettings_ReservedEntryName_Throws(string name)
+    {
+        var act = () => new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            [name] = new(),
+        });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*reserved*");
+    }
+
+    // ── Migrations assembly resolution ──
+    [Fact]
+    public void Constructor_EntryCollapsedToDefault_WithConflictingMigrationsAssembly_Throws()
+    {
+        var act = () => CreateSut(
+            new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["Conference"] = new() { SQLServerConnectionString = DefaultSql, SQLServerMigrationsAssembly = "Conference.Migrations" },
+            },
+            new ConnectionStringSettings { SQLServerConnectionString = DefaultSql, SQLServerMigrationsAssembly = "Main.Migrations" });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SQLServerMigrationsAssembly*");
+    }
+
+    [Fact]
+    public void Constructor_EntriesSharingConnection_WithConflictingMigrationsAssemblies_Throws()
+    {
+        var act = () => CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Alpha"] = new() { SQLServerConnectionString = OtherSql, SQLServerMigrationsAssembly = "Alpha.Migrations" },
+            ["Zebra"] = new() { SQLServerConnectionString = OtherSql, SQLServerMigrationsAssembly = "Zebra.Migrations" },
+        });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SQLServerMigrationsAssembly*");
+    }
+
+    [Fact]
+    public void GetPhysical_EntryCollapsedToDefault_WithAgreedMigrationsAssembly_DoesNotThrow()
+    {
+        var sut = CreateSut(
+            new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["Conference"] = new() { SQLServerConnectionString = DefaultSql, SQLServerMigrationsAssembly = "Main.Migrations" },
+            },
+            new ConnectionStringSettings { SQLServerConnectionString = DefaultSql, SQLServerMigrationsAssembly = "Main.Migrations" });
+
+        sut.GetPhysical(DataSourceKey.Default(DataSource.SQLServer))
+            .SqlServerMigrationsAssembly.Should().Be("Main.Migrations");
+    }
+
+    [Fact]
+    public void GetPhysical_NamedSourceWithOwnMigrationsAssembly_UsesIt()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Conference"] = new() { SQLServerConnectionString = OtherSql, SQLServerMigrationsAssembly = "Conference.Migrations" },
+        });
+
+        var key = sut.ResolveLogical(DataSource.SQLServer, "Conference");
+
+        sut.GetPhysical(key).SqlServerMigrationsAssembly.Should().Be("Conference.Migrations");
+    }
+
+    [Fact]
+    public void GetPhysical_NamedSourceWithoutMigrationsAssembly_FallsBackToTopLevel()
+    {
+        var sut = CreateSut(
+            new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["Conference"] = new() { SQLServerConnectionString = OtherSql },
+            },
+            new ConnectionStringSettings { SQLServerConnectionString = DefaultSql, SQLServerMigrationsAssembly = "Main.Migrations" });
+
+        var key = sut.ResolveLogical(DataSource.SQLServer, "Conference");
+
+        sut.GetPhysical(key).SqlServerMigrationsAssembly.Should().Be("Main.Migrations");
+    }
+
+    // ── GetPhysical ──
+    [Fact]
+    public void GetPhysical_Default_ReturnsTopLevelValues()
+    {
+        var sut = CreateSut();
+
+        var physical = sut.GetPhysical(DataSourceKey.Default(DataSource.SQLServer));
+
+        physical.ConnectionString.Should().Be(DefaultSql);
+        physical.CosmosDatabaseName.Should().Be("AtlDevCon");
+    }
+
+    [Fact]
+    public void GetPhysical_UnknownNamedKey_Throws()
+    {
+        var sut = CreateSut();
+
+        var act = () => sut.GetPhysical(new DataSourceKey(DataSource.SQLServer, "Unknown"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Unknown*");
+    }
+
+    [Fact]
+    public void GetPhysical_NamedSource_ReturnsEntryConnection()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["Conference"] = new() { SQLServerConnectionString = OtherSql },
+        });
+
+        var key = sut.ResolveLogical(DataSource.SQLServer, "Conference");
+
+        sut.GetPhysical(key).ConnectionString.Should().Be(OtherSql);
+    }
+
+    private static DataSourceResolver CreateSut(
+        Dictionary<string, DataSourceEntrySettings>? sources = null,
+        ConnectionStringSettings? connectionStrings = null) =>
+        new(
+            connectionStrings ?? new ConnectionStringSettings { SQLServerConnectionString = DefaultSql },
+            new DataSourcesSettings(sources),
+            NullLogger<DataSourceResolver>.Instance);
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/DesignTimeDbContextHelperTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/DesignTimeDbContextHelperTests.cs
@@ -1,0 +1,115 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Design;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.DataSources;
+
+public sealed class DesignTimeDbContextHelperTests
+{
+    // ── --datasource argument parsing ──
+    [Theory]
+    [InlineData(new[] { "--datasource", "Conference" }, "Conference")]
+    [InlineData(new[] { "--DataSource", "Conference" }, "Conference")]
+    [InlineData(new[] { "--datasource=Conference" }, "Conference")]
+    [InlineData(new[] { "--other", "x", "--datasource", "Identity" }, "Identity")]
+    public void ParseDataSourceName_ValidArguments_ReturnsName(string[] args, string expected) =>
+        DesignTimeDbContextHelper.ParseDataSourceName(args).Should().Be(expected);
+
+    [Fact]
+    public void ParseDataSourceName_NoArgument_ReturnsNull() =>
+        DesignTimeDbContextHelper.ParseDataSourceName(["--other", "x"]).Should().BeNull();
+
+    [Fact]
+    public void ParseDataSourceName_MissingValue_Throws()
+    {
+        var act = () => DesignTimeDbContextHelper.ParseDataSourceName(["--datasource"]);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*--datasource*");
+    }
+
+    // ── Context creation per data source ──
+    [Fact]
+    public void CreateSqlServer_NamedSource_BuildsModelWithOnlyThatSourcesEntities()
+    {
+        using var context = DesignTimeDbContextHelper.CreateSqlServer(
+            ["--datasource", "DesignAlpha"],
+            ConfigureOptions);
+
+        context.DataSourceKey.Should().Be(new DataSourceKey(DataSource.SQLServer, "DesignAlpha"));
+        context.Model.FindEntityType(typeof(DesignAlphaEntity)).Should().NotBeNull();
+        context.Model.FindEntityType(typeof(DesignBetaEntity)).Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateSqlServer_OtherNamedSource_BuildsItsOwnModel()
+    {
+        using var context = DesignTimeDbContextHelper.CreateSqlServer(
+            ["--datasource", "DesignBeta"],
+            ConfigureOptions);
+
+        context.DataSourceKey.Should().Be(new DataSourceKey(DataSource.SQLServer, "DesignBeta"));
+        context.Model.FindEntityType(typeof(DesignBetaEntity)).Should().NotBeNull();
+        context.Model.FindEntityType(typeof(DesignAlphaEntity)).Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateSqlServer_NoArgument_TargetsDefaultSource()
+    {
+        using var context = DesignTimeDbContextHelper.CreateSqlServer([], ConfigureOptions);
+
+        context.DataSourceKey.Should().Be(DataSourceKey.Default(DataSource.SQLServer));
+    }
+
+    [Fact]
+    public void CreateSqlServer_ExplicitOptionName_OverridesArguments()
+    {
+        using var context = DesignTimeDbContextHelper.CreateSqlServer(
+            ["--datasource", "DesignBeta"],
+            options =>
+            {
+                ConfigureOptions(options);
+                options.DataSourceName = "DesignAlpha";
+            });
+
+        context.DataSourceKey.Name.Should().Be("DesignAlpha");
+    }
+
+    private static void ConfigureOptions(DesignTimeDbContextOptions options)
+    {
+        options.ConnectionStrings = new ConnectionStringSettings
+        {
+            SQLServerConnectionString = "Server=design;Database=Main;",
+        };
+        options.DataSources["DesignAlpha"] = new DataSourceEntrySettings
+        {
+            SQLServerConnectionString = "Server=design;Database=Alpha;",
+            SQLServerMigrationsAssembly = "Design.Alpha.Migrations",
+        };
+        options.DataSources["DesignBeta"] = new DataSourceEntrySettings
+        {
+            SQLServerConnectionString = "Server=design;Database=Beta;",
+            SQLServerMigrationsAssembly = "Design.Beta.Migrations",
+        };
+        options.AddConfigurationAssembly(typeof(DesignTimeDbContextHelperTests).Assembly);
+    }
+
+    // ── Test entities & configurations ──
+    public sealed class DesignAlphaEntity : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class DesignBetaEntity : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [UseDatabase("DesignAlpha")]
+    private sealed class DesignAlphaEntityConfiguration : EntityTypeConfigurationSQLServer<DesignAlphaEntity, int>;
+
+    [UseDatabase("DesignBeta")]
+    private sealed class DesignBetaEntityConfiguration : EntityTypeConfigurationSQLServer<DesignBetaEntity, int>;
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/EntityDataSourceRegistryTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/EntityDataSourceRegistryTests.cs
@@ -1,0 +1,229 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Notifications.PushNotifications;
+using MMCA.Common.Infrastructure.Persistence;
+using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.DataSources;
+
+public sealed class EntityDataSourceRegistryTests
+{
+    private const string DefaultSql = "Server=localhost;Database=Main;";
+
+    // ── [UseDatabase] override ──
+    [Fact]
+    public void GetDataSourceKey_UseDatabaseAttribute_WithDataSourcesEntry_ReturnsNamedKey()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["RegistryNamedDb"] = new() { SqliteConnectionString = "Data Source=named.db" },
+        });
+
+        var key = sut.GetDataSourceKey(typeof(RegistryOrder));
+
+        key.Should().Be(new DataSourceKey(DataSource.Sqlite, "RegistryNamedDb"));
+    }
+
+    [Fact]
+    public void GetDataSourceKey_UseDatabaseAttribute_WithoutEntry_CollapsesToDefault()
+    {
+        var sut = CreateSut();
+
+        sut.GetDataSourceKey(typeof(RegistryOrder)).Should().Be(DataSourceKey.Default(DataSource.Sqlite));
+    }
+
+    // ── Fallback when neither attribute nor module namespace applies ──
+    [Fact]
+    public void GetDataSourceKey_NoAttributeAndNoDomainNamespace_ReturnsDefault()
+    {
+        var sut = CreateSut();
+
+        sut.GetDataSourceKey(typeof(RegistryInvoice)).Should().Be(DataSourceKey.Default(DataSource.Sqlite));
+    }
+
+    // ── Namespace-derived module names (shared with SQL schema derivation) ──
+    [Fact]
+    public void NamespaceConventions_TypeWithDomainSegment_ReturnsPrecedingSegment() =>
+        NamespaceConventions.GetModuleName(typeof(PushNotification)).Should().Be("Common");
+
+    [Fact]
+    public void NamespaceConventions_TypeWithoutDomainSegment_ReturnsNull() =>
+        NamespaceConventions.GetModuleName(typeof(string)).Should().BeNull();
+
+    // ── Engine comes from the configuration base class ──
+    [Fact]
+    public void GetDataSourceKey_SqlServerConfiguration_ReturnsSqlServerEngine()
+    {
+        var sut = CreateSut();
+
+        sut.GetDataSourceKey(typeof(RegistrySqlServerEntity)).Engine.Should().Be(DataSource.SQLServer);
+    }
+
+    // ── Real framework configuration: [UseDatabase("Notification")] on Common's notification configs ──
+    [Fact]
+    public void GetDataSourceKey_PushNotification_WithNotificationEntry_RoutesToNotificationSource()
+    {
+        var sut = CreateSut(
+            new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["Notification"] = new() { SQLServerConnectionString = "Server=localhost;Database=Notif;" },
+            },
+            assemblies: [typeof(DataSourceResolver).Assembly]);
+
+        sut.GetDataSourceKey(typeof(PushNotification))
+            .Should().Be(new DataSourceKey(DataSource.SQLServer, "Notification"));
+    }
+
+    [Fact]
+    public void GetDataSourceKey_PushNotification_WithoutEntry_CollapsesToDefault()
+    {
+        var sut = CreateSut(assemblies: [typeof(DataSourceResolver).Assembly]);
+
+        sut.GetDataSourceKey(typeof(PushNotification)).Should().Be(DataSourceKey.Default(DataSource.SQLServer));
+    }
+
+    // ── Duplicate registrations ──
+    [Fact]
+    public void Registry_DuplicateConfigs_AgreeingOnSource_DoesNotThrow()
+    {
+        // ConflictX/ConflictY have no DataSources entries, so both configurations collapse to
+        // Default and agree.
+        var sut = CreateSut();
+
+        sut.GetDataSourceKey(typeof(RegistryDuplicate)).Should().Be(DataSourceKey.Default(DataSource.Sqlite));
+    }
+
+    [Fact]
+    public void Registry_DuplicateConfigs_ConflictingSources_Throws()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["ConflictX"] = new() { SqliteConnectionString = "Data Source=x.db" },
+            ["ConflictY"] = new() { SqliteConnectionString = "Data Source=y.db" },
+        });
+
+        var act = () => sut.GetDataSourceKey(typeof(RegistryDuplicate));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{nameof(RegistryDuplicate)}*")
+            .WithMessage("*exactly one database*");
+    }
+
+    // ── Configurations without [UseDataSource] are skipped (legacy lenient behavior) ──
+    [Fact]
+    public void Registry_ConfigurationWithoutUseDataSourceAttribute_IsSkipped()
+    {
+        var sut = CreateSut();
+
+        sut.TryGetDataSourceKey(typeof(RegistryUnattributed).FullName!, out _).Should().BeFalse();
+    }
+
+    // ── Unknown entities ──
+    [Fact]
+    public void GetDataSourceKey_UnknownEntity_Throws()
+    {
+        var sut = CreateSut();
+
+        var act = () => sut.GetDataSourceKey("Does.Not.Exist");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Does.Not.Exist*");
+    }
+
+    [Fact]
+    public void TryGetDataSourceKey_UnknownEntity_ReturnsFalse()
+    {
+        var sut = CreateSut();
+
+        sut.TryGetDataSourceKey("Does.Not.Exist", out _).Should().BeFalse();
+    }
+
+    // ── GetPhysicalSourcesInUse ──
+    [Fact]
+    public void GetPhysicalSourcesInUse_ContainsNamedAndDefaultSources()
+    {
+        var sut = CreateSut(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["RegistryNamedDb"] = new() { SqliteConnectionString = "Data Source=named.db" },
+        });
+
+        var sources = sut.GetPhysicalSourcesInUse();
+
+        sources.Should().Contain(new DataSourceKey(DataSource.Sqlite, "RegistryNamedDb"));
+        sources.Should().Contain(DataSourceKey.Default(DataSource.Sqlite));
+    }
+
+    private static EntityDataSourceRegistry CreateSut(
+        Dictionary<string, DataSourceEntrySettings>? sources = null,
+        IReadOnlyList<Assembly>? assemblies = null)
+    {
+        var resolver = new DataSourceResolver(
+            new ConnectionStringSettings { SQLServerConnectionString = DefaultSql },
+            new DataSourcesSettings(sources),
+            NullLogger<DataSourceResolver>.Instance);
+
+        return new EntityDataSourceRegistry(
+            new FixedAssemblyProvider(assemblies ?? [typeof(EntityDataSourceRegistryTests).Assembly]),
+            resolver);
+    }
+
+    private sealed class FixedAssemblyProvider(IReadOnlyList<Assembly> assemblies) : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => assemblies;
+    }
+
+    // ── Test entities & configurations ──
+    public sealed class RegistryOrder : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class RegistryInvoice : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class RegistryDuplicate : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class RegistryUnattributed : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class RegistrySqlServerEntity : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    // NOTE: the configuration classes below are public (not private) because they are only
+    // referenced via the registry's reflection scan — analyzers would flag unused private types.
+    [UseDatabase("RegistryNamedDb")]
+    public sealed class RegistryOrderConfiguration : EntityTypeConfigurationSqlite<RegistryOrder, int>;
+
+    public sealed class RegistryInvoiceConfiguration : EntityTypeConfigurationSqlite<RegistryInvoice, int>;
+
+    public sealed class RegistrySqlServerEntityConfiguration : EntityTypeConfigurationSQLServer<RegistrySqlServerEntity, int>;
+
+    // Two configurations for the same entity. They only conflict when ConflictX/ConflictY are
+    // mapped to distinct connections in a test's DataSources settings; with no entries both
+    // collapse to Default and agree (keeping every other whole-assembly registry scan safe).
+    [UseDatabase("ConflictX")]
+    public sealed class RegistryDuplicateConfigurationA : EntityTypeConfigurationSqlite<RegistryDuplicate, int>;
+
+    [UseDatabase("ConflictY")]
+    public sealed class RegistryDuplicateConfigurationB : EntityTypeConfigurationSqlite<RegistryDuplicate, int>;
+
+    /// <summary>Implements the provider interface directly (no [UseDataSource]) — must be skipped.</summary>
+    public sealed class RegistryUnattributedConfiguration : IEntityTypeConfigurationSqlite<RegistryUnattributed, int>
+    {
+        public void Configure(EntityTypeBuilder<RegistryUnattributed> builder) => builder.HasKey(e => e.Id);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/MultiSourceSqliteIntegrationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/MultiSourceSqliteIntegrationTests.cs
@@ -1,0 +1,240 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Services;
+using MMCA.Common.Application.Settings;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence;
+using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Persistence.Repositories.Factory;
+using MMCA.Common.Infrastructure.Services;
+using MMCA.Common.Infrastructure.Settings;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.DataSources;
+
+/// <summary>
+/// End-to-end database-per-microservice tests over two real SQLite databases: entity routing via
+/// the unit of work, per-source outbox capture, same-connection collapse to one context, and
+/// cross-source navigation population through <see cref="NavigationLoader"/>.
+/// </summary>
+public sealed class MultiSourceSqliteIntegrationTests : IDisposable
+{
+    private readonly string _databaseAPath;
+    private readonly string _databaseBPath;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly DataSourceResolver _resolver;
+    private readonly EntityDataSourceRegistry _registry;
+    private readonly DbContextFactory _dbContextFactory;
+    private readonly UnitOfWork _unitOfWork;
+
+    public MultiSourceSqliteIntegrationTests()
+    {
+        _databaseAPath = Path.Combine(Path.GetTempPath(), $"mmca-multisource-a-{Guid.NewGuid():N}.db");
+        _databaseBPath = Path.Combine(Path.GetTempPath(), $"mmca-multisource-b-{Guid.NewGuid():N}.db");
+
+        var connectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "Server=unused;" };
+        var dataSources = new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["SourceA"] = new() { SqliteConnectionString = $"Data Source={_databaseAPath}" },
+            ["SourceB"] = new() { SqliteConnectionString = $"Data Source={_databaseBPath}" },
+        });
+
+        _resolver = new DataSourceResolver(connectionStrings, dataSources, NullLogger<DataSourceResolver>.Instance);
+
+        var assemblyProvider = new FixedAssemblyProvider();
+        _registry = new EntityDataSourceRegistry(assemblyProvider, _resolver);
+
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<ILoggerFactory, NullLoggerFactory>()
+            .AddSingleton(typeof(ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<IDomainEventDispatcher>())
+            .AddSingleton<IOutboxSignal, OutboxSignal>()
+            .AddSingleton<AuditSaveChangesInterceptor>()
+            .AddSingleton<DomainEventSaveChangesInterceptor>()
+            .AddSingleton<IEntityDataSourceRegistry>(_registry)
+            .AddSingleton<IDataSourceResolver>(_resolver)
+            .BuildServiceProvider();
+
+        var physicalFactory = new PhysicalDbContextFactory(_serviceProvider, _resolver, assemblyProvider);
+        _dbContextFactory = new DbContextFactory(physicalFactory, _registry, _resolver, Mock.Of<ICurrentUserService>());
+
+        var applicationSettings = Mock.Of<IApplicationSettings>();
+        _unitOfWork = new UnitOfWork(
+            _dbContextFactory,
+            new DataSourceService(_registry),
+            new RepositoryFactory(_serviceProvider, applicationSettings));
+
+        // Create both schemas (Default(Sqlite) has no connection string and is skipped).
+        CreateSchema("SourceA");
+        CreateSchema("SourceB");
+    }
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _dbContextFactory.Dispose();
+        _serviceProvider.Dispose();
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        TryDelete(_databaseAPath);
+        TryDelete(_databaseBPath);
+    }
+
+    // ── Routing: each entity lands in its own database ──
+    [Fact]
+    public async Task UnitOfWork_RoutesEachEntityToItsOwnDatabase()
+    {
+        var orderRepository = _unitOfWork.GetRepository<MultiSourceOrder, int>();
+        var customerRepository = _unitOfWork.GetRepository<MultiSourceCustomer, int>();
+
+        await orderRepository.AddAsync(new MultiSourceOrder { Id = 1, Name = "Order-1", CustomerId = 10 });
+        await customerRepository.AddAsync(new MultiSourceCustomer { Id = 10, Name = "Customer-10" });
+        await _unitOfWork.SaveChangesAsync();
+
+        // Each entity exists only in its own database.
+        var contextA = _dbContextFactory.GetDbContext(_resolver.ResolveLogical(DataSource.Sqlite, "SourceA"));
+        var contextB = _dbContextFactory.GetDbContext(_resolver.ResolveLogical(DataSource.Sqlite, "SourceB"));
+        ReferenceEquals(contextA, contextB).Should().BeFalse();
+
+        (await contextA.Set<MultiSourceOrder>().CountAsync()).Should().Be(1);
+        (await contextB.Set<MultiSourceCustomer>().CountAsync()).Should().Be(1);
+
+        contextA.Model.FindEntityType(typeof(MultiSourceCustomer)).Should().BeNull("Customer belongs to SourceB");
+        contextB.Model.FindEntityType(typeof(MultiSourceOrder)).Should().BeNull("Order belongs to SourceA");
+    }
+
+    // ── Outbox: domain events land in the same database as the aggregate ──
+    [Fact]
+    public async Task DomainEvent_IsCapturedInTheAggregatesOwnOutbox()
+    {
+        var order = new MultiSourceOrder { Id = 2, Name = "Order-2", CustomerId = 11 };
+        order.AddDomainEvent(new MultiSourceTestEvent());
+
+        var orderRepository = _unitOfWork.GetRepository<MultiSourceOrder, int>();
+        await orderRepository.AddAsync(order);
+        await _unitOfWork.SaveChangesAsync();
+
+        var contextA = _dbContextFactory.GetDbContext(_resolver.ResolveLogical(DataSource.Sqlite, "SourceA"));
+        var contextB = _dbContextFactory.GetDbContext(_resolver.ResolveLogical(DataSource.Sqlite, "SourceB"));
+
+        (await contextA.Set<OutboxMessage>().CountAsync()).Should().Be(1, "the event's aggregate lives in SourceA");
+        (await contextB.Set<OutboxMessage>().CountAsync()).Should().Be(0, "SourceB had no changes");
+    }
+
+    // ── Cross-source navigation population (parent in A, child in B) ──
+    [Fact]
+    public async Task NavigationLoader_PopulatesCrossSourceReference()
+    {
+        var customerRepository = _unitOfWork.GetRepository<MultiSourceCustomer, int>();
+        await customerRepository.AddAsync(new MultiSourceCustomer { Id = 20, Name = "Customer-20" });
+        await customerRepository.AddAsync(new MultiSourceCustomer { Id = 21, Name = "Customer-21" });
+
+        var orderRepository = _unitOfWork.GetRepository<MultiSourceOrder, int>();
+        await orderRepository.AddAsync(new MultiSourceOrder { Id = 3, Name = "Order-3", CustomerId = 20 });
+        await orderRepository.AddAsync(new MultiSourceOrder { Id = 4, Name = "Order-4", CustomerId = 21 });
+        await _unitOfWork.SaveChangesAsync();
+
+        var orders = await orderRepository.GetAllAsync([]);
+
+        // EF cannot Include across databases — the Customer navigation is not even part of
+        // SourceA's model. NavigationLoader batch-loads it through SourceB's repository instead.
+        await NavigationLoader.LoadFKPropertyAsync(
+            orders,
+            order => order.CustomerId,
+            customer => customer.Id,
+            _unitOfWork.GetReadRepository<MultiSourceCustomer, int>(),
+            (order, customers) => order.Customer = customers.FirstOrDefault(),
+            CancellationToken.None);
+
+        orders.Should().HaveCount(2);
+        orders.Single(o => o.Id == 3).Customer!.Name.Should().Be("Customer-20");
+        orders.Single(o => o.Id == 4).Customer!.Name.Should().Be("Customer-21");
+    }
+
+    // ── Collapse: logical names sharing a connection share one context instance ──
+    [Fact]
+    public void LogicalNamesSharingConnection_ResolveToSameContextInstance()
+    {
+        var connectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "Server=unused;" };
+        var shared = $"Data Source={Path.Combine(Path.GetTempPath(), $"mmca-collapse-{Guid.NewGuid():N}.db")}";
+        var resolver = new DataSourceResolver(
+            connectionStrings,
+            new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+            {
+                ["First"] = new() { SqliteConnectionString = shared },
+                ["Second"] = new() { SqliteConnectionString = shared },
+            }),
+            NullLogger<DataSourceResolver>.Instance);
+
+        var keyFirst = resolver.ResolveLogical(DataSource.Sqlite, "First");
+        var keySecond = resolver.ResolveLogical(DataSource.Sqlite, "Second");
+        keyFirst.Should().Be(keySecond, "equal connection strings must collapse to one physical source");
+
+        var physicalFactory = new PhysicalDbContextFactory(_serviceProvider, resolver, new FixedAssemblyProvider());
+        using var factory = new DbContextFactory(physicalFactory, _registry, resolver, Mock.Of<ICurrentUserService>());
+
+        ReferenceEquals(factory.GetDbContext(keyFirst), factory.GetDbContext(keySecond)).Should().BeTrue(
+            "one physical source must yield one context (one change tracker, one transaction)");
+    }
+
+    // ── Helpers ──
+    private void CreateSchema(string logicalName)
+    {
+        var key = _resolver.ResolveLogical(DataSource.Sqlite, logicalName);
+        _dbContextFactory.GetDbContext(key).Database.EnsureCreated();
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // Best-effort temp file cleanup.
+        }
+    }
+
+    private sealed class FixedAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() =>
+            [typeof(MultiSourceSqliteIntegrationTests).Assembly];
+    }
+
+    // ── Test entities & configurations ──
+    public sealed class MultiSourceOrder : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int CustomerId { get; set; }
+
+        public MultiSourceCustomer? Customer { get; set; }
+    }
+
+    public sealed class MultiSourceCustomer : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed record MultiSourceTestEvent : MMCA.Common.Domain.Interfaces.IDomainEvent
+    {
+        public DateTime DateOccurred { get; init; } = DateTime.UtcNow;
+    }
+
+    [UseDatabase("SourceA")]
+    private sealed class MultiSourceOrderConfiguration : EntityTypeConfigurationSqlite<MultiSourceOrder, int>;
+
+    [UseDatabase("SourceB")]
+    private sealed class MultiSourceCustomerConfiguration : EntityTypeConfigurationSqlite<MultiSourceCustomer, int>;
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryAdditionalTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryAdditionalTests.cs
@@ -1,9 +1,8 @@
 #pragma warning disable CA2000 // Dispose objects before losing scope — test doubles do not hold real resources
 
 using AwesomeAssertions;
-using Microsoft.EntityFrameworkCore;
 using MMCA.Common.Application.Interfaces.Infrastructure;
-using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 using Moq;
 
@@ -79,7 +78,7 @@ public sealed class DbContextFactoryAdditionalTests
 
     // -- EnsureCreatedAsync --
     [Fact]
-    public async Task EnsureCreatedAsync_WithNoContexts_CompletesSuccessfully()
+    public async Task EnsureCreatedAsync_WithNoSourcesInUse_CompletesSuccessfully()
     {
         await using var sut = CreateSut();
 
@@ -90,7 +89,7 @@ public sealed class DbContextFactoryAdditionalTests
 
     // -- MigrateAsync --
     [Fact]
-    public async Task MigrateAsync_WithNoContexts_CompletesSuccessfully()
+    public async Task MigrateAsync_WithNoSourcesInUse_CompletesSuccessfully()
     {
         await using var sut = CreateSut();
 
@@ -101,7 +100,7 @@ public sealed class DbContextFactoryAdditionalTests
 
     // -- HasPendingMigrationsAsync --
     [Fact]
-    public async Task HasPendingMigrationsAsync_WithNoContexts_ReturnsFalse()
+    public async Task HasPendingMigrationsAsync_WithNoSourcesInUse_ReturnsFalse()
     {
         await using var sut = CreateSut();
 
@@ -110,13 +109,15 @@ public sealed class DbContextFactoryAdditionalTests
         result.Should().BeFalse();
     }
 
-    private static DbContextFactory CreateSut(
-        Mock<IDbContextFactory<CosmosDbContext>>? cosmosFactory = null,
-        Mock<IDbContextFactory<SqliteDbContext>>? sqliteFactory = null,
-        Mock<IDbContextFactory<SQLServerDbContext>>? sqlServerFactory = null) =>
-        new(
-            (cosmosFactory ?? new Mock<IDbContextFactory<CosmosDbContext>>()).Object,
-            (sqliteFactory ?? new Mock<IDbContextFactory<SqliteDbContext>>()).Object,
-            (sqlServerFactory ?? new Mock<IDbContextFactory<SQLServerDbContext>>()).Object,
+    private static DbContextFactory CreateSut(Mock<IPhysicalDbContextFactory>? physicalFactory = null)
+    {
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+
+        return new DbContextFactory(
+            (physicalFactory ?? new Mock<IPhysicalDbContextFactory>()).Object,
+            registry.Object,
+            Mock.Of<IDataSourceResolver>(),
             Mock.Of<ICurrentUserService>());
+    }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryTests.cs
@@ -1,8 +1,8 @@
 #pragma warning disable CA2000 // Dispose objects before losing scope — test doubles do not hold real resources
 
 using AwesomeAssertions;
-using Microsoft.EntityFrameworkCore;
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 using Moq;
@@ -11,68 +11,104 @@ namespace MMCA.Common.Infrastructure.Tests.Persistence;
 
 public sealed class DbContextFactoryTests
 {
-    // -- Constructor null guard --
+    // -- Constructor null guards (one per parameter) --
+    [Fact]
+    public void Constructor_NullPhysicalDbContextFactory_Throws()
+    {
+        var act = () => new DbContextFactory(
+            null!,
+            Mock.Of<IEntityDataSourceRegistry>(),
+            Mock.Of<IDataSourceResolver>(),
+            Mock.Of<ICurrentUserService>());
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("physicalDbContextFactory");
+    }
+
+    [Fact]
+    public void Constructor_NullEntityDataSourceRegistry_Throws()
+    {
+        var act = () => new DbContextFactory(
+            Mock.Of<IPhysicalDbContextFactory>(),
+            null!,
+            Mock.Of<IDataSourceResolver>(),
+            Mock.Of<ICurrentUserService>());
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("entityDataSourceRegistry");
+    }
+
+    [Fact]
+    public void Constructor_NullDataSourceResolver_Throws()
+    {
+        var act = () => new DbContextFactory(
+            Mock.Of<IPhysicalDbContextFactory>(),
+            Mock.Of<IEntityDataSourceRegistry>(),
+            null!,
+            Mock.Of<ICurrentUserService>());
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("dataSourceResolver");
+    }
+
     [Fact]
     public void Constructor_NullCurrentUserService_Throws()
     {
         var act = () => new DbContextFactory(
-            Mock.Of<IDbContextFactory<CosmosDbContext>>(),
-            Mock.Of<IDbContextFactory<SqliteDbContext>>(),
-            Mock.Of<IDbContextFactory<SQLServerDbContext>>(),
+            Mock.Of<IPhysicalDbContextFactory>(),
+            Mock.Of<IEntityDataSourceRegistry>(),
+            Mock.Of<IDataSourceResolver>(),
             null!);
 
-        act.Should().Throw<ArgumentNullException>();
+        act.Should().Throw<ArgumentNullException>().WithParameterName("currentUserService");
     }
 
-    // -- GetDbContext calls correct factory --
+    // -- GetDbContext(DataSource) forwards to the engine's default physical source --
     [Fact]
-    public void GetDbContext_SQLServer_CallsSQLServerFactory()
+    public void GetDbContext_SQLServer_CreatesDefaultSQLServerSource()
     {
-        var sqlServerFactory = new Mock<IDbContextFactory<SQLServerDbContext>>();
-        sqlServerFactory.Setup(f => f.CreateDbContext()).Returns((SQLServerDbContext)null!);
-        var sut = CreateSut(sqlServerFactory: sqlServerFactory);
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory.Setup(f => f.Create(It.IsAny<DataSourceKey>())).Returns((ApplicationDbContext)null!);
+        var sut = CreateSut(physicalFactory);
 
         sut.GetDbContext(DataSource.SQLServer);
 
-        sqlServerFactory.Verify(f => f.CreateDbContext(), Times.Once);
+        physicalFactory.Verify(f => f.Create(DataSourceKey.Default(DataSource.SQLServer)), Times.Once);
     }
 
     [Fact]
-    public void GetDbContext_Sqlite_CallsSqliteFactory()
+    public void GetDbContext_Sqlite_CreatesDefaultSqliteSource()
     {
-        var sqliteFactory = new Mock<IDbContextFactory<SqliteDbContext>>();
-        sqliteFactory.Setup(f => f.CreateDbContext()).Returns((SqliteDbContext)null!);
-        var sut = CreateSut(sqliteFactory: sqliteFactory);
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory.Setup(f => f.Create(It.IsAny<DataSourceKey>())).Returns((ApplicationDbContext)null!);
+        var sut = CreateSut(physicalFactory);
 
         sut.GetDbContext(DataSource.Sqlite);
 
-        sqliteFactory.Verify(f => f.CreateDbContext(), Times.Once);
+        physicalFactory.Verify(f => f.Create(DataSourceKey.Default(DataSource.Sqlite)), Times.Once);
     }
 
     [Fact]
-    public void GetDbContext_CosmosDB_CallsCosmosFactory()
+    public void GetDbContext_CosmosDB_CreatesDefaultCosmosSource()
     {
-        var cosmosFactory = new Mock<IDbContextFactory<CosmosDbContext>>();
-        cosmosFactory.Setup(f => f.CreateDbContext()).Returns((CosmosDbContext)null!);
-        var sut = CreateSut(cosmosFactory: cosmosFactory);
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory.Setup(f => f.Create(It.IsAny<DataSourceKey>())).Returns((ApplicationDbContext)null!);
+        var sut = CreateSut(physicalFactory);
 
         sut.GetDbContext(DataSource.CosmosDB);
 
-        cosmosFactory.Verify(f => f.CreateDbContext(), Times.Once);
+        physicalFactory.Verify(f => f.Create(DataSourceKey.Default(DataSource.CosmosDB)), Times.Once);
     }
 
     [Fact]
     public void GetDbContext_RecreatesContext_WhenCachedValueIsNull()
     {
-        var sqlServerFactory = new Mock<IDbContextFactory<SQLServerDbContext>>();
-        sqlServerFactory.Setup(f => f.CreateDbContext()).Returns((SQLServerDbContext)null!);
-        var sut = CreateSut(sqlServerFactory: sqlServerFactory);
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory.Setup(f => f.Create(It.IsAny<DataSourceKey>())).Returns((ApplicationDbContext)null!);
+        var sut = CreateSut(physicalFactory);
 
         _ = sut.GetDbContext(DataSource.SQLServer);
         _ = sut.GetDbContext(DataSource.SQLServer);
 
         // Source code re-creates when cached value is null
-        sqlServerFactory.Verify(f => f.CreateDbContext(), Times.Exactly(2));
+        physicalFactory.Verify(f => f.Create(DataSourceKey.Default(DataSource.SQLServer)), Times.Exactly(2));
     }
 
     [Fact]
@@ -120,56 +156,15 @@ public sealed class DbContextFactoryTests
         act.Should().NotThrow();
     }
 
-    // -- Null factory in registry throws on demand --
-    [Fact]
-    public void GetDbContext_NullCosmosFactory_ThrowsArgumentNullException()
+    private static DbContextFactory CreateSut(Mock<IPhysicalDbContextFactory>? physicalFactory = null)
     {
-        using var sut = new DbContextFactory(
-            null!,
-            Mock.Of<IDbContextFactory<SqliteDbContext>>(),
-            Mock.Of<IDbContextFactory<SQLServerDbContext>>(),
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+
+        return new DbContextFactory(
+            (physicalFactory ?? new Mock<IPhysicalDbContextFactory>()).Object,
+            registry.Object,
+            Mock.Of<IDataSourceResolver>(),
             Mock.Of<ICurrentUserService>());
-
-        var act = () => sut.GetDbContext(DataSource.CosmosDB);
-
-        act.Should().Throw<ArgumentNullException>();
     }
-
-    [Fact]
-    public void GetDbContext_NullSqliteFactory_ThrowsArgumentNullException()
-    {
-        using var sut = new DbContextFactory(
-            Mock.Of<IDbContextFactory<CosmosDbContext>>(),
-            null!,
-            Mock.Of<IDbContextFactory<SQLServerDbContext>>(),
-            Mock.Of<ICurrentUserService>());
-
-        var act = () => sut.GetDbContext(DataSource.Sqlite);
-
-        act.Should().Throw<ArgumentNullException>();
-    }
-
-    [Fact]
-    public void GetDbContext_NullSQLServerFactory_ThrowsArgumentNullException()
-    {
-        using var sut = new DbContextFactory(
-            Mock.Of<IDbContextFactory<CosmosDbContext>>(),
-            Mock.Of<IDbContextFactory<SqliteDbContext>>(),
-            null!,
-            Mock.Of<ICurrentUserService>());
-
-        var act = () => sut.GetDbContext(DataSource.SQLServer);
-
-        act.Should().Throw<ArgumentNullException>();
-    }
-
-    private static DbContextFactory CreateSut(
-        Mock<IDbContextFactory<CosmosDbContext>>? cosmosFactory = null,
-        Mock<IDbContextFactory<SqliteDbContext>>? sqliteFactory = null,
-        Mock<IDbContextFactory<SQLServerDbContext>>? sqlServerFactory = null) =>
-        new(
-            (cosmosFactory ?? new Mock<IDbContextFactory<CosmosDbContext>>()).Object,
-            (sqliteFactory ?? new Mock<IDbContextFactory<SqliteDbContext>>()).Object,
-            (sqlServerFactory ?? new Mock<IDbContextFactory<SQLServerDbContext>>()).Object,
-            Mock.Of<ICurrentUserService>());
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DomainEventSaveChangesInterceptorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DomainEventSaveChangesInterceptorTests.cs
@@ -6,9 +6,11 @@ using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Domain.DomainEvents;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
@@ -182,7 +184,7 @@ public sealed class DomainEventSaveChangesInterceptorTests : IDisposable
         internal override bool SupportsOutbox => false;
 
         private TestDomainEventDbContext(DbContextOptions<TestDomainEventDbContext> options, IServiceProvider serviceProvider)
-            : base(options, serviceProvider, new NullAssemblyProvider())
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
         {
         }
 
@@ -192,6 +194,7 @@ public sealed class DomainEventSaveChangesInterceptorTests : IDisposable
             var auditInterceptor = new AuditSaveChangesInterceptor(TimeProvider.System);
             services.AddSingleton(auditInterceptor);
             services.AddSingleton(domainEventInterceptor);
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
             IServiceProvider sp = services.BuildServiceProvider();
 
             var options = new DbContextOptionsBuilder<TestDomainEventDbContext>()

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EntityTypeConfigurationBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EntityTypeConfigurationBaseTests.cs
@@ -1,29 +1,23 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
-using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
 
 /// <summary>
 /// Tests for <see cref="EntityTypeConfigurationBase{TEntity,TIdentifierType}"/> to verify
-/// that Configure registers data source and excludes DomainEvents for aggregate roots.
+/// that Configure excludes DomainEvents for aggregate roots. (The entity-to-data-source
+/// registration that used to happen here moved to the eagerly-built EntityDataSourceRegistry.)
 /// </summary>
 public sealed class EntityTypeConfigurationBaseTests
 {
     // ── Configure for aggregate root entity: excludes DomainEvents ──
     [Fact]
-    public void Configure_AggregateRootEntity_ExcludesDomainEventsAndRegistersDataSource()
+    public void Configure_AggregateRootEntity_ExcludesDomainEvents()
     {
-        var mockDataSourceService = new Mock<IDataSourceService>();
-        mockDataSourceService
-            .Setup(d => d.GetDataSource(typeof(TestAggregateEntity), It.IsAny<Type>()))
-            .Returns(DataSource.SQLServer);
-
-        var config = new TestAggregateEntityConfiguration(mockDataSourceService.Object);
+        var config = new TestAggregateEntityConfiguration();
 
         var options = new DbContextOptionsBuilder()
             .UseSqlite("DataSource=:memory:")
@@ -38,22 +32,12 @@ public sealed class EntityTypeConfigurationBaseTests
         // DomainEvents should be excluded (ignored) from the model
         var domainEventsProperty = entityType!.FindProperty("DomainEvents");
         domainEventsProperty.Should().BeNull("DomainEvents should be ignored for aggregate root entities");
-
-        // DataSourceService.GetDataSource was called to register the mapping
-        mockDataSourceService.Verify(
-            d => d.GetDataSource(typeof(TestAggregateEntity), typeof(TestAggregateEntityConfiguration)),
-            Times.Once);
     }
 
     [Fact]
-    public void Configure_NonAggregateEntity_RegistersDataSourceWithoutIgnoringDomainEvents()
+    public void Configure_NonAggregateEntity_MapsEntity()
     {
-        var mockDataSourceService = new Mock<IDataSourceService>();
-        mockDataSourceService
-            .Setup(d => d.GetDataSource(typeof(TestNonAggregateEntity), It.IsAny<Type>()))
-            .Returns(DataSource.Sqlite);
-
-        var config = new TestNonAggregateEntityConfiguration(mockDataSourceService.Object);
+        var config = new TestNonAggregateEntityConfiguration();
 
         var options = new DbContextOptionsBuilder()
             .UseSqlite("DataSource=:memory:")
@@ -64,11 +48,6 @@ public sealed class EntityTypeConfigurationBaseTests
         // The entity should be in the model
         var entityType = context.Model.FindEntityType(typeof(TestNonAggregateEntity));
         entityType.Should().NotBeNull();
-
-        // DataSourceService.GetDataSource was called
-        mockDataSourceService.Verify(
-            d => d.GetDataSource(typeof(TestNonAggregateEntity), typeof(TestNonAggregateEntityConfiguration)),
-            Times.Once);
     }
 
     public sealed class TestAggregateEntity : AuditableAggregateRootEntity<int>
@@ -81,8 +60,8 @@ public sealed class EntityTypeConfigurationBaseTests
         public string Value { get; set; } = string.Empty;
     }
 
-    public sealed class TestAggregateEntityConfiguration(IDataSourceService dataSourceService)
-        : EntityTypeConfigurationBase<TestAggregateEntity, int>(dataSourceService)
+    public sealed class TestAggregateEntityConfiguration
+        : EntityTypeConfigurationBase<TestAggregateEntity, int>
     {
         public override void Configure(EntityTypeBuilder<TestAggregateEntity> builder)
         {
@@ -93,8 +72,8 @@ public sealed class EntityTypeConfigurationBaseTests
         }
     }
 
-    public sealed class TestNonAggregateEntityConfiguration(IDataSourceService dataSourceService)
-        : EntityTypeConfigurationBase<TestNonAggregateEntity, int>(dataSourceService)
+    public sealed class TestNonAggregateEntityConfiguration
+        : EntityTypeConfigurationBase<TestNonAggregateEntity, int>
     {
         public override void Configure(EntityTypeBuilder<TestNonAggregateEntity> builder)
         {

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EntityTypeConfigurationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EntityTypeConfigurationTests.cs
@@ -1,10 +1,8 @@
 using AwesomeAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
-using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
 
@@ -57,8 +55,8 @@ public sealed class EntityTypeConfigurationTests : IDisposable
     }
 
     // -- Concrete Sqlite configuration --
-    public sealed class SqliteTestEntityConfig(IDataSourceService dataSourceService)
-        : EntityTypeConfigurationSqlite<SqliteTestEntity, int>(dataSourceService);
+    public sealed class SqliteTestEntityConfig
+        : EntityTypeConfigurationSqlite<SqliteTestEntity, int>;
 
     // -- Test DbContext using the Sqlite configuration --
     public sealed class SqliteTestDbContext(DbContextOptions options)
@@ -68,12 +66,7 @@ public sealed class EntityTypeConfigurationTests : IDisposable
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            var dataSourceService = new Mock<IDataSourceService>();
-            dataSourceService
-                .Setup(d => d.GetDataSource(It.IsAny<Type>(), It.IsAny<Type>()))
-                .Returns(DataSource.Sqlite);
-
-            var config = new SqliteTestEntityConfig(dataSourceService.Object);
+            var config = new SqliteTestEntityConfig();
             modelBuilder.Entity<SqliteTestEntity>(builder =>
             {
                 config.Configure(builder);

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/ModelBuilderExtensionsTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/ModelBuilderExtensionsTests.cs
@@ -117,19 +117,15 @@ public sealed class ModelBuilderExtensionsTests
 
     private sealed class TestDataSourceService : IDataSourceService
     {
-        public DataSource GetDataSource(Type entityType, Type configurationType) => DataSource.Sqlite;
+        public DataSourceKey GetDataSourceKey(Type entityType) => DataSourceKey.Default(DataSource.Sqlite);
 
-        public DataSource GetDataSource<TEntity, TIdentifierType, TEntityTypeConfiguration>()
-            where TEntity : AuditableBaseEntity<TIdentifierType>
-            where TEntityTypeConfiguration : class
-            where TIdentifierType : notnull
-            => DataSource.Sqlite;
+        public DataSourceKey GetDataSourceKey(string entityFullName) => DataSourceKey.Default(DataSource.Sqlite);
 
         public DataSource GetDataSource(string entityFullName) => DataSource.Sqlite;
 
         public DataSource GetDataSource(Type entityType) => DataSource.Sqlite;
 
-        public bool HaveIncludeSupport(DataSource first, DataSource second) => first == second;
+        public bool HaveIncludeSupport(DataSourceKey first, DataSourceKey second) => first == second;
 
         public bool HaveIncludeSupport(string firstEntityFullName, string secondEntityFullName) => true;
     }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorExecuteAsyncTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorExecuteAsyncTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using MMCA.Common.Infrastructure.Settings;
 using Moq;
@@ -14,11 +15,30 @@ namespace MMCA.Common.Infrastructure.Tests.Persistence;
 /// <summary>
 /// Tests for <see cref="OutboxProcessor.ExecuteAsync"/> edge cases that are not covered
 /// by the ProcessPendingMessagesAsync reflection-based tests in OutboxProcessorTests.
+/// The 5-second startup delay now happens BEFORE the disabled check, so tests asserting
+/// the disabled path wait for <see cref="Microsoft.Extensions.Hosting.BackgroundService.ExecuteTask"/>
+/// to complete instead of using short fixed delays.
 /// </summary>
 public sealed class OutboxProcessorExecuteAsyncTests
 {
+    private static Mock<IEntityDataSourceRegistry> CreateEmptyRegistryMock()
+    {
+        var registryMock = new Mock<IEntityDataSourceRegistry>();
+        registryMock.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+        return registryMock;
+    }
+
+    private static Mock<IDataSourceResolver> CreateResolverMock()
+    {
+        var resolverMock = new Mock<IDataSourceResolver>();
+        resolverMock
+            .Setup(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
+            .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
+        return resolverMock;
+    }
+
     [Fact]
-    public async Task ExecuteAsync_CosmosDBDataSource_ExitsImmediatelyWithoutProcessing()
+    public async Task ExecuteAsync_CosmosDBDataSource_ExitsWithoutProcessing()
     {
         var settings = new OutboxSettings
         {
@@ -31,18 +51,21 @@ public sealed class OutboxProcessorExecuteAsyncTests
             mockScopeFactory.Object,
             NullLogger<OutboxProcessor>.Instance,
             Options.Create(settings),
-            outboxSignal1.Object);
+            outboxSignal1.Object,
+            CreateEmptyRegistryMock().Object,
+            CreateResolverMock().Object);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        await sut.StartAsync(cts.Token);
+        await sut.StartAsync(CancellationToken.None);
 
-        await Task.Delay(200, CancellationToken.None);
+        // Cosmos target + empty registry → no outbox sources; the processor exits on its own
+        // after the 5-second startup delay. Wait for that completion rather than a fixed delay.
+        await sut.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(30));
         await sut.StopAsync(CancellationToken.None);
 
         mockScopeFactory.Verify(
             f => f.CreateScope(),
             Times.Never,
-            "Outbox processor should not create a DI scope when data source is CosmosDB");
+            "Outbox processor should not create a DI scope when no outbox-capable data sources exist");
     }
 
     [Fact]
@@ -59,7 +82,9 @@ public sealed class OutboxProcessorExecuteAsyncTests
             mockScopeFactory.Object,
             NullLogger<OutboxProcessor>.Instance,
             Options.Create(settings),
-            outboxSignal2.Object);
+            outboxSignal2.Object,
+            CreateEmptyRegistryMock().Object,
+            CreateResolverMock().Object);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
         await sut.StartAsync(cts.Token);
@@ -82,11 +107,18 @@ public sealed class OutboxProcessorExecuteAsyncTests
 
         var mockScopeFactory = new Mock<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>();
         var outboxSignal3 = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
-        using var sut = new OutboxProcessor(mockScopeFactory.Object, mockLogger.Object, Options.Create(settings), outboxSignal3.Object);
+        using var sut = new OutboxProcessor(
+            mockScopeFactory.Object,
+            mockLogger.Object,
+            Options.Create(settings),
+            outboxSignal3.Object,
+            CreateEmptyRegistryMock().Object,
+            CreateResolverMock().Object);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        await sut.StartAsync(cts.Token);
-        await Task.Delay(200, CancellationToken.None);
+        await sut.StartAsync(CancellationToken.None);
+
+        // The disabled log is only written after the 5-second startup delay elapses.
+        await sut.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(30));
         await sut.StopAsync(CancellationToken.None);
 
         mockLogger.Verify(l => l.IsEnabled(LogLevel.Information), Times.AtLeastOnce);

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
@@ -10,10 +10,12 @@ using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Messaging;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
 
@@ -50,6 +52,7 @@ public sealed class OutboxProcessorTests : IDisposable
             _dispatcherMock.Object, NullLogger<DomainEventSaveChangesInterceptor>.Instance, outboxSignal.Object));
         contextServices.AddSingleton(Mock.Of<IEntityConfigurationAssemblyProvider>(
             p => p.GetConfigurationAssemblies() == Array.Empty<Assembly>()));
+        contextServices.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
         ServiceProvider contextSp = contextServices.BuildServiceProvider();
 
         var options = new DbContextOptionsBuilder<OutboxTestDbContext>()
@@ -66,7 +69,7 @@ public sealed class OutboxProcessorTests : IDisposable
 
         var mockDbContextFactory = new Mock<IDbContextFactory>();
         mockDbContextFactory
-            .Setup(f => f.GetDbContext(DataSource.SQLServer))
+            .Setup(f => f.GetDbContext(DataSourceKey.Default(DataSource.SQLServer)))
             .Returns(_dbContext);
 
         var services = new ServiceCollection();
@@ -77,7 +80,21 @@ public sealed class OutboxProcessorTests : IDisposable
 
         var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
         var processorOutboxSignal = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
-        _sut = new OutboxProcessor(scopeFactory, NullLogger<OutboxProcessor>.Instance, Options.Create(new OutboxSettings()), processorOutboxSignal.Object);
+
+        var registryMock = new Mock<IEntityDataSourceRegistry>();
+        registryMock.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+        var resolverMock = new Mock<IDataSourceResolver>();
+        resolverMock
+            .Setup(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
+            .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
+
+        _sut = new OutboxProcessor(
+            scopeFactory,
+            NullLogger<OutboxProcessor>.Instance,
+            Options.Create(new OutboxSettings()),
+            processorOutboxSignal.Object,
+            registryMock.Object,
+            resolverMock.Object);
     }
 
     public void Dispose()
@@ -335,7 +352,7 @@ public sealed class OutboxProcessorTests : IDisposable
         DbContextOptions options,
         IServiceProvider serviceProvider,
         IEntityConfigurationAssemblyProvider assemblyProvider)
-        : ApplicationDbContext(options, serviceProvider, assemblyProvider)
+        : ApplicationDbContext(options, serviceProvider, assemblyProvider, TestPhysicalDataSources.Sqlite())
     {
         internal override bool SupportsOutbox => true;
 

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/UnitOfWorkAdditionalTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/UnitOfWorkAdditionalTests.cs
@@ -62,15 +62,15 @@ public sealed class UnitOfWorkAdditionalTests
         var (sut, mocks) = CreateSut();
         var mockRepo = new Mock<IRepository<FakeAggregate, int>>();
 
-        mocks.DataSourceService.Setup(x => x.GetDataSource(typeof(FakeAggregate))).Returns(DataSource.Sqlite);
-        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSource.Sqlite)).Returns((MMCA.Common.Infrastructure.Persistence.DbContexts.ApplicationDbContext)null!);
+        mocks.DataSourceService.Setup(x => x.GetDataSourceKey(typeof(FakeAggregate))).Returns(DataSourceKey.Default(DataSource.Sqlite));
+        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSourceKey.Default(DataSource.Sqlite))).Returns((MMCA.Common.Infrastructure.Persistence.DbContexts.ApplicationDbContext)null!);
         mocks.RepositoryFactory.Setup(x => x.Create<FakeAggregate, int>(It.IsAny<Microsoft.EntityFrameworkCore.DbContext>())).Returns(mockRepo.Object);
 
         var repo = sut.GetRepository<FakeAggregate, int>();
 
         repo.Should().BeSameAs(mockRepo.Object);
-        mocks.DataSourceService.Verify(x => x.GetDataSource(typeof(FakeAggregate)), Times.Once);
-        mocks.DbContextFactory.Verify(x => x.GetDbContext(DataSource.Sqlite), Times.Once);
+        mocks.DataSourceService.Verify(x => x.GetDataSourceKey(typeof(FakeAggregate)), Times.Once);
+        mocks.DbContextFactory.Verify(x => x.GetDbContext(DataSourceKey.Default(DataSource.Sqlite)), Times.Once);
     }
 
     [Fact]
@@ -79,15 +79,15 @@ public sealed class UnitOfWorkAdditionalTests
         var (sut, mocks) = CreateSut();
         var mockRepo = new Mock<IReadRepository<FakeEntity, int>>();
 
-        mocks.DataSourceService.Setup(x => x.GetDataSource(typeof(FakeEntity))).Returns(DataSource.CosmosDB);
-        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSource.CosmosDB)).Returns((MMCA.Common.Infrastructure.Persistence.DbContexts.ApplicationDbContext)null!);
+        mocks.DataSourceService.Setup(x => x.GetDataSourceKey(typeof(FakeEntity))).Returns(DataSourceKey.Default(DataSource.CosmosDB));
+        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSourceKey.Default(DataSource.CosmosDB))).Returns((MMCA.Common.Infrastructure.Persistence.DbContexts.ApplicationDbContext)null!);
         mocks.RepositoryFactory.Setup(x => x.CreateReadOnly<FakeEntity, int>(It.IsAny<Microsoft.EntityFrameworkCore.DbContext>())).Returns(mockRepo.Object);
 
         var repo = sut.GetReadRepository<FakeEntity, int>();
 
         repo.Should().BeSameAs(mockRepo.Object);
-        mocks.DataSourceService.Verify(x => x.GetDataSource(typeof(FakeEntity)), Times.Once);
-        mocks.DbContextFactory.Verify(x => x.GetDbContext(DataSource.CosmosDB), Times.Once);
+        mocks.DataSourceService.Verify(x => x.GetDataSourceKey(typeof(FakeEntity)), Times.Once);
+        mocks.DbContextFactory.Verify(x => x.GetDbContext(DataSourceKey.Default(DataSource.CosmosDB)), Times.Once);
     }
 
     public sealed class FakeAggregate : AuditableAggregateRootEntity<int>

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/UnitOfWorkTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/UnitOfWorkTests.cs
@@ -106,8 +106,8 @@ public sealed class UnitOfWorkTests
         var (sut, mocks) = CreateSut();
         var mockRepo = new Mock<IRepository<FakeAggregate, int>>();
 
-        mocks.DataSourceService.Setup(x => x.GetDataSource(typeof(FakeAggregate))).Returns(DataSource.SQLServer);
-        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSource.SQLServer)).Returns((ApplicationDbContext)null!);
+        mocks.DataSourceService.Setup(x => x.GetDataSourceKey(typeof(FakeAggregate))).Returns(DataSourceKey.Default(DataSource.SQLServer));
+        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSourceKey.Default(DataSource.SQLServer))).Returns((ApplicationDbContext)null!);
         mocks.RepositoryFactory.Setup(x => x.Create<FakeAggregate, int>(It.IsAny<DbContext>())).Returns(mockRepo.Object);
 
         var repo1 = sut.GetRepository<FakeAggregate, int>();
@@ -123,8 +123,8 @@ public sealed class UnitOfWorkTests
         var (sut, mocks) = CreateSut();
         var mockRepo = new Mock<IReadRepository<FakeEntity, int>>();
 
-        mocks.DataSourceService.Setup(x => x.GetDataSource(typeof(FakeEntity))).Returns(DataSource.SQLServer);
-        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSource.SQLServer)).Returns((ApplicationDbContext)null!);
+        mocks.DataSourceService.Setup(x => x.GetDataSourceKey(typeof(FakeEntity))).Returns(DataSourceKey.Default(DataSource.SQLServer));
+        mocks.DbContextFactory.Setup(x => x.GetDbContext(DataSourceKey.Default(DataSource.SQLServer))).Returns((ApplicationDbContext)null!);
         mocks.RepositoryFactory.Setup(x => x.CreateReadOnly<FakeEntity, int>(It.IsAny<DbContext>())).Returns(mockRepo.Object);
 
         var repo1 = sut.GetReadRepository<FakeEntity, int>();

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/DataSourceServiceAdditionalTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/DataSourceServiceAdditionalTests.cs
@@ -1,105 +1,87 @@
 using AwesomeAssertions;
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Services;
+using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Services;
 
+/// <summary>
+/// Additional <see cref="DataSourceService"/> facade tests complementing
+/// <see cref="DataSourceServiceTests"/>: edge cases for include-support
+/// classification by entity name and engine extraction by CLR type.
+/// </summary>
 public sealed class DataSourceServiceAdditionalTests
 {
-    private readonly DataSourceService _sut = new();
+    private readonly Mock<IEntityDataSourceRegistry> _registry = new();
+    private readonly DataSourceService _sut;
 
-    // ── GetDataSource generic method ──
+    public DataSourceServiceAdditionalTests() => _sut = new DataSourceService(_registry.Object);
+
+    // ── GetDataSource(Type): unregistered type propagates the registry exception ──
     [Fact]
-    public void GetDataSource_GenericMethod_ReturnsDataSource()
+    public void GetDataSource_ByType_WhenUnregistered_PropagatesInvalidOperationException()
     {
-        // First call caches via the two-type overload
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
+        _registry
+            .Setup(r => r.GetDataSourceKey(typeof(UnregisteredEntity)))
+            .Throws(new InvalidOperationException("No entity type configuration registers the entity."));
 
-        // Generic method delegates to GetDataSource(Type, Type)
-        var result = _sut.GetDataSource(typeof(FakeEntity));
-        result.Should().Be(DataSource.SQLServer);
-    }
-
-    // ── HaveIncludeSupport(string, string) edge cases ──
-    [Fact]
-    public void HaveIncludeSupport_ByName_FirstNotCached_ReturnsFalse() =>
-        _sut.HaveIncludeSupport("Not.Cached.Entity", typeof(FakeEntity).FullName!)
-            .Should().BeFalse();
-
-    [Fact]
-    public void HaveIncludeSupport_ByName_SecondNotCached_ReturnsFalse()
-    {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-
-        _sut.HaveIncludeSupport(typeof(FakeEntity).FullName!, "Not.Cached.Entity")
-            .Should().BeFalse();
-    }
-
-    [Fact]
-    public void HaveIncludeSupport_ByName_BothCosmos_ReturnsFalse()
-    {
-        _sut.GetDataSource(typeof(FakeCosmosEntity1), typeof(FakeCosmosConfig1));
-        _sut.GetDataSource(typeof(FakeCosmosEntity2), typeof(FakeCosmosConfig2));
-
-        _sut.HaveIncludeSupport(
-            typeof(FakeCosmosEntity1).FullName!,
-            typeof(FakeCosmosEntity2).FullName!).Should().BeFalse();
-    }
-
-    [Fact]
-    public void HaveIncludeSupport_ByName_DifferentDataSources_ReturnsFalse()
-    {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        _sut.GetDataSource(typeof(FakeSqliteEntity), typeof(FakeSqliteConfig));
-
-        _sut.HaveIncludeSupport(
-            typeof(FakeEntity).FullName!,
-            typeof(FakeSqliteEntity).FullName!).Should().BeFalse();
-    }
-
-    // ── GetDataSource(Type) when not cached throws ──
-    [Fact]
-    public void GetDataSource_ByType_WhenNotCached_ThrowsInvalidOperationException() =>
-        FluentActions.Invoking(() => _sut.GetDataSource(typeof(UncachedEntity)))
+        FluentActions.Invoking(() => _sut.GetDataSource(typeof(UnregisteredEntity)))
             .Should().Throw<InvalidOperationException>();
-
-    // ── HaveIncludeSupport with enum values ──
-    [Fact]
-    public void HaveIncludeSupport_SameSqlite_ReturnsTrue_ByName()
-    {
-        _sut.GetDataSource(typeof(FakeSqliteEntity), typeof(FakeSqliteConfig));
-        _sut.GetDataSource(typeof(FakeSqliteEntity2), typeof(FakeSqliteConfig2));
-
-        _sut.HaveIncludeSupport(
-            typeof(FakeSqliteEntity).FullName!,
-            typeof(FakeSqliteEntity2).FullName!).Should().BeTrue();
     }
+
+    // ── GetDataSource(Type): Cosmos engine extraction ──
+    [Fact]
+    public void GetDataSource_ByType_CosmosEntity_ReturnsCosmosDB()
+    {
+        _registry
+            .Setup(r => r.GetDataSourceKey(typeof(FakeEntity)))
+            .Returns(DataSourceKey.Default(DataSource.CosmosDB));
+
+        _sut.GetDataSource(typeof(FakeEntity)).Should().Be(DataSource.CosmosDB);
+    }
+
+    // ── HaveIncludeSupport(string, string): both Cosmos, same key → false ──
+    [Fact]
+    public void HaveIncludeSupport_ByName_BothCosmosSameKey_ReturnsFalse()
+    {
+        var cosmosKey = DataSourceKey.Default(DataSource.CosmosDB);
+        _registry.Setup(r => r.TryGetDataSourceKey("Cosmos.Entity.A", out cosmosKey)).Returns(true);
+        _registry.Setup(r => r.TryGetDataSourceKey("Cosmos.Entity.B", out cosmosKey)).Returns(true);
+
+        _sut.HaveIncludeSupport("Cosmos.Entity.A", "Cosmos.Entity.B").Should().BeFalse();
+    }
+
+    // ── HaveIncludeSupport(string, string): same engine, different database → false ──
+    [Fact]
+    public void HaveIncludeSupport_ByName_SameEngineDifferentName_ReturnsFalse()
+    {
+        var salesKey = new DataSourceKey(DataSource.SQLServer, "Sales");
+        var catalogKey = new DataSourceKey(DataSource.SQLServer, "Catalog");
+        _registry.Setup(r => r.TryGetDataSourceKey("Sales.Entity", out salesKey)).Returns(true);
+        _registry.Setup(r => r.TryGetDataSourceKey("Catalog.Entity", out catalogKey)).Returns(true);
+
+        _sut.HaveIncludeSupport("Sales.Entity", "Catalog.Entity").Should().BeFalse();
+    }
+
+    // ── HaveIncludeSupport(string, string): same non-default Sqlite source → true ──
+    [Fact]
+    public void HaveIncludeSupport_ByName_SameNamedSqliteSource_ReturnsTrue()
+    {
+        var key = new DataSourceKey(DataSource.Sqlite, "Engagement");
+        _registry.Setup(r => r.TryGetDataSourceKey("Sqlite.Entity.A", out key)).Returns(true);
+        _registry.Setup(r => r.TryGetDataSourceKey("Sqlite.Entity.B", out key)).Returns(true);
+
+        _sut.HaveIncludeSupport("Sqlite.Entity.A", "Sqlite.Entity.B").Should().BeTrue();
+    }
+
+    // ── HaveIncludeSupport(string, string): neither registered → false ──
+    [Fact]
+    public void HaveIncludeSupport_ByName_NeitherRegistered_ReturnsFalse() =>
+        _sut.HaveIncludeSupport("NonExistent.Entity1", "NonExistent.Entity2").Should().BeFalse();
 
     // ── Test types ──
     private sealed class FakeEntity { }
 
-    private sealed class FakeSqliteEntity { }
-
-    private sealed class FakeSqliteEntity2 { }
-
-    private sealed class FakeCosmosEntity1 { }
-
-    private sealed class FakeCosmosEntity2 { }
-
-    private sealed class UncachedEntity { }
-
-    [UseDataSource(DataSource.SQLServer)]
-    private sealed class FakeSqlServerConfig { }
-
-    [UseDataSource(DataSource.Sqlite)]
-    private sealed class FakeSqliteConfig { }
-
-    [UseDataSource(DataSource.Sqlite)]
-    private sealed class FakeSqliteConfig2 { }
-
-    [UseDataSource(DataSource.CosmosDB)]
-    private sealed class FakeCosmosConfig1 { }
-
-    [UseDataSource(DataSource.CosmosDB)]
-    private sealed class FakeCosmosConfig2 { }
+    private sealed class UnregisteredEntity { }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/DataSourceServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/DataSourceServiceTests.cs
@@ -1,134 +1,166 @@
 using AwesomeAssertions;
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Services;
+using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Services;
 
-public class DataSourceServiceTests
+/// <summary>
+/// Tests for the <see cref="DataSourceService"/> facade over <see cref="IEntityDataSourceRegistry"/>:
+/// key pass-through, engine extraction, and include-support classification.
+/// </summary>
+public sealed class DataSourceServiceTests
 {
-    private readonly DataSourceService _sut = new();
+    private readonly Mock<IEntityDataSourceRegistry> _registry = new();
+    private readonly DataSourceService _sut;
 
-    // ── GetDataSource(Type, Type) ──
+    public DataSourceServiceTests() => _sut = new DataSourceService(_registry.Object);
+
+    // ── GetDataSourceKey(Type): pass-through ──
     [Fact]
-    public void GetDataSource_WithAttributeOnConfig_ReturnsDataSource()
+    public void GetDataSourceKey_ByType_DelegatesToRegistry()
     {
-        var result = _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
+        var key = new DataSourceKey(DataSource.SQLServer, "Sales");
+        _registry.Setup(r => r.GetDataSourceKey(typeof(FakeEntity))).Returns(key);
+
+        var result = _sut.GetDataSourceKey(typeof(FakeEntity));
+
+        result.Should().Be(key);
+    }
+
+    // ── GetDataSourceKey(string): pass-through ──
+    [Fact]
+    public void GetDataSourceKey_ByName_DelegatesToRegistry()
+    {
+        var key = new DataSourceKey(DataSource.Sqlite, "Conference");
+        _registry.Setup(r => r.GetDataSourceKey(typeof(FakeEntity).FullName!)).Returns(key);
+
+        var result = _sut.GetDataSourceKey(typeof(FakeEntity).FullName!);
+
+        result.Should().Be(key);
+    }
+
+    // ── GetDataSource(Type): engine extraction ──
+    [Fact]
+    public void GetDataSource_ByType_ReturnsEngineOfRegistryKey()
+    {
+        _registry
+            .Setup(r => r.GetDataSourceKey(typeof(FakeEntity)))
+            .Returns(new DataSourceKey(DataSource.SQLServer, "Sales"));
+
+        var result = _sut.GetDataSource(typeof(FakeEntity));
+
         result.Should().Be(DataSource.SQLServer);
     }
 
+    // ── GetDataSource(string): engine extraction ──
     [Fact]
-    public void GetDataSource_WithSqliteAttribute_ReturnsSqlite()
+    public void GetDataSource_ByName_ReturnsEngineOfRegistryKey()
     {
-        var result = _sut.GetDataSource(typeof(FakeEntity2), typeof(FakeSqliteConfig));
+        _registry
+            .Setup(r => r.GetDataSourceKey(typeof(FakeEntity).FullName!))
+            .Returns(DataSourceKey.Default(DataSource.Sqlite));
+
+        var result = _sut.GetDataSource(typeof(FakeEntity).FullName!);
+
         result.Should().Be(DataSource.Sqlite);
     }
 
+    // ── Unknown entity name: registry's InvalidOperationException propagates ──
     [Fact]
-    public void GetDataSource_WithoutAttribute_ThrowsInvalidOperationException() =>
-        FluentActions.Invoking(() => _sut.GetDataSource(typeof(FakeEntity3), typeof(NoAttributeConfig)))
-            .Should().Throw<InvalidOperationException>();
-
-    // ── GetDataSource(string) ──
-    [Fact]
-    public void GetDataSource_ByName_AfterCaching_ReturnsDataSource()
+    public void GetDataSourceKey_ByName_UnknownEntity_PropagatesInvalidOperationException()
     {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        var result = _sut.GetDataSource(typeof(FakeEntity).FullName!);
-        result.Should().Be(DataSource.SQLServer);
+        _registry
+            .Setup(r => r.GetDataSourceKey("NonExistent.Entity"))
+            .Throws(new InvalidOperationException("No entity type configuration registers the entity."));
+
+        FluentActions.Invoking(() => _sut.GetDataSourceKey("NonExistent.Entity"))
+            .Should().Throw<InvalidOperationException>();
     }
 
     [Fact]
-    public void GetDataSource_ByName_WhenNotCached_ThrowsInvalidOperationException() =>
+    public void GetDataSource_ByName_UnknownEntity_PropagatesInvalidOperationException()
+    {
+        _registry
+            .Setup(r => r.GetDataSourceKey("NonExistent.Entity"))
+            .Throws(new InvalidOperationException("No entity type configuration registers the entity."));
+
         FluentActions.Invoking(() => _sut.GetDataSource("NonExistent.Entity"))
             .Should().Throw<InvalidOperationException>();
-
-    // ── GetDataSource(Type) ──
-    [Fact]
-    public void GetDataSource_ByType_AfterCaching_ReturnsDataSource()
-    {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        var result = _sut.GetDataSource(typeof(FakeEntity));
-        result.Should().Be(DataSource.SQLServer);
     }
 
-    // ── Caching ──
+    // ── HaveIncludeSupport(DataSourceKey, DataSourceKey) ──
     [Fact]
-    public void GetDataSource_CachesResult_ReturnsSameOnSecondCall()
-    {
-        var first = _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        var second = _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        first.Should().Be(second);
-    }
-
-    // ── HaveIncludeSupport ──
-    [Fact]
-    public void HaveIncludeSupport_SameNonCosmos_ReturnsTrue() =>
-        _sut.HaveIncludeSupport(DataSource.SQLServer, DataSource.SQLServer).Should().BeTrue();
+    public void HaveIncludeSupport_SameSQLServerKey_ReturnsTrue() =>
+        _sut.HaveIncludeSupport(
+            DataSourceKey.Default(DataSource.SQLServer),
+            DataSourceKey.Default(DataSource.SQLServer)).Should().BeTrue();
 
     [Fact]
-    public void HaveIncludeSupport_SameSqlite_ReturnsTrue() =>
-        _sut.HaveIncludeSupport(DataSource.Sqlite, DataSource.Sqlite).Should().BeTrue();
+    public void HaveIncludeSupport_SameSqliteKey_ReturnsTrue() =>
+        _sut.HaveIncludeSupport(
+            DataSourceKey.Default(DataSource.Sqlite),
+            DataSourceKey.Default(DataSource.Sqlite)).Should().BeTrue();
 
     [Fact]
-    public void HaveIncludeSupport_DifferentDataSources_ReturnsFalse() =>
-        _sut.HaveIncludeSupport(DataSource.SQLServer, DataSource.Sqlite).Should().BeFalse();
+    public void HaveIncludeSupport_DifferentEngines_ReturnsFalse() =>
+        _sut.HaveIncludeSupport(
+            DataSourceKey.Default(DataSource.SQLServer),
+            DataSourceKey.Default(DataSource.Sqlite)).Should().BeFalse();
 
     [Fact]
-    public void HaveIncludeSupport_BothCosmos_ReturnsFalse() =>
-        _sut.HaveIncludeSupport(DataSource.CosmosDB, DataSource.CosmosDB).Should().BeFalse();
+    public void HaveIncludeSupport_SameCosmosKey_ReturnsFalse() =>
+        _sut.HaveIncludeSupport(
+            DataSourceKey.Default(DataSource.CosmosDB),
+            DataSourceKey.Default(DataSource.CosmosDB)).Should().BeFalse();
+
+    [Fact]
+    public void HaveIncludeSupport_SameEngineDifferentName_ReturnsFalse() =>
+        _sut.HaveIncludeSupport(
+            new DataSourceKey(DataSource.SQLServer, "Sales"),
+            new DataSourceKey(DataSource.SQLServer, "Catalog")).Should().BeFalse();
 
     // ── HaveIncludeSupport(string, string) ──
     [Fact]
-    public void HaveIncludeSupport_ByName_SameDataSource_ReturnsTrue()
+    public void HaveIncludeSupport_ByName_SamePhysicalSource_ReturnsTrue()
     {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        _sut.GetDataSource(typeof(FakeEntity2), typeof(FakeSqlServerConfig2));
+        var key = DataSourceKey.Default(DataSource.SQLServer);
+        _registry.Setup(r => r.TryGetDataSourceKey("Entity.A", out key)).Returns(true);
+        _registry.Setup(r => r.TryGetDataSourceKey("Entity.B", out key)).Returns(true);
 
-        _sut.HaveIncludeSupport(
-            typeof(FakeEntity).FullName!,
-            typeof(FakeEntity2).FullName!).Should().BeTrue();
+        _sut.HaveIncludeSupport("Entity.A", "Entity.B").Should().BeTrue();
     }
 
     [Fact]
-    public void HaveIncludeSupport_ByName_FirstNotCached_ReturnsFalse() =>
-        _sut.HaveIncludeSupport("NonExistent.Entity1", "NonExistent.Entity2").Should().BeFalse();
-
-    [Fact]
-    public void HaveIncludeSupport_ByName_DifferentDataSources_ReturnsFalse()
+    public void HaveIncludeSupport_ByName_DifferentEngines_ReturnsFalse()
     {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
-        _sut.GetDataSource(typeof(FakeEntity2), typeof(FakeSqliteConfig));
+        var sqlKey = DataSourceKey.Default(DataSource.SQLServer);
+        var sqliteKey = DataSourceKey.Default(DataSource.Sqlite);
+        _registry.Setup(r => r.TryGetDataSourceKey("Entity.A", out sqlKey)).Returns(true);
+        _registry.Setup(r => r.TryGetDataSourceKey("Entity.B", out sqliteKey)).Returns(true);
 
-        _sut.HaveIncludeSupport(
-            typeof(FakeEntity).FullName!,
-            typeof(FakeEntity2).FullName!).Should().BeFalse();
+        _sut.HaveIncludeSupport("Entity.A", "Entity.B").Should().BeFalse();
     }
 
     [Fact]
-    public void HaveIncludeSupport_ByName_SecondNotCached_ReturnsFalse()
+    public void HaveIncludeSupport_ByName_FirstUnregistered_ReturnsFalse()
     {
-        _sut.GetDataSource(typeof(FakeEntity), typeof(FakeSqlServerConfig));
+        var key = DataSourceKey.Default(DataSource.SQLServer);
+        _registry.Setup(r => r.TryGetDataSourceKey("Entity.B", out key)).Returns(true);
 
-        _sut.HaveIncludeSupport(
-            typeof(FakeEntity).FullName!,
-            "NonExistent.Entity").Should().BeFalse();
+        _sut.HaveIncludeSupport("NonExistent.Entity", "Entity.B").Should().BeFalse();
+    }
+
+    [Fact]
+    public void HaveIncludeSupport_ByName_SecondUnregistered_ReturnsFalse()
+    {
+        var key = DataSourceKey.Default(DataSource.SQLServer);
+        _registry.Setup(r => r.TryGetDataSourceKey("Entity.A", out key)).Returns(true);
+
+        _sut.HaveIncludeSupport("Entity.A", "NonExistent.Entity").Should().BeFalse();
     }
 
     // ── Test types ──
     private sealed class FakeEntity { }
-
-    private sealed class FakeEntity2 { }
-
-    private sealed class FakeEntity3 { }
-
-    [UseDataSource(DataSource.SQLServer)]
-    private sealed class FakeSqlServerConfig { }
-
-    [UseDataSource(DataSource.SQLServer)]
-    private sealed class FakeSqlServerConfig2 { }
-
-    [UseDataSource(DataSource.Sqlite)]
-    private sealed class FakeSqliteConfig { }
-
-    private sealed class NoAttributeConfig { }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/InProcessEventBusOutboxTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/InProcessEventBusOutboxTests.cs
@@ -6,11 +6,13 @@ using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using MMCA.Common.Infrastructure.Services;
 using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
 
@@ -24,6 +26,7 @@ public sealed class InProcessEventBusOutboxTests : IDisposable
 {
     private readonly Mock<IDbContextFactory> _mockDbContextFactory = new();
     private readonly Mock<IDomainEventDispatcher> _mockDispatcher = new();
+    private readonly Mock<IDataSourceResolver> _mockResolver = new();
     private readonly OutboxSettings _outboxSettings = new() { DataSource = DataSource.SQLServer };
     private readonly TestOutboxContext _testContext;
     private readonly InProcessEventBus _sut;
@@ -32,11 +35,14 @@ public sealed class InProcessEventBusOutboxTests : IDisposable
     {
         _testContext = TestOutboxContext.Create();
         _mockDbContextFactory
-            .Setup(x => x.GetDbContext(It.IsAny<DataSource>()))
+            .Setup(x => x.GetDbContext(It.IsAny<DataSourceKey>()))
             .Returns(_testContext);
+        _mockResolver
+            .Setup(x => x.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
+            .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
 
         IOptions<OutboxSettings> options = Options.Create(_outboxSettings);
-        _sut = new InProcessEventBus(_mockDbContextFactory.Object, _mockDispatcher.Object, options);
+        _sut = new InProcessEventBus(_mockDbContextFactory.Object, _mockDispatcher.Object, _mockResolver.Object, options);
     }
 
     public void Dispose() => _testContext.Dispose();
@@ -99,7 +105,7 @@ public sealed class InProcessEventBusOutboxTests : IDisposable
         internal override bool SupportsOutbox => true;
 
         private TestOutboxContext(DbContextOptions<TestOutboxContext> options, IServiceProvider serviceProvider)
-            : base(options, serviceProvider, new NullAssemblyProvider())
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
         {
         }
 
@@ -115,6 +121,7 @@ public sealed class InProcessEventBusOutboxTests : IDisposable
                 var outboxSignal = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
                 return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
             });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
             IServiceProvider sp = services.BuildServiceProvider();
 
             var options = new DbContextOptionsBuilder<TestOutboxContext>()

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/InProcessEventBusTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/InProcessEventBusTests.cs
@@ -6,10 +6,12 @@ using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Services;
 using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
 
@@ -19,6 +21,7 @@ public sealed class InProcessEventBusTests : IDisposable
 {
     private readonly Mock<IDbContextFactory> _mockDbContextFactory = new();
     private readonly Mock<IDomainEventDispatcher> _mockDispatcher = new();
+    private readonly Mock<IDataSourceResolver> _mockResolver = new();
     private readonly OutboxSettings _outboxSettings = new() { DataSource = DataSource.SQLServer };
     private readonly TestNonOutboxContext _testContext;
     private readonly InProcessEventBus _sut;
@@ -27,11 +30,14 @@ public sealed class InProcessEventBusTests : IDisposable
     {
         _testContext = TestNonOutboxContext.Create();
         _mockDbContextFactory
-            .Setup(x => x.GetDbContext(It.IsAny<DataSource>()))
+            .Setup(x => x.GetDbContext(It.IsAny<DataSourceKey>()))
             .Returns(_testContext);
+        _mockResolver
+            .Setup(x => x.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
+            .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
 
         IOptions<OutboxSettings> options = Options.Create(_outboxSettings);
-        _sut = new InProcessEventBus(_mockDbContextFactory.Object, _mockDispatcher.Object, options);
+        _sut = new InProcessEventBus(_mockDbContextFactory.Object, _mockDispatcher.Object, _mockResolver.Object, options);
     }
 
     public void Dispose() => _testContext.Dispose();
@@ -110,7 +116,7 @@ public sealed class InProcessEventBusTests : IDisposable
         internal override bool SupportsOutbox => false;
 
         private TestNonOutboxContext(DbContextOptions<TestNonOutboxContext> options, IServiceProvider serviceProvider)
-            : base(options, serviceProvider, new NullAssemblyProvider())
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
         {
         }
 
@@ -126,6 +132,7 @@ public sealed class InProcessEventBusTests : IDisposable
                 var outboxSignal = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
                 return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
             });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
             IServiceProvider sp = services.BuildServiceProvider();
 
             var options = new DbContextOptionsBuilder<TestNonOutboxContext>()

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/TestDoubles/TestDataSourceDoubles.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/TestDoubles/TestDataSourceDoubles.cs
@@ -1,0 +1,42 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+
+namespace MMCA.Common.Infrastructure.Tests.TestDoubles;
+
+/// <summary>
+/// An <see cref="IEntityDataSourceRegistry"/> with no registered entities. With an empty registry
+/// the cross-source degrade convention no-ops during model building, preserving the legacy
+/// single-database model behavior for test contexts.
+/// </summary>
+internal sealed class EmptyEntityDataSourceRegistry : IEntityDataSourceRegistry
+{
+    public DataSourceKey GetDataSourceKey(Type entityType) =>
+        throw new InvalidOperationException($"No data source registered for entity type \"{entityType}\".");
+
+    public DataSourceKey GetDataSourceKey(string entityFullName) =>
+        throw new InvalidOperationException($"No data source registered for entity \"{entityFullName}\".");
+
+    public bool TryGetDataSourceKey(string entityFullName, out DataSourceKey key)
+    {
+        key = default;
+        return false;
+    }
+
+    public IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse() => [];
+}
+
+/// <summary>
+/// Ready-made <see cref="PhysicalDataSource"/> values for constructing
+/// <c>ApplicationDbContext</c>-derived test contexts.
+/// </summary>
+internal static class TestPhysicalDataSources
+{
+    public static PhysicalDataSource Sqlite(string connectionString = "DataSource=:memory:") =>
+        new(DataSourceKey.Default(DataSource.Sqlite), connectionString, null, "AtlDevCon");
+
+    public static PhysicalDataSource SqlServer(string connectionString = "Server=test;Database=test") =>
+        new(DataSourceKey.Default(DataSource.SQLServer), connectionString, null, "AtlDevCon");
+
+    public static PhysicalDataSource Cosmos(string connectionString = "AccountEndpoint=https://test;AccountKey=dGVzdA==") =>
+        new(DataSourceKey.Default(DataSource.CosmosDB), connectionString, null, "AtlDevCon");
+}


### PR DESCRIPTION
Extends the persistence framework from one-database-per-engine to **multiple named databases per engine**, so a module/service can own its own database while existing idioms are preserved. **Backward compatible by default:** with no `DataSources` configuration every entity collapses onto the engine's single `Default` source, so a monolith behaves exactly as before (proven by a model-equivalence test).

## What's new
- `DataSourceKey(Engine, Name)` physical identity; `IDataSourceService` reshaped to `GetDataSourceKey` + key-based `HaveIncludeSupport`.
- `[UseDatabase("Name")]` attribute + namespace convention: an entity's logical database is the attribute, else the module namespace (segment before `Domain`), else `Default`.
- `DataSources` config section + `DataSourceResolver` (collapses logical names sharing a connection string onto one physical source; falls back to top-level `ConnectionStrings`) + eager `EntityDataSourceRegistry`.
- One context class per engine, instantiated per physical source: `PhysicalDataSource` ctor, `DataSourceModelCacheKeyFactory`, key-based routing, never-pooled `PhysicalDbContextFactory`.
- `CrossDataSourceDegradeConvention`: relationships crossing physical sources auto-degrade (FK + navigation removed, scalar column + index kept); runtime navigation flows through the existing `INavigationPopulator` loaders.
- Outbox per physical database; `DesignTimeDbContextHelper` for `dotnet ef ... -- --datasource <Name>` (one migrations project per database).

## Fixes found along the way
- `DomainEventSaveChangesInterceptor`: clear domain events before the nested outbox save (duplicate outbox rows).
- Concurrency token is `IsRowVersion` only on SQL Server; plain token elsewhere (SQLite INSERTs no longer fail on `RowVersion`).

## Compatibility
`EntityTypeConfiguration` base classes drop the `IDataSourceService` ctor parameter; downstream consumers (Store, ADC) are swept in the same release (see their PRs). Full suite green (1486 tests).

**Merge + tag `v1.48.0`** to publish the package that the ADC/Store PRs consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)