### PR TITLE
Add outbox smart wait and poll telemetry suppression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Source/
 Tests/                               # Mirrors Source/ structure
 ├── Core/           (Shared.Tests, Domain.Tests, Application.Tests, Infrastructure.Tests)
 ├── Presentation/   (API.Tests, Grpc.Tests, UI.Tests)
+├── Hosting/        (Aspire.Tests)
 └── Architecture/   (Architecture.Tests — NetArchTest layer/purity/extraction rules)
 ```
 
@@ -161,7 +162,7 @@ Every entity resolves to a **physical data source** — a `DataSourceKey(Engine,
 
 ### Outbox Pattern
 
-`OutboxMessage` entries are persisted atomically with aggregate changes, in the **same database as the aggregate** (every relational physical source has its own `OutboxMessages` table). `OutboxProcessor` (background service) drains the outbox of every relational source the host uses — a host never races for another service's outbox rows. Polls on signal or interval, processes in batches of 50, retries up to 5 times. Integration events published via `IEventBus` target the source named by `Outbox:DataSource` + `Outbox:DatabaseName` (default: SQL Server / Default). Provides at-least-once delivery guarantee with OpenTelemetry metrics for dead-letter tracking.
+`OutboxMessage` entries are persisted atomically with aggregate changes, in the **same database as the aggregate** (every relational physical source has its own `OutboxMessages` table). `OutboxProcessor` (background service) drains the outbox of every relational source the host uses — a host never races for another service's outbox rows. Wakes on signal (new entries written) or a **smart wait**: when a cycle sees pending-but-not-yet-eligible rows it sleeps only until the earliest becomes eligible (messages are eligible `Outbox:ProcessingDelaySeconds` after creation, default 5s), otherwise it sleeps the full fallback interval (`Outbox:PollingIntervalSeconds`, default 2s — deployed environments set it high, e.g. 300s, to cut idle polling without adding latency). Processes in batches of 50, retries up to 5 times; a full batch that made progress re-polls immediately. Failed-message retries pace at the polling interval. Integration events published via `IEventBus` target the source named by `Outbox:DataSource` + `Outbox:DatabaseName` (default: SQL Server / Default). Provides at-least-once delivery guarantee with OpenTelemetry metrics for dead-letter tracking. The poll query runs inside an `OutboxPoll` activity that `OutboxPollFilterProcessor` (Aspire package) suppresses from telemetry export.
 
 ### Microservices Extraction Seams
 
@@ -183,7 +184,7 @@ The framework is designed so a module can be lifted out of the monolith into its
 
 ### Aspire Package
 
-`AddServiceDefaults()` configures OpenTelemetry (logging, metrics, tracing), service discovery, and Polly resilience handlers (30s attempt timeout, 60s circuit breaker window, 90s total timeout). `MapDefaultEndpoints()` adds `/health` (readiness) and `/alive` (liveness) endpoints.
+`AddServiceDefaults()` configures OpenTelemetry (logging, metrics, tracing), service discovery, and Polly resilience handlers (30s attempt timeout, 60s circuit breaker window, 90s total timeout). `MapDefaultEndpoints()` adds `/health` (readiness) and `/alive` (liveness) endpoints. The tracing pipeline registers `OutboxPollFilterProcessor`, which drops recurring outbox poll spans (and their SqlClient children from the Azure Monitor distro) from export so idle polling does not dominate telemetry ingestion cost.
 
 ### Testing Package
 

--- a/MMCA.Common.slnx
+++ b/MMCA.Common.slnx
@@ -34,6 +34,9 @@
     <Project Path="Tests/Presentation/MMCA.Common.Grpc.Tests/MMCA.Common.Grpc.Tests.csproj" />
     <Project Path="Tests/Presentation/MMCA.Common.UI.Tests/MMCA.Common.UI.Tests.csproj" />
   </Folder>
+  <Folder Name="/Tests/Hosting/">
+    <Project Path="Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj" />
+  </Folder>
   <Folder Name="/Tests/Architecture/">
     <Project Path="Tests/Architecture/MMCA.Common.Architecture.Tests/MMCA.Common.Architecture.Tests.csproj" />
   </Folder>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxCycleResult.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxCycleResult.cs
@@ -1,0 +1,19 @@
+namespace MMCA.Common.Infrastructure.Persistence.Outbox;
+
+/// <summary>
+/// Outcome of one outbox polling cycle, used by <see cref="OutboxProcessor"/> to decide
+/// how long to wait before the next cycle.
+/// </summary>
+/// <param name="HasMoreEligibleWork">
+/// Whether a full batch of eligible messages was fetched and at least one made progress
+/// (dispatched or dead-lettered) — more eligible rows may be waiting, so the processor
+/// re-polls immediately. The progress requirement prevents hot-spinning when an entire
+/// batch fails dispatch and stays eligible.
+/// </param>
+/// <param name="EarliestPendingOccurredOn">
+/// The <see cref="OutboxMessage.OccurredOn"/> of the oldest message that is not yet eligible
+/// (younger than the processing delay), or <see langword="null"/> when none are pending.
+/// The processor smart-waits until this message becomes eligible instead of sleeping the
+/// full polling interval.
+/// </param>
+internal readonly record struct OutboxCycleResult(bool HasMoreEligibleWork, DateTime? EarliestPendingOccurredOn);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -44,6 +44,17 @@ public sealed partial class OutboxProcessor(
 {
     private readonly OutboxSettings _settings = outboxOptions.Value;
 
+    /// <summary>
+    /// Name of the per-cycle poll activity wrapping the outbox fetch query. Must stay in sync
+    /// with <c>OutboxPollFilterProcessor</c> in MMCA.Common.Aspire, which suppresses these spans
+    /// and their SqlClient children from telemetry export (Aspire has no project references, so
+    /// the string is deliberately duplicated there).
+    /// </summary>
+    internal const string PollActivityName = "OutboxPoll";
+
+    /// <summary>Floor for the computed wait so an overdue pending message cannot hot-loop the processor.</summary>
+    private static readonly TimeSpan MinimumWait = TimeSpan.FromSeconds(1);
+
     private static readonly ActivitySource OutboxActivitySource = new("MMCA.Common.Outbox");
     private static readonly Meter OutboxMeter = new("MMCA.Common.Outbox");
     private static readonly Counter<long> DeadLetterCounter = OutboxMeter.CreateCounter<long>(
@@ -65,9 +76,10 @@ public sealed partial class OutboxProcessor(
 
         while (!stoppingToken.IsCancellationRequested)
         {
+            OutboxCycleResult cycle = default;
             try
             {
-                await ProcessPendingMessagesAsync(stoppingToken).ConfigureAwait(false);
+                cycle = await ProcessPendingMessagesAsync(stoppingToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -79,9 +91,49 @@ public sealed partial class OutboxProcessor(
                 LogProcessingError(logger, ex);
             }
 
-            // Wait for a signal (new outbox entries written) or fall back to polling interval.
-            await outboxSignal.WaitAsync(TimeSpan.FromSeconds(_settings.PollingIntervalSeconds), stoppingToken).ConfigureAwait(false);
+            if (cycle.HasMoreEligibleWork)
+            {
+                // A full batch was drained with progress — more eligible rows may be waiting.
+                continue;
+            }
+
+            // Wait for a signal (new outbox entries written), the moment the earliest pending
+            // message becomes eligible (smart wait), or the fallback polling interval —
+            // whichever comes first.
+            var wait = ComputeWaitTime(
+                cycle.EarliestPendingOccurredOn,
+                DateTime.UtcNow,
+                TimeSpan.FromSeconds(_settings.ProcessingDelaySeconds),
+                TimeSpan.FromSeconds(_settings.PollingIntervalSeconds));
+            await outboxSignal.WaitAsync(wait, stoppingToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Computes how long to wait before the next polling cycle: until the earliest pending
+    /// message becomes eligible (<paramref name="earliestPendingOccurredOn"/> plus the
+    /// processing delay), capped at the polling interval and floored at one second to avoid
+    /// hot-looping. Failed-but-already-eligible messages never shorten the wait — they retry
+    /// on the next signal or interval, which throttles permanently failing messages.
+    /// </summary>
+    internal static TimeSpan ComputeWaitTime(
+        DateTime? earliestPendingOccurredOn,
+        DateTime utcNow,
+        TimeSpan processingDelay,
+        TimeSpan pollingInterval)
+    {
+        if (earliestPendingOccurredOn is null)
+        {
+            return pollingInterval;
+        }
+
+        var untilEligible = earliestPendingOccurredOn.Value + processingDelay - utcNow;
+        if (untilEligible < MinimumWait)
+        {
+            untilEligible = MinimumWait;
+        }
+
+        return untilEligible < pollingInterval ? untilEligible : pollingInterval;
     }
 
     /// <summary>
@@ -102,13 +154,27 @@ public sealed partial class OutboxProcessor(
         return [.. sources.Distinct()];
     }
 
-    private async Task ProcessPendingMessagesAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// Drains every outbox source once and aggregates the per-source results: any source with
+    /// more eligible work triggers an immediate re-poll, and the earliest pending timestamp
+    /// across all sources drives the smart wait.
+    /// </summary>
+    internal async Task<OutboxCycleResult> ProcessPendingMessagesAsync(CancellationToken cancellationToken)
     {
+        var hasMoreEligibleWork = false;
+        DateTime? earliestPendingOccurredOn = null;
+
         foreach (var source in GetOutboxSources())
         {
             try
             {
-                await ProcessSourceAsync(source, cancellationToken).ConfigureAwait(false);
+                var result = await ProcessSourceAsync(source, cancellationToken).ConfigureAwait(false);
+                hasMoreEligibleWork |= result.HasMoreEligibleWork;
+                if (result.EarliestPendingOccurredOn is { } pending
+                    && (earliestPendingOccurredOn is null || pending < earliestPendingOccurredOn))
+                {
+                    earliestPendingOccurredOn = pending;
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -117,12 +183,16 @@ public sealed partial class OutboxProcessor(
             catch (Exception ex)
             {
                 // One unreachable database must not starve the other sources' outboxes.
+                // A failing source contributes nothing to the wait — its rows are retried
+                // on the next signal or polling interval.
                 LogSourceProcessingError(logger, source.ToString(), ex);
             }
         }
+
+        return new OutboxCycleResult(hasMoreEligibleWork, earliestPendingOccurredOn);
     }
 
-    private async Task ProcessSourceAsync(DataSourceKey source, CancellationToken cancellationToken)
+    private async Task<OutboxCycleResult> ProcessSourceAsync(DataSourceKey source, CancellationToken cancellationToken)
     {
         var sourceName = source.ToString();
         using var scope = scopeFactory.CreateScope();
@@ -133,20 +203,71 @@ public sealed partial class OutboxProcessor(
 
         var cutoff = DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(_settings.ProcessingDelaySeconds));
 
-        var messages = await context.Set<OutboxMessage>()
-            .Where(m => m.ProcessedOn == null && m.OccurredOn < cutoff && m.RetryCount < _settings.MaxRetries)
-            .OrderBy(m => m.OccurredOn)
-            .Take(_settings.BatchSize)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        if (messages.Count == 0)
+        // The fetch query runs inside its own activity (explicit using block, not using var)
+        // so OutboxPollFilterProcessor in MMCA.Common.Aspire can suppress it and its SqlClient
+        // child span from export — an idle fleet polling around the clock would otherwise
+        // dominate telemetry ingestion. Everything after the block (per-message dispatch,
+        // the final SaveChangesAsync) stays outside the wrapper and is exported normally.
+        List<OutboxMessage> messages;
+        using (var pollActivity = OutboxActivitySource.StartActivity(PollActivityName))
         {
-            return;
+            pollActivity?.SetTag("messaging.outbox.data_source", sourceName);
+
+            // No OccurredOn cutoff in SQL: rows younger than the processing delay are fetched
+            // too, so the caller can smart-wait until the earliest becomes eligible. Ordering
+            // by OccurredOn guarantees eligible rows sort before pending ones, so a full batch
+            // can never starve eligible work behind pending rows.
+            messages = await context.Set<OutboxMessage>()
+                .Where(m => m.ProcessedOn == null && m.RetryCount < _settings.MaxRetries)
+                .OrderBy(m => m.OccurredOn)
+                .Take(_settings.BatchSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        LogProcessingBatch(logger, messages.Count, sourceName);
+        // Split the ordered batch: the eligible prefix is processed now; the pending remainder
+        // only informs how long to wait before the next cycle.
+        var eligibleCount = 0;
+        while (eligibleCount < messages.Count && messages[eligibleCount].OccurredOn < cutoff)
+        {
+            eligibleCount++;
+        }
 
+        DateTime? earliestPending = eligibleCount < messages.Count ? messages[eligibleCount].OccurredOn : null;
+
+        if (eligibleCount == 0)
+        {
+            return new OutboxCycleResult(HasMoreEligibleWork: false, earliestPending);
+        }
+
+        LogProcessingBatch(logger, eligibleCount, sourceName);
+
+        var processedAny = await DispatchMessagesAsync(
+            messages.Take(eligibleCount), source, dispatcher, messageBus, cancellationToken).ConfigureAwait(false);
+
+        // Use the base DbContext.SaveChangesAsync to bypass audit stamping and event dispatch.
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // A full eligible batch with progress means more eligible rows may be waiting; the
+        // progress requirement stops a fully-failing batch from hot-spinning the processor.
+        return new OutboxCycleResult(
+            HasMoreEligibleWork: eligibleCount == _settings.BatchSize && processedAny,
+            earliestPending);
+    }
+
+    /// <summary>
+    /// Dispatches each eligible message, marking successes and dead-letters as processed and
+    /// incrementing retry counts on failure. Returns whether any message made progress
+    /// (dispatched or dead-lettered) this cycle.
+    /// </summary>
+    private async Task<bool> DispatchMessagesAsync(
+        IEnumerable<OutboxMessage> messages,
+        DataSourceKey source,
+        IDomainEventDispatcher dispatcher,
+        IMessageBus messageBus,
+        CancellationToken cancellationToken)
+    {
+        var processedAny = false;
         foreach (var message in messages)
         {
             using var activity = StartOutboxActivity(message, source);
@@ -157,6 +278,7 @@ public sealed partial class OutboxProcessor(
                 {
                     message.LastError = $"Cannot resolve type: {message.EventType}";
                     message.ProcessedOn = DateTime.UtcNow;
+                    processedAny = true;
                     DeadLetterCounter.Add(1, new KeyValuePair<string, object?>("event_type", message.EventType));
                     LogDeadLetter(logger, message.Id, message.EventType);
                     continue;
@@ -175,6 +297,7 @@ public sealed partial class OutboxProcessor(
                 }
 
                 message.ProcessedOn = DateTime.UtcNow;
+                processedAny = true;
                 LogMessageProcessed(logger, message.Id, message.EventType);
             }
             catch (Exception ex)
@@ -186,8 +309,7 @@ public sealed partial class OutboxProcessor(
             }
         }
 
-        // Use the base DbContext.SaveChangesAsync to bypass audit stamping and event dispatch.
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return processedAny;
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
@@ -22,14 +22,22 @@ public sealed class OutboxSettings
 
     /// <summary>
     /// Gets the fallback polling interval in seconds. With signal-based wakeup, this acts as
-    /// a safety net — the outbox processor normally wakes immediately on new entries.
+    /// a safety net — the outbox processor normally wakes immediately on new entries, and when
+    /// it sees pending-but-not-yet-eligible messages it smart-waits only until the earliest one
+    /// becomes eligible. Deployed environments can therefore set this high (e.g. 300) to cut
+    /// idle polling without adding latency for real messages.
     /// </summary>
-    [Range(1, 300)]
+    [Range(1, 3600)]
     public int PollingIntervalSeconds { get; init; } = 2;
 
-    /// <summary>Gets the delay in seconds after message creation before it becomes eligible for processing.</summary>
+    /// <summary>
+    /// Gets the delay in seconds after message creation before it becomes eligible for processing.
+    /// This bounds the duplicate-dispatch window: the in-process pipeline (save → dispatch → mark
+    /// processed) must complete within this delay or the processor may re-dispatch the event.
+    /// Handlers are required to be idempotent regardless (at-least-once delivery).
+    /// </summary>
     [Range(0, 600)]
-    public int ProcessingDelaySeconds { get; init; } = 30;
+    public int ProcessingDelaySeconds { get; init; } = 5;
 
     /// <summary>
     /// Gets the engine of the data source where integration events published via

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -144,7 +144,14 @@ public static class Extensions
                 tracing.AddSource(builder.Environment.ApplicationName)
                     .AddSource("MMCA.Common.Outbox")
                     .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation());
+                    .AddHttpClientInstrumentation()
+
+                    // Drops recurring outbox poll spans (and their SqlClient children from the
+                    // Azure Monitor distro) from export — idle polling would otherwise dominate
+                    // telemetry ingestion cost. Must be registered here, before
+                    // AddOpenTelemetryExporters() below, so its OnEnd clears the Recorded flag
+                    // before the exporters' batch processors check it.
+                    .AddProcessor(new Telemetry.OutboxPollFilterProcessor()));
 
         builder.AddOpenTelemetryExporters();
 

--- a/Source/Hosting/MMCA.Common.Aspire/Telemetry/OutboxPollFilterProcessor.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Telemetry/OutboxPollFilterProcessor.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace MMCA.Common.Aspire.Telemetry;
+
+/// <summary>
+/// Suppresses outbox poll spans — and their children, such as the SqlClient dependency span
+/// created by the Azure Monitor distro's automatic instrumentation — from telemetry export.
+/// The <c>OutboxProcessor</c> polls every relational outbox table on a recurring cycle; in a
+/// deployed environment those idle polls would otherwise dominate Application Insights /
+/// Log Analytics ingestion (and spam the local Aspire dashboard). Real outbox work is
+/// unaffected: per-message <c>OutboxProcess</c> spans use explicit parent contexts restored
+/// from the stored trace ids and are never descendants of the poll span.
+/// </summary>
+public sealed class OutboxPollFilterProcessor : BaseProcessor<Activity>
+{
+    // Both names must stay in sync with OutboxProcessor in MMCA.Common.Infrastructure
+    // (OutboxActivitySource / PollActivityName). Duplicated deliberately: the Aspire package
+    // has no project references by design.
+    private const string OutboxActivitySourceName = "MMCA.Common.Outbox";
+    private const string PollActivityName = "OutboxPoll";
+
+    /// <inheritdoc />
+    public override void OnEnd(Activity data)
+    {
+        if (data is null)
+        {
+            // Never throw from a telemetry callback.
+            return;
+        }
+
+        // Walk the in-process parent chain: matching on both source and operation name avoids
+        // suppressing an unrelated consumer span that happens to be called "OutboxPoll".
+        for (var current = data; current is not null; current = current.Parent)
+        {
+            if (current.OperationName == PollActivityName
+                && current.Source.Name == OutboxActivitySourceName)
+            {
+                // Clearing Recorded makes the batch export processors (Azure Monitor, OTLP)
+                // skip this activity. This processor is registered before the exporters, so
+                // its OnEnd runs first.
+                data.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                return;
+            }
+        }
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
@@ -31,6 +31,9 @@ public sealed class OutboxProcessorTests : IDisposable
     private readonly OutboxTestDbContext _dbContext;
     private readonly Mock<IDomainEventDispatcher> _dispatcherMock;
     private readonly Mock<IMessageBus> _messageBusMock;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IEntityDataSourceRegistry _registry;
+    private readonly IDataSourceResolver _resolver;
     private readonly OutboxProcessor _sut;
 
     public OutboxProcessorTests()
@@ -78,24 +81,33 @@ public sealed class OutboxProcessorTests : IDisposable
         services.AddSingleton(_messageBusMock.Object);
         ServiceProvider rootProvider = services.BuildServiceProvider();
 
-        var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
-        var processorOutboxSignal = new Mock<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>();
+        _scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
 
         var registryMock = new Mock<IEntityDataSourceRegistry>();
         registryMock.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+        _registry = registryMock.Object;
+
         var resolverMock = new Mock<IDataSourceResolver>();
         resolverMock
             .Setup(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
             .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
+        _resolver = resolverMock.Object;
 
-        _sut = new OutboxProcessor(
-            scopeFactory,
-            NullLogger<OutboxProcessor>.Instance,
-            Options.Create(new OutboxSettings()),
-            processorOutboxSignal.Object,
-            registryMock.Object,
-            resolverMock.Object);
+        _sut = CreateProcessor(new OutboxSettings());
     }
+
+    /// <summary>
+    /// Builds a processor over the shared SQLite fixture with the given settings — lets
+    /// individual tests vary <see cref="OutboxSettings.BatchSize"/> etc.
+    /// </summary>
+    private OutboxProcessor CreateProcessor(OutboxSettings settings) =>
+        new(
+            _scopeFactory,
+            NullLogger<OutboxProcessor>.Instance,
+            Options.Create(settings),
+            Mock.Of<MMCA.Common.Infrastructure.Persistence.Outbox.IOutboxSignal>(),
+            _registry,
+            _resolver);
 
     public void Dispose()
     {
@@ -107,19 +119,12 @@ public sealed class OutboxProcessorTests : IDisposable
     // ── Helpers ──
 
     /// <summary>
-    /// Invokes the private <c>ProcessPendingMessagesAsync</c> method via reflection to avoid
-    /// the 5-second startup delay and infinite loop of <c>ExecuteAsync</c>.
+    /// Invokes the internal <c>ProcessPendingMessagesAsync</c> method directly to avoid the
+    /// 5-second startup delay and infinite loop of <c>ExecuteAsync</c>, returning the cycle
+    /// result so tests can assert on the smart-wait inputs.
     /// </summary>
-    private async Task InvokeProcessPendingMessagesAsync()
-    {
-        MethodInfo? method = typeof(OutboxProcessor)
-            .GetMethod("ProcessPendingMessagesAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-
-        method.Should().NotBeNull("OutboxProcessor must have a private ProcessPendingMessagesAsync method");
-
-        var task = (Task)method!.Invoke(_sut, [CancellationToken.None])!;
-        await task.ConfigureAwait(false);
-    }
+    private Task<OutboxCycleResult> InvokeProcessPendingMessagesAsync() =>
+        _sut.ProcessPendingMessagesAsync(CancellationToken.None);
 
     /// <summary>
     /// Creates an outbox message eligible for processing (old enough, unprocessed, zero retries).
@@ -163,7 +168,7 @@ public sealed class OutboxProcessorTests : IDisposable
     [Fact]
     public async Task SkipsRecentMessages_DoesNotProcessMessagesWithinDelay()
     {
-        // Arrange: OccurredOn is now, within the 30-second processing delay window
+        // Arrange: OccurredOn is now, within the 5-second processing delay window
         OutboxMessage message = CreateEligibleMessage(occurredOn: DateTime.UtcNow);
         _dbContext.Set<OutboxMessage>().Add(message);
         await _dbContext.SaveChangesAsync();
@@ -295,6 +300,93 @@ public sealed class OutboxProcessorTests : IDisposable
         succeeded.ProcessedOn.Should().NotBeNull();
         succeeded.RetryCount.Should().Be(0);
         succeeded.LastError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PendingOnlyMessages_ReturnsEarliestPending_AndProcessesNothing()
+    {
+        // Arrange: both messages are younger than the 5s processing delay — not yet eligible.
+        OutboxMessage older = CreateEligibleMessage(occurredOn: DateTime.UtcNow.AddSeconds(-2));
+        OutboxMessage newer = CreateEligibleMessage(occurredOn: DateTime.UtcNow.AddSeconds(-1));
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(older, newer);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        OutboxCycleResult result = await InvokeProcessPendingMessagesAsync();
+
+        // Assert: nothing processed, the oldest pending timestamp drives the smart wait.
+        result.HasMoreEligibleWork.Should().BeFalse();
+        result.EarliestPendingOccurredOn.Should().NotBeNull();
+        result.EarliestPendingOccurredOn!.Value.Should().BeCloseTo(older.OccurredOn, TimeSpan.FromMilliseconds(1));
+
+        List<OutboxMessage> all = await _dbContext.Set<OutboxMessage>().ToListAsync();
+        all.Should().AllSatisfy(m => m.ProcessedOn.Should().BeNull());
+        _dispatcherMock.Verify(
+            d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task MixedEligibleAndPending_ProcessesOnlyEligible_ReturnsPendingTimestamp()
+    {
+        // Arrange: one eligible message (5 min old) and one pending (just written).
+        OutboxMessage eligible = CreateEligibleMessage();
+        OutboxMessage pending = CreateEligibleMessage(occurredOn: DateTime.UtcNow);
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(eligible, pending);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        OutboxCycleResult result = await InvokeProcessPendingMessagesAsync();
+
+        // Assert
+        result.HasMoreEligibleWork.Should().BeFalse("the eligible batch was not full");
+        result.EarliestPendingOccurredOn.Should().NotBeNull();
+        result.EarliestPendingOccurredOn!.Value.Should().BeCloseTo(pending.OccurredOn, TimeSpan.FromMilliseconds(1));
+
+        OutboxMessage processed = await _dbContext.Set<OutboxMessage>().SingleAsync(m => m.Id == eligible.Id);
+        processed.ProcessedOn.Should().NotBeNull();
+        OutboxMessage untouched = await _dbContext.Set<OutboxMessage>().SingleAsync(m => m.Id == pending.Id);
+        untouched.ProcessedOn.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FullEligibleBatch_WithProgress_ReportsMoreEligibleWork()
+    {
+        // Arrange: three eligible messages but a batch size of two — the first cycle drains a
+        // full batch successfully, so the processor should re-poll immediately.
+        using OutboxProcessor processor = CreateProcessor(new OutboxSettings { BatchSize = 2 });
+        var messages = Enumerable.Range(0, 3).Select(_ => CreateEligibleMessage()).ToArray();
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(messages);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        OutboxCycleResult result = await processor.ProcessPendingMessagesAsync(CancellationToken.None);
+
+        // Assert
+        result.HasMoreEligibleWork.Should().BeTrue("a full batch made progress, more rows may be waiting");
+    }
+
+    [Fact]
+    public async Task FullEligibleBatch_AllFailing_DoesNotReportMoreEligibleWork()
+    {
+        // Arrange: a full batch where every dispatch fails — without the progress guard the
+        // processor would hot-spin retrying the same rows back-to-back.
+        _dispatcherMock
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Dispatch failed"));
+
+        using OutboxProcessor processor = CreateProcessor(new OutboxSettings { BatchSize = 2 });
+        var messages = Enumerable.Range(0, 2).Select(_ => CreateEligibleMessage()).ToArray();
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(messages);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        OutboxCycleResult result = await processor.ProcessPendingMessagesAsync(CancellationToken.None);
+
+        // Assert: no progress → no immediate re-poll, and failed-but-eligible rows must not
+        // shorten the smart wait (they retry on the next signal or polling interval).
+        result.HasMoreEligibleWork.Should().BeFalse("a fully-failing batch must not hot-spin the processor");
+        result.EarliestPendingOccurredOn.Should().BeNull("failed eligible rows are not pending rows");
     }
 
     [Fact]

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorWaitTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorWaitTests.cs
@@ -1,0 +1,59 @@
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Unit tests for <see cref="OutboxProcessor.ComputeWaitTime"/> — the smart-wait computation
+/// deciding how long the processor sleeps between polling cycles.
+/// </summary>
+public sealed class OutboxProcessorWaitTests
+{
+    private static readonly DateTime Now = new(2026, 6, 7, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Delay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(300);
+
+    [Fact]
+    public void NoPendingMessages_WaitsFullPollingInterval()
+    {
+        var wait = OutboxProcessor.ComputeWaitTime(null, Now, Delay, Interval);
+
+        wait.Should().Be(Interval);
+    }
+
+    [Fact]
+    public void PendingMessage_WaitsUntilItBecomesEligible()
+    {
+        // Message occurred 2s ago, eligible after 5s → due in 3s.
+        var wait = OutboxProcessor.ComputeWaitTime(Now.AddSeconds(-2), Now, Delay, Interval);
+
+        wait.Should().Be(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public void OverduePendingMessage_FlooredAtOneSecond()
+    {
+        // Became eligible between the query and the wait computation — never hot-loop.
+        var wait = OutboxProcessor.ComputeWaitTime(Now.AddSeconds(-10), Now, Delay, Interval);
+
+        wait.Should().Be(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void WaitNeverExceedsPollingInterval()
+    {
+        // A long processing delay with a short interval: capped at the interval.
+        var wait = OutboxProcessor.ComputeWaitTime(Now, Now, TimeSpan.FromMinutes(10), TimeSpan.FromSeconds(5));
+
+        wait.Should().Be(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void FutureDatedMessage_CappedAtPollingInterval()
+    {
+        // Clock skew: a future OccurredOn must not extend the wait beyond the interval.
+        var wait = OutboxProcessor.ComputeWaitTime(Now.AddHours(1), Now, Delay, Interval);
+
+        wait.Should().Be(Interval);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Settings/SettingsTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Settings/SettingsTests.cs
@@ -196,8 +196,8 @@ public class OutboxSettingsTests
         new OutboxSettings().PollingIntervalSeconds.Should().Be(2);
 
     [Fact]
-    public void Default_ProcessingDelaySeconds_Is30() =>
-        new OutboxSettings().ProcessingDelaySeconds.Should().Be(30);
+    public void Default_ProcessingDelaySeconds_Is5() =>
+        new OutboxSettings().ProcessingDelaySeconds.Should().Be(5);
 
     [Fact]
     public void Default_DataSource_IsSQLServer() =>

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/GlobalUsings.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Source\Hosting\MMCA.Common.Aspire\MMCA.Common.Aspire.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/OutboxPollFilterProcessorTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/OutboxPollFilterProcessorTests.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using AwesomeAssertions;
+using MMCA.Common.Aspire.Telemetry;
+
+namespace MMCA.Common.Aspire.Tests.Telemetry;
+
+/// <summary>
+/// Unit tests for <see cref="OutboxPollFilterProcessor"/>: outbox poll spans and their
+/// descendants (e.g. the SqlClient dependency span) must be unrecorded so exporters skip
+/// them, while unrelated spans and real outbox work spans stay recorded.
+/// </summary>
+public sealed class OutboxPollFilterProcessorTests : IDisposable
+{
+    private readonly ActivitySource _outboxSource = new("MMCA.Common.Outbox");
+    private readonly ActivitySource _otherSource = new("Test.Other");
+    private readonly ActivityListener _listener;
+    private readonly OutboxPollFilterProcessor _sut = new();
+
+    public OutboxPollFilterProcessorTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+                string.Equals(source.Name, "MMCA.Common.Outbox", StringComparison.Ordinal)
+                || string.Equals(source.Name, "Test.Other", StringComparison.Ordinal),
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _outboxSource.Dispose();
+        _otherSource.Dispose();
+        _sut.Dispose();
+    }
+
+    private static bool IsRecorded(Activity activity) =>
+        activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded);
+
+    [Fact]
+    public void PollSpan_IsUnrecorded()
+    {
+        using var poll = _outboxSource.StartActivity("OutboxPoll");
+        poll.Should().NotBeNull();
+
+        _sut.OnEnd(poll!);
+
+        IsRecorded(poll!).Should().BeFalse("poll spans must be suppressed from export");
+    }
+
+    [Fact]
+    public void ChildOfPollSpan_IsUnrecorded()
+    {
+        // The child simulates the SqlClient dependency span the Azure Monitor distro creates
+        // for the poll query — different source, parented to the poll span via Activity.Current.
+        using var poll = _outboxSource.StartActivity("OutboxPoll");
+        using var sqlChild = _otherSource.StartActivity("SELECT OutboxMessages");
+        sqlChild.Should().NotBeNull();
+
+        _sut.OnEnd(sqlChild!);
+
+        IsRecorded(sqlChild!).Should().BeFalse("children of poll spans must be suppressed");
+    }
+
+    [Fact]
+    public void GrandchildOfPollSpan_IsUnrecorded()
+    {
+        using var poll = _outboxSource.StartActivity("OutboxPoll");
+        using var child = _otherSource.StartActivity("Intermediate");
+        using var grandchild = _otherSource.StartActivity("Leaf");
+        grandchild.Should().NotBeNull();
+
+        _sut.OnEnd(grandchild!);
+
+        IsRecorded(grandchild!).Should().BeFalse("the full parent chain is walked");
+    }
+
+    [Fact]
+    public void UnrelatedRootSpan_StaysRecorded()
+    {
+        using var unrelated = _otherSource.StartActivity("SomeRequest");
+        unrelated.Should().NotBeNull();
+
+        _sut.OnEnd(unrelated!);
+
+        IsRecorded(unrelated!).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SameNameFromDifferentSource_StaysRecorded()
+    {
+        // A consumer span that happens to be called "OutboxPoll" must not be suppressed.
+        using var lookalike = _otherSource.StartActivity("OutboxPoll");
+        lookalike.Should().NotBeNull();
+
+        _sut.OnEnd(lookalike!);
+
+        IsRecorded(lookalike!).Should().BeTrue("only the MMCA.Common.Outbox source is filtered");
+    }
+
+    [Fact]
+    public void OutboxProcessSpan_StaysRecorded()
+    {
+        // Real outbox work — the per-message processing span — must keep flowing to exporters.
+        using var process = _outboxSource.StartActivity("OutboxProcess");
+        process.Should().NotBeNull();
+
+        _sut.OnEnd(process!);
+
+        IsRecorded(process!).Should().BeTrue("real outbox work spans are not poll noise");
+    }
+
+    [Fact]
+    public void NullActivity_DoesNotThrow()
+    {
+        Action act = () => _sut.OnEnd(null!);
+
+        act.Should().NotThrow("telemetry callbacks must never throw");
+    }
+}


### PR DESCRIPTION
## Why

Reduce deployed-environment cost from outbox polling. Each service polls its outbox table every 2s around the clock; with the Azure Monitor distro auto-instrumenting SqlClient, that is ~173k dependency-telemetry records/day across the 4 ADC prod services from an idle app — pure Log Analytics ingestion cost.

## What

- **Smart wait in `OutboxProcessor`**: the poll query no longer filters by the eligibility cutoff in SQL. Pending-but-not-yet-eligible rows now tell the processor exactly how long to sleep (until the earliest becomes eligible), capped at `PollingIntervalSeconds`. A full eligible batch that made progress re-polls immediately; a fully-failing batch does not (progress guard prevents hot-spin). Failed-but-eligible retries pace at the polling interval, as before.
- **`OutboxSettings`**: `ProcessingDelaySeconds` default 30s → **5s** (it bounds the in-process duplicate-dispatch window; handlers are idempotent per ADR-003). `PollingIntervalSeconds` `[Range]` widened to 3600 so deployed environments can poll rarely (e.g. 300s) while signal + smart wait keep real-message latency at ~5s.
- **Poll telemetry suppression**: the poll query runs inside an `OutboxPoll` activity; new `OutboxPollFilterProcessor` (MMCA.Common.Aspire) clears the `Recorded` flag on poll spans and their descendants (e.g. the SqlClient dependency span) so exporters skip them. Real outbox work (`OutboxProcess` spans, logs, dead-letter metrics) is unaffected.
- New `Tests/Hosting/MMCA.Common.Aspire.Tests` project; outbox tests now call the internal cycle method directly and cover the smart-wait computation and progress guard.

## Behavior changes to be aware of

- Persistent failures dead-letter after ~`MaxRetries × PollingIntervalSeconds` instead of every-2s retries (healthier backoff).
- Crash-orphaned rows (no signal) wait up to the polling interval.

## Testing

- `dotnet test --solution MMCA.Common.slnx`: 1502 passed, 0 failed (includes 5 new smart-wait tests, 4 new cycle-result tests, 7 new filter-processor tests).

Follow-up: ADC PR bumps packages and sets `Outbox__PollingIntervalSeconds=300` in prod Bicep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)