### PR TITLE
chore: PR-based contribution governance (protect main, CODEOWNERS, PR template, canary)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for MMCA.Common.
+# https://docs.github.com/en/repositories/managing-your-repos-settings-and-features/customizing-your-repository/about-code-owners
+#
+# MMCA.Common is the shared framework: a change here breaks every consumer
+# (MMCA.ADC, MMCA.Store, MMCA.Helpdesk) on the next release, so review matters most here.
+#
+# Today the main ruleset requires 0 approving reviews (transitional), so this file only
+# auto-requests review from the owners below. When a second reviewer joins, ratchet the
+# ruleset to require 1 approval and CODEOWNERS review, and add per-area owners.
+
+# Default owner for everything in the repo.
+*                           @ivanball
+
+# Per-layer owners (uncomment / reassign as the team grows):
+# /Source/Core/             @ivanball
+# /Source/Presentation/     @ivanball
+# /Source/Hosting/          @ivanball
+# /ADRs/                    @ivanball
+# /.github/                 @ivanball

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+<!-- MMCA.Common pull request. Keep the summary short; the checklist is the important part. -->
+
+## Summary
+
+<!-- What changed and why. Link the ADR / scorecard category / issue if there is one. -->
+
+## Scope of change
+
+- [ ] No public API change (internal only)
+- [ ] Public API change (new/changed types, members, or signatures) - **breaking for consumers?** describe the impact below
+- [ ] New or changed cross-cutting pattern (an ADR is read/updated below)
+
+## Consumer impact (fill in if the public API changed)
+
+<!-- A change to a public type flows to MMCA.ADC / MMCA.Store / MMCA.Helpdesk only after a
+     release + lockstep sweep (ADR-016). If this is a breaking change, say what consumers
+     must change. The Helpdesk source-build canary job validates the framework against a real
+     consumer inside this PR. -->
+
+## Checklist
+
+- [ ] `dotnet build MMCA.Common.slnx -c Release` is clean (`TreatWarningsAsErrors` on, 5 analyzers at error).
+- [ ] `dotnet test --solution MMCA.Common.slnx -c Release` passes (domain + architecture run headless; SQL-dependent tests run in CI).
+- [ ] If a project reference or a type moved between packages, both layer gates were updated (the compile-time `LayerEnforcement.targets` guard and the NetArchTest fitness rules).
+- [ ] `FACTS.md` regenerated if this changes the version, package list, ADR range, or fitness counts: `dotnet run --project build/facts -- .` (CI gates on `--check` drift).
+- [ ] The relevant ADR in `ADRs/` was read, and updated/added if a pattern it describes changed.
+- [ ] `ArchitectureScorecard.md` / `RemediationBacklog.md` updated if this closes or moves a remediation item.
+- [ ] Commit messages follow Scoped Commits (`<scope>: <description>`; `§<m>:` for scorecard work, `ADR-NNN:` for ADR work). See CONTRIBUTING.md.
+- [ ] No secrets staged (`.pem`, `.env`, `credentials`, `local.props`).
+
+<!-- Releases are cut separately, after merge, via the /push-release flow (tag -> publish 15 packages -> sweep consumers). Do not bump versions in this PR. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,3 +250,48 @@ jobs:
           line=$(sed -n 's/.*Line coverage:[[:space:]]*\([0-9.]*\)%.*/\1/p' coverage-unit-report/Summary.txt | head -1)
           test -n "$line" || { echo "::error::could not parse unit line coverage"; exit 1; }
           awk -v l="$line" -v m="68.3" 'BEGIN{ if (l+0 < m+0) { printf("::error::Unit line coverage %.1f%% is below the %.1f%% floor\n", l, m); exit 1 } printf("Unit line coverage %.1f%% meets the %.1f%% floor\n", l, m) }'
+
+  # Cross-repo pre-merge canary: build a real consumer (MMCA.Helpdesk) against THIS PR's framework
+  # source, so a breaking public-API change fails here instead of surfacing only after a release +
+  # lockstep sweep. Helpdesk is the ideal canary: minimal single-module app, no database and no
+  # GitHub Packages token to build (it ships a committed local.props that swaps the MMCA.Common.*
+  # PackageReferences for ProjectReferences into ../MMCA.Common/Source via UseLocalMMCA). The two
+  # repos are checked out as siblings so Helpdesk's local.props path (..\MMCA.Common\Source)
+  # resolves to this PR's checkout. Advisory (continue-on-error) until it holds a green streak;
+  # then promote it to a required merge gate (add its context to the branch ruleset).
+  consumer-source-build:
+    name: Consumer source build (Helpdesk)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - name: Checkout MMCA.Common (this PR)
+        uses: actions/checkout@v5
+        with:
+          path: MMCA.Common
+          fetch-depth: 0 # MinVer needs full history
+
+      - name: Checkout MMCA.Helpdesk (consumer canary)
+        uses: actions/checkout@v5
+        with:
+          repository: ivanball/MMCA.Helpdesk
+          ref: main
+          path: MMCA.Helpdesk
+          fetch-depth: 0
+          # Public repo builds with the default token; if Helpdesk is private, set a
+          # CONSUMER_CANARY_PAT secret with contents:read on it.
+          token: ${{ secrets.CONSUMER_CANARY_PAT || github.token }}
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build Helpdesk against Common source (UseLocalMMCA)
+        working-directory: MMCA.Helpdesk
+        # Helpdesk's committed local.props already sets UseLocalMMCA=true and points at the sibling
+        # ../MMCA.Common/Source, so this compiles the reference app against the PR's framework source.
+        run: dotnet build MMCA.Helpdesk.slnx -c Release
+
+      - name: Test Helpdesk (domain + architecture, no DB)
+        working-directory: MMCA.Helpdesk
+        run: dotnet test --solution MMCA.Helpdesk.slnx -c Release --no-build --minimum-expected-tests 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,83 @@ dotnet test --solution MMCA.Common.slnx -c Release
   Read the relevant one in [ADRs/README.md](ADRs/README.md) before changing a pattern it
   describes; substantive pattern changes should update or add an ADR.
 
+## Pull request workflow
+
+`main` is protected. All changes land through a pull request; nobody pushes to `main` directly.
+
+1. Branch from an up-to-date `main` (e.g. `feature/<short-name>` or `fix/<short-name>`).
+2. Commit your work (Scoped Commits, above), push the branch, and open a PR against `main`.
+3. CI runs automatically. The required merge gates are:
+   - `build-and-test` (includes the FACTS drift gate, the vuln audit, and the tests)
+   - `Build MMCA.Common.UI.Maui (windows, 4 TFMs)`
+   - `UI a11y + render smoke (chromium)` and `UI a11y + render smoke (firefox)`
+   - `coverage` (the unit-tier line-coverage floor)
+   - `Consumer source build (Helpdesk)` - the cross-repo canary (see below)
+
+   `UI a11y + render smoke (webkit)` is advisory (not required). The automated Claude review
+   also comments on every PR.
+4. Merge once the required checks are green. The ruleset requires **0 approving reviews today**
+   (transitional, while the team is small); a maintainer may self-merge a green PR. This will
+   ratchet to 1 required approval once a second reviewer is available.
+
+If the **FACTS drift gate** goes red, regenerate and commit the file on your branch:
+`dotnet run --project build/facts -- .` then `git add FACTS.md`. Do not hand-edit the computed
+values.
+
+## Validating a cross-repo change
+
+MMCA.Common publishes its public API as versioned NuGet packages; consumers (MMCA.ADC,
+MMCA.Store, MMCA.Helpdesk) only pick up a change **after** a release + lockstep sweep. Two things
+let you catch a breaking change before it ships:
+
+- **The Helpdesk source-build canary** (CI) builds MMCA.Helpdesk against this branch's framework
+  *source* (`UseLocalMMCA`), so an API break in your PR fails the PR instead of the next release.
+- **Local source mode** lets you iterate a consumer against your Common branch with no token:
+  in a consumer repo, `cp local.props.template local.props` (it sets `UseLocalMMCA=true` and points
+  at `../MMCA.Common/Source/`). Rebuild Common in Debug first (`dotnet build <Common proj> -c Debug`)
+  before rebuilding the consumer, or the IDE binds a stale ref assembly and reports phantom `CS0103`.
+  A green local source-mode build is not proof CI package-mode is green; expect a CI round-trip.
+
+## Releases are separate
+
+Do **not** bump versions in a feature PR. A release is cut after merge by the maintainer via the
+`/push-release` flow: tag `vX.Y.Z` on the merged `main` (publishes all 15 packages in lockstep),
+then a follow-up FACTS-regen PR and one lockstep version-bump PR per consumer. See
+[VERSIONING.md](VERSIONING.md).
+
+## Branch protection (maintainer, run once)
+
+The ruleset lives in GitHub settings, not in the repo. To reproduce it with the CLI (a repo admin,
+once), require a PR with the checks above and 0 approvals:
+
+```bash
+gh api -X PUT repos/ivanball/MMCA.Common/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "build-and-test"},
+      {"context": "Build MMCA.Common.UI.Maui (windows, 4 TFMs)"},
+      {"context": "UI a11y + render smoke (chromium)"},
+      {"context": "UI a11y + render smoke (firefox)"},
+      {"context": "coverage"}
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {"required_approving_review_count": 0},
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+```
+
+Add `{"context": "Consumer source build (Helpdesk)"}` to the checks list once that canary job has a
+green streak and is promoted from advisory to required. Do not add a `v*` tag protection rule:
+release tags must keep triggering `release.yml`.
+
 ## License
 
 By contributing you agree that your contributions are licensed under the

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A .NET 10.0 framework for building modular monolith applications using DDD, Clea
 | `MMCA.Common.API` | Base controllers, middleware, idempotency, error-to-HTTP mapping, JWKS endpoint |
 | `MMCA.Common.Grpc` | gRPC server defaults, Result→RpcException mapping, JWT-forwarding client interceptor, typed gRPC clients |
 | `MMCA.Common.UI` | Blazor shared components, auth state, MudBlazor theme |
+| `MMCA.Common.UI.Web` | Blazor Web (Server + WASM) UI host helpers built on `MMCA.Common.UI` |
+| `MMCA.Common.UI.Maui` | .NET MAUI UI head (the one MAUI-TFM package; built/packed by dedicated windows jobs, outside `MMCA.Common.slnx`, ADR-042) |
 | `MMCA.Common.Aspire` | Service defaults, OpenTelemetry, health checks, Polly resilience |
 | `MMCA.Common.Aspire.Hosting` | Aspire AppHost extensions: RabbitMQ broker, JWKS service discovery, gRPC project wiring |
 | `MMCA.Common.Testing` | Integration test base, JWT generator, fixtures |


### PR DESCRIPTION
Prepares MMCA.Common for multi-developer, PR-based contributions into a protected `main`.

## What this adds
- **CODEOWNERS** + **PR template** (FACTS regen / ADR / consumer-impact checklist).
- **CONTRIBUTING.md**: the PR workflow, required-check list, cross-repo validation via `UseLocalMMCA` source mode, and the `gh api` command that reproduces the branch-protection ruleset.
- **ci.yml**: an advisory `Consumer source build (Helpdesk)` canary that builds MMCA.Helpdesk against this PR's framework source (no token; both repos public), so a breaking public-API change fails here instead of after a release + lockstep sweep. Promote it to a required check after a green streak.
- **README.md**: package table completed to 15 (adds `UI.Web`, `UI.Maui`; `FACTS.md` remains the authoritative count).

No source or public-API change; docs + CI only. Releases stay separate (`/push-release`).