### PR TITLE
docs: dedup CLAUDE.md shared conventions, link package list to FACTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MMCA.Common is a .NET 10.0 NuGet package framework for building modular monolith applications using DDD, Clean Architecture, and CQRS patterns. It publishes fifteen NuGet packages to GitHub Packages; it is not a runnable app itself. (`MMCA.Common.UI.Maui` is the one MAUI-TFM package: outside `MMCA.Common.slnx`, built/packed by dedicated windows jobs in `ci.yml`/`release.yml`, ADR-042.)
+MMCA.Common is a .NET 10.0 NuGet package framework for building modular monolith applications using DDD, Clean Architecture, and CQRS patterns. It publishes its NuGet packages to GitHub Packages (see `FACTS.md` for the authoritative package list and count); it is not a runnable app itself. (`MMCA.Common.UI.Maui` is the one MAUI-TFM package: outside `MMCA.Common.slnx`, built/packed by dedicated windows jobs in `ci.yml`/`release.yml`, ADR-042.)
 
 The framework also provides the seams for **extracting modules into standalone microservices** (gRPC transport, a transport-agnostic message bus, cross-service JWKS auth, and Aspire hosting extensions). See "Microservices Extraction Seams" below — much of the recent work targets this path.
 
@@ -85,7 +85,7 @@ Tests/                               # Mirrors Source/ structure
 
 `Tests/Presentation/MMCA.Common.UI.Gallery` (a backend-less Blazor host rendering the real Login/Register pages + a primitives showcase) and `MMCA.Common.UI.E2E.Tests` (Playwright axe/render-smoke) are **intentionally excluded from `MMCA.Common.slnx`** so `dotnet build`/`dotnet test --solution` stay fast. They reference MMCA.Common source projects directly (no GitHub Packages token needed) and only run in CI's `ui-e2e` job. Build/test them by csproj path.
 
-All fifteen `Source/` projects are packable (each has a `PackageId`); NuGet metadata is applied in bulk via `Directory.Build.props` to any project under `Source/`. Versions come from MinVer (a `MinVer` `PackageReference` is present in each packable project). `Source/Presentation/MMCA.Common.UI.Maui` is the exception to the slnx rule: it is packable but lives OUTSIDE `MMCA.Common.slnx` (its four MAUI TFMs cannot build on the ubuntu CI runner) and is built/packed by the `build-maui`/`publish-maui` windows jobs.
+Every `Source/` project is packable (each has a `PackageId`); NuGet metadata is applied in bulk via `Directory.Build.props` to any project under `Source/`. Versions come from MinVer (a `MinVer` `PackageReference` is present in each packable project). `Source/Presentation/MMCA.Common.UI.Maui` is the exception to the slnx rule: it is packable but lives OUTSIDE `MMCA.Common.slnx` (its four MAUI TFMs cannot build on the ubuntu CI runner) and is built/packed by the `build-maui`/`publish-maui` windows jobs.
 
 ## Architecture
 
@@ -218,17 +218,13 @@ This project uses C# extension types (`extension(T)` syntax) — requires `LangV
 
 ## Code Style
 
-The `.editorconfig` enforces strict rules at **error** severity with 5 analyzers (Meziantou, SonarAnalyzer, StyleCop, Roslynator, Microsoft.VisualStudio.Threading). Key conventions:
+The workspace `../CLAUDE.md` "Shared Conventions" covers the cross-cutting rules shared across all four repos (the 5 error-severity analyzers Meziantou/SonarAnalyzer/StyleCop/Roslynator/Microsoft.VisualStudio.Threading, file-scoped namespaces, braces always, `var`-only-when-apparent, `_camelCase` private fields, `TreatWarningsAsErrors`, Result pattern, soft-delete, audit fields, identifier aliases). Don't re-derive those here. The `.editorconfig` additionally enforces, at **error** severity:
 
-- File-scoped namespaces (error)
-- Braces always required (error)
-- `var` only when type is apparent; explicit types for built-ins and non-obvious types (error)
-- Private fields: `_camelCase`; constants/static readonly: `PascalCase`
-- Expression-bodied members preferred (error)
-- `readonly` fields required where possible (error)
-- All accessibility modifiers required (error)
-- No `this.` qualification (error)
-- `TreatWarningsAsErrors` is enabled globally
+- Expression-bodied members preferred
+- `readonly` fields required where possible
+- All accessibility modifiers required
+- No `this.` qualification
+- Constants / static readonly: `PascalCase`
 
 ## Testing
 
@@ -249,7 +245,7 @@ These docs live **in this repo** (committable, unlike the workspace-level `Docs/
 - `FACTS.md` — the **single source of truth** for framework-wide facts (version, the package list, ADR range, fitness-method/base counts). Link here / to `ADRs/README.md`; do not restate these numbers inline. **Generated from source and CI-gated** by `build/facts` (a dependency-free tool) — regenerate with `dotnet run --project build/facts -- .`; the `build-and-test` CI job runs it with `--check` and fails on drift, so don't hand-edit the computed values. (The workspace `Tools/invtool -- facts ./MMCA.Common` shares the same generator.)
 - `ArchitectureScorecard.md` — the **canonical, two-axis** architecture scorecard for this repo (per-category Maturity+Implementation + indices + evidence). This is the single source of truth for Common's scores (it replaced the former single-axis snapshot; the old workspace `ArchitectureEvaluation-MMCA.Common.md` is now a pointer). Category numbers (`#1`–`#34`) are referenced as `§NN` in commits.
 - `RemediationBacklog.md` — the dated, wave-by-wave remediation log derived from the scorecard; tracks what's done vs. remaining per category. The workspace `Docs/Architecture/ArchitectureRemediation.md` is a thin cross-repo `[C→A]` roll-up that links here (no status restated).
-- `VERSIONING.md`: SemVer + breaking-change policy; the fifteen packages release in lockstep, versions come from MinVer git tags (`vX.Y.Z`), consumers are swept in one pass (no phased rollout).
+- `VERSIONING.md`: SemVer + breaking-change policy; the packages release in lockstep, versions come from MinVer git tags (`vX.Y.Z`), consumers are swept in one pass (no phased rollout).
 - `CHANGELOG.md`, `SECURITY.md` — release notes (behavior changes called out) and the security model / consumer responsibilities.
 - `COST.md` — FinOps notes (rubric §31): the framework's cost-relevant defaults (telemetry-span filtering, outbox poll/retention tuning) and the right-sizing / attribution / surge-revert levers consumers set downstream.
 - `RESPONSIVE.md` covers responsive design & cross-browser support (rubric §22): the supported-device/breakpoint matrix (C# `BreakpointConstants` ↔ CSS media queries), the shared `.mmca-touch-target` 48px affordance, the `DataGridListPageBase` density option, and the Playwright browser matrix (chromium required; firefox/webkit advisory).


### PR DESCRIPTION
## What

Token-optimization pass on this repo's `CLAUDE.md` (part of a workspace-wide effort to cut always-loaded context):

- **Code Style block** now points at the workspace `../CLAUDE.md` "Shared Conventions" for the cross-cutting rules (analyzers, file-scoped namespaces, `var`-when-apparent, `_camelCase`, `TreatWarningsAsErrors`, Result/soft-delete/audit/identifier-aliases), keeping only the Common-specific stricter rules inline (expression-bodied, `readonly`, accessibility modifiers, no `this.`, `PascalCase` constants).
- **Package count** ("fifteen packages", "all fifteen `Source/` projects", "the fifteen packages release in lockstep") replaced with a pointer to `FACTS.md`, the authoritative source. Removes a drift risk (the count is owned by `FACTS.md`).

## Why

The four sub-project `CLAUDE.md` files repeated the same shared-conventions block; this repo consumes them from the workspace root. Docs only, no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)