### PR TITLE
§8: child-entity SetOriginalRowVersion overload (ADR-035 amendment)

### DIFF
--- a/ADRs/035-optimistic-concurrency.md
+++ b/ADRs/035-optimistic-concurrency.md
@@ -1,7 +1,7 @@
 # ADR-035: Optimistic Concurrency via RowVersion Round-Trip
 
 ## Status
-Accepted (2026-07-02).
+Accepted (2026-07-02). Amended 2026-07-16: a child-entity overload of `SetOriginalRowVersion` was added (see Decision).
 
 ## Context
 Every mutable aggregate in the framework is edited through a load-modify-save handler: the update use
@@ -41,6 +41,14 @@ update fails as a conflict.
   and no-ops when the value is null or empty. The update handler calls it right after loading the
   entity (before applying the request), so EF compares the client's token against the row's current
   token inside the UPDATE statement, atomically, with no read-then-check race.
+- **Child entities get the same protection through the `IRowVersioned` overload (2026-07-16
+  amendment).** The original method is typed to the repository's aggregate root (`TEntity`), so a
+  child edit (e.g. a `ProductVariant` under a `Product`) could not receive the token. A second
+  overload, `SetOriginalRowVersion(IRowVersioned childEntity, byte[]? rowVersion)`, accepts any
+  tracked auditable entity (`AuditableBaseEntity<TId>` implements the new
+  `MMCA.Common.Domain.Interfaces.IRowVersioned`), stamping the child's original token with the same
+  null-or-empty no-op contract. Update handlers that mutate children through the aggregate's
+  repository call it per child after loading.
 - **A conflict maps to `409 Conflict` at the edge.** `DbUpdateConcurrencyException` is a
   `DbUpdateException`, and `DbUpdateExceptionHandler` translates any `DbUpdateException` into a
   `409 Conflict` RFC 9457 ProblemDetails, with a generic detail message so the database schema is not

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
@@ -173,6 +173,18 @@ public interface IWriteRepository<TEntity, TIdentifierType>
     void SetOriginalRowVersion(TEntity entity, byte[]? rowVersion);
 
     /// <summary>
+    /// Applies a client-supplied optimistic-concurrency token to a tracked CHILD entity of this
+    /// aggregate (e.g. a <c>ProductVariant</c> under a <c>Product</c>), so a child-level edit gets
+    /// the same stale-token 409 protection as the aggregate root (ADR-035). The aggregate-typed
+    /// overload above cannot reach children because the repository's <c>TEntity</c> is the root;
+    /// this overload accepts any <see cref="Domain.Interfaces.IRowVersioned"/> entity instead.
+    /// No-op when <paramref name="rowVersion"/> is null or empty (legacy clients / first write).
+    /// </summary>
+    /// <param name="childEntity">The tracked child entity whose original concurrency token should be set.</param>
+    /// <param name="rowVersion">The client's last-observed <c>RowVersion</c>, or null to skip the check.</param>
+    void SetOriginalRowVersion(Domain.Interfaces.IRowVersioned childEntity, byte[]? rowVersion);
+
+    /// <summary>
     /// Executes a bulk delete directly in the database, bypassing change tracking.
     /// WARNING: Does NOT trigger domain events, audit stamps, or soft-delete behavior.
     /// Use only for maintenance scenarios where domain events are not needed.

--- a/Source/Core/MMCA.Common.Domain/Entities/AuditableBaseEntity.cs
+++ b/Source/Core/MMCA.Common.Domain/Entities/AuditableBaseEntity.cs
@@ -10,7 +10,7 @@ namespace MMCA.Common.Domain.Entities;
 /// <c>entry.Property(...).CurrentValue</c> reflection — the domain layer never sets them directly.
 /// </summary>
 /// <typeparam name="TIdentifierType">The entity's identifier type.</typeparam>
-public abstract class AuditableBaseEntity<TIdentifierType> : BaseEntity<TIdentifierType>, IAuditableEntity
+public abstract class AuditableBaseEntity<TIdentifierType> : BaseEntity<TIdentifierType>, IAuditableEntity, IRowVersioned
         where TIdentifierType : notnull
 {
     /// <summary>

--- a/Source/Core/MMCA.Common.Domain/Interfaces/IRowVersioned.cs
+++ b/Source/Core/MMCA.Common.Domain/Interfaces/IRowVersioned.cs
@@ -1,0 +1,17 @@
+namespace MMCA.Common.Domain.Interfaces;
+
+/// <summary>
+/// An entity carrying a database-managed optimistic-concurrency token. Implemented by
+/// <c>AuditableBaseEntity&lt;TIdentifierType&gt;</c>, so every auditable entity (aggregate roots AND
+/// their child entities) exposes its <c>RowVersion</c> through one shape. Exists so the repository's
+/// child-entity <c>SetOriginalRowVersion</c> overload can accept any tracked child (e.g. a
+/// <c>ProductVariant</c> under a <c>Product</c> aggregate) without a second generic parameter for
+/// the child's identifier type (ADR-035: the aggregate-typed overload cannot reach children).
+/// </summary>
+public interface IRowVersioned
+{
+    /// <summary>Gets the database-managed optimistic concurrency token (SQL Server rowversion).</summary>
+#pragma warning disable CA1819 // byte[] is EF Core's native rowversion shape (mirrors AuditableBaseEntity.RowVersion)
+    byte[] RowVersion { get; }
+#pragma warning restore CA1819
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Interfaces;
 
 namespace MMCA.Common.Infrastructure.Persistence.Repositories;
 
@@ -75,6 +76,18 @@ internal sealed class EFRepository<TEntity, TIdentifierType>(
             return;
 
         _context.Entry(entity)
+            .Property(nameof(AuditableBaseEntity<>.RowVersion))
+            .OriginalValue = rowVersion;
+    }
+
+    /// <inheritdoc />
+    public void SetOriginalRowVersion(IRowVersioned childEntity, byte[]? rowVersion)
+    {
+        ArgumentNullException.ThrowIfNull(childEntity);
+        if (rowVersion is not { Length: > 0 })
+            return;
+
+        _context.Entry((object)childEntity)
             .Property(nameof(AuditableBaseEntity<>.RowVersion))
             .OriginalValue = rowVersion;
     }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepositoryDecorator.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepositoryDecorator.cs
@@ -1,5 +1,6 @@
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Interfaces;
 
 namespace MMCA.Common.Infrastructure.Persistence.Repositories;
 
@@ -39,6 +40,10 @@ internal sealed class EFRepositoryDecorator<TEntity, TIdentifierType>(IRepositor
 
     public void SetOriginalRowVersion(TEntity entity, byte[]? rowVersion) =>
         _inner.SetOriginalRowVersion(entity, rowVersion);
+
+    /// <inheritdoc />
+    public void SetOriginalRowVersion(IRowVersioned childEntity, byte[]? rowVersion) =>
+        _inner.SetOriginalRowVersion(childEntity, rowVersion);
 
     public Task<int> ExecuteDeleteAsync(
         System.Linq.Expressions.Expression<Func<TEntity, bool>> where,

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFRepositoryIntegrationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFRepositoryIntegrationTests.cs
@@ -423,6 +423,39 @@ public sealed class EFRepositoryIntegrationTests : IDisposable
         found!.Name.Should().Be("Second");
     }
 
+    // ── SetOriginalRowVersion (child-entity overload, ADR-035) ──
+    // The aggregate-typed overload cannot reach child entities (the repository's TEntity is the
+    // root), so the IRowVersioned overload must set the token on any OTHER tracked entity type.
+    [Fact]
+    public async Task SetOriginalRowVersion_OnChildEntity_SetsTheTrackedOriginalToken()
+    {
+        var child = new TestChildEntity { Id = 10, Label = "variant" };
+        _context.Add(child);
+        await _context.SaveChangesAsync();
+        var clientToken = new byte[] { 1, 2, 3, 4 };
+
+        _sut.SetOriginalRowVersion(child, clientToken);
+
+        _context.Entry(child).Property(nameof(TestChildEntity.RowVersion)).OriginalValue
+            .Should().BeEquivalentTo(clientToken,
+                because: "the child overload must stamp the client's last-observed token as the tracked ORIGINAL value, so a mismatching database row raises DbUpdateConcurrencyException (409) on save");
+    }
+
+    [Fact]
+    public async Task SetOriginalRowVersion_OnChildEntity_NullOrEmptyToken_IsANoOp()
+    {
+        var child = new TestChildEntity { Id = 11, Label = "variant" };
+        _context.Add(child);
+        await _context.SaveChangesAsync();
+        var original = _context.Entry(child).Property(nameof(TestChildEntity.RowVersion)).OriginalValue;
+
+        _sut.SetOriginalRowVersion(child, null);
+        _sut.SetOriginalRowVersion(child, []);
+
+        _context.Entry(child).Property(nameof(TestChildEntity.RowVersion)).OriginalValue
+            .Should().BeSameAs(original, because: "legacy clients that send no token skip the concurrency check, matching the aggregate-typed overload's contract");
+    }
+
     // ── Test entity & context ──
     public sealed class TestEntity : AuditableAggregateRootEntity<int>
     {
@@ -432,16 +465,32 @@ public sealed class EFRepositoryIntegrationTests : IDisposable
             new() { Id = id, Name = name };
     }
 
+    /// <summary>A NON-aggregate child entity (a different CLR type than the repository's TEntity).</summary>
+    public sealed class TestChildEntity : AuditableBaseEntity<int>
+    {
+        public string Label { get; set; } = string.Empty;
+    }
+
     public sealed class TestDbContext(DbContextOptions options) : DbContext(options)
     {
         public DbSet<TestEntity> TestEntities => Set<TestEntity>();
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        public DbSet<TestChildEntity> TestChildEntities => Set<TestChildEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
             modelBuilder.Entity<TestEntity>(b =>
             {
                 b.HasKey(e => e.Id);
                 b.Property(e => e.Id).ValueGeneratedNever();
                 b.Property(e => e.Name);
             });
+            modelBuilder.Entity<TestChildEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.Property(e => e.Label);
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
Ships the [C to A] lever both consumer backlogs point at: child entities under an aggregate (Store's `ProductVariant` is the named case) could not receive the client's optimistic-concurrency token because `SetOriginalRowVersion` is typed to the repository's aggregate root.

- New `MMCA.Common.Domain.Interfaces.IRowVersioned` (implemented by `AuditableBaseEntity<TId>`, so every auditable entity exposes `RowVersion` through one shape).
- New `IWriteRepository.SetOriginalRowVersion(IRowVersioned childEntity, byte[]? rowVersion)` overload; `EFRepository` stamps the tracked child's ORIGINAL RowVersion, no-op on null/empty (same contract as the root overload); decorator forwards.
- ADR-035 amended (status line + Decision bullet).
- Two SQLite-backed integration tests pin the stamp and the no-op against a child CLR type distinct from the repository's TEntity.

## Verification
- Full MMCA.Common.slnx suite green (2229 tests incl. the 2 new).
- FACTS regenerated (no computed-fact drift).

Consumer wiring (Store ProductVariant edit handlers + the ADC equivalent) lands with the next release + pin sweep (Wave 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)