### PR TITLE
§20: Secondary brand tokens single-sourced + Store cart CSS moved out

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/Theme/BrandColors.cs
+++ b/Source/Presentation/MMCA.Common.UI/Theme/BrandColors.cs
@@ -17,4 +17,17 @@ public static class BrandColors
 
     /// <summary>Lightened primary, used for accents and dark-mode contrast.</summary>
     public const string PrimaryLight = "#42A5F5";
+
+    /// <summary>
+    /// Secondary brand teal (CSS: <c>--mmca-secondary</c>). Teal 700: <c>Color.Secondary</c> renders
+    /// muted helper text, and #00796B holds ~5.3:1 contrast on light surfaces (the Teal 600 #00897B
+    /// it replaced was ~4.0:1, under the WCAG 2.1 AA 4.5:1 floor).
+    /// </summary>
+    public const string Secondary = "#00796B";
+
+    /// <summary>Darkened secondary (CSS: <c>--mmca-secondary-dark</c>).</summary>
+    public const string SecondaryDark = "#00695C";
+
+    /// <summary>Lightened secondary, used for accents and dark-mode contrast.</summary>
+    public const string SecondaryLight = "#4DB6AC";
 }

--- a/Source/Presentation/MMCA.Common.UI/Theme/MMCATheme.cs
+++ b/Source/Presentation/MMCA.Common.UI/Theme/MMCATheme.cs
@@ -18,12 +18,10 @@ public static class MMCATheme
             Primary = BrandColors.Primary,
             PrimaryDarken = BrandColors.PrimaryDark,
             PrimaryLighten = BrandColors.PrimaryLight,
-            // Teal 700 (was Teal 600 #00897B). Color.Secondary is used for muted helper text
-            // (mud-secondary-text); on light surfaces #00897B is ~4.0:1, just under the WCAG 2.1 AA
-            // 4.5:1 floor for normal text. #00796B is ~5.3:1 and keeps the brand teal aesthetic.
-            Secondary = "#00796B",
-            SecondaryDarken = "#00695C",
-            SecondaryLighten = "#4DB6AC",
+            // Contrast rationale lives on BrandColors.Secondary (Teal 700, WCAG AA on light surfaces).
+            Secondary = BrandColors.Secondary,
+            SecondaryDarken = BrandColors.SecondaryDark,
+            SecondaryLighten = BrandColors.SecondaryLight,
             Tertiary = "#7B1FA2",
             Info = "#1976D2",
             Success = "#2E7D32",
@@ -58,7 +56,7 @@ public static class MMCATheme
             // white label is ~2.65:1 on #42A5F5 and fails the WCAG 2.1 AA 4.5:1 floor on every filled
             // primary button (caught by the gated dark-mode axe scan); dark text is ~6.6:1.
             PrimaryContrastText = "rgba(0,0,0,0.87)",
-            Secondary = "#4DB6AC",
+            Secondary = BrandColors.SecondaryLight,
             SecondaryDarken = "#00897B",
             SecondaryLighten = "#80CBC4",
             Tertiary = "#CE93D8",

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
@@ -12,6 +12,8 @@
        BrandColorTokenTests enforces that these stay in sync. */
     --mmca-primary: #1565C0;
     --mmca-primary-dark: #0D47A1;
+    --mmca-secondary: #00796B;
+    --mmca-secondary-dark: #00695C;
 
     /* Spacing scale */
     --mmca-space-xs: 0.25rem;
@@ -120,22 +122,6 @@ h1:focus {
 @media (max-width: 1023.98px) {
     .mud-snackbar-location-top-center {
         z-index: var(--mmca-z-snackbar-mobile, 10000) !important;
-    }
-}
-
-/* ── CartDrawer: responsive width tiers ──
-   Override the CSS variable so MudBlazor calculates both the open width
-   AND the closed-state offset (right: calc(-1 * var(--mud-drawer-width)))
-   from the same value. Overriding `width` directly would desync these. */
-@media (max-width: 599px) {
-    .cart-drawer {
-        --mud-drawer-width: 100vw !important;
-    }
-}
-
-@media (min-width: 1920px) {
-    .cart-drawer {
-        --mud-drawer-width: 440px !important;
     }
 }
 

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Theme/BrandColorTokenTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Theme/BrandColorTokenTests.cs
@@ -35,6 +35,8 @@ public sealed class BrandColorTokenTests
     [Theory]
     [InlineData("--mmca-primary", nameof(BrandColors.Primary))]
     [InlineData("--mmca-primary-dark", nameof(BrandColors.PrimaryDark))]
+    [InlineData("--mmca-secondary", nameof(BrandColors.Secondary))]
+    [InlineData("--mmca-secondary-dark", nameof(BrandColors.SecondaryDark))]
     public void CssBrandToken_MatchesBrandColorsConstant(string cssVariable, string brandConstantName)
     {
         var cssValue = ReadCssVariable(ReadAppCss(), cssVariable);
@@ -52,6 +54,17 @@ public sealed class BrandColorTokenTests
     {
         ToHex(MMCATheme.Instance.PaletteLight.Primary).Should().BeEquivalentTo(BrandColors.Primary);
         ToHex(MMCATheme.Instance.PaletteLight.PrimaryDarken).Should().BeEquivalentTo(BrandColors.PrimaryDark);
+    }
+
+    [Fact]
+    public void ThemeSecondary_IsSourcedFromBrandColors()
+    {
+        // The Secondary family previously hard-coded its hex in the palette (the drift the guard
+        // missed, rubric §20); both palettes must now source it from BrandColors.
+        ToHex(MMCATheme.Instance.PaletteLight.Secondary).Should().BeEquivalentTo(BrandColors.Secondary);
+        ToHex(MMCATheme.Instance.PaletteLight.SecondaryDarken).Should().BeEquivalentTo(BrandColors.SecondaryDark);
+        ToHex(MMCATheme.Instance.PaletteLight.SecondaryLighten).Should().BeEquivalentTo(BrandColors.SecondaryLight);
+        ToHex(MMCATheme.Instance.PaletteDark.Secondary).Should().BeEquivalentTo(BrandColors.SecondaryLight);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Closes the Common-side #20 residuals both consumer backlogs point at:

- **Secondary token drift guard**: the Secondary palette family was hard-coded in `MMCATheme` (`#00796B`/`#00695C`/`#4DB6AC`), invisible to `BrandColorTokenTests` (which guarded Primary only). `BrandColors` now owns the three values (unchanged hex; the WCAG contrast rationale moved onto the constant), both palettes source from it, `app.css` gains `--mmca-secondary`/`--mmca-secondary-dark`, and the guard covers the new tokens plus palette sourcing in both light and dark.
- **Store cart CSS out of the framework stylesheet**: the `.cart-drawer` responsive width tiers were Store-specific rules living in Common's `app.css`. Removed here; the identical rules land in Store's own CSS in the Wave 5 pin-sweep PR (Store only picks up this removal when it bumps, so there is no regression window).

Zero visual change: every hex value is identical; this is sourcing + guardrails.

## Verification
- Full `MMCA.Common.slnx` suite green (2230 tests, including the new Secondary guard rows/facts).
- FACTS regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)