### PR TITLE
docs: /update-adrs drift fixes (ADR-036, 041, 042, 045)

### DIFF
--- a/ADRs/036-external-oauth-login.md
+++ b/ADRs/036-external-oauth-login.md
@@ -1,7 +1,7 @@
 # ADR-036: External OAuth Login (Federated Google/GitHub) with Local-JWT Exchange
 
 ## Status
-Accepted (2026-07-02, migration attribution corrected 2026-07-06).
+Accepted (2026-07-02, migration attribution corrected 2026-07-06, native-callback redirect branch added 2026-07-17 per ADR-043).
 
 ## Context
 The framework's Identity story so far is entirely first-party: a user registers with an email and
@@ -44,8 +44,13 @@ a local `User`.
   `IAuthenticationService.ExternalLoginAsync`. On success it signs the external cookie out immediately,
   so the external principal lives no longer than the exchange.
 - **Tokens never ride the redirect URL.** `CompleteAsync` mints a single-use opaque code, stashes the
-  minted token pair server-side in the cache under a short TTL, and redirects to the UI carrying only
-  that code. The UI calls `ExchangeAsync` (`POST`) out of band to swap the code for the tokens; the
+  minted token pair server-side in the cache under a short TTL, and redirects carrying only that code.
+  The redirect target defaults to `OAuth:UIBaseUrl`, but when the stashed `returnUrl` is an absolute URI
+  whose custom scheme is allow-listed in `OAuth:AllowedReturnUrlSchemes` it targets that native-app URL
+  instead, so a system-browser `WebAuthenticator` window captures the code and closes (ADR-043); an
+  empty allowlist (the default) keeps the web-only behavior exactly, and http/https `returnUrl`s never
+  match, so the allowlist cannot become an open redirect. Completion errors follow the same branch. The
+  UI calls `ExchangeAsync` (`POST`) out of band to swap the code for the tokens; the
   code is burned on first use, and a missing, replayed, or expired code yields HTTP 400. Access and
   refresh tokens therefore never land in the address bar, browser history, the `Referer` header, or
   upstream access logs.
@@ -131,4 +136,6 @@ ADR-004 (the RS256/JWKS token this flow exchanges the external identity *for*, a
 everywhere after), ADR-022 (the browser cookies that carry the resulting session), ADR-029 (the
 brute-force protection on the first-party credential surface this flow sits beside), ADR-032 (the
 password hashing external accounts deliberately skip), ADR-020 (the inert-until-configured opt-in
-posture this mirrors), ADR-005 (`User.Anonymize` clears the provider fields on erasure).
+posture this mirrors), ADR-005 (`User.Anonymize` clears the provider fields on erasure), ADR-043 (the
+native-app callback that adds the allow-listed custom-scheme redirect branch to this flow's
+`CompleteAsync`).

--- a/ADRs/041-observability-and-telemetry.md
+++ b/ADRs/041-observability-and-telemetry.md
@@ -26,7 +26,7 @@ for the CQRS and outbox paths, and expose cost knobs with fail-safe defaults.
 - **One shared telemetry baseline on every host.** `ConfigureOpenTelemetry`
   (`Source/Hosting/MMCA.Common.Aspire/Extensions.cs:136`) wires OpenTelemetry logging with formatted
   messages and scopes (`Extensions.cs:139`), metrics from ASP.NET Core, `HttpClient`, and the runtime
-  (`Extensions.cs:147`), and tracing from ASP.NET Core and `HttpClient` (`Extensions.cs:159`). It is
+  (`Extensions.cs:147`), and tracing from ASP.NET Core and `HttpClient` (`Extensions.cs:180`). It is
   called from `AddServiceDefaults` (`Extensions.cs:36`), so a host opts in once and every project in
   the Aspire model inherits the same pipeline.
 
@@ -40,14 +40,14 @@ for the CQRS and outbox paths, and expose cost knobs with fail-safe defaults.
   The `outcome` tag takes `completed`, `failed` (a `Result` failure), or `exception`
   (`LoggingCommandDecorator.cs:30`, `:38`, `:52`), so count gives rate, the tag gives errors, and the
   histogram gives duration. The Aspire host subscribes the meter by literal name
-  (`Extensions.cs:154`).
+  (`Extensions.cs:174`).
 
 - **An outbox dead-letter counter.** The outbox processor owns a meter `MMCA.Common.Outbox`
   (`Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs:59`) and a counter
   `outbox.dead_letter.count` (`OutboxProcessor.cs:60`), incremented with an `event_type` tag whenever
   a message is dead-lettered because its type cannot be resolved (`OutboxProcessor.cs:282`). The same
   source emits outbox spans (`OutboxProcessor.cs:58`); both the meter and the trace source are
-  registered by literal name in the Aspire defaults (`Extensions.cs:153`, `Extensions.cs:158`).
+  registered by literal name in the Aspire defaults (`Extensions.cs:173`, `Extensions.cs:179`).
 
 - **Correlation-ID middleware ties the request together.** `CorrelationIdMiddleware`
   (`Source/Presentation/MMCA.Common.API/Middleware/CorrelationIdMiddleware.cs:15`) uses the
@@ -60,16 +60,16 @@ for the CQRS and outbox paths, and expose cost knobs with fail-safe defaults.
   up for one request.
 
 - **Head-based sampling as a cost knob, off by default.** `Telemetry:TracesSampleRatio`
-  (`Extensions.cs:174`, parsed by `TryGetTraceSampleRatio` at `Extensions.cs:189`) is unset by
+  (`Extensions.cs:195`, parsed by `TryGetTraceSampleRatio` at `Extensions.cs:210`) is unset by
   default, so a host samples everything and behavior does not change. A deployed host sets a ratio in
   the open interval (0,1) to keep that fraction of traces; the value wraps a `TraceIdRatioBasedSampler`
-  in a `ParentBasedSampler` (`Extensions.cs:175`) so a sampled-in request keeps its whole trace across
+  in a `ParentBasedSampler` (`Extensions.cs:196`) so a sampled-in request keeps its whole trace across
   service boundaries. A key that is absent, unparseable, or outside (0,1) falls back to sample-all
-  (`Extensions.cs:193`), so a typo can never silently drop all telemetry.
+  (`Extensions.cs:214`), so a typo can never silently drop all telemetry.
 
 - **Outbox poll spans are filtered out of export.** `OutboxPollFilterProcessor`
   (`Source/Hosting/MMCA.Common.Aspire/Telemetry/OutboxPollFilterProcessor.cs:15`), registered before
-  the exporters (`Extensions.cs:167`), clears the `Recorded` flag on the recurring `OutboxPoll` span
+  the exporters (`Extensions.cs:188`), clears the `Recorded` flag on the recurring `OutboxPoll` span
   and its children (`OutboxPollFilterProcessor.cs:42`). The poll query runs inside that span
   (`OutboxProcessor.cs:212`, named at `OutboxProcessor.cs:53`), so steady-state polling does not flood
   Application Insights. Real outbox work is untouched: each per-message `OutboxProcess` span is started
@@ -77,10 +77,10 @@ for the CQRS and outbox paths, and expose cost knobs with fail-safe defaults.
   (`OutboxProcessor.cs:327`), so it is never a child of the poll span.
 
 - **Dual exporters, either or both.** `AddOpenTelemetryExporters` enables OTLP when
-  `OTEL_EXPORTER_OTLP_ENDPOINT` is present (`Extensions.cs:307`, the Aspire dashboard sets it) and
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is present (`Extensions.cs:339`, the Aspire dashboard sets it) and
   Azure Monitor via `UseAzureMonitor` when `APPLICATIONINSIGHTS_CONNECTION_STRING` is present
-  (`Extensions.cs:315`, set by the cloud deployment). Both can be active at once
-  (`Extensions.cs:302`), so local development ships to the Aspire dashboard and production ships to
+  (`Extensions.cs:347`, set by the cloud deployment). Both can be active at once
+  (`Extensions.cs:334`), so local development ships to the Aspire dashboard and production ships to
   workspace-based Application Insights with no code change.
 
 ## Rationale
@@ -103,7 +103,7 @@ for the CQRS and outbox paths, and expose cost knobs with fail-safe defaults.
 ## Trade-offs
 - **Custom instrumentation carries a maintenance cost.** The Aspire package has no reference to
   Application or Infrastructure by design, so the meter and activity-source names are duplicated as
-  literals (`Extensions.cs:151`, and the sync notes at `CqrsMetrics.cs:8` and
+  literals (`Extensions.cs:171`, and the sync notes at `CqrsMetrics.cs:8` and
   `OutboxPollFilterProcessor.cs:17`). A rename on one side silently stops export until the literal is
   updated. That is the price of the decoupled package graph.
 - **Sampling trades trace completeness for cost.** A sampled-out trace is simply gone; deep debugging

--- a/ADRs/042-device-capability-abstraction.md
+++ b/ADRs/042-device-capability-abstraction.md
@@ -1,7 +1,7 @@
 # ADR-042: Device Capability Abstraction (MAUI Blazor Hybrid)
 
 ## Status
-Accepted (2026-07-10).
+Accepted (2026-07-10, amended 2026-07-17).
 
 ## Context
 The consumer apps ship the same Blazor component set through three heads: MAUI Blazor Hybrid
@@ -93,6 +93,10 @@ Add a per-capability contract layer to `MMCA.Common.UI` and a fifteenth package,
   `UseMauiDeviceCapabilities()` silently loses haptics rather than failing fast). Accepted for
   decoration-grade capabilities; feature waves that depend on a capability assert `IsSupported` in
   their UI and surface the gap visibly.
-- Biometrics, speech-to-text, and the external-auth broker ship contracts (and web/null fallbacks)
-  before their native implementations, which land with their feature waves. Until then the MAUI
-  head resolves their null defaults.
+- Biometrics, speech-to-text, and the external-auth broker now ship native MAUI implementations,
+  all three registered by `AddMauiDeviceCapabilities()`
+  (`Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs:44`, `:45`, `:59`). The residual
+  trade-off is configuration, not code: `MauiExternalAuthBroker` registers unconditionally but
+  reports `IsAvailable == false` (`Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiExternalAuthBroker.cs:39`)
+  until the head supplies `OAuth:MobileRedirectScheme`, so a misconfigured head quietly keeps the web
+  anchor flow rather than failing fast.

--- a/ADRs/045-managed-file-storage-and-avatars.md
+++ b/ADRs/045-managed-file-storage-and-avatars.md
@@ -34,8 +34,9 @@ directly against the Azure SDK inside a module, unusable by the next consumer an
   degraded path.
 - **Avatar contract (BR-116a, applied per consumer)**: one avatar per user; accept jpeg/png/webp
   up to 2 MB; server re-encodes to 256x256 JPEG via `IImageProcessor` (client-declared content
-  types are advisory only); blob name `avatars/{userId}-{random8}.jpg` in a public-read
-  container; upload deletes the previous blob; the URL lives on the user entity as `[Pii]`,
+  types are advisory only); blob name `{userId}-{random8}.jpg` in the infrastructure-provisioned
+  public-read `avatars` container (so the URL path reads `avatars/{userId}-{random8}.jpg`);
+  upload deletes the previous blob; the URL lives on the user entity as `[Pii]`,
   nulled on anonymize with the blob deleted; exported in the GDPR data export.
 
 ## Consequences

--- a/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
@@ -18,9 +18,9 @@ public static class DependencyInjection
     {
         /// <summary>
         /// Registers the MAUI implementations for every capability the framework currently
-        /// backs natively. Contracts without a native implementation yet (biometrics,
-        /// speech-to-text, external-auth broker) keep their null defaults until their
-        /// feature wave lands.
+        /// backs natively, including biometrics, speech-to-text, and the external-auth
+        /// broker (the broker stays inert until the head configures
+        /// OAuth:MobileRedirectScheme; see the registration below).
         /// </summary>
         public IServiceCollection AddMauiDeviceCapabilities()
         {

--- a/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.117, )",
-        "resolved": "3.0.117",
-        "contentHash": "22L/6jjjhTwOpGqN+3A4EMCWc8Kc0dAd49zINAlxjLYDxERnD1qPKDkE9Z6cZPjiOs32J9nsieyya1FO+kXHCw=="
+        "requested": "[3.0.122, )",
+        "resolved": "3.0.122",
+        "contentHash": "bmo+TIK9fLG/NzlZ2Qi5lto2jG/N6/zmc7gDVp5uzvVmnDKMV5SmUR7jToSbx/oqTPMV3ajyCmo2kFBdPDlU0A=="
       },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
@@ -59,9 +59,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.27.0.140913, )",
-        "resolved": "10.27.0.140913",
-        "contentHash": "cxk12QjN9io1SjN36B1QO+9dRf+ek2CGfQGsOWtHBojE35cKchKJod48raxZwe47jHhzmAUO4AJSh7+hF0GS4g=="
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -1850,9 +1850,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.117, )",
-        "resolved": "3.0.117",
-        "contentHash": "22L/6jjjhTwOpGqN+3A4EMCWc8Kc0dAd49zINAlxjLYDxERnD1qPKDkE9Z6cZPjiOs32J9nsieyya1FO+kXHCw=="
+        "requested": "[3.0.122, )",
+        "resolved": "3.0.122",
+        "contentHash": "bmo+TIK9fLG/NzlZ2Qi5lto2jG/N6/zmc7gDVp5uzvVmnDKMV5SmUR7jToSbx/oqTPMV3ajyCmo2kFBdPDlU0A=="
       },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
@@ -1901,9 +1901,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.27.0.140913, )",
-        "resolved": "10.27.0.140913",
-        "contentHash": "cxk12QjN9io1SjN36B1QO+9dRf+ek2CGfQGsOWtHBojE35cKchKJod48raxZwe47jHhzmAUO4AJSh7+hF0GS4g=="
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -2629,9 +2629,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.117, )",
-        "resolved": "3.0.117",
-        "contentHash": "22L/6jjjhTwOpGqN+3A4EMCWc8Kc0dAd49zINAlxjLYDxERnD1qPKDkE9Z6cZPjiOs32J9nsieyya1FO+kXHCw=="
+        "requested": "[3.0.122, )",
+        "resolved": "3.0.122",
+        "contentHash": "bmo+TIK9fLG/NzlZ2Qi5lto2jG/N6/zmc7gDVp5uzvVmnDKMV5SmUR7jToSbx/oqTPMV3ajyCmo2kFBdPDlU0A=="
       },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
@@ -2680,9 +2680,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.27.0.140913, )",
-        "resolved": "10.27.0.140913",
-        "contentHash": "cxk12QjN9io1SjN36B1QO+9dRf+ek2CGfQGsOWtHBojE35cKchKJod48raxZwe47jHhzmAUO4AJSh7+hF0GS4g=="
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -3408,9 +3408,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.117, )",
-        "resolved": "3.0.117",
-        "contentHash": "22L/6jjjhTwOpGqN+3A4EMCWc8Kc0dAd49zINAlxjLYDxERnD1qPKDkE9Z6cZPjiOs32J9nsieyya1FO+kXHCw=="
+        "requested": "[3.0.122, )",
+        "resolved": "3.0.122",
+        "contentHash": "bmo+TIK9fLG/NzlZ2Qi5lto2jG/N6/zmc7gDVp5uzvVmnDKMV5SmUR7jToSbx/oqTPMV3ajyCmo2kFBdPDlU0A=="
       },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
@@ -3454,9 +3454,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.27.0.140913, )",
-        "resolved": "10.27.0.140913",
-        "contentHash": "cxk12QjN9io1SjN36B1QO+9dRf+ek2CGfQGsOWtHBojE35cKchKJod48raxZwe47jHhzmAUO4AJSh7+hF0GS4g=="
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
Full-sweep /update-adrs audit of all 48 ADRs (evidence-verifier per ADR + adversarial second pass): 44 up-to-date, 4 needed edits, 0 supersedes. No new ADRs minted (all four coverage-scout candidates were flagged borderline and declined), so the ADR range is unchanged and FACTS.md needs no regen.

## Verdicts applied

| ADR | Drift | Evidence |
|---|---|---|
| 036 External OAuth Login | CompleteAsync also redirects to allow-listed native-app schemes since ADR-043; ADR described only the OAuth:UIBaseUrl target and had no Related link to 043 | OAuthControllerBase.cs:90-91, 120-126, 233-247 |
| 041 Observability | 13 Extensions.cs line citations stale after the metrics cost-control block was inserted; citation-only refresh, no prose changes | MMCA.Common.Aspire/Extensions.cs |
| 042 Device Capability | Trade-offs still claimed biometrics/speech-to-text/external-auth broker awaited native implementations; they shipped in Wave 4 (b102c6c) and are registered by AddMauiDeviceCapabilities() | UI.Maui/DependencyInjection.cs:44-59 |
| 045 File Storage/Avatars | ADR conflated container name with blob name; blob name is {userId}-{random8}.jpg inside the avatars container | SetUserAvatarHandler.cs:60-61, main.bicep:576 |

Also included:
- UI.Maui AddMauiDeviceCapabilities() XML doc comment updated (same stale claim as ADR-042).
- Catch-up packages.lock.json regeneration for UI.Maui: PR #46 bumped Meziantou/Sonar centrally but the out-of-slnx project's lock was never regenerated.

ADRs/README.md untouched: no decision changed, only descriptions and citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvQTSNFCB5gyLgULEZFaqF