### PR TITLE
perf(outbox): purge dead-lettered messages so they leave the hot pending set

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxCleanupService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxCleanupService.cs
@@ -12,13 +12,16 @@ using MMCA.Common.Infrastructure.Settings;
 namespace MMCA.Common.Infrastructure.Persistence.Outbox;
 
 /// <summary>
-/// Background service that periodically purges <b>processed</b> <see cref="OutboxMessage"/> rows
-/// older than <see cref="OutboxSettings.RetentionDays"/> from every relational data source in use.
+/// Background service that periodically purges spent <see cref="OutboxMessage"/> rows older than
+/// <see cref="OutboxSettings.RetentionDays"/> from every relational data source in use: both
+/// <b>processed</b> rows and <b>dead-lettered</b> rows (retries exhausted, never delivered).
 /// <para>
-/// The <see cref="OutboxProcessor"/> only ever sets <c>ProcessedOn</c>; without this sweep the
-/// outbox table — which stores serialized event payloads that may contain personal data — grows
-/// without bound (ADR-003 / ADR-005). Set <see cref="OutboxSettings.RetentionDays"/> to <c>0</c>
-/// to disable purging.
+/// The <see cref="OutboxProcessor"/> only ever sets <c>ProcessedOn</c>; a message that exhausts
+/// <see cref="OutboxSettings.MaxRetries"/> keeps <c>ProcessedOn</c> null forever, so without this
+/// sweep the outbox table — which stores serialized event payloads that may contain personal data —
+/// grows without bound (ADR-003 / ADR-005), and dead rows also linger in the pending index where
+/// every poll re-scans them. Set <see cref="OutboxSettings.RetentionDays"/> to <c>0</c> to disable
+/// purging.
 /// </para>
 /// </summary>
 /// <param name="scopeFactory">Factory for creating a DI scope per sweep.</param>
@@ -96,6 +99,25 @@ public sealed partial class OutboxCleanupService(
                     LogPurged(logger, deleted, sourceName);
                 }
 
+                // Dead-lettered rows (retries exhausted) keep ProcessedOn null forever, so the
+                // OutboxProcessor's poll excludes them (RetryCount < MaxRetries) but the processed
+                // sweep above never reaches them: they accumulate without bound AND stay in the
+                // ProcessedOn-IS-NULL pending index, re-scanned by every poll cycle. Purge them on
+                // the same retention window, keyed on OccurredOn since they have no ProcessedOn.
+                // This permanently abandons an undelivered event after RetentionDays; the failure is
+                // already recorded on the row (LastError) and logged by the processor before then.
+                var deadLettered = await context.Set<OutboxMessage>()
+                    .Where(m => m.ProcessedOn == null
+                        && m.RetryCount >= _settings.MaxRetries
+                        && m.OccurredOn < cutoff)
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (deadLettered > 0)
+                {
+                    LogDeadLetterPurged(logger, deadLettered, sourceName);
+                }
+
                 if (_inboxEnabled)
                 {
                     await PurgeInboxAsync(context, cutoff, sourceName, cancellationToken).ConfigureAwait(false);
@@ -153,6 +175,9 @@ public sealed partial class OutboxCleanupService(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Purged {Count} processed outbox messages older than retention from {DataSourceName}")]
     private static partial void LogPurged(ILogger logger, int count, string dataSourceName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Purged {Count} dead-lettered (retries exhausted) outbox messages older than retention from {DataSourceName}")]
+    private static partial void LogDeadLetterPurged(ILogger logger, int count, string dataSourceName);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Purged {Count} processed inbox messages older than retention from {DataSourceName}")]
     private static partial void LogInboxPurged(ILogger logger, int count, string dataSourceName);

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxCleanupServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxCleanupServiceTests.cs
@@ -36,6 +36,7 @@ public sealed class OutboxCleanupServiceTests
     // LoggerMessage event names (the source generator names the EventId after the logging method);
     // the sweep tests use them both to assert specific log entries and as completion signals.
     private const string PurgedEvent = "LogPurged";
+    private const string DeadLetterPurgedEvent = "LogDeadLetterPurged";
     private const string InboxPurgedEvent = "LogInboxPurged";
     private const string SourceErrorEvent = "LogSourcePurgeError";
 
@@ -263,6 +264,43 @@ public sealed class OutboxCleanupServiceTests
         remaining.Should().BeEquivalentTo(
             [recentProcessed.Id, pending.Id],
             "only PROCESSED rows older than the retention cutoff are purged; newer processed rows and pending rows survive");
+    }
+
+    // ── Purge sweep: dead-lettered rows (retries exhausted) older than retention are purged ──
+    [Fact]
+    public async Task PurgeSweep_DeletesDeadLetteredRowsOlderThanRetention_KeepsRecentAndStillRetrying()
+    {
+        var timeProvider = new FakeTimeProvider(SweepStart);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(CancellationToken.None);
+        await using var context = CleanupTestContext.Create(connection);
+
+        // MaxRetries 3: RetryCount >= 3 is dead-lettered; RetryCount 1 is still eligible to retry.
+        var oldDeadLettered = DeadLetteredOutboxMessage(SweepStart.UtcDateTime.AddDays(-8), retryCount: 3);
+        var recentDeadLettered = DeadLetteredOutboxMessage(SweepStart.UtcDateTime.AddDays(-1), retryCount: 3);
+        var oldStillRetrying = PendingWithRetries(SweepStart.UtcDateTime.AddDays(-30), retryCount: 1);
+        context.AddRange(oldDeadLettered, recentDeadLettered, oldStillRetrying);
+        await context.SaveChangesAsync(CancellationToken.None);
+
+        var (sut, sweepObserved, _, scopeServices) = CreateSweepSut(
+            timeProvider,
+            _ => context,
+            [DataSourceKey.Default(DataSource.Sqlite)],
+            new OutboxSettings { RetentionDays = 7, CleanupIntervalHours = 1, MaxRetries = 3, DataSource = DataSource.Sqlite },
+            observedLogEvent: DeadLetterPurgedEvent);
+        await using var scope = scopeServices;
+        using var service = sut;
+
+        await service.StartAsync(CancellationToken.None);
+        await AdvanceUntilSweepAsync(timeProvider, TimeSpan.FromHours(1), sweepObserved);
+        await service.StopAsync(CancellationToken.None);
+
+        List<Guid> remaining = await context.Set<OutboxMessage>().AsNoTracking()
+            .Select(m => m.Id)
+            .ToListAsync(CancellationToken.None);
+        remaining.Should().BeEquivalentTo(
+            [recentDeadLettered.Id, oldStillRetrying.Id],
+            "only dead-lettered rows older than retention are purged; recent dead rows and still-retrying rows survive");
     }
 
     // ── Purge sweep: one unreachable source must not stop the others from being purged ──
@@ -498,6 +536,23 @@ public sealed class OutboxCleanupServiceTests
         EventType = "Test.Event",
         Payload = "{}",
         OccurredOn = occurredOn,
+    };
+
+    private static OutboxMessage DeadLetteredOutboxMessage(DateTime occurredOn, int retryCount) => new()
+    {
+        EventType = "Test.Event",
+        Payload = "{}",
+        OccurredOn = occurredOn,
+        RetryCount = retryCount,
+        LastError = "boom",
+    };
+
+    private static OutboxMessage PendingWithRetries(DateTime occurredOn, int retryCount) => new()
+    {
+        EventType = "Test.Event",
+        Payload = "{}",
+        OccurredOn = occurredOn,
+        RetryCount = retryCount,
     };
 
     private static InboxMessage InboxMessageProcessedOn(DateTime processedOn) => new()


### PR DESCRIPTION
## Summary

Tier-2 framework quick-win **H** from the performance review: give poison (dead-lettered) outbox messages a terminal fate so they stop degrading the poll.

A message that exhausts `MaxRetries` keeps `ProcessedOn` null forever. The `OutboxProcessor` poll already excludes it (`RetryCount < MaxRetries`), but the cleanup sweep only purged `ProcessedOn != null` rows, so dead-lettered rows:
- accumulated **without bound** (the table stores serialized event payloads that may contain PII), and
- lingered in the `ProcessedOn IS NULL` filtered pending index, where **every poll cycle re-scanned them** (the `RetryCount < MaxRetries` predicate is a residual filter, not covered by the index).

## Fix

Extend the cleanup sweep to also purge dead-lettered rows (`RetryCount >= MaxRetries`) older than `RetentionDays`, keyed on `OccurredOn` (they have no `ProcessedOn`), with a distinct `Warning` log line. This bounds growth and clears the dead rows from the pending index after the retention window.

- **No schema change** — consumers pick it up on the next Common release with no migration.
- Permanently abandons an undelivered event after `RetentionDays`; the failure is already recorded on the row (`LastError`) and logged by the processor before purge.

## Tests

New `PurgeSweep_DeletesDeadLetteredRowsOlderThanRetention_KeepsRecentAndStillRetrying` (dead rows older than retention are purged; recent dead rows and still-retrying rows survive). Full `OutboxCleanupServiceTests` (12) pass; Common solution builds clean in Release under TWAE.

## Context

Part of the four-repo performance program (plan `do-a-full-performance-lexical-turtle.md`). The other Tier-2 items (F by-id fast path, G single ChangeTracker walk, the IN filter operator that unblocks My-Schedule paging) are sequenced as separate PRs; item I (output-cache cardinality) was found unsafe to narrow (`QueryKeys="*"` is load-bearing for ADC's dashboard cache-bust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CPb4jeHc9p7Gw7NySCkPP
