### PR TITLE
feat(filtering): add IN operator to the dynamic query filter contract

### DIFF
--- a/Source/Core/MMCA.Common.Application/Services/Filtering/FilterValueParser.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/FilterValueParser.cs
@@ -1,0 +1,41 @@
+namespace MMCA.Common.Application.Services.Filtering;
+
+/// <summary>
+/// Parses the comma-separated value list carried by the <c>IN</c> filter operator into a typed
+/// list. Values that fail to parse are skipped (consistent with the single-value strategies, which
+/// silently ignore an unparseable value), so a malformed entry never fails the whole request.
+/// </summary>
+internal static class FilterValueParser
+{
+    private static readonly char[] Separator = [','];
+
+    /// <summary>Parses a comma-separated list of value-type items (e.g. int, Guid).</summary>
+    /// <typeparam name="T">The value type each item parses to.</typeparam>
+    /// <param name="value">The raw comma-separated value.</param>
+    /// <param name="parse">Parses one item, returning <see langword="null"/> when it is unparseable.</param>
+    /// <returns>The successfully parsed items, in order.</returns>
+    public static List<T> ParseList<T>(string value, Func<string, T?> parse)
+        where T : struct
+    {
+        var result = new List<T>();
+        if (string.IsNullOrWhiteSpace(value))
+            return result;
+
+        foreach (var part in value.Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (parse(part) is { } parsed)
+                result.Add(parsed);
+        }
+
+        return result;
+    }
+
+    /// <summary>Parses a comma-separated list of non-empty strings.</summary>
+    public static List<string> ParseStringList(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return [];
+
+        return [.. value.Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
@@ -12,11 +12,14 @@ internal sealed class GuidFilterStrategy : IFilterStrategy
 {
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
-        "EQUALS", "NOT EQUALS"
+        "EQUALS", "NOT EQUALS", "IN"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
     {
+        if (op == "IN")
+            return ApplyIn(query, property, value);
+
         if (!Guid.TryParse(value, out var guidValue))
             return query;
 
@@ -26,5 +29,11 @@ internal sealed class GuidFilterStrategy : IFilterStrategy
             "NOT EQUALS" => query.Where($"{property} != @0", guidValue),
             _ => query
         };
+    }
+
+    private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
+    {
+        var values = FilterValueParser.ParseList(value, static s => Guid.TryParse(s, out var g) ? g : (Guid?)null);
+        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
@@ -13,11 +13,15 @@ internal sealed class IntFilterStrategy : IFilterStrategy
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
         "EQUALS", "NOT EQUALS", "GREATER THAN", "LESS THAN",
-        "GREATER THAN OR EQUAL", "LESS THAN OR EQUAL"
+        "GREATER THAN OR EQUAL", "LESS THAN OR EQUAL", "IN"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
     {
+        // IN takes a comma-separated set; every other operator takes a single value.
+        if (op == "IN")
+            return ApplyIn(query, property, value);
+
         if (!int.TryParse(value, out var intValue))
             return query;
 
@@ -31,5 +35,11 @@ internal sealed class IntFilterStrategy : IFilterStrategy
             "LESS THAN OR EQUAL" => query.Where($"{property} <= @0", intValue),
             _ => query
         };
+    }
+
+    private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
+    {
+        var values = FilterValueParser.ParseList(value, static s => int.TryParse(s, out var v) ? v : (int?)null);
+        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/StringFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/StringFilterStrategy.cs
@@ -14,7 +14,7 @@ internal sealed class StringFilterStrategy : IFilterStrategy
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
         "CONTAINS", "NOT CONTAINS", "EQUALS", "NOT EQUALS",
-        "STARTS WITH", "ENDS WITH", "IS EMPTY", "IS NOT EMPTY"
+        "STARTS WITH", "ENDS WITH", "IS EMPTY", "IS NOT EMPTY", "IN"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
@@ -26,8 +26,23 @@ internal sealed class StringFilterStrategy : IFilterStrategy
             "NOT EQUALS" => query.Where($"{property} != @0", value),
             "STARTS WITH" => query.Where($"{property}.StartsWith(@0)", value),
             "ENDS WITH" => query.Where($"{property}.EndsWith(@0)", value),
+            _ => ApplyPresenceOrSet(query, property, op, value),
+        };
+
+    // Presence checks (value-independent) and the comma-separated IN set, split out of the main
+    // switch to keep each method under the cyclomatic-complexity ceiling.
+    private static IQueryable<T> ApplyPresenceOrSet<T>(IQueryable<T> query, string property, string op, string value)
+        => op switch
+        {
             "IS EMPTY" => query.Where($"string.IsNullOrEmpty({property})"),
             "IS NOT EMPTY" => query.Where($"!string.IsNullOrEmpty({property})"),
+            "IN" => ApplyIn(query, property, value),
             _ => query
         };
+
+    private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
+    {
+        var values = FilterValueParser.ParseStringList(value);
+        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+    }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/GuidFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/GuidFilterStrategyTests.cs
@@ -49,4 +49,17 @@ public sealed class GuidFilterStrategyTests
     [Fact]
     public void UnknownOperator_ReturnsAll() =>
         Filter("CONTAINS", Guid1String).Should().HaveCount(4);
+
+    // ── IN ──
+    [Fact]
+    public void In_ReturnsItemsMatchingAnyListedValue() =>
+        Filter("IN", $"{Guid1String},{Guid2String}").Should().HaveCount(2);
+
+    [Fact]
+    public void In_SkipsUnparseableValues() =>
+        Filter("IN", $"{Guid1String},not-a-guid").Should().ContainSingle();
+
+    [Fact]
+    public void In_WithNoParseableValues_ReturnsAll() =>
+        Filter("IN", "nope").Should().HaveCount(4);
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/IntFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/IntFilterStrategyTests.cs
@@ -66,4 +66,25 @@ public sealed class IntFilterStrategyTests
     [Fact]
     public void UnknownOperator_ReturnsAll() =>
         Filter("CONTAINS", "10").Should().HaveCount(4);
+
+    // ── IN ──
+    [Fact]
+    public void In_ReturnsItemsMatchingAnyListedValue() =>
+        Filter("IN", "5,15").Select(i => i.Count).Should().BeEquivalentTo([5, 15]);
+
+    [Fact]
+    public void In_TrimsWhitespaceAroundValues() =>
+        Filter("IN", " 10 , 20 ").Should().HaveCount(2);
+
+    [Fact]
+    public void In_SkipsUnparseableValues() =>
+        Filter("IN", "5,not-a-number,20").Select(i => i.Count).Should().BeEquivalentTo([5, 20]);
+
+    [Fact]
+    public void In_WithNoParseableValues_ReturnsAll() =>
+        Filter("IN", "a,b,c").Should().HaveCount(4);
+
+    [Fact]
+    public void In_WithEmptyValue_ReturnsAll() =>
+        Filter("IN", string.Empty).Should().HaveCount(4);
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/StringFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/StringFilterStrategyTests.cs
@@ -72,4 +72,18 @@ public sealed class StringFilterStrategyTests
     [Fact]
     public void UnknownOperator_ReturnsAll() =>
         Filter("BETWEEN", "Alice").Should().HaveCount(5);
+
+    // ── IN ──
+    [Fact]
+    public void In_ReturnsItemsMatchingAnyListedValue() =>
+        Filter("IN", "Alice,David").Select(i => i.Name).Should()
+            .HaveCount(2).And.Contain("Alice").And.Contain("David");
+
+    [Fact]
+    public void In_TrimsWhitespaceAroundValues() =>
+        Filter("IN", " Bob , Charlie ").Should().HaveCount(2);
+
+    [Fact]
+    public void In_WithEmptyValue_ReturnsAll() =>
+        Filter("IN", string.Empty).Should().HaveCount(5);
 }


### PR DESCRIPTION
## Summary

Tier-2 framework capability from the performance review: add an **`IN` operator** to the dynamic query-filter contract.

The filter contract only supported single-value operators (`EQUALS`, comparisons, string ops), so a caller could not filter a column against a **set** of values server-side. That gap is what forced ADC's "My Schedule" view to fetch a 500-row page and filter to the bookmarked set in memory (perf review fix D). This adds `IN` to the `Int`, `Guid`, and `String` filter strategies.

## Behavior

- `IN` takes a comma-separated value list and matches the property against any listed value, via a parameterized `@0.Contains(property)` expression, so it is EF-translatable and can seek an indexed key column.
- Unparseable list entries are skipped; an all-unparseable or empty list returns the query unfiltered, consistent with the existing single-value strategies (which silently ignore an unparseable value).
- Shared parsing lives in a small `FilterValueParser` helper.
- `IN` is added to each strategy's `SupportedOperators`, so the upstream operator validation accepts it.

## Tests

11 new tests across `Int`/`Guid`/`String` strategy tests, executed through `QueryFilterService.ApplyFilters` against in-memory queryables — which exercises the real Dynamic.Core expression (matching, whitespace trimming, skipping unparseable entries, empty-list passthrough). Full `MMCA.Common.Application.Tests` (469) pass; Common builds clean in Release under TWAE.

## Follow-on

Once this ships in a Common release and reaches ADC, the "My Schedule" page (perf fix D) becomes a trivial server-side paged filter instead of the current 500-row in-memory fetch. Sibling framework PR: #78 (outbox dead-letter purge). Both are part of the four-repo performance program (plan `do-a-full-performance-lexical-turtle.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CPb4jeHc9p7Gw7NySCkPP
