### PR TITLE
perf(query): keyed fast path for plain by-id reads

### DIFF
--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq.Expressions;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -58,6 +61,88 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
     protected virtual IReadOnlyDictionary<string, string> DTOToEntityPropertyMap { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
     private const string IdField = "Id";
+
+    // Cached TypeConverter per identifier type: the by-id fast path parses the string id into the
+    // typed key without per-call reflection. A type with no usable string converter simply misses
+    // the fast path and uses the pipeline.
+    private static readonly ConcurrentDictionary<Type, TypeConverter?> IdConverterCache = new();
+
+    /// <summary>
+    /// Attempts the keyed by-id fast path: for a plain primary-key lookup (no field projection, no
+    /// includes, no specification, default id field) it issues a single <c>TOP 1 WHERE Id = @id</c>
+    /// via the repository's include overload, skipping the dynamic-filter pipeline (which parses a
+    /// string predicate and emits <c>TOP 1000</c> + a client-side <c>FirstOrDefault</c>). That
+    /// overload runs on the filtered <c>TableNoTracking</c>, so soft-delete query filters still
+    /// apply (unlike <c>FindAsync</c>, which bypasses them). Returns <see langword="null"/> when the
+    /// request is not a plain key lookup or the id is not convertible, so the caller uses the
+    /// pipeline.
+    /// </summary>
+    private async Task<Result<TEntity>?> TryGetByIdFastPathAsync(
+        string idValue,
+        string? idField,
+        bool includeFKs,
+        bool includeChildren,
+        Specification<TEntity, TIdentifierType>? specification,
+        string? fields,
+        bool asTracking,
+        CancellationToken cancellationToken)
+    {
+        if (!IsPrimaryKeyOnlyLookup(idField, includeFKs, includeChildren, specification, fields)
+            || !TryConvertId(idValue, out var typedId))
+        {
+            return null;
+        }
+
+        var entity = await Repository.GetByIdAsync(typedId, [], asTracking, cancellationToken).ConfigureAwait(false);
+        return entity is null
+            ? Result.Failure<TEntity>(Error.NotFound.WithSource(nameof(GetByIdAsync)).WithTarget(typeof(TEntity).Name))
+            : Result.Success(entity);
+    }
+
+    private static bool IsPrimaryKeyOnlyLookup(
+        string? idField,
+        bool includeFKs,
+        bool includeChildren,
+        Specification<TEntity, TIdentifierType>? specification,
+        string? fields)
+        => fields is null
+            && !includeFKs
+            && !includeChildren
+            && specification is null
+            && (idField is null || string.Equals(idField, IdField, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Converts the string id to <typeparamref name="TIdentifierType"/> for the keyed fast path.
+    /// Returns <see langword="false"/> (so the caller falls back to the pipeline) when the value is
+    /// not convertible, preserving the pipeline's tolerance of malformed ids.
+    /// </summary>
+    private static bool TryConvertId(string idValue, out TIdentifierType id)
+    {
+        id = default!;
+        var converter = IdConverterCache.GetOrAdd(typeof(TIdentifierType), static t =>
+        {
+            var c = TypeDescriptor.GetConverter(t);
+            return c.CanConvertFrom(typeof(string)) ? c : null;
+        });
+
+        if (converter is null)
+            return false;
+
+        try
+        {
+            if (converter.ConvertFromString(null, CultureInfo.InvariantCulture, idValue) is TIdentifierType converted)
+            {
+                id = converted;
+                return true;
+            }
+        }
+        catch (Exception ex) when (ex is FormatException or NotSupportedException or ArgumentException)
+        {
+            // Malformed id for this key type: fall back to the pipeline path.
+        }
+
+        return false;
+    }
 
     /// <inheritdoc />
     public virtual async Task<Result<PagedCollectionResult<object>>> GetAllAsync(
@@ -201,6 +286,14 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
 
             return Result.Failure<TEntity>(errors);
         }
+
+        // Fast path: a plain primary-key lookup skips the dynamic-filter pipeline (see
+        // TryGetByIdFastPathAsync). Any other shape falls through to the full pipeline unchanged.
+        Result<TEntity>? fastPath = await TryGetByIdFastPathAsync(
+            idValue, idField, includeFKs, includeChildren, specification, fields, asTracking, cancellationToken)
+            .ConfigureAwait(false);
+        if (fastPath is not null)
+            return fastPath;
 
         var filters = new Dictionary<string, (string Operator, string Value)>(StringComparer.OrdinalIgnoreCase)
         {

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryServiceTests.cs
@@ -139,6 +139,52 @@ public sealed class EntityQueryServiceTests
         result.Should().BeTrue();
     }
 
+    // ── By-id fast path ──
+    [Fact]
+    public async Task GetEntityByIdAsync_PlainKeyLookup_UsesKeyedRepositoryFastPath()
+    {
+        var entity = new FakeEntity { Id = 5, Name = "Five" };
+        var (sut, repo) = CreateSutWithReadRepo();
+        repo.Setup(r => r.GetByIdAsync(5, It.IsAny<IEnumerable<string>>(), false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        // The pipeline is left unmocked: a success here can ONLY come from the keyed fast path,
+        // since the pipeline mock returns nothing.
+        var result = await sut.GetEntityByIdAsync("5");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(entity);
+        repo.Verify(r => r.GetByIdAsync(5, It.IsAny<IEnumerable<string>>(), false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetEntityByIdAsync_PlainKeyLookup_WhenMissing_ReturnsNotFound()
+    {
+        var (sut, repo) = CreateSutWithReadRepo();
+        repo.Setup(r => r.GetByIdAsync(It.IsAny<int>(), It.IsAny<IEnumerable<string>>(), false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((FakeEntity?)null);
+
+        var result = await sut.GetEntityByIdAsync("5");
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    private static (EntityQueryService<FakeEntity, FakeEntityDTO, int> Sut, Mock<IReadRepository<FakeEntity, int>> Repo) CreateSutWithReadRepo()
+    {
+        var repo = new Mock<IReadRepository<FakeEntity, int>>();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork.Setup(x => x.GetReadRepository<FakeEntity, int>()).Returns(repo.Object);
+
+        var sut = new EntityQueryService<FakeEntity, FakeEntityDTO, int>(
+            unitOfWork.Object,
+            Mock.Of<INavigationMetadataProvider>(),
+            Mock.Of<IEntityQueryPipeline>(),
+            Mock.Of<IEntityDTOMapper<FakeEntity, FakeEntityDTO, int>>(),
+            Mock.Of<INavigationPopulator<FakeEntity>>());
+
+        return (sut, repo);
+    }
+
     // ── DTOToEntityPropertyMap defaults to empty ──
     [Fact]
     public void DTOToEntityPropertyMap_DefaultsToEmptyDictionary()


### PR DESCRIPTION
## Summary

Tier-2 framework quick-win **F** from the performance review (deferred from the eighteenth runtime-performance wave): a keyed fast path for plain by-id reads.

`EntityQueryService.GetEntityByIdAsync` synthesized an `Id EQUALS <value>` filter and ran the full dynamic-query pipeline for **every** by-id read: a `System.Linq.Dynamic.Core` string-predicate parse, `TOP 1000` materialization, then a client-side `FirstOrDefault`. For a plain primary-key lookup that is all wasted work.

## Fix

Short-circuit the plain-key case (no `fields`, no `includeFKs`/`includeChildren`, no `specification`, default id field) to a single `TOP 1 WHERE Id = @id` via the repository's include overload. Any other shape (field projection, includes, specification, or a custom id field) falls through to the pipeline **unchanged**.

## Correctness notes

- The fast path uses the repository's include overload (`FirstOrDefaultAsync` on the filtered `TableNoTracking`), **not** `FindAsync`. `FindAsync` bypasses EF global query filters, which would resurrect soft-deleted rows; the include overload keeps the `IsDeleted = 0` filter, so behavior matches the pipeline exactly.
- The string id is converted to the typed key through a cached `TypeConverter`; an unconvertible id returns `null` from the converter and falls back to the pipeline, preserving the pipeline's existing tolerance of malformed ids.

## Tests

New tests: the fast path issues the keyed repo call and returns the entity; a missing row returns NotFound. All 471 `MMCA.Common.Application.Tests` pass (the existing field/include/spec by-id tests continue to exercise the pipeline path). Common builds clean in Release under TWAE.

## Program context

Third framework PR in the four-repo performance program (plan `do-a-full-performance-lexical-turtle.md`), alongside #78 (outbox dead-letter purge) and #79 (IN filter operator). Note on the sibling item G (collapse the two SaveChanges ChangeTracker enumerations): on inspection its real saving is one filtered enumeration, not a second `DetectChanges` (EF runs DetectChanges once on the first `Entries<>()` access), so it is marginal on the critical save path and is being recommended for deferral rather than shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CPb4jeHc9p7Gw7NySCkPP
