### PR TITLE
chore: regenerate FACTS for v1.119.0

### DIFF
--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-07-18 (framework v1.118.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-07-19 (framework v1.119.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A bare `(001-NNN)` ADR
@@ -10,7 +10,7 @@ _As of: 2026-07-18 (framework v1.118.0) — **generated from source by `build/fa
 > repo's own test totals and scorecard indices) live in that repo's `ArchitectureScorecard.md`, **not** here.
 
 ## Framework version
-- **Current: `v1.118.0`** (MinVer-derived from the git tag at `main` HEAD).
+- **Current: `v1.119.0`** (MinVer-derived from the git tag at `main` HEAD).
 - All consumers (**MMCA.ADC**, **MMCA.Store**, MMCA.Helpdesk) track this version in **lockstep** — every
   `MMCA.Common.*` entry in each consumer's `Directory.Packages.props` is bumped together (ADR-016; no phased
   rollout).


### PR DESCRIPTION
Post-tag FACTS regeneration pinning to the v1.119.0 release (per the release flow). Only the version/date line changes; package count (15), ADR range (001-048), and fitness counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CPb4jeHc9p7Gw7NySCkPP