### PR TITLE
refactor: complete C# 14 extension-block migration

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ModelBuilderExtensions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ModelBuilderExtensions.cs
@@ -9,59 +9,60 @@ namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 /// </summary>
 internal static class ModelBuilderExtensions
 {
-    /// <summary>
-    /// Scans the given assembly for concrete classes implementing <paramref name="interfaceType"/>
-    /// (a provider-specific configuration interface like <c>IEntityTypeConfigurationSQLServer&lt;,&gt;</c>),
-    /// instantiates each via DI, and applies it to the model builder. An optional
-    /// <paramref name="entityFilter"/> restricts application to entities belonging to the
-    /// context's physical data source.
-    /// </summary>
-    /// <param name="modelBuilder">The model builder to apply configurations to.</param>
-    /// <param name="serviceProvider">Service provider for resolving configuration constructor dependencies.</param>
-    /// <param name="assembly">The assembly to scan for configuration classes.</param>
-    /// <param name="interfaceType">The open generic interface type to match (e.g., <c>IEntityTypeConfigurationSQLServer&lt;,&gt;</c>).</param>
-    /// <param name="entityFilter">Optional predicate over the entity CLR type; configurations whose entity fails the predicate are skipped.</param>
-    internal static void ApplyAllConfigurations(
-        this ModelBuilder modelBuilder,
-        IServiceProvider serviceProvider,
-        Assembly assembly,
-        Type interfaceType,
-        Func<Type, bool>? entityFilter = null)
+    extension(ModelBuilder modelBuilder)
     {
-        ArgumentNullException.ThrowIfNull(modelBuilder);
-        ArgumentNullException.ThrowIfNull(serviceProvider);
-        ArgumentNullException.ThrowIfNull(assembly);
-        ArgumentNullException.ThrowIfNull(interfaceType);
-
-        // Resolve the open generic ApplyConfiguration<TEntity>(IEntityTypeConfiguration<TEntity>) method
-        // so we can close it per entity type below.
-        var applyConfigMethod = typeof(ModelBuilder)
-            .GetMethods()
-            .First(m => m.Name == nameof(ModelBuilder.ApplyConfiguration) && m.GetParameters().Length == 1);
-
-        var configTypes = assembly
-            .GetTypes()
-            .Where(t => !t.IsAbstract && !t.IsGenericTypeDefinition)
-            .Select(t => new
-            {
-                Type = t,
-                Interface = t.GetInterfaces()
-                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceType)
-            })
-            .Where(x => x.Interface is not null);
-
-        foreach (var config in configTypes)
+        /// <summary>
+        /// Scans the given assembly for concrete classes implementing <paramref name="interfaceType"/>
+        /// (a provider-specific configuration interface like <c>IEntityTypeConfigurationSQLServer&lt;,&gt;</c>),
+        /// instantiates each via DI, and applies it to the model builder. An optional
+        /// <paramref name="entityFilter"/> restricts application to entities belonging to the
+        /// context's physical data source.
+        /// </summary>
+        /// <param name="serviceProvider">Service provider for resolving configuration constructor dependencies.</param>
+        /// <param name="assembly">The assembly to scan for configuration classes.</param>
+        /// <param name="interfaceType">The open generic interface type to match (e.g., <c>IEntityTypeConfigurationSQLServer&lt;,&gt;</c>).</param>
+        /// <param name="entityFilter">Optional predicate over the entity CLR type; configurations whose entity fails the predicate are skipped.</param>
+        internal void ApplyAllConfigurations(
+            IServiceProvider serviceProvider,
+            Assembly assembly,
+            Type interfaceType,
+            Func<Type, bool>? entityFilter = null)
         {
-            // First generic argument is the entity type (TEntity).
-            var entityType = config.Interface!.GenericTypeArguments[0];
-            if (entityFilter is not null && !entityFilter(entityType))
-            {
-                continue;
-            }
+            ArgumentNullException.ThrowIfNull(modelBuilder);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+            ArgumentNullException.ThrowIfNull(assembly);
+            ArgumentNullException.ThrowIfNull(interfaceType);
 
-            var configInstance = ActivatorUtilities.CreateInstance(serviceProvider, config.Type);
-            var genericMethod = applyConfigMethod.MakeGenericMethod(entityType);
-            genericMethod.Invoke(modelBuilder, [configInstance]);
+            // Resolve the open generic ApplyConfiguration<TEntity>(IEntityTypeConfiguration<TEntity>) method
+            // so we can close it per entity type below.
+            var applyConfigMethod = typeof(ModelBuilder)
+                .GetMethods()
+                .First(m => m.Name == nameof(ModelBuilder.ApplyConfiguration) && m.GetParameters().Length == 1);
+
+            var configTypes = assembly
+                .GetTypes()
+                .Where(t => !t.IsAbstract && !t.IsGenericTypeDefinition)
+                .Select(t => new
+                {
+                    Type = t,
+                    Interface = t.GetInterfaces()
+                        .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceType)
+                })
+                .Where(x => x.Interface is not null);
+
+            foreach (var config in configTypes)
+            {
+                // First generic argument is the entity type (TEntity).
+                var entityType = config.Interface!.GenericTypeArguments[0];
+                if (entityFilter is not null && !entityFilter(entityType))
+                {
+                    continue;
+                }
+
+                var configInstance = ActivatorUtilities.CreateInstance(serviceProvider, config.Type);
+                var genericMethod = applyConfigMethod.MakeGenericMethod(entityType);
+                genericMethod.Invoke(modelBuilder, [configInstance]);
+            }
         }
     }
 }

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -14,6 +15,10 @@ namespace MMCA.Common.Aspire.Hosting;
 /// services do not pull in the full <c>Aspire.Hosting</c> package and its dependencies.
 /// </para>
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class Extensions
 {
     /// <summary>
@@ -21,221 +26,217 @@ public static class Extensions
     /// </summary>
     public const string DefaultBrokerResourceName = "rabbitmq";
 
-    /// <summary>
-    /// Provisions a RabbitMQ container resource with the management plugin enabled and
-    /// returns the resource builder for further wiring. Production deployments should
-    /// override the connection string via configuration so the same projects can target
-    /// Azure Service Bus without changing the AppHost.
-    /// </summary>
-    /// <param name="builder">The distributed application builder.</param>
-    /// <param name="name">The resource name (defaults to <see cref="DefaultBrokerResourceName"/>).</param>
-    /// <returns>The RabbitMQ resource builder for chaining.</returns>
-    public static IResourceBuilder<RabbitMQServerResource> AddMessageBroker(
-        this IDistributedApplicationBuilder builder,
-        string name = DefaultBrokerResourceName)
+    extension(IDistributedApplicationBuilder builder)
     {
-        ArgumentNullException.ThrowIfNull(builder);
-        return builder.AddRabbitMQ(name).WithManagementPlugin();
-    }
-
-    /// <summary>
-    /// Wires the message-bus connection string and provider env var onto a project
-    /// resource so the consuming service's <c>AddBrokerMessaging</c> picks up RabbitMQ
-    /// as the active transport. Adds a wait-for so the project does not start until the
-    /// broker container is healthy.
-    /// </summary>
-    /// <typeparam name="TResource">The project resource type.</typeparam>
-    /// <param name="service">The project resource builder.</param>
-    /// <param name="broker">The broker resource builder.</param>
-    /// <returns>The project resource builder for chaining.</returns>
-    public static IResourceBuilder<TResource> WithBroker<TResource>(
-        this IResourceBuilder<TResource> service,
-        IResourceBuilder<RabbitMQServerResource> broker)
-        where TResource : IResourceWithEnvironment, IResourceWithWaitSupport
-    {
-        ArgumentNullException.ThrowIfNull(service);
-        ArgumentNullException.ThrowIfNull(broker);
-
-        return service
-            .WithReference(broker)
-            .WaitFor(broker)
-            .WithEnvironment("MessageBus__Provider", "RabbitMq");
-    }
-
-    /// <summary>
-    /// Wires JWKS-based JWT authority discovery onto a project resource. The consuming
-    /// service should call <c>AddForwardedJwtBearer(authority, audience)</c> using the
-    /// <c>Authentication__JwtBearer__Authority</c> environment variable that this method sets,
-    /// so its JWT bearer middleware fetches the Identity service's JWKS document and
-    /// validates tokens against the published RSA public key.
-    /// </summary>
-    /// <typeparam name="TResource">The project resource type.</typeparam>
-    /// <param name="service">The project resource builder.</param>
-    /// <param name="identity">The Identity service project resource builder.</param>
-    /// <param name="gateway">
-    /// Optional gateway resource. When provided, the JwtBearer authority is set to the gateway's
-    /// HTTPS endpoint (which supports HTTP/1.1 + HTTP/2 via ALPN and forwards /.well-known/* to
-    /// Identity). When omitted, falls back to Identity's HTTPS endpoint (which is Http2-only
-    /// and may reject default HttpClient HTTP/1.1 requests).
-    /// </param>
-    /// <returns>The project resource builder for chaining.</returns>
-    public static IResourceBuilder<TResource> WithJwksDiscovery<TResource>(
-        this IResourceBuilder<TResource> service,
-        IResourceBuilder<ProjectResource> identity,
-        IResourceBuilder<ProjectResource>? gateway = null)
-        where TResource : IResourceWithEnvironment, IResourceWithWaitSupport
-    {
-        ArgumentNullException.ThrowIfNull(service);
-        ArgumentNullException.ThrowIfNull(identity);
-
-        return service
-            .WithReference(identity)
-            .WaitFor(identity)
-            .WithEnvironment(context =>
-            {
-                // Identity (and the other extracted services) listen Http2-only on cleartext so
-                // cross-service gRPC clients can negotiate h2c prior knowledge. The downside is
-                // that the default JwtBearer backchannel HttpClient sends HTTP/1.1, which Kestrel
-                // rejects on Http2-only endpoints. Route the JwtBearer's metadata fetch through
-                // the gateway instead: the gateway terminates TLS, supports both HTTP/1.1 and
-                // HTTP/2 via ALPN, and (per the Gateway forwarder) routes /.well-known/* to
-                // Identity over HTTP/2. So the default HTTP/1.1 backchannel works end-to-end.
-                //
-                // Fallback when no gateway is passed: use Identity's HTTPS endpoint. ALPN will
-                // negotiate HTTP/2 with a default HttpClient — same caveat about HTTP/1.1
-                // clients on Http2-only endpoints applies, so callers should prefer the gateway.
-                var endpoint = gateway is not null
-                    ? gateway.GetEndpoint("https")
-                    : identity.GetEndpoint("https");
-                context.EnvironmentVariables["Authentication__JwtBearer__Authority"] = endpoint;
-            });
-    }
-
-    /// <summary>
-    /// CI/E2E only: forwards an ephemeral RSA keypair from the AppHost's own environment to the
-    /// Identity service so it can sign RS256 tokens. The signing keys are normally supplied via
-    /// user-secrets (local) or Key Vault (prod); E2E workflows generate a throwaway keypair and pass
-    /// it through the <c>E2E_JWT_PRIVATE_KEY_PEM</c> / <c>E2E_JWT_PUBLIC_KEY_PEM</c> environment
-    /// variables. When both are present this maps them onto <c>Jwt__RsaPrivateKeyPem</c> /
-    /// <c>Jwt__RsaPublicKeyPem</c> / <c>Jwks__RsaPublicKeyPem</c>; without the forwarding every CI
-    /// login/register fails ("No supported key formats were found") and the readiness gate times
-    /// out. No-op locally and in prod (vars absent, so user-secrets / Key Vault are used).
-    /// </summary>
-    /// <param name="identity">The Identity service project resource builder.</param>
-    /// <returns>The Identity resource builder for chaining.</returns>
-    public static IResourceBuilder<ProjectResource> WithE2eRsaKeys(this IResourceBuilder<ProjectResource> identity)
-    {
-        ArgumentNullException.ThrowIfNull(identity);
-
-        var privateKey = Environment.GetEnvironmentVariable("E2E_JWT_PRIVATE_KEY_PEM");
-        var publicKey = Environment.GetEnvironmentVariable("E2E_JWT_PUBLIC_KEY_PEM");
-        if (string.IsNullOrWhiteSpace(privateKey) || string.IsNullOrWhiteSpace(publicKey))
+        /// <summary>
+        /// Provisions a RabbitMQ container resource with the management plugin enabled and
+        /// returns the resource builder for further wiring. Production deployments should
+        /// override the connection string via configuration so the same projects can target
+        /// Azure Service Bus without changing the AppHost.
+        /// </summary>
+        /// <param name="name">The resource name (defaults to <see cref="DefaultBrokerResourceName"/>).</param>
+        /// <returns>The RabbitMQ resource builder for chaining.</returns>
+        public IResourceBuilder<RabbitMQServerResource> AddMessageBroker(
+            string name = DefaultBrokerResourceName)
         {
-            return identity;
+            ArgumentNullException.ThrowIfNull(builder);
+            return builder.AddRabbitMQ(name).WithManagementPlugin();
+        }
+    }
+
+    extension<TResource>(IResourceBuilder<TResource> service)
+        where TResource : IResourceWithEnvironment, IResourceWithWaitSupport
+    {
+        /// <summary>
+        /// Wires the message-bus connection string and provider env var onto a project
+        /// resource so the consuming service's <c>AddBrokerMessaging</c> picks up RabbitMQ
+        /// as the active transport. Adds a wait-for so the project does not start until the
+        /// broker container is healthy.
+        /// </summary>
+        /// <param name="broker">The broker resource builder.</param>
+        /// <returns>The project resource builder for chaining.</returns>
+        public IResourceBuilder<TResource> WithBroker(
+            IResourceBuilder<RabbitMQServerResource> broker)
+        {
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentNullException.ThrowIfNull(broker);
+
+            return service
+                .WithReference(broker)
+                .WaitFor(broker)
+                .WithEnvironment("MessageBus__Provider", "RabbitMq");
         }
 
-        return identity
-            .WithEnvironment("Jwt__RsaPrivateKeyPem", privateKey)
-            .WithEnvironment("Jwt__RsaPublicKeyPem", publicKey)
-            .WithEnvironment("Jwks__RsaPublicKeyPem", publicKey);
+        /// <summary>
+        /// Wires JWKS-based JWT authority discovery onto a project resource. The consuming
+        /// service should call <c>AddForwardedJwtBearer(authority, audience)</c> using the
+        /// <c>Authentication__JwtBearer__Authority</c> environment variable that this method sets,
+        /// so its JWT bearer middleware fetches the Identity service's JWKS document and
+        /// validates tokens against the published RSA public key.
+        /// </summary>
+        /// <param name="identity">The Identity service project resource builder.</param>
+        /// <param name="gateway">
+        /// Optional gateway resource. When provided, the JwtBearer authority is set to the gateway's
+        /// HTTPS endpoint (which supports HTTP/1.1 + HTTP/2 via ALPN and forwards /.well-known/* to
+        /// Identity). When omitted, falls back to Identity's HTTPS endpoint (which is Http2-only
+        /// and may reject default HttpClient HTTP/1.1 requests).
+        /// </param>
+        /// <returns>The project resource builder for chaining.</returns>
+        public IResourceBuilder<TResource> WithJwksDiscovery(
+            IResourceBuilder<ProjectResource> identity,
+            IResourceBuilder<ProjectResource>? gateway = null)
+        {
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentNullException.ThrowIfNull(identity);
+
+            return service
+                .WithReference(identity)
+                .WaitFor(identity)
+                .WithEnvironment(context =>
+                {
+                    // Identity (and the other extracted services) listen Http2-only on cleartext so
+                    // cross-service gRPC clients can negotiate h2c prior knowledge. The downside is
+                    // that the default JwtBearer backchannel HttpClient sends HTTP/1.1, which Kestrel
+                    // rejects on Http2-only endpoints. Route the JwtBearer's metadata fetch through
+                    // the gateway instead: the gateway terminates TLS, supports both HTTP/1.1 and
+                    // HTTP/2 via ALPN, and (per the Gateway forwarder) routes /.well-known/* to
+                    // Identity over HTTP/2. So the default HTTP/1.1 backchannel works end-to-end.
+                    //
+                    // Fallback when no gateway is passed: use Identity's HTTPS endpoint. ALPN will
+                    // negotiate HTTP/2 with a default HttpClient — same caveat about HTTP/1.1
+                    // clients on Http2-only endpoints applies, so callers should prefer the gateway.
+                    var endpoint = gateway is not null
+                        ? gateway.GetEndpoint("https")
+                        : identity.GetEndpoint("https");
+                    context.EnvironmentVariables["Authentication__JwtBearer__Authority"] = endpoint;
+                });
+        }
     }
 
-    /// <summary>
-    /// Wires a service project to its own SQL Server database ("database per microservice", ADR-006).
-    /// References the given database and injects its connection string twice:
-    /// <list type="bullet">
-    ///   <item><c>DataSources__{logicalName}__SQLServerConnectionString</c> — feeds the
-    ///   MMCA.Common multi-database routing (entities whose logical source matches
-    ///   <paramref name="logicalName"/> resolve to this database).</item>
-    ///   <item><c>ConnectionStrings__SQLServerConnectionString</c> — keeps the framework's
-    ///   <c>[Required]</c> validation and the <c>AddSqlServer</c> health checks working, and makes
-    ///   the service's <c>Default</c> source point at its own database. Because both values are
-    ///   identical, the resolver collapses the logical name onto Default — one context, one
-    ///   change tracker, one migration set per service.</item>
-    /// </list>
-    /// </summary>
-    /// <param name="service">The service project resource.</param>
-    /// <param name="database">The service's own database resource.</param>
-    /// <param name="logicalName">The module's logical data source name (e.g. <c>"Catalog"</c>).</param>
-    /// <returns>The service resource builder for chaining.</returns>
-    public static IResourceBuilder<ProjectResource> WithSQLServerDataSource(
-        this IResourceBuilder<ProjectResource> service,
-        IResourceBuilder<SqlServerDatabaseResource> database,
-        string logicalName)
+    extension(IResourceBuilder<ProjectResource> identity)
     {
-        ArgumentNullException.ThrowIfNull(service);
-        ArgumentNullException.ThrowIfNull(database);
+        /// <summary>
+        /// CI/E2E only: forwards an ephemeral RSA keypair from the AppHost's own environment to the
+        /// Identity service so it can sign RS256 tokens. The signing keys are normally supplied via
+        /// user-secrets (local) or Key Vault (prod); E2E workflows generate a throwaway keypair and pass
+        /// it through the <c>E2E_JWT_PRIVATE_KEY_PEM</c> / <c>E2E_JWT_PUBLIC_KEY_PEM</c> environment
+        /// variables. When both are present this maps them onto <c>Jwt__RsaPrivateKeyPem</c> /
+        /// <c>Jwt__RsaPublicKeyPem</c> / <c>Jwks__RsaPublicKeyPem</c>; without the forwarding every CI
+        /// login/register fails ("No supported key formats were found") and the readiness gate times
+        /// out. No-op locally and in prod (vars absent, so user-secrets / Key Vault are used).
+        /// </summary>
+        /// <returns>The Identity resource builder for chaining.</returns>
+        public IResourceBuilder<ProjectResource> WithE2eRsaKeys()
+        {
+            ArgumentNullException.ThrowIfNull(identity);
 
-        return service
-            .WithReference(database)
-            .WaitFor(database)
-            .WithEnvironment($"DataSources__{logicalName}__SQLServerConnectionString", database.Resource.ConnectionStringExpression)
-            .WithEnvironment("ConnectionStrings__SQLServerConnectionString", database.Resource.ConnectionStringExpression);
+            var privateKey = Environment.GetEnvironmentVariable("E2E_JWT_PRIVATE_KEY_PEM");
+            var publicKey = Environment.GetEnvironmentVariable("E2E_JWT_PUBLIC_KEY_PEM");
+            if (string.IsNullOrWhiteSpace(privateKey) || string.IsNullOrWhiteSpace(publicKey))
+            {
+                return identity;
+            }
+
+            return identity
+                .WithEnvironment("Jwt__RsaPrivateKeyPem", privateKey)
+                .WithEnvironment("Jwt__RsaPublicKeyPem", publicKey)
+                .WithEnvironment("Jwks__RsaPublicKeyPem", publicKey);
+        }
     }
 
-    /// <summary>
-    /// Wires a service project to an Azure Cosmos DB database for a given logical data source
-    /// (polyglot persistence — entities whose configuration inherits <c>EntityTypeConfigurationCosmos</c>
-    /// and resolve to <paramref name="logicalName"/> are stored here). Injects:
-    /// <list type="bullet">
-    ///   <item><c>DataSources__{logicalName}__CosmosConnectionString</c> — the account connection
-    ///   string the multi-database resolver hands to <c>CosmosDbContext.UseCosmos(...)</c>.</item>
-    ///   <item><c>DataSources__{logicalName}__CosmosDatabaseName</c> — the Cosmos database name
-    ///   (<c>UseCosmos</c> takes the database separately from the connection string).</item>
-    ///   <item><c>ConnectionStrings__CosmosConnectionString</c> — the framework's <c>[Required]</c>
-    ///   validation / <c>Default</c> Cosmos source fallback.</item>
-    /// </list>
-    /// Unlike SQL Server, a service typically uses Cosmos for ONE module alongside its SQL Server
-    /// source, so this is layered on top of (not instead of) <see cref="WithSQLServerDataSource"/>.
-    /// </summary>
-    /// <param name="service">The service project resource.</param>
-    /// <param name="database">The Cosmos database resource (from <c>AddAzureCosmosDB(...).AddCosmosDatabase(...)</c>).</param>
-    /// <param name="logicalName">The module's logical data source name (e.g. <c>"Conference"</c>).</param>
-    /// <returns>The service resource builder for chaining.</returns>
-    public static IResourceBuilder<ProjectResource> WithCosmosDataSource(
-        this IResourceBuilder<ProjectResource> service,
-        IResourceBuilder<AzureCosmosDBDatabaseResource> database,
-        string logicalName)
+    extension(IResourceBuilder<ProjectResource> service)
     {
-        ArgumentNullException.ThrowIfNull(service);
-        ArgumentNullException.ThrowIfNull(database);
+        /// <summary>
+        /// Wires a service project to its own SQL Server database ("database per microservice", ADR-006).
+        /// References the given database and injects its connection string twice:
+        /// <list type="bullet">
+        ///   <item><c>DataSources__{logicalName}__SQLServerConnectionString</c> — feeds the
+        ///   MMCA.Common multi-database routing (entities whose logical source matches
+        ///   <paramref name="logicalName"/> resolve to this database).</item>
+        ///   <item><c>ConnectionStrings__SQLServerConnectionString</c> — keeps the framework's
+        ///   <c>[Required]</c> validation and the <c>AddSqlServer</c> health checks working, and makes
+        ///   the service's <c>Default</c> source point at its own database. Because both values are
+        ///   identical, the resolver collapses the logical name onto Default — one context, one
+        ///   change tracker, one migration set per service.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="database">The service's own database resource.</param>
+        /// <param name="logicalName">The module's logical data source name (e.g. <c>"Catalog"</c>).</param>
+        /// <returns>The service resource builder for chaining.</returns>
+        public IResourceBuilder<ProjectResource> WithSQLServerDataSource(
+            IResourceBuilder<SqlServerDatabaseResource> database,
+            string logicalName)
+        {
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentNullException.ThrowIfNull(database);
 
-        return service
-            .WithReference(database)
-            .WaitFor(database)
-            .WithEnvironment($"DataSources__{logicalName}__CosmosConnectionString", database.Resource.ConnectionStringExpression)
-            .WithEnvironment($"DataSources__{logicalName}__CosmosDatabaseName", database.Resource.DatabaseName)
-            .WithEnvironment("ConnectionStrings__CosmosConnectionString", database.Resource.ConnectionStringExpression);
-    }
+            return service
+                .WithReference(database)
+                .WaitFor(database)
+                .WithEnvironment($"DataSources__{logicalName}__SQLServerConnectionString", database.Resource.ConnectionStringExpression)
+                .WithEnvironment("ConnectionStrings__SQLServerConnectionString", database.Resource.ConnectionStringExpression);
+        }
 
-    /// <summary>
-    /// Wires a service project to a SQLite database file for a given logical data source (polyglot
-    /// persistence — entities whose configuration inherits <c>EntityTypeConfigurationSqlite</c> and
-    /// resolve to <paramref name="logicalName"/> are stored here). SQLite has no Aspire container
-    /// resource (it is an in-process file), so this only injects connection-string env vars:
-    /// <list type="bullet">
-    ///   <item><c>DataSources__{logicalName}__SqliteConnectionString</c> — <c>Data Source=&lt;path&gt;</c>
-    ///   handed to <c>SqliteDbContext.UseSqlite(...)</c>.</item>
-    ///   <item><c>ConnectionStrings__SqliteConnectionString</c> — the framework's <c>Default</c>
-    ///   SQLite source fallback.</item>
-    /// </list>
-    /// </summary>
-    /// <param name="service">The service project resource.</param>
-    /// <param name="logicalName">The module's logical data source name (e.g. <c>"Conference"</c>).</param>
-    /// <param name="filePath">The absolute path to the SQLite database file.</param>
-    /// <returns>The service resource builder for chaining.</returns>
-    public static IResourceBuilder<ProjectResource> WithSqliteDataSource(
-        this IResourceBuilder<ProjectResource> service,
-        string logicalName,
-        string filePath)
-    {
-        ArgumentNullException.ThrowIfNull(service);
-        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        /// <summary>
+        /// Wires a service project to an Azure Cosmos DB database for a given logical data source
+        /// (polyglot persistence — entities whose configuration inherits <c>EntityTypeConfigurationCosmos</c>
+        /// and resolve to <paramref name="logicalName"/> are stored here). Injects:
+        /// <list type="bullet">
+        ///   <item><c>DataSources__{logicalName}__CosmosConnectionString</c> — the account connection
+        ///   string the multi-database resolver hands to <c>CosmosDbContext.UseCosmos(...)</c>.</item>
+        ///   <item><c>DataSources__{logicalName}__CosmosDatabaseName</c> — the Cosmos database name
+        ///   (<c>UseCosmos</c> takes the database separately from the connection string).</item>
+        ///   <item><c>ConnectionStrings__CosmosConnectionString</c> — the framework's <c>[Required]</c>
+        ///   validation / <c>Default</c> Cosmos source fallback.</item>
+        /// </list>
+        /// Unlike SQL Server, a service typically uses Cosmos for ONE module alongside its SQL Server
+        /// source, so this is layered on top of (not instead of) <see cref="WithSQLServerDataSource"/>.
+        /// </summary>
+        /// <param name="database">The Cosmos database resource (from <c>AddAzureCosmosDB(...).AddCosmosDatabase(...)</c>).</param>
+        /// <param name="logicalName">The module's logical data source name (e.g. <c>"Conference"</c>).</param>
+        /// <returns>The service resource builder for chaining.</returns>
+        public IResourceBuilder<ProjectResource> WithCosmosDataSource(
+            IResourceBuilder<AzureCosmosDBDatabaseResource> database,
+            string logicalName)
+        {
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentNullException.ThrowIfNull(database);
 
-        var connectionString = $"Data Source={filePath}";
+            return service
+                .WithReference(database)
+                .WaitFor(database)
+                .WithEnvironment($"DataSources__{logicalName}__CosmosConnectionString", database.Resource.ConnectionStringExpression)
+                .WithEnvironment($"DataSources__{logicalName}__CosmosDatabaseName", database.Resource.DatabaseName)
+                .WithEnvironment("ConnectionStrings__CosmosConnectionString", database.Resource.ConnectionStringExpression);
+        }
 
-        return service
-            .WithEnvironment($"DataSources__{logicalName}__SqliteConnectionString", connectionString)
-            .WithEnvironment("ConnectionStrings__SqliteConnectionString", connectionString);
+        /// <summary>
+        /// Wires a service project to a SQLite database file for a given logical data source (polyglot
+        /// persistence — entities whose configuration inherits <c>EntityTypeConfigurationSqlite</c> and
+        /// resolve to <paramref name="logicalName"/> are stored here). SQLite has no Aspire container
+        /// resource (it is an in-process file), so this only injects connection-string env vars:
+        /// <list type="bullet">
+        ///   <item><c>DataSources__{logicalName}__SqliteConnectionString</c> — <c>Data Source=&lt;path&gt;</c>
+        ///   handed to <c>SqliteDbContext.UseSqlite(...)</c>.</item>
+        ///   <item><c>ConnectionStrings__SqliteConnectionString</c> — the framework's <c>Default</c>
+        ///   SQLite source fallback.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="logicalName">The module's logical data source name (e.g. <c>"Conference"</c>).</param>
+        /// <param name="filePath">The absolute path to the SQLite database file.</param>
+        /// <returns>The service resource builder for chaining.</returns>
+        public IResourceBuilder<ProjectResource> WithSqliteDataSource(
+            string logicalName,
+            string filePath)
+        {
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+            var connectionString = $"Data Source={filePath}";
+
+            return service
+                .WithEnvironment($"DataSources__{logicalName}__SqliteConnectionString", connectionString)
+                .WithEnvironment("ConnectionStrings__SqliteConnectionString", connectionString);
+        }
     }
 }

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -20,185 +21,301 @@ namespace MMCA.Common.Aspire;
 /// Configures OpenTelemetry, health checks, service discovery, and HTTP resilience
 /// policies so that individual projects do not need to repeat this setup.
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class Extensions
 {
-    /// <summary>
-    /// Registers all service defaults: OpenTelemetry, health checks, service discovery,
-    /// and HTTP client resilience (Polly). Call this early in <c>Program.cs</c> before
-    /// adding module-specific services.
-    /// </summary>
-    /// <typeparam name="TBuilder">The host application builder type.</typeparam>
-    /// <param name="builder">The host application builder to configure.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder)
+    extension<TBuilder>(TBuilder builder)
         where TBuilder : IHostApplicationBuilder
     {
-        builder.ConfigureOpenTelemetry();
-        builder.AddDefaultHealthChecks();
-        builder.AddWarmupReadiness();
-        builder.Services.AddServiceDiscovery();
-
-        // HttpClient defaults applied via ConfigureHttpClientDefaults — affects every
-        // HttpClient registered downstream (typed clients, named clients, YARP forwarder).
-        builder.Services.ConfigureHttpClientDefaults(http =>
+        /// <summary>
+        /// Registers all service defaults: OpenTelemetry, health checks, service discovery,
+        /// and HTTP client resilience (Polly). Call this early in <c>Program.cs</c> before
+        /// adding module-specific services.
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddServiceDefaults()
         {
-            // Polly resilience pipeline (values from HttpResilienceDefaults, shared with the
-            // gRPC typed clients in MMCA.Common.Grpc):
-            //   - 30s per-attempt timeout
-            //   - Circuit breaker sampled over 60s
-            //   - 90s total request timeout (including retries)
-            //   - ONE retry per hop: the UI service base classes own user-facing retries;
-            //     stacking full retry budgets at every hop multiplies load during a backend
-            //     brownout (previously up to 4 outer x 4 inner = 16 gateway hits per action).
-            http.AddStandardResilienceHandler(options =>
+            builder.ConfigureOpenTelemetry();
+            builder.AddDefaultHealthChecks();
+            builder.AddWarmupReadiness();
+            builder.Services.AddServiceDiscovery();
+
+            // HttpClient defaults applied via ConfigureHttpClientDefaults — affects every
+            // HttpClient registered downstream (typed clients, named clients, YARP forwarder).
+            builder.Services.ConfigureHttpClientDefaults(http =>
             {
-                options.AttemptTimeout.Timeout = HttpResilienceDefaults.AttemptTimeout;
-                options.CircuitBreaker.SamplingDuration = HttpResilienceDefaults.CircuitBreakerSamplingDuration;
-                options.TotalRequestTimeout.Timeout = HttpResilienceDefaults.TotalRequestTimeout;
-                options.Retry.MaxRetryAttempts = HttpResilienceDefaults.MaxRetryAttempts;
+                // Polly resilience pipeline (values from HttpResilienceDefaults, shared with the
+                // gRPC typed clients in MMCA.Common.Grpc):
+                //   - 30s per-attempt timeout
+                //   - Circuit breaker sampled over 60s
+                //   - 90s total request timeout (including retries)
+                //   - ONE retry per hop: the UI service base classes own user-facing retries;
+                //     stacking full retry budgets at every hop multiplies load during a backend
+                //     brownout (previously up to 4 outer x 4 inner = 16 gateway hits per action).
+                http.AddStandardResilienceHandler(options =>
+                {
+                    options.AttemptTimeout.Timeout = HttpResilienceDefaults.AttemptTimeout;
+                    options.CircuitBreaker.SamplingDuration = HttpResilienceDefaults.CircuitBreakerSamplingDuration;
+                    options.TotalRequestTimeout.Timeout = HttpResilienceDefaults.TotalRequestTimeout;
+                    options.Retry.MaxRetryAttempts = HttpResilienceDefaults.MaxRetryAttempts;
+                });
+                http.AddServiceDiscovery();
+
+                // SocketsHttpHandler tuned to survive long idle periods on ACA Consumption plan:
+                //   - PooledConnectionLifetime: recycle connections every 10 min so DNS changes
+                //     (e.g., ACA replica rollover) are picked up without app restart.
+                //   - PooledConnectionIdleTimeout: keep idle connections in the pool for 5 min so
+                //     low-traffic inter-service calls don't pay TCP+TLS handshake every time.
+                //   - KeepAlivePingDelay/Timeout: socket-level keep-alive pings every 60s keep the
+                //     TCP connection alive without generating HTTP traffic — crucially, this does
+                //     NOT count as user traffic to the ACA platform, so the replica stays on
+                //     idle-vCPU billing (~8x cheaper than active).
+                //   - EnableMultipleHttp2Connections: HTTP/2 connections are multiplexed but a
+                //     single connection can become a bottleneck; allow new ones when needed.
+                http.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+                {
+                    PooledConnectionLifetime = HttpResilienceDefaults.PooledConnectionLifetime,
+                    PooledConnectionIdleTimeout = HttpResilienceDefaults.PooledConnectionIdleTimeout,
+                    KeepAlivePingDelay = HttpResilienceDefaults.KeepAlivePingDelay,
+                    KeepAlivePingTimeout = HttpResilienceDefaults.KeepAlivePingTimeout,
+                    KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests,
+                    EnableMultipleHttp2Connections = true,
+                });
             });
-            http.AddServiceDiscovery();
 
-            // SocketsHttpHandler tuned to survive long idle periods on ACA Consumption plan:
-            //   - PooledConnectionLifetime: recycle connections every 10 min so DNS changes
-            //     (e.g., ACA replica rollover) are picked up without app restart.
-            //   - PooledConnectionIdleTimeout: keep idle connections in the pool for 5 min so
-            //     low-traffic inter-service calls don't pay TCP+TLS handshake every time.
-            //   - KeepAlivePingDelay/Timeout: socket-level keep-alive pings every 60s keep the
-            //     TCP connection alive without generating HTTP traffic — crucially, this does
-            //     NOT count as user traffic to the ACA platform, so the replica stays on
-            //     idle-vCPU billing (~8x cheaper than active).
-            //   - EnableMultipleHttp2Connections: HTTP/2 connections are multiplexed but a
-            //     single connection can become a bottleneck; allow new ones when needed.
-            http.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-            {
-                PooledConnectionLifetime = HttpResilienceDefaults.PooledConnectionLifetime,
-                PooledConnectionIdleTimeout = HttpResilienceDefaults.PooledConnectionIdleTimeout,
-                KeepAlivePingDelay = HttpResilienceDefaults.KeepAlivePingDelay,
-                KeepAlivePingTimeout = HttpResilienceDefaults.KeepAlivePingTimeout,
-                KeepAlivePingPolicy = HttpKeepAlivePingPolicy.WithActiveRequests,
-                EnableMultipleHttp2Connections = true,
-            });
-        });
+            return builder;
+        }
 
-        return builder;
-    }
-
-    /// <summary>
-    /// Registers the warm-up infrastructure: a singleton <see cref="WarmupReadinessGate"/>,
-    /// the <see cref="WarmupHostedService"/> background runner, the
-    /// <see cref="WarmupReadinessHealthCheck"/> tagged <c>ready</c>, and the built-in
-    /// <see cref="OpenIdConnectMetadataWarmupTask"/> that pre-fetches the OIDC discovery
-    /// document for every configured JwtBearer scheme. Additional tasks can be registered
-    /// with <c>AddWarmupTask&lt;T&gt;()</c>.
-    /// </summary>
-    /// <typeparam name="TBuilder">The host application builder type.</typeparam>
-    /// <param name="builder">The host application builder to configure.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static TBuilder AddWarmupReadiness<TBuilder>(this TBuilder builder)
-        where TBuilder : IHostApplicationBuilder
-    {
-        builder.Services.AddSingleton<WarmupReadinessGate>();
-        builder.Services.AddHostedService<WarmupHostedService>();
-
-        builder.Services.AddSingleton<IWarmupTask, OpenIdConnectMetadataWarmupTask>();
-
-        builder.Services.AddHealthChecks()
-            .AddCheck<WarmupReadinessHealthCheck>("warmup", tags: ["ready"]);
-
-        return builder;
-    }
-
-    /// <summary>
-    /// Registers a custom <see cref="IWarmupTask"/> implementation that will run once at host
-    /// startup alongside the built-in tasks. Use for service-specific pre-fetches (output cache,
-    /// reference data, etc.).
-    /// </summary>
-    /// <typeparam name="TTask">The warm-up task implementation type.</typeparam>
-    /// <param name="services">The service collection to register the task in.</param>
-    /// <returns>The same service collection for chaining.</returns>
-    public static IServiceCollection AddWarmupTask<TTask>(this IServiceCollection services)
-        where TTask : class, IWarmupTask
-    {
-        services.AddSingleton<IWarmupTask, TTask>();
-        return services;
-    }
-
-    /// <summary>
-    /// Configures OpenTelemetry logging, metrics (ASP.NET Core, HttpClient, .NET runtime),
-    /// and distributed tracing. Exports are sent to the OTLP endpoint when the
-    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> environment variable is set (automatically
-    /// provided by the Aspire dashboard).
-    /// </summary>
-    /// <typeparam name="TBuilder">The host application builder type.</typeparam>
-    /// <param name="builder">The host application builder to configure.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder)
-        where TBuilder : IHostApplicationBuilder
-    {
-        builder.Logging.AddOpenTelemetry(logging =>
+        /// <summary>
+        /// Registers the warm-up infrastructure: a singleton <see cref="WarmupReadinessGate"/>,
+        /// the <see cref="WarmupHostedService"/> background runner, the
+        /// <see cref="WarmupReadinessHealthCheck"/> tagged <c>ready</c>, and the built-in
+        /// <see cref="OpenIdConnectMetadataWarmupTask"/> that pre-fetches the OIDC discovery
+        /// document for every configured JwtBearer scheme. Additional tasks can be registered
+        /// with <c>AddWarmupTask&lt;T&gt;()</c>.
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddWarmupReadiness()
         {
-            logging.IncludeFormattedMessage = true;
-            logging.IncludeScopes = true;
-        });
+            builder.Services.AddSingleton<WarmupReadinessGate>();
+            builder.Services.AddHostedService<WarmupHostedService>();
 
-        builder.Services.AddOpenTelemetry()
-            .WithMetrics(metrics =>
+            builder.Services.AddSingleton<IWarmupTask, OpenIdConnectMetadataWarmupTask>();
+
+            builder.Services.AddHealthChecks()
+                .AddCheck<WarmupReadinessHealthCheck>("warmup", tags: ["ready"]);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures OpenTelemetry logging, metrics (ASP.NET Core, HttpClient, .NET runtime),
+        /// and distributed tracing. Exports are sent to the OTLP endpoint when the
+        /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> environment variable is set (automatically
+        /// provided by the Aspire dashboard).
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder ConfigureOpenTelemetry()
+        {
+            builder.Logging.AddOpenTelemetry(logging =>
             {
-                metrics.AddAspNetCoreInstrumentation();
-
-                // Cost control (rubric §31): HttpClient connection/request metrics
-                // (http.client.open_connections / active_requests / request.duration) are the single
-                // highest-volume AppMetrics contributor on a low-traffic multi-service deployment — the
-                // pooled gRPC / service-discovery channels emit a high-frequency connection-gauge stream.
-                // A deployed host sets Telemetry:DisableHttpClientMetrics=true to drop them; outbound
-                // dependency latency is still captured as AppDependencies traces. Unset (default) keeps
-                // them, so no behavior change for a host that does not opt in.
-                if (!IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableHttpClientMetrics"))
-                {
-                    metrics.AddHttpClientInstrumentation();
-                }
-
-                // Cost control (rubric §31): .NET runtime metrics (dotnet.gc.* / jit.* / thread_pool.* —
-                // ~17 instruments emitted every collection interval regardless of traffic) are the second
-                // highest-volume contributor and are rarely consulted operationally for these apps. A
-                // deployed host sets Telemetry:DisableRuntimeMetrics=true to drop them. Unset keeps them.
-                if (!IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableRuntimeMetrics"))
-                {
-                    metrics.AddRuntimeInstrumentation();
-                }
-
-                // MMCA.Common meters (literal names — Aspire has no reference to the defining
-                // assemblies): outbox dead-letter counter and CQRS RED histograms.
-                metrics.AddMeter("MMCA.Common.Outbox")
-                    .AddMeter("MMCA.Common.Cqrs");
-            })
-            .WithTracing(tracing =>
-            {
-                tracing.AddSource(builder.Environment.ApplicationName)
-                    .AddSource("MMCA.Common.Outbox")
-                    .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-
-                    // Drops recurring outbox poll spans (and their SqlClient children from the
-                    // Azure Monitor distro) from export — idle polling would otherwise dominate
-                    // telemetry ingestion cost. Must be registered here, before
-                    // AddOpenTelemetryExporters() below, so its OnEnd clears the Recorded flag
-                    // before the exporters' batch processors check it.
-                    .AddProcessor(new Telemetry.OutboxPollFilterProcessor());
-
-                // Cost control (rubric §31): head-based trace sampling. Unset by default, so a
-                // host samples everything (no behavior change). A deployed host sets
-                // Telemetry:TracesSampleRatio in (0,1) — e.g. 0.1 to keep 10% of traces — to cut
-                // trace-ingestion cost, the largest observability line item. ParentBased so a
-                // sampled-in request keeps its whole trace intact across service boundaries.
-                if (TryGetTraceSampleRatio(builder.Configuration, out var traceSampleRatio))
-                    tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(traceSampleRatio)));
+                logging.IncludeFormattedMessage = true;
+                logging.IncludeScopes = true;
             });
 
-        builder.AddOpenTelemetryExporters();
+            builder.Services.AddOpenTelemetry()
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddAspNetCoreInstrumentation();
 
-        return builder;
+                    // Cost control (rubric §31): HttpClient connection/request metrics
+                    // (http.client.open_connections / active_requests / request.duration) are the single
+                    // highest-volume AppMetrics contributor on a low-traffic multi-service deployment — the
+                    // pooled gRPC / service-discovery channels emit a high-frequency connection-gauge stream.
+                    // A deployed host sets Telemetry:DisableHttpClientMetrics=true to drop them; outbound
+                    // dependency latency is still captured as AppDependencies traces. Unset (default) keeps
+                    // them, so no behavior change for a host that does not opt in.
+                    if (!IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableHttpClientMetrics"))
+                    {
+                        metrics.AddHttpClientInstrumentation();
+                    }
+
+                    // Cost control (rubric §31): .NET runtime metrics (dotnet.gc.* / jit.* / thread_pool.* —
+                    // ~17 instruments emitted every collection interval regardless of traffic) are the second
+                    // highest-volume contributor and are rarely consulted operationally for these apps. A
+                    // deployed host sets Telemetry:DisableRuntimeMetrics=true to drop them. Unset keeps them.
+                    if (!IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableRuntimeMetrics"))
+                    {
+                        metrics.AddRuntimeInstrumentation();
+                    }
+
+                    // MMCA.Common meters (literal names — Aspire has no reference to the defining
+                    // assemblies): outbox dead-letter counter and CQRS RED histograms.
+                    metrics.AddMeter("MMCA.Common.Outbox")
+                        .AddMeter("MMCA.Common.Cqrs");
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.AddSource(builder.Environment.ApplicationName)
+                        .AddSource("MMCA.Common.Outbox")
+                        .AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+
+                        // Drops recurring outbox poll spans (and their SqlClient children from the
+                        // Azure Monitor distro) from export — idle polling would otherwise dominate
+                        // telemetry ingestion cost. Must be registered here, before
+                        // AddOpenTelemetryExporters() below, so its OnEnd clears the Recorded flag
+                        // before the exporters' batch processors check it.
+                        .AddProcessor(new Telemetry.OutboxPollFilterProcessor());
+
+                    // Cost control (rubric §31): head-based trace sampling. Unset by default, so a
+                    // host samples everything (no behavior change). A deployed host sets
+                    // Telemetry:TracesSampleRatio in (0,1) — e.g. 0.1 to keep 10% of traces — to cut
+                    // trace-ingestion cost, the largest observability line item. ParentBased so a
+                    // sampled-in request keeps its whole trace intact across service boundaries.
+                    if (TryGetTraceSampleRatio(builder.Configuration, out var traceSampleRatio))
+                        tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(traceSampleRatio)));
+                });
+
+            builder.AddOpenTelemetryExporters();
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a baseline "self" health check tagged with "live". The /alive endpoint filters
+        /// to this tag for Kubernetes-style liveness probes, while /health requires all checks
+        /// (including module and database checks added elsewhere) to pass.
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddDefaultHealthChecks()
+        {
+            builder.Services.AddHealthChecks()
+                .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Conditionally registers health checks for infrastructure dependencies (Redis, RabbitMQ)
+        /// when their connection strings are configured. These are tagged as readiness checks only —
+        /// they appear in <c>/health</c> but not <c>/alive</c>, so a transient infrastructure outage
+        /// does not kill the process.
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddInfrastructureHealthChecks()
+        {
+            var healthChecks = builder.Services.AddHealthChecks();
+
+            var redisConnectionString = builder.Configuration.GetConnectionString("redis");
+            if (!string.IsNullOrWhiteSpace(redisConnectionString))
+            {
+                healthChecks.AddRedis(redisConnectionString, name: "redis");
+            }
+
+            var rabbitConnectionString = builder.Configuration.GetConnectionString("rabbitmq")
+                ?? builder.Configuration.GetConnectionString("messaging");
+            if (!string.IsNullOrWhiteSpace(rabbitConnectionString)
+                && Uri.TryCreate(rabbitConnectionString, UriKind.Absolute, out var rabbitUri))
+            {
+                healthChecks.AddRabbitMQ(async _ =>
+                {
+                    var factory = new RabbitMQ.Client.ConnectionFactory { Uri = rabbitUri };
+                    return await factory.CreateConnectionAsync().ConfigureAwait(false);
+                }, name: "rabbitmq");
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Conditionally enables telemetry exporters based on the environment:
+        /// <list type="bullet">
+        ///   <item>OTLP when <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is present (the Aspire
+        ///     dashboard sets this automatically; standalone deployments must supply it
+        ///     explicitly).</item>
+        ///   <item>Azure Monitor (Application Insights) when
+        ///     <c>APPLICATIONINSIGHTS_CONNECTION_STRING</c> is present — set by the cloud
+        ///     deployment (e.g., Container Apps Bicep) so logs, metrics, and traces flow to
+        ///     the workspace-based Application Insights resource.</item>
+        /// </list>
+        /// Both can be active simultaneously; each exporter only ships its own copy.
+        /// </summary>
+        private void AddOpenTelemetryExporters()
+        {
+            var useOtlpExporter = !string.IsNullOrWhiteSpace(
+                builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+            if (useOtlpExporter)
+            {
+                builder.Services.AddOpenTelemetry().UseOtlpExporter();
+            }
+
+            var useAzureMonitor = !string.IsNullOrWhiteSpace(
+                builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]);
+
+            if (useAzureMonitor)
+            {
+                builder.Services.AddOpenTelemetry().UseAzureMonitor();
+            }
+        }
+    }
+
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Registers a custom <see cref="IWarmupTask"/> implementation that will run once at host
+        /// startup alongside the built-in tasks. Use for service-specific pre-fetches (output cache,
+        /// reference data, etc.).
+        /// </summary>
+        /// <typeparam name="TTask">The warm-up task implementation type.</typeparam>
+        /// <returns>The same service collection for chaining.</returns>
+        public IServiceCollection AddWarmupTask<TTask>()
+            where TTask : class, IWarmupTask
+        {
+            services.AddSingleton<IWarmupTask, TTask>();
+            return services;
+        }
+    }
+
+    extension(WebApplication app)
+    {
+        /// <summary>
+        /// Maps the standard health-check endpoints:
+        /// <list type="bullet">
+        ///   <item><c>/health</c> — all checks must pass (used by humans/dashboards).</item>
+        ///   <item><c>/alive</c> — liveness probe; only "live"-tagged checks must pass.</item>
+        ///   <item><c>/health/ready</c> — readiness probe; everything except "live"-only checks.
+        ///     Reports unhealthy until the <see cref="WarmupReadinessGate"/> opens, so ACA
+        ///     ingress holds back traffic from a replica that is still warming up.</item>
+        /// </list>
+        /// </summary>
+        /// <returns>The same application instance for chaining.</returns>
+        public WebApplication MapDefaultEndpoints()
+        {
+            app.MapHealthChecks("/health");
+
+            // Liveness: only the "self" check (tagged "live") — avoids marking the
+            // process as dead when an external dependency (e.g., SQL Server) is down.
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+
+            // Readiness: everything except "live"-only checks. Warm-up gate is tagged "ready"
+            // and reports unhealthy until WarmupHostedService finishes; untagged dependency
+            // checks (e.g., AddSqlServer) also show up here so a failing dependency removes
+            // the replica from traffic without restarting the container.
+            app.MapHealthChecks("/health/ready", new HealthCheckOptions
+            {
+                Predicate = r => !r.Tags.Contains("live")
+            });
+
+            return app;
+        }
     }
 
     /// <summary>
@@ -232,124 +349,4 @@ public static class Extensions
     /// </summary>
     internal static bool IsInstrumentationDisabled(IConfiguration configuration, string configKey)
         => bool.TryParse(configuration[configKey], out var disabled) && disabled;
-
-    /// <summary>
-    /// Adds a baseline "self" health check tagged with "live". The /alive endpoint filters
-    /// to this tag for Kubernetes-style liveness probes, while /health requires all checks
-    /// (including module and database checks added elsewhere) to pass.
-    /// </summary>
-    /// <typeparam name="TBuilder">The host application builder type.</typeparam>
-    /// <param name="builder">The host application builder to configure.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder)
-        where TBuilder : IHostApplicationBuilder
-    {
-        builder.Services.AddHealthChecks()
-            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
-
-        return builder;
-    }
-
-    /// <summary>
-    /// Conditionally registers health checks for infrastructure dependencies (Redis, RabbitMQ)
-    /// when their connection strings are configured. These are tagged as readiness checks only —
-    /// they appear in <c>/health</c> but not <c>/alive</c>, so a transient infrastructure outage
-    /// does not kill the process.
-    /// </summary>
-    /// <typeparam name="TBuilder">The host application builder type.</typeparam>
-    /// <param name="builder">The host application builder to configure.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static TBuilder AddInfrastructureHealthChecks<TBuilder>(this TBuilder builder)
-        where TBuilder : IHostApplicationBuilder
-    {
-        var healthChecks = builder.Services.AddHealthChecks();
-
-        var redisConnectionString = builder.Configuration.GetConnectionString("redis");
-        if (!string.IsNullOrWhiteSpace(redisConnectionString))
-        {
-            healthChecks.AddRedis(redisConnectionString, name: "redis");
-        }
-
-        var rabbitConnectionString = builder.Configuration.GetConnectionString("rabbitmq")
-            ?? builder.Configuration.GetConnectionString("messaging");
-        if (!string.IsNullOrWhiteSpace(rabbitConnectionString)
-            && Uri.TryCreate(rabbitConnectionString, UriKind.Absolute, out var rabbitUri))
-        {
-            healthChecks.AddRabbitMQ(async _ =>
-            {
-                var factory = new RabbitMQ.Client.ConnectionFactory { Uri = rabbitUri };
-                return await factory.CreateConnectionAsync().ConfigureAwait(false);
-            }, name: "rabbitmq");
-        }
-
-        return builder;
-    }
-
-    /// <summary>
-    /// Maps the standard health-check endpoints:
-    /// <list type="bullet">
-    ///   <item><c>/health</c> — all checks must pass (used by humans/dashboards).</item>
-    ///   <item><c>/alive</c> — liveness probe; only "live"-tagged checks must pass.</item>
-    ///   <item><c>/health/ready</c> — readiness probe; everything except "live"-only checks.
-    ///     Reports unhealthy until the <see cref="WarmupReadinessGate"/> opens, so ACA
-    ///     ingress holds back traffic from a replica that is still warming up.</item>
-    /// </list>
-    /// </summary>
-    /// <param name="app">The web application to configure.</param>
-    /// <returns>The same application instance for chaining.</returns>
-    public static WebApplication MapDefaultEndpoints(this WebApplication app)
-    {
-        app.MapHealthChecks("/health");
-
-        // Liveness: only the "self" check (tagged "live") — avoids marking the
-        // process as dead when an external dependency (e.g., SQL Server) is down.
-        app.MapHealthChecks("/alive", new HealthCheckOptions
-        {
-            Predicate = r => r.Tags.Contains("live")
-        });
-
-        // Readiness: everything except "live"-only checks. Warm-up gate is tagged "ready"
-        // and reports unhealthy until WarmupHostedService finishes; untagged dependency
-        // checks (e.g., AddSqlServer) also show up here so a failing dependency removes
-        // the replica from traffic without restarting the container.
-        app.MapHealthChecks("/health/ready", new HealthCheckOptions
-        {
-            Predicate = r => !r.Tags.Contains("live")
-        });
-
-        return app;
-    }
-
-    /// <summary>
-    /// Conditionally enables telemetry exporters based on the environment:
-    /// <list type="bullet">
-    ///   <item>OTLP when <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is present (the Aspire
-    ///     dashboard sets this automatically; standalone deployments must supply it
-    ///     explicitly).</item>
-    ///   <item>Azure Monitor (Application Insights) when
-    ///     <c>APPLICATIONINSIGHTS_CONNECTION_STRING</c> is present — set by the cloud
-    ///     deployment (e.g., Container Apps Bicep) so logs, metrics, and traces flow to
-    ///     the workspace-based Application Insights resource.</item>
-    /// </list>
-    /// Both can be active simultaneously; each exporter only ships its own copy.
-    /// </summary>
-    private static void AddOpenTelemetryExporters<TBuilder>(this TBuilder builder)
-        where TBuilder : IHostApplicationBuilder
-    {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(
-            builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-
-        if (useOtlpExporter)
-        {
-            builder.Services.AddOpenTelemetry().UseOtlpExporter();
-        }
-
-        var useAzureMonitor = !string.IsNullOrWhiteSpace(
-            builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]);
-
-        if (useAzureMonitor)
-        {
-            builder.Services.AddOpenTelemetry().UseAzureMonitor();
-        }
-    }
 }

--- a/Source/Hosting/MMCA.Common.Aspire/GatewayCorsExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/GatewayCorsExtensions.cs
@@ -15,43 +15,45 @@ namespace MMCA.Common.Aspire;
 /// </summary>
 public static class GatewayCorsExtensions
 {
-    /// <summary>
-    /// Registers the default gateway CORS policy: allow-any in Development; in other environments,
-    /// origins from <c>Cors:AllowedOrigins</c> with any header/method and credentials allowed.
-    /// </summary>
-    public static IServiceCollection AddCommonGatewayCors(
-        this IServiceCollection services,
-        IConfiguration configuration,
-        IHostEnvironment environment)
+    extension(IServiceCollection services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(configuration);
-        ArgumentNullException.ThrowIfNull(environment);
-
-        services.AddCors(options =>
+        /// <summary>
+        /// Registers the default gateway CORS policy: allow-any in Development; in other environments,
+        /// origins from <c>Cors:AllowedOrigins</c> with any header/method and credentials allowed.
+        /// </summary>
+        public IServiceCollection AddCommonGatewayCors(
+            IConfiguration configuration,
+            IHostEnvironment environment)
         {
-            if (environment.IsDevelopment())
-            {
-#pragma warning disable S5122 // Allow-any-origin is scoped to Development only; production restricts origins to Cors:AllowedOrigins below
-                options.AddDefaultPolicy(p => p
-                    .AllowAnyOrigin()
-                    .AllowAnyHeader()
-                    .AllowAnyMethod());
-#pragma warning restore S5122
-            }
-            else
-            {
-                var origins = configuration
-                    .GetSection("Cors:AllowedOrigins")
-                    .Get<string[]>() ?? [];
-                options.AddDefaultPolicy(p => p
-                    .WithOrigins(origins)
-                    .AllowAnyHeader()
-                    .AllowAnyMethod()
-                    .AllowCredentials());
-            }
-        });
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(configuration);
+            ArgumentNullException.ThrowIfNull(environment);
 
-        return services;
+            services.AddCors(options =>
+            {
+                if (environment.IsDevelopment())
+                {
+#pragma warning disable S5122 // Allow-any-origin is scoped to Development only; production restricts origins to Cors:AllowedOrigins below
+                    options.AddDefaultPolicy(p => p
+                        .AllowAnyOrigin()
+                        .AllowAnyHeader()
+                        .AllowAnyMethod());
+#pragma warning restore S5122
+                }
+                else
+                {
+                    var origins = configuration
+                        .GetSection("Cors:AllowedOrigins")
+                        .Get<string[]>() ?? [];
+                    options.AddDefaultPolicy(p => p
+                        .WithOrigins(origins)
+                        .AllowAnyHeader()
+                        .AllowAnyMethod()
+                        .AllowCredentials());
+                }
+            });
+
+            return services;
+        }
     }
 }

--- a/Source/Hosting/MMCA.Common.Aspire/Security/SecurityHeaders.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Security/SecurityHeaders.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -146,40 +147,49 @@ public sealed class SecurityHeadersMiddleware
 }
 
 /// <summary>Registration + pipeline extensions for the common security-headers middleware.</summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class SecurityHeadersExtensions
 {
-    /// <summary>
-    /// Registers <see cref="SecurityHeadersSettings"/> (bound from the <c>"SecurityHeaders"</c> section
-    /// when <paramref name="configuration"/> is supplied) and the default static
-    /// <see cref="ICspPolicyProvider"/>. Register a custom <see cref="ICspPolicyProvider"/> before calling
-    /// this to supply a dynamic policy.
-    /// </summary>
-    public static IServiceCollection AddCommonSecurityHeaders(
-        this IServiceCollection services,
-        IConfiguration? configuration = null,
-        Action<SecurityHeadersSettings>? configure = null)
+    extension(IServiceCollection services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-
-        var optionsBuilder = services.AddOptions<SecurityHeadersSettings>();
-        if (configuration is not null)
+        /// <summary>
+        /// Registers <see cref="SecurityHeadersSettings"/> (bound from the <c>"SecurityHeaders"</c> section
+        /// when <paramref name="configuration"/> is supplied) and the default static
+        /// <see cref="ICspPolicyProvider"/>. Register a custom <see cref="ICspPolicyProvider"/> before calling
+        /// this to supply a dynamic policy.
+        /// </summary>
+        public IServiceCollection AddCommonSecurityHeaders(
+            IConfiguration? configuration = null,
+            Action<SecurityHeadersSettings>? configure = null)
         {
-            optionsBuilder.Bind(configuration.GetSection(SecurityHeadersSettings.SectionName));
-        }
+            ArgumentNullException.ThrowIfNull(services);
 
-        if (configure is not null)
-        {
-            optionsBuilder.Configure(configure);
-        }
+            var optionsBuilder = services.AddOptions<SecurityHeadersSettings>();
+            if (configuration is not null)
+            {
+                optionsBuilder.Bind(configuration.GetSection(SecurityHeadersSettings.SectionName));
+            }
 
-        services.TryAddSingleton<ICspPolicyProvider, StaticCspPolicyProvider>();
-        return services;
+            if (configure is not null)
+            {
+                optionsBuilder.Configure(configure);
+            }
+
+            services.TryAddSingleton<ICspPolicyProvider, StaticCspPolicyProvider>();
+            return services;
+        }
     }
 
-    /// <summary>Adds <see cref="SecurityHeadersMiddleware"/> to the request pipeline (call early).</summary>
-    public static IApplicationBuilder UseCommonSecurityHeaders(this IApplicationBuilder app)
+    extension(IApplicationBuilder app)
     {
-        ArgumentNullException.ThrowIfNull(app);
-        return app.UseMiddleware<SecurityHeadersMiddleware>();
+        /// <summary>Adds <see cref="SecurityHeadersMiddleware"/> to the request pipeline (call early).</summary>
+        public IApplicationBuilder UseCommonSecurityHeaders()
+        {
+            ArgumentNullException.ThrowIfNull(app);
+            return app.UseMiddleware<SecurityHeadersMiddleware>();
+        }
     }
 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Controllers.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Controllers.cs
@@ -37,7 +37,7 @@ public static partial class ArchitectureRules
     public static void ControllersAreSealed(IArchitectureMap map)
     {
         var offenders = map.Api()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsController)
             .Where(t => !t.IsSealed)
             .Select(t => $"  - {t.FullName}");
@@ -56,7 +56,7 @@ public static partial class ArchitectureRules
         var exempt = exemptFullNames is null ? [] : exemptFullNames.ToHashSet(StringComparer.Ordinal);
         var offenders = map.Layers
             .Where(l => l.Layer == Layer.Api && l.Module.Length > 0)
-            .SelectMany(l => l.Assembly.ConcreteClasses())
+            .SelectMany(l => l.Assembly.ConcreteClasses)
             .Where(IsController)
             .Where(t => !exempt.Contains(t.FullName ?? t.Name))
             .Where(t => !t.HasBaseTypeStartingWith("MMCA.Common.API.Controllers.ApiControllerBase")
@@ -68,7 +68,7 @@ public static partial class ArchitectureRules
     }
 
     private static bool IsController(Type type) =>
-        type.SimpleName().EndsWith("Controller", StringComparison.Ordinal)
+        type.SimpleName.EndsWith("Controller", StringComparison.Ordinal)
         || type.HasBaseTypeStartingWith("Microsoft.AspNetCore.Mvc.ControllerBase")
         || type.HasBaseTypeStartingWith("Microsoft.AspNetCore.Mvc.Controller");
 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Entities.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Entities.cs
@@ -8,8 +8,8 @@ public static partial class ArchitectureRules
     public static void DomainExposesAggregateRoots(IArchitectureMap map)
     {
         var roots = map.OfLayer(Layer.Domain)
-            .SelectMany(a => a.ConcreteClasses())
-            .Where(t => t.InheritsAggregateRoot());
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => t.InheritsAggregateRoot);
 
         roots.Should().NotBeEmpty(
             because: "the aggregate-root reflection filter must find roots, or the DDD fitness suite is vacuous");
@@ -20,7 +20,7 @@ public static partial class ArchitectureRules
     {
         var violations = new List<string>();
 
-        foreach (var type in map.OfLayer(Layer.Domain).SelectMany(a => a.ConcreteClasses()).Where(t => t.InheritsAggregateRoot()))
+        foreach (var type in map.OfLayer(Layer.Domain).SelectMany(a => a.ConcreteClasses).Where(t => t.InheritsAggregateRoot))
         {
             var createMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .Where(m => string.Equals(m.Name, "Create", StringComparison.Ordinal))
@@ -51,8 +51,8 @@ public static partial class ArchitectureRules
     public static void DomainAggregateRootsHaveNoPublicConstructors(IArchitectureMap map)
     {
         var violations = map.OfLayer(Layer.Domain)
-            .SelectMany(a => a.ConcreteClasses())
-            .Where(t => t.InheritsAggregateRoot()
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => t.InheritsAggregateRoot
                 && t.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Length > 0)
             .Select(t => $"  - {t.FullName}");
 
@@ -64,8 +64,8 @@ public static partial class ArchitectureRules
     public static void DomainEntitiesAreSealed(IArchitectureMap map)
     {
         var violations = map.ModuleDomain()
-            .SelectMany(a => a.ConcreteClasses())
-            .Where(t => t.InheritsAuditableEntity() && !t.IsSealed)
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => t.InheritsAuditableEntity && !t.IsSealed)
             .Select(t => $"  - {t.FullName}");
 
         ArchitectureAssert.NoViolations(violations,
@@ -76,8 +76,8 @@ public static partial class ArchitectureRules
     public static void AggregateRootsHaveNoPublicConstructors(IArchitectureMap map)
     {
         var violations = map.ModuleDomain()
-            .SelectMany(a => a.ConcreteClasses())
-            .Where(t => t.InheritsAggregateRoot()
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => t.InheritsAggregateRoot
                 && t.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Length > 0)
             .Select(t => $"  - {t.FullName}");
 
@@ -91,8 +91,8 @@ public static partial class ArchitectureRules
         Layer[] nonDomain = [Layer.Application, Layer.Infrastructure];
         var violations = map.Layers
             .Where(l => nonDomain.Contains(l.Layer))
-            .SelectMany(l => l.Assembly.ConcreteClasses())
-            .Where(t => t.InheritsAuditableEntity())
+            .SelectMany(l => l.Assembly.ConcreteClasses)
+            .Where(t => t.InheritsAuditableEntity)
             .Select(t => $"  - {t.FullName}");
 
         ArchitectureAssert.NoViolations(violations,
@@ -108,17 +108,17 @@ public static partial class ArchitectureRules
     public static void DtosAndRequestsAreNotInDomainOrInfrastructure(IArchitectureMap map)
     {
         var domainViolations = map.OfLayer(Layer.Domain)
-            .SelectMany(a => a.GetLoadableTypes())
+            .SelectMany(a => a.LoadableTypes)
             .Where(t => t is { IsClass: true } or { IsValueType: true })
-            .Where(t => t.SimpleName().EndsWith("DTO", StringComparison.Ordinal)
-                || t.SimpleName().EndsWith("Request", StringComparison.Ordinal)
+            .Where(t => t.SimpleName.EndsWith("DTO", StringComparison.Ordinal)
+                || t.SimpleName.EndsWith("Request", StringComparison.Ordinal)
                 || ImplementsBaseDto(t))
             .Select(t => $"  - {t.FullName} (DTO/request in Domain)");
 
         var infrastructureViolations = map.Infrastructure()
-            .SelectMany(a => a.GetLoadableTypes())
+            .SelectMany(a => a.LoadableTypes)
             .Where(t => t is { IsClass: true } or { IsValueType: true })
-            .Where(t => t.SimpleName().EndsWith("DTO", StringComparison.Ordinal) || ImplementsBaseDto(t))
+            .Where(t => t.SimpleName.EndsWith("DTO", StringComparison.Ordinal) || ImplementsBaseDto(t))
             .Select(t => $"  - {t.FullName} (DTO in Infrastructure)");
 
         ArchitectureAssert.NoViolations(domainViolations.Concat(infrastructureViolations),

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Events.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Events.cs
@@ -59,7 +59,7 @@ public static partial class ArchitectureRules
 
     private static IEnumerable<Type> IntegrationEvents(IArchitectureMap map) =>
         map.Layers.Select(l => l.Assembly).Distinct()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsIntegrationEvent);
 
     private static bool IsIntegrationEvent(Type type) =>

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Governance.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Governance.cs
@@ -11,7 +11,7 @@ public static partial class ArchitectureRules
     public static void EntitiesWithPiiImplementAnonymizable(IArchitectureMap map)
     {
         var violations = map.OfLayer(Layer.Domain)
-            .SelectMany(a => a.GetLoadableTypes())
+            .SelectMany(a => a.LoadableTypes)
             .Where(HasPiiProperty)
             .Where(t => !t.GetInterfaces().Any(i => string.Equals(i.FullName, AnonymizableFullName, StringComparison.Ordinal)))
             .Select(t => $"  - {t.FullName} declares [Pii] properties and must implement {AnonymizableFullName} (ADR-005)");
@@ -24,9 +24,9 @@ public static partial class ArchitectureRules
     public static void UpdateRequestsAreConcurrencyAware(IArchitectureMap map)
     {
         var violations = map.ModuleApplication()
-            .SelectMany(a => a.GetLoadableTypes())
+            .SelectMany(a => a.LoadableTypes)
             .Where(t => t is { IsClass: true } or { IsValueType: true }
-                && t.SimpleName().EndsWith("UpdateRequest", StringComparison.Ordinal))
+                && t.SimpleName.EndsWith("UpdateRequest", StringComparison.Ordinal))
             .Where(t => !t.GetInterfaces().Any(i => string.Equals(i.FullName, ConcurrencyAwareFullName, StringComparison.Ordinal)))
             .Select(t => $"  - {t.FullName} must implement {ConcurrencyAwareFullName} (RowVersion) so concurrent edits surface as 409 Conflict");
 

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.HandlerResults.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.HandlerResults.cs
@@ -64,8 +64,8 @@ public static partial class ArchitectureRules
     /// </summary>
     private static IEnumerable<(Type Handler, Type ClosedInterface)> HandlerInterfaces(IArchitectureMap map, string interfaceFullName) =>
         map.OfLayer(Layer.Application)
-            .SelectMany(a => a.ConcreteClasses())
-            .Where(t => !t.SimpleName().EndsWith("Decorator", StringComparison.Ordinal))
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => !t.SimpleName.EndsWith("Decorator", StringComparison.Ordinal))
             .SelectMany(t => t.GetInterfaces()
                 .Where(i => i.IsGenericType
                     && string.Equals(i.GetGenericTypeDefinition().FullName, interfaceFullName, StringComparison.Ordinal))

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Handlers.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Handlers.cs
@@ -6,7 +6,7 @@ public static partial class ArchitectureRules
     public static void HandlersResideInApplicationLayer(IArchitectureMap map)
     {
         var offenders = map.ModuleDomain().Concat(map.Infrastructure())
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsHandler)
             .Select(t => $"  - {t.FullName}");
 
@@ -18,7 +18,7 @@ public static partial class ArchitectureRules
     public static void HandlersDoNotInjectOtherHandlers(IArchitectureMap map)
     {
         var offenders = map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsHandler)
             .Where(t => t.GetConstructors().SelectMany(c => c.GetParameters()).Any(p => IsHandlerParameter(p.ParameterType)))
             .Select(t => $"  - {t.FullName}");
@@ -31,7 +31,7 @@ public static partial class ArchitectureRules
     public static void ApplicationServicesDoNotInjectHandlers(IArchitectureMap map)
     {
         var offenders = map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => !IsHandler(t))
             .Where(t => t.GetConstructors().SelectMany(c => c.GetParameters()).Any(p => IsHandlerParameter(p.ParameterType)))
             .Select(t => $"  - {t.FullName}");
@@ -46,8 +46,8 @@ public static partial class ArchitectureRules
         var offenders = new List<string>();
 
         foreach (var type in map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
-            .Where(t => t.SimpleName().EndsWith("Service", StringComparison.Ordinal)))
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => t.SimpleName.EndsWith("Service", StringComparison.Ordinal)))
         {
             var ctors = type.GetConstructors();
             if (ctors.Length == 0)
@@ -70,7 +70,7 @@ public static partial class ArchitectureRules
     public static void ValidatorsResideInApplicationLayer(IArchitectureMap map)
     {
         var offenders = map.ModuleDomain().Concat(map.Infrastructure())
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith("FluentValidation.AbstractValidator"))
             .Select(t => $"  - {t.FullName}");
 
@@ -82,12 +82,12 @@ public static partial class ArchitectureRules
     public static void DomainEventHandlersResideInApplicationAndSealed(IArchitectureMap map)
     {
         var misplaced = map.ModuleDomain()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsEventHandler)
             .Select(t => $"  - {t.FullName} (event handler must not be in Domain)");
 
         var unsealed = map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => IsEventHandler(t) && !t.IsSealed)
             .Select(t => $"  - {t.FullName} (event handler must be sealed)");
 

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Immutability.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Immutability.cs
@@ -6,7 +6,7 @@ public static partial class ArchitectureRules
     public static void DtosAreImmutable(IArchitectureMap map)
     {
         var offenders = map.ModuleShared()
-            .SelectMany(a => a.GetLoadableTypes())
+            .SelectMany(a => a.LoadableTypes)
             .Where(ImplementsBaseDto)
             .SelectMany(MutablePropertyViolations);
 
@@ -18,7 +18,7 @@ public static partial class ArchitectureRules
     public static void CommandsAndQueriesAreImmutable(IArchitectureMap map)
     {
         var messageTypes = map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .SelectMany(h => h.GetInterfaces())
             .Where(i => i.IsGenericType && i.Name is "ICommandHandler`2" or "IQueryHandler`2")
             .Select(i => i.GetGenericArguments()[0])
@@ -34,7 +34,7 @@ public static partial class ArchitectureRules
     public static void DomainEventsAreImmutable(IArchitectureMap map)
     {
         var offenders = map.ModuleDomain()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith("MMCA.Common.Domain.DomainEvents.BaseDomainEvent"))
             .SelectMany(MutablePropertyViolations);
 
@@ -45,7 +45,7 @@ public static partial class ArchitectureRules
     public static void IntegrationEventsAreImmutable(IArchitectureMap map)
     {
         var offenders = map.Layers.Select(l => l.Assembly).Distinct()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsIntegrationEvent)
             .SelectMany(MutablePropertyViolations);
 
@@ -57,7 +57,7 @@ public static partial class ArchitectureRules
     {
         var sharedAssemblies = map.OfLayer(Layer.Shared).ToHashSet();
         var valueObjects = map.Layers.Select(l => l.Assembly).Distinct()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith("MMCA.Common.Shared.ValueObjects.ValueObject"))
             .ToList();
 
@@ -74,7 +74,7 @@ public static partial class ArchitectureRules
     }
 
     private static IEnumerable<string> MutablePropertyViolations(Type type) =>
-        type.DeclaredPublicProperties()
-            .Where(p => p.HasPublicMutableSetter())
+        type.DeclaredPublicProperties
+            .Where(p => p.HasPublicMutableSetter)
             .Select(p => $"  - {type.FullName}.{p.Name} has a public mutable setter");
 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Naming.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Naming.cs
@@ -6,9 +6,9 @@ public static partial class ArchitectureRules
     public static void HandlersAreSealedWithHandlerSuffix(IArchitectureMap map)
     {
         var offenders = map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(IsHandler)
-            .Where(t => !t.SimpleName().EndsWith("Handler", StringComparison.Ordinal) || !t.IsSealed)
+            .Where(t => !t.SimpleName.EndsWith("Handler", StringComparison.Ordinal) || !t.IsSealed)
             .Select(t => $"  - {t.FullName} (handlers must end in 'Handler' and be sealed)");
 
         ArchitectureAssert.NoViolations(offenders, "command/query handlers must end in 'Handler' and be sealed");
@@ -26,10 +26,10 @@ public static partial class ArchitectureRules
     public static void ValidatorsHaveValidatorOrRulesSuffix(IArchitectureMap map)
     {
         var offenders = map.ModuleApplication()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith("FluentValidation.AbstractValidator"))
-            .Where(t => !t.SimpleName().EndsWith("Validator", StringComparison.Ordinal)
-                && !t.SimpleName().EndsWith("Rules", StringComparison.Ordinal))
+            .Where(t => !t.SimpleName.EndsWith("Validator", StringComparison.Ordinal)
+                && !t.SimpleName.EndsWith("Rules", StringComparison.Ordinal))
             .Select(t => $"  - {t.FullName}");
 
         ArchitectureAssert.NoViolations(offenders, "validators must end in 'Validator' or 'Rules'");
@@ -39,10 +39,10 @@ public static partial class ArchitectureRules
     public static void SharedDtosHaveDtoOrLookupSuffix(IArchitectureMap map)
     {
         var offenders = map.ModuleShared()
-            .SelectMany(a => a.GetLoadableTypes())
+            .SelectMany(a => a.LoadableTypes)
             .Where(ImplementsBaseDto)
-            .Where(t => !t.SimpleName().EndsWith("DTO", StringComparison.Ordinal)
-                && !t.SimpleName().EndsWith("Lookup", StringComparison.Ordinal))
+            .Where(t => !t.SimpleName.EndsWith("DTO", StringComparison.Ordinal)
+                && !t.SimpleName.EndsWith("Lookup", StringComparison.Ordinal))
             .Select(t => $"  - {t.FullName}");
 
         ArchitectureAssert.NoViolations(offenders, "shared DTO contracts must end in 'DTO' or 'Lookup'");
@@ -52,7 +52,7 @@ public static partial class ArchitectureRules
     public static void DomainEventsAreSealedInDomainEventsNamespace(IArchitectureMap map)
     {
         var offenders = map.ModuleDomain()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith("MMCA.Common.Domain.DomainEvents.BaseDomainEvent"))
             .Where(t => !t.IsSealed || t.Namespace?.Contains(".DomainEvents", StringComparison.Ordinal) != true)
             .Select(t => $"  - {t.FullName} (domain events must be sealed and in a *.DomainEvents namespace)");
@@ -64,8 +64,8 @@ public static partial class ArchitectureRules
     public static void InvariantClassesAreStatic(IArchitectureMap map)
     {
         var offenders = map.ModuleDomain()
-            .SelectMany(a => a.GetLoadableTypes())
-            .Where(t => t.IsClass && t.SimpleName().EndsWith("Invariants", StringComparison.Ordinal))
+            .SelectMany(a => a.LoadableTypes)
+            .Where(t => t.IsClass && t.SimpleName.EndsWith("Invariants", StringComparison.Ordinal))
             .Where(t => !(t.IsAbstract && t.IsSealed))
             .Select(t => $"  - {t.FullName}");
 
@@ -76,9 +76,9 @@ public static partial class ArchitectureRules
     public static void EfConfigurationsAreSealedWithConfigurationSuffix(IArchitectureMap map)
     {
         var offenders = map.Infrastructure()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.Name == "IEntityTypeConfiguration`1"))
-            .Where(t => !t.SimpleName().EndsWith("Configuration", StringComparison.Ordinal) || !t.IsSealed)
+            .Where(t => !t.SimpleName.EndsWith("Configuration", StringComparison.Ordinal) || !t.IsSealed)
             .Select(t => $"  - {t.FullName} (EF configurations must end in 'Configuration' and be sealed)");
 
         ArchitectureAssert.NoViolations(offenders, "EF entity configurations must end in 'Configuration' and be sealed");
@@ -89,9 +89,9 @@ public static partial class ArchitectureRules
     {
         var offenders = map.Layers
             .Where(l => l.Layer is Layer.Domain or Layer.Application)
-            .SelectMany(l => l.Assembly.ConcreteClasses())
+            .SelectMany(l => l.Assembly.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith("MMCA.Common.Domain.Specifications.Specification"))
-            .Where(t => !t.SimpleName().EndsWith("Specification", StringComparison.Ordinal) || !t.IsSealed)
+            .Where(t => !t.SimpleName.EndsWith("Specification", StringComparison.Ordinal) || !t.IsSealed)
             .Select(t => $"  - {t.FullName} (specifications must end in 'Specification' and be sealed)");
 
         ArchitectureAssert.NoViolations(offenders, "specifications must end in 'Specification' and be sealed");
@@ -101,11 +101,11 @@ public static partial class ArchitectureRules
     public static void RepositoriesHaveRepositorySuffix(IArchitectureMap map)
     {
         var offenders = map.Infrastructure()
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.GetInterfaces().Any(i => i.IsGenericType
                 && i.Name is "IRepository`2" or "IReadRepository`2" or "IWriteRepository`2"))
-            .Where(t => !t.SimpleName().EndsWith("Repository", StringComparison.Ordinal)
-                && !t.SimpleName().EndsWith("Decorator", StringComparison.Ordinal))
+            .Where(t => !t.SimpleName.EndsWith("Repository", StringComparison.Ordinal)
+                && !t.SimpleName.EndsWith("Decorator", StringComparison.Ordinal))
             .Select(t => $"  - {t.FullName}");
 
         ArchitectureAssert.NoViolations(offenders,
@@ -116,13 +116,13 @@ public static partial class ArchitectureRules
     {
         var offenders = new List<string>();
 
-        foreach (var handler in map.ModuleApplication().SelectMany(a => a.ConcreteClasses()))
+        foreach (var handler in map.ModuleApplication().SelectMany(a => a.ConcreteClasses))
         {
             foreach (var handlerInterface in handler.GetInterfaces()
                 .Where(i => i.IsGenericType && i.Name == handlerInterfaceName))
             {
                 var messageType = handlerInterface.GetGenericArguments()[0];
-                if (!suffixes.Any(s => messageType.SimpleName().EndsWith(s, StringComparison.Ordinal)))
+                if (!suffixes.Any(s => messageType.SimpleName.EndsWith(s, StringComparison.Ordinal)))
                 {
                     offenders.Add($"  - {messageType.FullName} (handled by {handler.Name})");
                 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Slices.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Slices.cs
@@ -14,7 +14,7 @@ public static partial class ArchitectureRules
     {
         var offenders = new List<string>();
 
-        foreach (var handler in map.OfLayer(Layer.Application).SelectMany(a => a.ConcreteClasses()).Where(IsHandler))
+        foreach (var handler in map.OfLayer(Layer.Application).SelectMany(a => a.ConcreteClasses).Where(IsHandler))
         {
             var contract = HandlerContract(handler);
             if (contract is null || !IsSameAssemblyConcreteContract(contract, handler))
@@ -24,7 +24,7 @@ public static partial class ArchitectureRules
 
             if (!NamespacesMatch(contract, handler))
             {
-                offenders.Add($"  - {handler.FullName}: handles {contract.SimpleName()} in '{contract.Namespace}' but lives in '{handler.Namespace}'");
+                offenders.Add($"  - {handler.FullName}: handles {contract.SimpleName} in '{contract.Namespace}' but lives in '{handler.Namespace}'");
             }
         }
 
@@ -42,7 +42,7 @@ public static partial class ArchitectureRules
     {
         var offenders = new List<string>();
 
-        foreach (var validator in map.OfLayer(Layer.Application).SelectMany(a => a.ConcreteClasses()))
+        foreach (var validator in map.OfLayer(Layer.Application).SelectMany(a => a.ConcreteClasses))
         {
             var validated = ValidatedType(validator);
             if (validated is null || !IsSameAssemblyConcreteContract(validated, validator))
@@ -52,7 +52,7 @@ public static partial class ArchitectureRules
 
             if (!NamespacesMatch(validated, validator))
             {
-                offenders.Add($"  - {validator.FullName}: validates {validated.SimpleName()} in '{validated.Namespace}' but lives in '{validator.Namespace}'");
+                offenders.Add($"  - {validator.FullName}: validates {validated.SimpleName} in '{validated.Namespace}' but lives in '{validator.Namespace}'");
             }
         }
 

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Specifications.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Specifications.cs
@@ -29,7 +29,7 @@ public static partial class ArchitectureRules
 
         var specTypes = map.OfLayer(Layer.Application)
             .Concat(map.OfLayer(Layer.Domain))
-            .SelectMany(a => a.ConcreteClasses())
+            .SelectMany(a => a.ConcreteClasses)
             .Where(t => t.HasBaseTypeStartingWith(SpecificationBaseFullNamePrefix));
 
         foreach (var specType in specTypes)
@@ -120,7 +120,7 @@ public static partial class ArchitectureRules
 
         private static Type? EntityTypeOf(Type propertyType)
         {
-            if (propertyType.InheritsAuditableEntity())
+            if (propertyType.InheritsAuditableEntity)
             {
                 return propertyType;
             }
@@ -129,7 +129,7 @@ public static partial class ArchitectureRules
             if (propertyType.IsGenericType)
             {
                 var elementType = propertyType.GetGenericArguments().FirstOrDefault();
-                if (elementType is not null && elementType.InheritsAuditableEntity())
+                if (elementType is not null && elementType.InheritsAuditableEntity)
                 {
                     return elementType;
                 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/RouteAuthorizationTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/RouteAuthorizationTestsBase.cs
@@ -49,7 +49,7 @@ public abstract class RouteAuthorizationTestsBase
     [Fact]
     public void GovernedPages_RequireDeclaredRole()
     {
-        var offenders = TargetAssembly.GetLoadableTypes()
+        var offenders = TargetAssembly.LoadableTypes
             .Where(t => IsRoutablePage(t) && IsGovernedPage(t) && !RequiresRole(t, RequiredRole))
             .Select(t => $"{t.FullName} [{Routes(t)}]")
             .ToList();
@@ -65,7 +65,7 @@ public abstract class RouteAuthorizationTestsBase
     {
         // Guard the guard: if a refactor moves the governed namespaces or renames the pinned pages,
         // IsGovernedPage would match nothing and the assertion above would pass vacuously.
-        var count = TargetAssembly.GetLoadableTypes().Count(t => IsRoutablePage(t) && IsGovernedPage(t));
+        var count = TargetAssembly.LoadableTypes.Count(t => IsRoutablePage(t) && IsGovernedPage(t));
 
         count.Should().BeGreaterThanOrEqualTo(
             MinimumGovernedPages,

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/RuleHelpers.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/RuleHelpers.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace MMCA.Common.Testing.Architecture;
 
 /// <summary>
@@ -5,105 +7,133 @@ namespace MMCA.Common.Testing.Architecture;
 /// method return types, generic-argument constraints, property accessors, or attribute usage, so
 /// those rules reflect over loaded types directly via these helpers.
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 internal static class RuleHelpers
 {
-    /// <summary>Types that actually loaded, tolerating a partially-resolvable assembly.</summary>
-    internal static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+    extension(Assembly assembly)
     {
-        try
+        /// <summary>Gets the types that actually loaded, tolerating a partially-resolvable assembly.</summary>
+        internal IEnumerable<Type> LoadableTypes
         {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            // OfType<Type>() both filters nulls and narrows the element type — no null-forgiving needed.
-            return ex.Types.OfType<Type>();
-        }
-    }
-
-    /// <summary>Concrete (non-abstract, non-interface) classes in an assembly.</summary>
-    internal static IEnumerable<Type> ConcreteClasses(this Assembly assembly) =>
-        assembly.GetLoadableTypes().Where(t => t is { IsClass: true, IsAbstract: false });
-
-    /// <summary>
-    /// The type's simple name with the generic-arity marker stripped, so suffix conventions match on
-    /// generic types too (e.g. <c>EFRepository`2</c> → <c>EFRepository</c>, <c>DeleteEntityCommand`2</c>
-    /// → <c>DeleteEntityCommand</c>).
-    /// </summary>
-    internal static string SimpleName(this Type type)
-    {
-        var name = type.Name;
-        var tick = name.IndexOf('`', StringComparison.Ordinal);
-        return tick >= 0 ? name[..tick] : name;
-    }
-
-    /// <summary>True if <paramref name="type"/> derives from the given open generic base type.</summary>
-    internal static bool InheritsGeneric(this Type type, Type openGenericBase)
-    {
-        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
-        {
-            if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == openGenericBase)
+            get
             {
-                return true;
+                try
+                {
+                    return assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    // OfType<Type>() both filters nulls and narrows the element type: no null-forgiving needed.
+                    return ex.Types.OfType<Type>();
+                }
             }
         }
 
-        return false;
+        /// <summary>Gets the concrete (non-abstract, non-interface) classes in the assembly.</summary>
+        internal IEnumerable<Type> ConcreteClasses =>
+            assembly.LoadableTypes.Where(t => t is { IsClass: true, IsAbstract: false });
     }
 
-    /// <summary>True if <paramref name="type"/> implements the given open generic interface.</summary>
-    internal static bool ImplementsGeneric(this Type type, Type openGenericInterface) =>
-        type.GetInterfaces().Any(i => i.IsGenericType
-            && i.GetGenericTypeDefinition() == openGenericInterface);
-
-    /// <summary>
-    /// True if any base type's full name starts with the given prefix — used to detect framework
-    /// base types (e.g. <c>FluentValidation.AbstractValidator`1</c>) without a compile dependency.
-    /// </summary>
-    internal static bool HasBaseTypeStartingWith(this Type type, string fullNamePrefix)
+    extension(Type type)
     {
-        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        /// <summary>
+        /// Gets the type's simple name with the generic-arity marker stripped, so suffix conventions
+        /// match on generic types too (e.g. <c>EFRepository`2</c> → <c>EFRepository</c>,
+        /// <c>DeleteEntityCommand`2</c> → <c>DeleteEntityCommand</c>).
+        /// </summary>
+        internal string SimpleName
         {
-            if (baseType.FullName?.StartsWith(fullNamePrefix, StringComparison.Ordinal) == true)
+            get
             {
-                return true;
+                var name = type.Name;
+                var tick = name.IndexOf('`', StringComparison.Ordinal);
+                return tick >= 0 ? name[..tick] : name;
             }
         }
 
-        return false;
-    }
-
-    /// <summary>Public instance properties declared on the type (not inherited).</summary>
-    internal static IEnumerable<PropertyInfo> DeclaredPublicProperties(this Type type) =>
-        type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-
-    /// <summary>
-    /// True if a property has a publicly-settable, non-init setter — i.e. it is mutable after
-    /// construction. <c>init</c>-only setters carry the <c>IsExternalInit</c> modreq and are treated
-    /// as immutable.
-    /// </summary>
-    internal static bool HasPublicMutableSetter(this PropertyInfo property)
-    {
-        var setter = property.SetMethod;
-        if (setter is null || !setter.IsPublic)
+        /// <summary>True if the type derives from the given open generic base type.</summary>
+        internal bool InheritsGeneric(Type openGenericBase)
         {
+            for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == openGenericBase)
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
 
-        var isInitOnly = setter.ReturnParameter
-            .GetRequiredCustomModifiers()
-            .Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+        /// <summary>True if the type implements the given open generic interface.</summary>
+        internal bool ImplementsGeneric(Type openGenericInterface) =>
+            type.GetInterfaces().Any(i => i.IsGenericType
+                && i.GetGenericTypeDefinition() == openGenericInterface);
 
-        return !isInitOnly;
+        /// <summary>
+        /// True if any base type's full name starts with the given prefix: used to detect framework
+        /// base types (e.g. <c>FluentValidation.AbstractValidator`1</c>) without a compile dependency.
+        /// </summary>
+        internal bool HasBaseTypeStartingWith(string fullNamePrefix)
+        {
+            for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                if (baseType.FullName?.StartsWith(fullNamePrefix, StringComparison.Ordinal) == true)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>Gets the public instance properties declared on the type (not inherited).</summary>
+        internal IEnumerable<PropertyInfo> DeclaredPublicProperties =>
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        /// <summary>
+        /// Gets a value indicating whether the type derives from the aggregate-root base type used
+        /// across MMCA modules.
+        /// </summary>
+        internal bool InheritsAggregateRoot =>
+            type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.AuditableAggregateRootEntity");
+
+        /// <summary>
+        /// Gets a value indicating whether the type derives from an auditable-entity base type
+        /// (covers child entities and aggregate roots).
+        /// </summary>
+        internal bool InheritsAuditableEntity =>
+            type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.AuditableBaseEntity")
+            || type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.AuditableAggregateRootEntity")
+            || type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.BaseEntity");
     }
 
-    /// <summary>The aggregate-root base type name used across MMCA modules.</summary>
-    internal static bool InheritsAggregateRoot(this Type type) =>
-        type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.AuditableAggregateRootEntity");
+    extension(PropertyInfo property)
+    {
+        /// <summary>
+        /// Gets a value indicating whether the property has a publicly-settable, non-init setter,
+        /// i.e. it is mutable after construction. <c>init</c>-only setters carry the
+        /// <c>IsExternalInit</c> modreq and are treated as immutable.
+        /// </summary>
+        internal bool HasPublicMutableSetter
+        {
+            get
+            {
+                var setter = property.SetMethod;
+                if (setter is null || !setter.IsPublic)
+                {
+                    return false;
+                }
 
-    /// <summary>The auditable-entity base type name (covers child entities and aggregate roots).</summary>
-    internal static bool InheritsAuditableEntity(this Type type) =>
-        type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.AuditableBaseEntity")
-        || type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.AuditableAggregateRootEntity")
-        || type.HasBaseTypeStartingWith("MMCA.Common.Domain.Entities.BaseEntity");
+                var isInitOnly = setter.ReturnParameter
+                    .GetRequiredCustomModifiers()
+                    .Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+
+                return !isInitOnly;
+            }
+        }
+    }
 }

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PageExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PageExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Deque.AxeCore.Commons;
 using Deque.AxeCore.Playwright;
@@ -11,282 +12,296 @@ namespace MMCA.Common.Testing.E2E.Infrastructure;
 /// WASM runtime initialises. These helpers ensure the page is fully interactive before
 /// tests start filling forms or clicking buttons.
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class PageExtensions
 {
-    /// <summary>
-    /// Waits for the Blazor runtime to finish initialising after a full page load.
-    /// Without this, event handlers are not wired up and clicks/fills are silently ignored.
-    /// </summary>
-    public static async Task WaitForBlazorAsync(this IPage page, float timeout = 30_000)
+    extension(IPage page)
     {
-        // blazor.web.js sets window.Blazor on load, then populates _internal after the
-        // WASM CLR (or SignalR circuit) is ready. The exact properties inside _internal
-        // may vary across .NET versions, so we check for any truthy _internal object.
-        await page.WaitForFunctionAsync(
-            "() => !!window.Blazor?._internal",
-            new PageWaitForFunctionOptions { Timeout = timeout });
-
-        // Blazor's component rendering is asynchronous — it happens AFTER the runtime
-        // reports as ready. Wait for two animation frames + a short delay to let the
-        // render pipeline flush, event handlers get attached, and DOM settle.
-        await page.EvaluateAsync(
-            "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))");
-    }
-
-    /// <summary>
-    /// Navigates to <paramref name="path"/>, waits for network idle, then waits for Blazor
-    /// interactivity. Use this instead of the bare GotoAsync + WaitForLoadState pair.
-    /// </summary>
-    public static async Task GotoAndWaitForBlazorAsync(this IPage page, string path)
-    {
-        await page.GotoAsync(path);
-        // Use Load instead of NetworkIdle — Blazor InteractiveAuto keeps a persistent
-        // SignalR WebSocket open, so NetworkIdle is never reached.
-        await page.WaitForLoadStateAsync(LoadState.Load);
-        await page.WaitForBlazorAsync();
-    }
-
-    /// <summary>
-    /// Navigates using Blazor's client-side router instead of a full page load.
-    /// Use this for auth-protected pages when already logged in — avoids the server-side
-    /// prerender which lacks the JWT token stored in browser storage.
-    /// Requires Blazor to already be initialised on the current page.
-    /// </summary>
-    public static async Task BlazorNavigateAsync(this IPage page, string path)
-    {
-        // Trigger client-side navigation. A forceLoad navigateTo can tear the JS context down
-        // synchronously, so tolerate the evaluate racing with that reload.
-        try
+        /// <summary>
+        /// Waits for the Blazor runtime to finish initialising after a full page load.
+        /// Without this, event handlers are not wired up and clicks/fills are silently ignored.
+        /// </summary>
+        public async Task WaitForBlazorAsync(float timeout = 30_000)
         {
-            await page.EvaluateAsync($"() => Blazor.navigateTo('{path}')");
-        }
-        catch (PlaywrightException)
-        {
-            // navigateTo did an immediate full reload that destroyed the context mid-call — fine,
-            // the navigation is already underway.
+            // blazor.web.js sets window.Blazor on load, then populates _internal after the
+            // WASM CLR (or SignalR circuit) is ready. The exact properties inside _internal
+            // may vary across .NET versions, so we check for any truthy _internal object.
+            await page.WaitForFunctionAsync(
+                "() => !!window.Blazor?._internal",
+                new PageWaitForFunctionOptions { Timeout = timeout });
+
+            // Blazor's component rendering is asynchronous — it happens AFTER the runtime
+            // reports as ready. Wait for two animation frames + a short delay to let the
+            // render pipeline flush, event handlers get attached, and DOM settle.
+            await page.EvaluateAsync(
+                "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))");
         }
 
-        // Client-side navigation fires NO load event, so do NOT use WaitForURLAsync (its default
-        // WaitUntil=Load hangs on same-document nav and leaves the page perpetually "navigating",
-        // blocking later actions). Poll window.location instead — Playwright re-injects this across
-        // a full reload too, so it settles on the target pathname either way.
-        await page.WaitForFunctionAsync(
-            $"() => window.location.pathname === '{path}'",
-            new PageWaitForFunctionOptions { Timeout = 15_000 });
-
-        // Re-assert Blazor interactivity (fast no-op after a pure SPA nav; waits for re-init after a
-        // full reload) and flush the render pipeline. Guard against a context-destroyed race from an
-        // in-flight reload, then re-assert on the fresh context.
-        try
+        /// <summary>
+        /// Navigates to <paramref name="path"/>, waits for network idle, then waits for Blazor
+        /// interactivity. Use this instead of the bare GotoAsync + WaitForLoadState pair.
+        /// </summary>
+        public async Task GotoAndWaitForBlazorAsync(string path)
         {
+            await page.GotoAsync(path);
+            // Use Load instead of NetworkIdle — Blazor InteractiveAuto keeps a persistent
+            // SignalR WebSocket open, so NetworkIdle is never reached.
+            await page.WaitForLoadStateAsync(LoadState.Load);
             await page.WaitForBlazorAsync();
         }
-        catch (PlaywrightException)
+
+        /// <summary>
+        /// Navigates using Blazor's client-side router instead of a full page load.
+        /// Use this for auth-protected pages when already logged in — avoids the server-side
+        /// prerender which lacks the JWT token stored in browser storage.
+        /// Requires Blazor to already be initialised on the current page.
+        /// </summary>
+        public async Task BlazorNavigateAsync(string path)
         {
-            await page.WaitForBlazorAsync();
-        }
-    }
-
-    /// <summary>
-    /// Navigates to an auth-protected Blazor page using client-side routing. SSR cannot read JWT
-    /// tokens from browser localStorage, so full page loads to [Authorize] pages redirect to /login.
-    /// This ensures the Blazor runtime is available (by loading a public page if needed) before using
-    /// <see cref="BlazorNavigateAsync"/> for client-side navigation, and re-routes via "/" first so
-    /// navigating to the target path always triggers a fresh component lifecycle.
-    /// </summary>
-    public static async Task GotoProtectedAsync(this IPage page, string path)
-    {
-        ArgumentNullException.ThrowIfNull(page);
-
-        bool blazorReady;
-        try
-        {
-            blazorReady = await page.EvaluateAsync<bool>("() => !!window.Blazor?._internal");
-        }
-        catch (PlaywrightException)
-        {
-            blazorReady = false;
-        }
-
-        if (!blazorReady)
-        {
-            // External page (e.g., Stripe) or Blazor not initialized — load a public page first.
-            await page.GotoAndWaitForBlazorAsync("/");
-        }
-        else
-        {
-            // Ensure we're on a different route so navigating to the target path
-            // always triggers a fresh component lifecycle (OnInitializedAsync, ServerData, etc.).
-            var currentPath = await page.EvaluateAsync<string>("() => window.location.pathname");
-            if (!string.Equals(currentPath, "/", StringComparison.Ordinal))
-            {
-                await page.BlazorNavigateAsync("/");
-            }
-        }
-
-        await page.BlazorNavigateAsync(path);
-    }
-
-    /// <summary>
-    /// Waits for a full page load + Blazor readiness. Use after clicking a link or button
-    /// that triggers a full-page navigation (e.g., clicking "View Details" on a product card).
-    /// </summary>
-    public static async Task WaitForPageAndBlazorAsync(this IPage page)
-    {
-        // For full page navigations, wait for the load event. For Blazor enhanced
-        // navigation (SPA-style), this resolves immediately — harmless.
-        await page.WaitForLoadStateAsync(LoadState.Load);
-        // Wait for Blazor render cycle — covers both full-page and enhanced navigation.
-        await page.EvaluateAsync(
-            "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))");
-    }
-
-    /// <summary>
-    /// Fills a form field and waits for the value to persist. Blazor InteractiveAuto re-hydrates the
-    /// page after the runtime loads, replacing pre-rendered inputs and wiping any value filled before
-    /// hydration completed. Rather than sleeping a fixed interval and hoping hydration has finished,
-    /// this fills the field then uses Playwright's auto-waiting <c>ToHaveValueAsync</c> assertion,
-    /// which polls until the value sticks (or <paramref name="timeout"/> elapses). If the pre-render
-    /// value was wiped before it stuck, the field is re-typed character-by-character and re-asserted.
-    /// This is the single fill helper shared by <c>E2ETestBase</c>, <c>LoginPage</c>, and
-    /// <c>RegisterPage</c>; it replaces the duplicated fixed-delay retry loops.
-    /// </summary>
-    public static async Task FillAndVerifyAsync(this ILocator field, string value, float timeout = 10_000)
-    {
-        ArgumentNullException.ThrowIfNull(field);
-
-        // FillAsync is fast and dispatches input+change events in one shot.
-        await field.FillAsync(value);
-        try
-        {
-            await Assertions.Expect(field).ToHaveValueAsync(value, new() { Timeout = timeout });
-        }
-        catch (PlaywrightException)
-        {
-            // The pre-render value was wiped by Blazor re-hydration before it stuck. Re-type
-            // character-by-character (individual key events the Blazor event system reliably
-            // handles after enhanced navigation), then assert it persists.
-            await field.ClearAsync();
-            await field.PressSequentiallyAsync(value, new() { Delay = 20 });
-            await Assertions.Expect(field).ToHaveValueAsync(value, new() { Timeout = timeout });
-        }
-    }
-
-    /// <summary>
-    /// Clicks <paramref name="button"/> and waits for <paramref name="expected"/> (the action's visible
-    /// effect, e.g. a "saved successfully" snackbar) to appear, re-clicking if it does not. This is the
-    /// submit-side counterpart to <see cref="FillAndVerifyAsync"/>: Blazor InteractiveAuto prerenders the
-    /// page as static HTML, so a click that lands before the runtime wires the component's
-    /// <c>@onclick</c> is silently ignored (see the type-level remarks) and the action never fires. On a
-    /// fast host the bare click routinely beats hydration, so a single click is unreliable. This polls:
-    /// click, wait a slice of <paramref name="timeout"/> for the effect, and if it has not appeared
-    /// re-assert interactivity and click again. A successful action surfaces its effect well within one
-    /// slice, so a genuinely-applied click is not re-issued (no double submit); only a no-op click is
-    /// retried. Use for create/edit/delete submits that assert on a resulting snackbar or navigation.
-    /// </summary>
-    public static async Task ClickAndVerifyAsync(this ILocator button, ILocator expected, float timeout = 15_000)
-    {
-        ArgumentNullException.ThrowIfNull(button);
-        ArgumentNullException.ThrowIfNull(expected);
-
-        var page = button.Page;
-        // The handler must be wired before the first click counts; without this the click is a no-op.
-        await page.WaitForBlazorAsync();
-
-        const int maxAttempts = 3;
-        var perAttempt = timeout / maxAttempts;
-        for (var attempt = 1; attempt < maxAttempts; attempt++)
-        {
-            await button.ClickAsync();
+            // Trigger client-side navigation. A forceLoad navigateTo can tear the JS context down
+            // synchronously, so tolerate the evaluate racing with that reload.
             try
             {
-                await Assertions.Expect(expected).ToBeVisibleAsync(new() { Timeout = perAttempt });
-                return;
+                await page.EvaluateAsync($"() => Blazor.navigateTo('{path}')");
             }
             catch (PlaywrightException)
             {
-                // The click most likely did not register (handler not yet attached on this fast host).
-                // Re-assert interactivity, then click again on the next loop turn.
+                // navigateTo did an immediate full reload that destroyed the context mid-call — fine,
+                // the navigation is already underway.
+            }
+
+            // Client-side navigation fires NO load event, so do NOT use WaitForURLAsync (its default
+            // WaitUntil=Load hangs on same-document nav and leaves the page perpetually "navigating",
+            // blocking later actions). Poll window.location instead — Playwright re-injects this across
+            // a full reload too, so it settles on the target pathname either way.
+            await page.WaitForFunctionAsync(
+                $"() => window.location.pathname === '{path}'",
+                new PageWaitForFunctionOptions { Timeout = 15_000 });
+
+            // Re-assert Blazor interactivity (fast no-op after a pure SPA nav; waits for re-init after a
+            // full reload) and flush the render pipeline. Guard against a context-destroyed race from an
+            // in-flight reload, then re-assert on the fresh context.
+            try
+            {
+                await page.WaitForBlazorAsync();
+            }
+            catch (PlaywrightException)
+            {
                 await page.WaitForBlazorAsync();
             }
         }
 
-        // Final attempt: click once more and let the assertion throw with full diagnostics if it still
-        // has not taken effect (a real failure, not a hydration race).
-        await button.ClickAsync();
-        await Assertions.Expect(expected).ToBeVisibleAsync(new() { Timeout = perAttempt });
-    }
-
-    /// <summary>
-    /// Clicks a locator that navigates (typically an in-cell link on a grid row) and verifies the
-    /// navigation actually happened, re-clicking if it did not. This is the navigation-side
-    /// counterpart to <see cref="ClickAndVerifyAsync"/>: list pages often have NO RowClick handler
-    /// because every cell wraps its content in a MudLink Href, so clicking the ROW element's center
-    /// lands on cell padding between the inline anchors and silently does nothing. Call this on
-    /// <c>row.GetByRole(AriaRole.Link).First</c>, never on the row itself; the URL verify stays as
-    /// the belt because a link click can still race a grid re-render. Waits for the page and Blazor
-    /// to settle once the URL matches <paramref name="urlPattern"/> (a regular expression).
-    /// </summary>
-    public static async Task ClickAndWaitForUrlAsync(this ILocator clickable, IPage page, string urlPattern)
-    {
-        ArgumentNullException.ThrowIfNull(clickable);
-        ArgumentNullException.ThrowIfNull(page);
-
-        for (var attempt = 0; attempt < 3; attempt++)
+        /// <summary>
+        /// Navigates to an auth-protected Blazor page using client-side routing. SSR cannot read JWT
+        /// tokens from browser localStorage, so full page loads to [Authorize] pages redirect to /login.
+        /// This ensures the Blazor runtime is available (by loading a public page if needed) before using
+        /// <see cref="BlazorNavigateAsync"/> for client-side navigation, and re-routes via "/" first so
+        /// navigating to the target path always triggers a fresh component lifecycle.
+        /// </summary>
+        public async Task GotoProtectedAsync(string path)
         {
-            await clickable.ClickAsync();
+            ArgumentNullException.ThrowIfNull(page);
+
+            bool blazorReady;
             try
             {
-                await page.WaitForURLAsync(new Regex(urlPattern), new() { Timeout = 5_000 });
-                await page.WaitForPageAndBlazorAsync();
+                blazorReady = await page.EvaluateAsync<bool>("() => !!window.Blazor?._internal");
+            }
+            catch (PlaywrightException)
+            {
+                blazorReady = false;
+            }
+
+            if (!blazorReady)
+            {
+                // External page (e.g., Stripe) or Blazor not initialized — load a public page first.
+                await page.GotoAndWaitForBlazorAsync("/");
+            }
+            else
+            {
+                // Ensure we're on a different route so navigating to the target path
+                // always triggers a fresh component lifecycle (OnInitializedAsync, ServerData, etc.).
+                var currentPath = await page.EvaluateAsync<string>("() => window.location.pathname");
+                if (!string.Equals(currentPath, "/", StringComparison.Ordinal))
+                {
+                    await page.BlazorNavigateAsync("/");
+                }
+            }
+
+            await page.BlazorNavigateAsync(path);
+        }
+
+        /// <summary>
+        /// Waits for a full page load + Blazor readiness. Use after clicking a link or button
+        /// that triggers a full-page navigation (e.g., clicking "View Details" on a product card).
+        /// </summary>
+        public async Task WaitForPageAndBlazorAsync()
+        {
+            // For full page navigations, wait for the load event. For Blazor enhanced
+            // navigation (SPA-style), this resolves immediately — harmless.
+            await page.WaitForLoadStateAsync(LoadState.Load);
+            // Wait for Blazor render cycle — covers both full-page and enhanced navigation.
+            await page.EvaluateAsync(
+                "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))");
+        }
+
+        /// <summary>
+        /// Runs an axe-core accessibility scan against the current page and throws an
+        /// <see cref="AccessibilityViolationException"/> if any violation is found. Call from a
+        /// consumer E2E test once the page is interactive (e.g. after
+        /// <see cref="GotoAndWaitForBlazorAsync"/>).
+        /// </summary>
+        public async Task AssertNoAccessibilityViolationsAsync(AxeRunOptions? options = null)
+        {
+            ArgumentNullException.ThrowIfNull(page);
+
+            var result = options is null
+                ? await page.RunAxe().ConfigureAwait(false)
+                : await page.RunAxe(options).ConfigureAwait(false);
+
+            if (result.Violations.Length == 0)
+            {
                 return;
             }
-            catch (Exception ex) when (ex is TimeoutException or PlaywrightException)
+
+            var summary = string.Join(
+                Environment.NewLine,
+                result.Violations.Select(v =>
+                {
+                    var nodes = string.Join(
+                        Environment.NewLine,
+                        v.Nodes.Select(n => $"      → {CompactHtml(n.Html)}"));
+                    return $"  [{v.Impact}] {v.Id}: {v.Help} ({v.Nodes.Length} node(s)){Environment.NewLine}{nodes}";
+                }));
+
+            throw new AccessibilityViolationException(
+                $"{result.Violations.Length} accessibility violation(s) found:{Environment.NewLine}{summary}");
+        }
+    }
+
+    extension(ILocator locator)
+    {
+        /// <summary>
+        /// Fills a form field and waits for the value to persist. Blazor InteractiveAuto re-hydrates the
+        /// page after the runtime loads, replacing pre-rendered inputs and wiping any value filled before
+        /// hydration completed. Rather than sleeping a fixed interval and hoping hydration has finished,
+        /// this fills the field then uses Playwright's auto-waiting <c>ToHaveValueAsync</c> assertion,
+        /// which polls until the value sticks (or <paramref name="timeout"/> elapses). If the pre-render
+        /// value was wiped before it stuck, the field is re-typed character-by-character and re-asserted.
+        /// This is the single fill helper shared by <c>E2ETestBase</c>, <c>LoginPage</c>, and
+        /// <c>RegisterPage</c>; it replaces the duplicated fixed-delay retry loops.
+        /// </summary>
+        public async Task FillAndVerifyAsync(string value, float timeout = 10_000)
+        {
+            ArgumentNullException.ThrowIfNull(locator);
+
+            // FillAsync is fast and dispatches input+change events in one shot.
+            await locator.FillAsync(value);
+            try
             {
-                // Swallowed click: the URL never changed. Re-click the now-settled element.
+                await Assertions.Expect(locator).ToHaveValueAsync(value, new() { Timeout = timeout });
+            }
+            catch (PlaywrightException)
+            {
+                // The pre-render value was wiped by Blazor re-hydration before it stuck. Re-type
+                // character-by-character (individual key events the Blazor event system reliably
+                // handles after enhanced navigation), then assert it persists.
+                await locator.ClearAsync();
+                await locator.PressSequentiallyAsync(value, new() { Delay = 20 });
+                await Assertions.Expect(locator).ToHaveValueAsync(value, new() { Timeout = timeout });
             }
         }
 
-        await clickable.ClickAsync();
-        await page.WaitForURLAsync(new Regex(urlPattern), new() { Timeout = 15_000 });
-        await page.WaitForPageAndBlazorAsync();
-    }
-
-    /// <summary>
-    /// Runs an axe-core accessibility scan against the current page and throws an
-    /// <see cref="AccessibilityViolationException"/> if any violation is found. Call from a
-    /// consumer E2E test once the page is interactive (e.g. after
-    /// <see cref="GotoAndWaitForBlazorAsync"/>).
-    /// </summary>
-    public static async Task AssertNoAccessibilityViolationsAsync(this IPage page, AxeRunOptions? options = null)
-    {
-        ArgumentNullException.ThrowIfNull(page);
-
-        var result = options is null
-            ? await page.RunAxe().ConfigureAwait(false)
-            : await page.RunAxe(options).ConfigureAwait(false);
-
-        if (result.Violations.Length == 0)
+        /// <summary>
+        /// Clicks this locator (a button) and waits for <paramref name="expected"/> (the action's visible
+        /// effect, e.g. a "saved successfully" snackbar) to appear, re-clicking if it does not. This is the
+        /// submit-side counterpart to <see cref="FillAndVerifyAsync"/>: Blazor InteractiveAuto prerenders the
+        /// page as static HTML, so a click that lands before the runtime wires the component's
+        /// <c>@onclick</c> is silently ignored (see the type-level remarks) and the action never fires. On a
+        /// fast host the bare click routinely beats hydration, so a single click is unreliable. This polls:
+        /// click, wait a slice of <paramref name="timeout"/> for the effect, and if it has not appeared
+        /// re-assert interactivity and click again. A successful action surfaces its effect well within one
+        /// slice, so a genuinely-applied click is not re-issued (no double submit); only a no-op click is
+        /// retried. Use for create/edit/delete submits that assert on a resulting snackbar or navigation.
+        /// </summary>
+        public async Task ClickAndVerifyAsync(ILocator expected, float timeout = 15_000)
         {
-            return;
+            ArgumentNullException.ThrowIfNull(locator);
+            ArgumentNullException.ThrowIfNull(expected);
+
+            var page = locator.Page;
+            // The handler must be wired before the first click counts; without this the click is a no-op.
+            await page.WaitForBlazorAsync();
+
+            const int maxAttempts = 3;
+            var perAttempt = timeout / maxAttempts;
+            for (var attempt = 1; attempt < maxAttempts; attempt++)
+            {
+                await locator.ClickAsync();
+                try
+                {
+                    await Assertions.Expect(expected).ToBeVisibleAsync(new() { Timeout = perAttempt });
+                    return;
+                }
+                catch (PlaywrightException)
+                {
+                    // The click most likely did not register (handler not yet attached on this fast host).
+                    // Re-assert interactivity, then click again on the next loop turn.
+                    await page.WaitForBlazorAsync();
+                }
+            }
+
+            // Final attempt: click once more and let the assertion throw with full diagnostics if it still
+            // has not taken effect (a real failure, not a hydration race).
+            await locator.ClickAsync();
+            await Assertions.Expect(expected).ToBeVisibleAsync(new() { Timeout = perAttempt });
         }
 
-        var summary = string.Join(
-            Environment.NewLine,
-            result.Violations.Select(v =>
-            {
-                var nodes = string.Join(
-                    Environment.NewLine,
-                    v.Nodes.Select(n => $"      → {CompactHtml(n.Html)}"));
-                return $"  [{v.Impact}] {v.Id}: {v.Help} ({v.Nodes.Length} node(s)){Environment.NewLine}{nodes}";
-            }));
+        /// <summary>
+        /// Clicks a locator that navigates (typically an in-cell link on a grid row) and verifies the
+        /// navigation actually happened, re-clicking if it did not. This is the navigation-side
+        /// counterpart to <see cref="ClickAndVerifyAsync"/>: list pages often have NO RowClick handler
+        /// because every cell wraps its content in a MudLink Href, so clicking the ROW element's center
+        /// lands on cell padding between the inline anchors and silently does nothing. Call this on
+        /// <c>row.GetByRole(AriaRole.Link).First</c>, never on the row itself; the URL verify stays as
+        /// the belt because a link click can still race a grid re-render. Waits for the page and Blazor
+        /// to settle once the URL matches <paramref name="urlPattern"/> (a regular expression).
+        /// </summary>
+        public async Task ClickAndWaitForUrlAsync(IPage page, string urlPattern)
+        {
+            ArgumentNullException.ThrowIfNull(locator);
+            ArgumentNullException.ThrowIfNull(page);
 
-        throw new AccessibilityViolationException(
-            $"{result.Violations.Length} accessibility violation(s) found:{Environment.NewLine}{summary}");
+            for (var attempt = 0; attempt < 3; attempt++)
+            {
+                await locator.ClickAsync();
+                try
+                {
+                    await page.WaitForURLAsync(new Regex(urlPattern), new() { Timeout = 5_000 });
+                    await page.WaitForPageAndBlazorAsync();
+                    return;
+                }
+                catch (Exception ex) when (ex is TimeoutException or PlaywrightException)
+                {
+                    // Swallowed click: the URL never changed. Re-click the now-settled element.
+                }
+            }
+
+            await locator.ClickAsync();
+            await page.WaitForURLAsync(new Regex(urlPattern), new() { Timeout = 15_000 });
+            await page.WaitForPageAndBlazorAsync();
+        }
     }
 
     // Collapses a violating node's markup to a single trimmed line so the failure message points at the
     // exact offending element (e.g. which low-contrast text node) without dumping multi-line HTML.
+    [SuppressMessage(
+        "Style",
+        "IDE0051:Remove unused private members",
+        Justification = "Called from AssertNoAccessibilityViolationsAsync inside the extension(IPage page) block above. The IDE0051 analyzer in .NET SDK 10.0.201+ does not see references that cross the boundary between a C# preview extension type block and outer-scope private members of the same containing class, so it reports a false positive. The local SDK 10.0.104 analyzer correctly resolves the call. Remove this suppression once Roslyn fixes the cross-block reference tracking.")]
     private static string CompactHtml(string? html)
     {
         if (string.IsNullOrWhiteSpace(html))

--- a/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitInteractionExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitInteractionExtensions.cs
@@ -11,24 +11,25 @@ namespace MMCA.Common.Testing.UI;
 /// </summary>
 public static class BunitInteractionExtensions
 {
-    /// <summary>Finds the first <c>&lt;button&gt;</c> whose visible text contains <paramref name="text"/> (case-insensitive). Throws with the available button texts if none match.</summary>
-    public static IElement FindButtonByText<TComponent>(this IRenderedComponent<TComponent> cut, string text)
+    extension<TComponent>(IRenderedComponent<TComponent> cut)
         where TComponent : IComponent
     {
-        var buttons = cut.FindAll("button");
-        return buttons.FirstOrDefault(b => b.TextContent.Contains(text, StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException(
-                $"No <button> containing text '{text}' was found. Buttons present: " +
-                $"[{string.Join(" | ", buttons.Select(b => b.TextContent.Trim()))}]");
+        /// <summary>Finds the first <c>&lt;button&gt;</c> whose visible text contains <paramref name="text"/> (case-insensitive). Throws with the available button texts if none match.</summary>
+        public IElement FindButtonByText(string text)
+        {
+            var buttons = cut.FindAll("button");
+            return buttons.FirstOrDefault(b => b.TextContent.Contains(text, StringComparison.OrdinalIgnoreCase))
+                ?? throw new InvalidOperationException(
+                    $"No <button> containing text '{text}' was found. Buttons present: " +
+                    $"[{string.Join(" | ", buttons.Select(b => b.TextContent.Trim()))}]");
+        }
+
+        /// <summary>Clicks the first <c>&lt;button&gt;</c> whose visible text contains <paramref name="text"/>.</summary>
+        public void ClickButtonByText(string text)
+            => cut.FindButtonByText(text).Click();
+
+        /// <summary>True if the component's current markup contains <paramref name="text"/> (case-insensitive).</summary>
+        public bool HasText(string text)
+            => cut.Markup.Contains(text, StringComparison.OrdinalIgnoreCase);
     }
-
-    /// <summary>Clicks the first <c>&lt;button&gt;</c> whose visible text contains <paramref name="text"/>.</summary>
-    public static void ClickButtonByText<TComponent>(this IRenderedComponent<TComponent> cut, string text)
-        where TComponent : IComponent
-        => cut.FindButtonByText(text).Click();
-
-    /// <summary>True if the component's current markup contains <paramref name="text"/> (case-insensitive).</summary>
-    public static bool HasText<TComponent>(this IRenderedComponent<TComponent> cut, string text)
-        where TComponent : IComponent
-        => cut.Markup.Contains(text, StringComparison.OrdinalIgnoreCase);
 }

--- a/Source/Hosting/MMCA.Common.Testing/FeatureManagementTestExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing/FeatureManagementTestExtensions.cs
@@ -9,28 +9,29 @@ namespace MMCA.Common.Testing;
 /// </summary>
 public static class FeatureManagementTestExtensions
 {
-    /// <summary>
-    /// Adds feature management with the specified feature flags configured via in-memory settings.
-    /// Call this in <c>ConfigureServices</c> of a test <c>WebApplicationFactory</c> to override
-    /// feature flag values from <c>appsettings.json</c>.
-    /// </summary>
-    /// <param name="services">The service collection to configure.</param>
-    /// <param name="features">A dictionary of feature flag names to their enabled/disabled state.</param>
-    /// <returns>The service collection for chaining.</returns>
-    public static IServiceCollection ConfigureTestFeatureFlags(
-        this IServiceCollection services,
-        Dictionary<string, bool> features)
+    extension(IServiceCollection services)
     {
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(
-                features.Select(kvp =>
-                    new KeyValuePair<string, string?>(
-                        $"FeatureManagement:{kvp.Key}", kvp.Value.ToString())))
-            .Build();
+        /// <summary>
+        /// Adds feature management with the specified feature flags configured via in-memory settings.
+        /// Call this in <c>ConfigureServices</c> of a test <c>WebApplicationFactory</c> to override
+        /// feature flag values from <c>appsettings.json</c>.
+        /// </summary>
+        /// <param name="features">A dictionary of feature flag names to their enabled/disabled state.</param>
+        /// <returns>The service collection for chaining.</returns>
+        public IServiceCollection ConfigureTestFeatureFlags(
+            Dictionary<string, bool> features)
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    features.Select(kvp =>
+                        new KeyValuePair<string, string?>(
+                            $"FeatureManagement:{kvp.Key}", kvp.Value.ToString())))
+                .Build();
 
-        services.AddSingleton<IConfiguration>(config);
-        services.AddFeatureManagement(config.GetSection("FeatureManagement"));
+            services.AddSingleton<IConfiguration>(config);
+            services.AddFeatureManagement(config.GetSection("FeatureManagement"));
 
-        return services;
+            return services;
+        }
     }
 }

--- a/Source/Presentation/MMCA.Common.API/Notifications/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.API/Notifications/DependencyInjection.cs
@@ -8,16 +8,18 @@ namespace MMCA.Common.API.Notifications;
 /// </summary>
 public static class DependencyInjection
 {
-    /// <summary>
-    /// Adds the Common notification API controllers to the MVC application parts so they are
-    /// discoverable by ASP.NET Core routing. Required because these controllers reside in the
-    /// MMCA.Common.API NuGet assembly, which is not scanned by default.
-    /// </summary>
-    /// <param name="builder">The MVC builder to configure.</param>
-    /// <returns>The MVC builder for chaining.</returns>
-    public static IMvcBuilder AddNotificationControllers(this IMvcBuilder builder)
+    extension(IMvcBuilder builder)
     {
-        builder.AddApplicationPart(typeof(NotificationsController).Assembly);
-        return builder;
+        /// <summary>
+        /// Adds the Common notification API controllers to the MVC application parts so they are
+        /// discoverable by ASP.NET Core routing. Required because these controllers reside in the
+        /// MMCA.Common.API NuGet assembly, which is not scanned by default.
+        /// </summary>
+        /// <returns>The MVC builder for chaining.</returns>
+        public IMvcBuilder AddNotificationControllers()
+        {
+            builder.AddApplicationPart(typeof(NotificationsController).Assembly);
+            return builder;
+        }
     }
 }

--- a/Source/Presentation/MMCA.Common.API/SessionCookies/CookieSessionRefreshMiddleware.cs
+++ b/Source/Presentation/MMCA.Common.API/SessionCookies/CookieSessionRefreshMiddleware.cs
@@ -35,13 +35,16 @@ public sealed class CookieSessionRefreshMiddleware(RequestDelegate next, ICookie
 /// <summary>Pipeline extension for <see cref="CookieSessionRefreshMiddleware"/>.</summary>
 public static class CookieSessionRefreshMiddlewareExtensions
 {
-    /// <summary>
-    /// Adds the SSR validate-or-refresh middleware. Register it immediately <b>before</b>
-    /// <c>UseAuthentication()</c> on the Blazor Server (UI.Web) host.
-    /// </summary>
-    public static IApplicationBuilder UseCookieSessionRefresh(this IApplicationBuilder app)
+    extension(IApplicationBuilder app)
     {
-        ArgumentNullException.ThrowIfNull(app);
-        return app.UseMiddleware<CookieSessionRefreshMiddleware>();
+        /// <summary>
+        /// Adds the SSR validate-or-refresh middleware. Register it immediately <b>before</b>
+        /// <c>UseAuthentication()</c> on the Blazor Server (UI.Web) host.
+        /// </summary>
+        public IApplicationBuilder UseCookieSessionRefresh()
+        {
+            ArgumentNullException.ThrowIfNull(app);
+            return app.UseMiddleware<CookieSessionRefreshMiddleware>();
+        }
     }
 }

--- a/Source/Presentation/MMCA.Common.API/SessionCookies/SessionCookieEndpoints.cs
+++ b/Source/Presentation/MMCA.Common.API/SessionCookies/SessionCookieEndpoints.cs
@@ -17,47 +17,50 @@ public static class SessionCookieEndpoints
     public const string AccessTokenCookieName = "mmca_auth_access";
     public const string RefreshTokenCookieName = "mmca_auth_refresh";
 
-    public static IEndpointRouteBuilder MapSessionCookieEndpoints(this IEndpointRouteBuilder endpoints)
+    extension(IEndpointRouteBuilder endpoints)
     {
-        ArgumentNullException.ThrowIfNull(endpoints);
-
-        var group = endpoints.MapGroup("/auth/session-cookie")
-            .ExcludeFromDescription();
-
-        group.MapPost(string.Empty, (SessionCookieRequest request, HttpContext httpContext, IWebHostEnvironment env) =>
+        public IEndpointRouteBuilder MapSessionCookieEndpoints()
         {
-            SessionCookieJar.Append(httpContext, request.AccessToken, request.RefreshToken, env);
-            return Results.NoContent();
-        }).DisableAntiforgery();
+            ArgumentNullException.ThrowIfNull(endpoints);
 
-        group.MapDelete(string.Empty, (HttpContext httpContext, IWebHostEnvironment env) =>
-        {
-            SessionCookieJar.Delete(httpContext, env);
-            return Results.NoContent();
-        }).DisableAntiforgery();
+            var group = endpoints.MapGroup("/auth/session-cookie")
+                .ExcludeFromDescription();
 
-        // Same-origin validate-or-refresh. The browser calls this (credentials:'same-origin') to hydrate
-        // its in-memory access token from the HttpOnly cookies; the refresh token never leaves the server.
-        // 401 (JSON) when there is no valid session. AllowAnonymous (it authenticates via the cookies),
-        // antiforgery disabled (no token cookie), CSRF-guarded by POST + SameSite=Lax + Sec-Fetch-Site.
-        endpoints.MapPost("/auth/session/token", async (
-            HttpContext httpContext, ICookieSessionRefresher refresher, CancellationToken cancellationToken) =>
-        {
-            if (IsCrossSite(httpContext.Request))
+            group.MapPost(string.Empty, (SessionCookieRequest request, HttpContext httpContext, IWebHostEnvironment env) =>
             {
-                return Results.StatusCode(StatusCodes.Status403Forbidden);
-            }
+                SessionCookieJar.Append(httpContext, request.AccessToken, request.RefreshToken, env);
+                return Results.NoContent();
+            }).DisableAntiforgery();
 
-            var result = await refresher.GetOrRefreshAsync(httpContext, cancellationToken).ConfigureAwait(false);
-            return result is null
-                ? Results.Json(new { error = "no_session" }, statusCode: StatusCodes.Status401Unauthorized)
-                : Results.Json(new SessionTokenResponse(result.Value.AccessToken, result.Value.AccessTokenExpiry));
-        })
-        .ExcludeFromDescription()
-        .AllowAnonymous()
-        .DisableAntiforgery();
+            group.MapDelete(string.Empty, (HttpContext httpContext, IWebHostEnvironment env) =>
+            {
+                SessionCookieJar.Delete(httpContext, env);
+                return Results.NoContent();
+            }).DisableAntiforgery();
 
-        return endpoints;
+            // Same-origin validate-or-refresh. The browser calls this (credentials:'same-origin') to hydrate
+            // its in-memory access token from the HttpOnly cookies; the refresh token never leaves the server.
+            // 401 (JSON) when there is no valid session. AllowAnonymous (it authenticates via the cookies),
+            // antiforgery disabled (no token cookie), CSRF-guarded by POST + SameSite=Lax + Sec-Fetch-Site.
+            endpoints.MapPost("/auth/session/token", async (
+                HttpContext httpContext, ICookieSessionRefresher refresher, CancellationToken cancellationToken) =>
+            {
+                if (IsCrossSite(httpContext.Request))
+                {
+                    return Results.StatusCode(StatusCodes.Status403Forbidden);
+                }
+
+                var result = await refresher.GetOrRefreshAsync(httpContext, cancellationToken).ConfigureAwait(false);
+                return result is null
+                    ? Results.Json(new { error = "no_session" }, statusCode: StatusCodes.Status401Unauthorized)
+                    : Results.Json(new SessionTokenResponse(result.Value.AccessToken, result.Value.AccessTokenExpiry));
+            })
+            .ExcludeFromDescription()
+            .AllowAnonymous()
+            .DisableAntiforgery();
+
+            return endpoints;
+        }
     }
 
     // Reject obvious cross-site POSTs (defense-in-depth alongside the cookie's SameSite=Lax, which already

--- a/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
@@ -16,75 +16,76 @@ namespace MMCA.Common.API.Startup;
 /// </summary>
 public static class DatabaseInitializationExtensions
 {
-    /// <summary>
-    /// Initializes databases by creating contexts, applying schema changes based on
-    /// <see cref="ApplicationSettings.DatabaseInitStrategy"/>, and running module seeders.
-    /// </summary>
-    /// <param name="services">The service provider (typically from <c>app.Services</c>).</param>
-    /// <param name="applicationSettings">Application settings containing the database init strategy.</param>
-    /// <param name="moduleLoader">The module loader to seed enabled modules.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    public static async Task InitializeDatabaseAsync(
-        this IServiceProvider services,
-        ApplicationSettings applicationSettings,
-        ModuleLoader moduleLoader,
-        CancellationToken cancellationToken = default)
+    extension(IServiceProvider services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(applicationSettings);
-        ArgumentNullException.ThrowIfNull(moduleLoader);
-
-        using var scope = services.CreateScope();
-
-        // Warm the entity data-source registry: this scans configuration assemblies once and makes
-        // entity-to-database routing deterministic before the first repository call (replacing the
-        // legacy model-building side effect that populated the lazy DataSourceService cache).
-        var registry = scope.ServiceProvider.GetRequiredService<IEntityDataSourceRegistry>();
-        var resolver = scope.ServiceProvider.GetRequiredService<IDataSourceResolver>();
-        var sourcesInUse = registry.GetPhysicalSourcesInUse();
-
-        var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
-
-        // Cosmos and SQLite sources are optional — integration tests may omit their connection
-        // strings. Neither engine has EF Core schema migrations, so both are always created via
-        // EnsureCreated up front, independent of the SQL-Server-oriented DatabaseInitStrategy
-        // below. This is the ONLY path that creates SQLite sources under the "Migrate" and "None"
-        // strategies (which act on SQL Server alone) — without it a SQLite source in use is never
-        // created and the first repository call fails.
-        foreach (var migrationlessKey in sourcesInUse
-            .Where(k => k.Engine is DataSource.CosmosDB or DataSource.Sqlite))
+        /// <summary>
+        /// Initializes databases by creating contexts, applying schema changes based on
+        /// <see cref="ApplicationSettings.DatabaseInitStrategy"/>, and running module seeders.
+        /// </summary>
+        /// <param name="applicationSettings">Application settings containing the database init strategy.</param>
+        /// <param name="moduleLoader">The module loader to seed enabled modules.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public async Task InitializeDatabaseAsync(
+            ApplicationSettings applicationSettings,
+            ModuleLoader moduleLoader,
+            CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrEmpty(resolver.GetPhysical(migrationlessKey).ConnectionString))
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(applicationSettings);
+            ArgumentNullException.ThrowIfNull(moduleLoader);
+
+            using var scope = services.CreateScope();
+
+            // Warm the entity data-source registry: this scans configuration assemblies once and makes
+            // entity-to-database routing deterministic before the first repository call (replacing the
+            // legacy model-building side effect that populated the lazy DataSourceService cache).
+            var registry = scope.ServiceProvider.GetRequiredService<IEntityDataSourceRegistry>();
+            var resolver = scope.ServiceProvider.GetRequiredService<IDataSourceResolver>();
+            var sourcesInUse = registry.GetPhysicalSourcesInUse();
+
+            var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
+
+            // Cosmos and SQLite sources are optional — integration tests may omit their connection
+            // strings. Neither engine has EF Core schema migrations, so both are always created via
+            // EnsureCreated up front, independent of the SQL-Server-oriented DatabaseInitStrategy
+            // below. This is the ONLY path that creates SQLite sources under the "Migrate" and "None"
+            // strategies (which act on SQL Server alone) — without it a SQLite source in use is never
+            // created and the first repository call fails.
+            foreach (var migrationlessKey in sourcesInUse
+                .Where(k => k.Engine is DataSource.CosmosDB or DataSource.Sqlite))
             {
-                continue;
+                if (string.IsNullOrEmpty(resolver.GetPhysical(migrationlessKey).ConnectionString))
+                {
+                    continue;
+                }
+
+                await dbContextFactory.GetDbContext(migrationlessKey).Database
+                    .EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await dbContextFactory.GetDbContext(migrationlessKey).Database
-                .EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-        }
+            // Apply schema initialisation based on the configured strategy:
+            //   "Migrate"       — auto-apply pending EF Core migrations per SQL Server source (development/testing).
+            //   "EnsureCreated" — legacy EnsureCreated behavior for every source in use.
+            //   "None"          — production: validate no pending migrations on any source, throw if behind.
+            switch (applicationSettings.DatabaseInitStrategy)
+            {
+                case "Migrate":
+                    await dbContextFactory.MigrateAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case "EnsureCreated":
+                    await dbContextFactory.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case "None":
+                    await ThrowIfPendingMigrationsAsync(dbContextFactory, sourcesInUse, cancellationToken).ConfigureAwait(false);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown DatabaseInitStrategy: '{applicationSettings.DatabaseInitStrategy}'. " +
+                        "Valid values are: Migrate, EnsureCreated, None.");
+            }
 
-        // Apply schema initialisation based on the configured strategy:
-        //   "Migrate"       — auto-apply pending EF Core migrations per SQL Server source (development/testing).
-        //   "EnsureCreated" — legacy EnsureCreated behavior for every source in use.
-        //   "None"          — production: validate no pending migrations on any source, throw if behind.
-        switch (applicationSettings.DatabaseInitStrategy)
-        {
-            case "Migrate":
-                await dbContextFactory.MigrateAsync(cancellationToken).ConfigureAwait(false);
-                break;
-            case "EnsureCreated":
-                await dbContextFactory.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
-                break;
-            case "None":
-                await ThrowIfPendingMigrationsAsync(dbContextFactory, sourcesInUse, cancellationToken).ConfigureAwait(false);
-                break;
-            default:
-                throw new InvalidOperationException(
-                    $"Unknown DatabaseInitStrategy: '{applicationSettings.DatabaseInitStrategy}'. " +
-                    "Valid values are: Migrate, EnsureCreated, None.");
+            await moduleLoader.SeedAllAsync(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
         }
-
-        await moduleLoader.SeedAllAsync(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Source/Presentation/MMCA.Common.Grpc/ResultGrpcExtensions.cs
+++ b/Source/Presentation/MMCA.Common.Grpc/ResultGrpcExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Grpc.Core;
 using MMCA.Common.Grpc.Exceptions;
@@ -19,6 +20,10 @@ namespace MMCA.Common.Grpc;
 ///   <item><see cref="ErrorType.UnprocessableEntity"/> → <see cref="StatusCode.FailedPrecondition"/></item>
 /// </list>
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class ResultGrpcExtensions
 {
     /// <summary>
@@ -38,88 +43,95 @@ public static class ResultGrpcExtensions
             [ErrorType.Failure] = StatusCode.InvalidArgument,
         }.ToFrozenDictionary();
 
-    /// <summary>
-    /// Resolves the gRPC <see cref="StatusCode"/> for the given <see cref="ErrorType"/>,
-    /// falling back to <see cref="StatusCode.InvalidArgument"/> if no explicit mapping exists.
-    /// </summary>
-    /// <param name="errorType">The domain error type to translate.</param>
-    /// <returns>The corresponding gRPC status code.</returns>
-    public static StatusCode ToGrpcStatusCode(this ErrorType errorType) =>
-        ErrorTypeToStatusCode.GetValueOrDefault(errorType, StatusCode.InvalidArgument);
-
-    /// <summary>
-    /// Throws a <see cref="ResultFailureException"/> if the result is a failure, allowing
-    /// gRPC service implementations to surface domain errors with a single guard clause.
-    /// The <c>GrpcResultExceptionInterceptor</c> server interceptor will translate the
-    /// exception into an <see cref="RpcException"/> with the right status code.
-    /// </summary>
-    /// <param name="result">The result to check.</param>
-    /// <exception cref="ResultFailureException">Thrown when <paramref name="result"/> is a failure.</exception>
-    public static void ThrowIfFailure(this Result result)
+    extension(ErrorType errorType)
     {
-        ArgumentNullException.ThrowIfNull(result);
-        if (result.IsFailure)
+        /// <summary>
+        /// Resolves the gRPC <see cref="StatusCode"/> for the given <see cref="ErrorType"/>,
+        /// falling back to <see cref="StatusCode.InvalidArgument"/> if no explicit mapping exists.
+        /// </summary>
+        /// <returns>The corresponding gRPC status code.</returns>
+        public StatusCode ToGrpcStatusCode() =>
+            ErrorTypeToStatusCode.GetValueOrDefault(errorType, StatusCode.InvalidArgument);
+    }
+
+    extension(Result result)
+    {
+        /// <summary>
+        /// Throws a <see cref="ResultFailureException"/> if the result is a failure, allowing
+        /// gRPC service implementations to surface domain errors with a single guard clause.
+        /// The <c>GrpcResultExceptionInterceptor</c> server interceptor will translate the
+        /// exception into an <see cref="RpcException"/> with the right status code.
+        /// </summary>
+        /// <exception cref="ResultFailureException">Thrown when the result is a failure.</exception>
+        public void ThrowIfFailure()
         {
-            throw new ResultFailureException(result.Errors);
+            ArgumentNullException.ThrowIfNull(result);
+            if (result.IsFailure)
+            {
+                throw new ResultFailureException(result.Errors);
+            }
         }
     }
 
-    /// <summary>
-    /// Returns the success value or throws <see cref="ResultFailureException"/> on failure.
-    /// </summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <param name="result">The typed result to unwrap.</param>
-    /// <returns>The success value carried by the result.</returns>
-    /// <exception cref="ResultFailureException">Thrown when the result is a failure.</exception>
-    public static T UnwrapOrThrow<T>(this Result<T> result)
+    extension<T>(Result<T> result)
     {
-        ArgumentNullException.ThrowIfNull(result);
-        if (result.IsFailure)
+        /// <summary>
+        /// Returns the success value or throws <see cref="ResultFailureException"/> on failure.
+        /// </summary>
+        /// <returns>The success value carried by the result.</returns>
+        /// <exception cref="ResultFailureException">Thrown when the result is a failure.</exception>
+        public T UnwrapOrThrow()
         {
-            throw new ResultFailureException(result.Errors);
-        }
+            ArgumentNullException.ThrowIfNull(result);
+            if (result.IsFailure)
+            {
+                throw new ResultFailureException(result.Errors);
+            }
 
-        return result.Value!;
+            return result.Value!;
+        }
     }
 
-    /// <summary>
-    /// Builds an <see cref="RpcException"/> from a list of <see cref="Error"/> instances.
-    /// The first error's <see cref="Error.Type"/> determines the status code; all errors are
-    /// serialized into the trailers as <c>error-{i}-code</c>, <c>error-{i}-message</c>, and
-    /// <c>error-{i}-type</c> entries for consumers that need structured access to the failure.
-    /// </summary>
-    /// <param name="errors">The errors to translate.</param>
-    /// <returns>An <see cref="RpcException"/> populated with status, detail, and trailing metadata.</returns>
-    public static RpcException ToRpcException(this IReadOnlyList<Error> errors)
+    extension(IReadOnlyList<Error> errors)
     {
-        ArgumentNullException.ThrowIfNull(errors);
-
-        var statusCode = errors.Count > 0
-            ? errors[0].Type.ToGrpcStatusCode()
-            : StatusCode.Internal;
-
-        var detail = errors.Count > 0
-            ? string.Join("; ", errors.Select(e => $"{e.Code}: {e.Message}"))
-            : "Unspecified failure";
-
-        var trailers = new Metadata();
-        for (var i = 0; i < errors.Count; i++)
+        /// <summary>
+        /// Builds an <see cref="RpcException"/> from a list of <see cref="Error"/> instances.
+        /// The first error's <see cref="Error.Type"/> determines the status code; all errors are
+        /// serialized into the trailers as <c>error-{i}-code</c>, <c>error-{i}-message</c>, and
+        /// <c>error-{i}-type</c> entries for consumers that need structured access to the failure.
+        /// </summary>
+        /// <returns>An <see cref="RpcException"/> populated with status, detail, and trailing metadata.</returns>
+        public RpcException ToRpcException()
         {
-            var error = errors[i];
-            trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-code"), error.Code);
-            trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-message"), error.Message);
-            trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-type"), error.Type.ToString());
-            if (!string.IsNullOrEmpty(error.Source))
+            ArgumentNullException.ThrowIfNull(errors);
+
+            var statusCode = errors.Count > 0
+                ? errors[0].Type.ToGrpcStatusCode()
+                : StatusCode.Internal;
+
+            var detail = errors.Count > 0
+                ? string.Join("; ", errors.Select(e => $"{e.Code}: {e.Message}"))
+                : "Unspecified failure";
+
+            var trailers = new Metadata();
+            for (var i = 0; i < errors.Count; i++)
             {
-                trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-source"), error.Source);
+                var error = errors[i];
+                trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-code"), error.Code);
+                trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-message"), error.Message);
+                trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-type"), error.Type.ToString());
+                if (!string.IsNullOrEmpty(error.Source))
+                {
+                    trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-source"), error.Source);
+                }
+
+                if (!string.IsNullOrEmpty(error.Target))
+                {
+                    trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-target"), error.Target);
+                }
             }
 
-            if (!string.IsNullOrEmpty(error.Target))
-            {
-                trailers.Add(string.Create(CultureInfo.InvariantCulture, $"error-{i}-target"), error.Target);
-            }
+            return new RpcException(new Status(statusCode, detail), trailers);
         }
-
-        return new RpcException(new Status(statusCode, detail), trailers);
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Extensions/MoneyExtensions.cs
+++ b/Source/Presentation/MMCA.Common.UI/Extensions/MoneyExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using MMCA.Common.Shared.ValueObjects;
 
@@ -6,29 +7,39 @@ namespace MMCA.Common.UI.Extensions;
 /// <summary>
 /// Formatting helpers that convert <see cref="Money"/> value objects into user-friendly price strings.
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class MoneyExtensions
 {
-    /// <summary>Formats a single price as <c>$12.50 USD</c>.</summary>
-    public static string ToDisplayString(this Money price) =>
-        $"${price.Amount.ToString("N2", CultureInfo.InvariantCulture)} {price.Currency.Code}";
-
-    /// <summary>
-    /// Formats a collection of prices as a range (e.g., <c>$10.00 -- $25.00 USD</c>).
-    /// When all prices are equal, a single price is displayed instead of a range.
-    /// </summary>
-    public static string ToDisplayRange(this IReadOnlyCollection<Money> prices)
+    extension(Money price)
     {
-        if (prices.Count == 0)
+        /// <summary>Formats a single price as <c>$12.50 USD</c>.</summary>
+        public string ToDisplayString() =>
+            $"${price.Amount.ToString("N2", CultureInfo.InvariantCulture)} {price.Currency.Code}";
+    }
+
+    extension(IReadOnlyCollection<Money> prices)
+    {
+        /// <summary>
+        /// Formats a collection of prices as a range (e.g., <c>$10.00 -- $25.00 USD</c>).
+        /// When all prices are equal, a single price is displayed instead of a range.
+        /// </summary>
+        public string ToDisplayRange()
         {
-            return string.Empty;
+            if (prices.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var min = prices.Min(p => p.Amount);
+            var max = prices.Max(p => p.Amount);
+            var currency = prices.First().Currency.Code;
+
+            return min == max
+                ? $"${min.ToString("N2", CultureInfo.InvariantCulture)} {currency}"
+                : $"${min.ToString("N2", CultureInfo.InvariantCulture)} — ${max.ToString("N2", CultureInfo.InvariantCulture)} {currency}";
         }
-
-        var min = prices.Min(p => p.Amount);
-        var max = prices.Max(p => p.Amount);
-        var currency = prices.First().Currency.Code;
-
-        return min == max
-            ? $"${min.ToString("N2", CultureInfo.InvariantCulture)} {currency}"
-            : $"${min.ToString("N2", CultureInfo.InvariantCulture)} — ${max.ToString("N2", CultureInfo.InvariantCulture)} {currency}";
     }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
@@ -501,6 +501,7 @@ public sealed class OutboxProcessorTests : IDisposable
             .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("permanently failing handler"));
 
+        var gate = new System.Threading.Lock();
         var measurements = new List<(long Value, string? Reason)>();
         using var listener = new MeterListener();
         listener.InstrumentPublished = (instrument, l) =>
@@ -521,7 +522,7 @@ public sealed class OutboxProcessorTests : IDisposable
                 }
             }
 
-            lock (measurements)
+            lock (gate)
             {
                 measurements.Add((value, reason));
             }
@@ -551,7 +552,7 @@ public sealed class OutboxProcessorTests : IDisposable
             Times.Once,
             "exhaustion is the operator's last loud signal and must log at Error");
 
-        lock (measurements)
+        lock (gate)
         {
             measurements.Should().Contain(
                 m => m.Value == 1 && m.Reason == "retries_exhausted",


### PR DESCRIPTION
## Summary
- Migrates the 15 remaining classic `this T` extension classes (~40 methods) in Source/ to C# 14 `extension(T)` blocks, completing the adoption already established in the DI registration files (~28 files). Zero classic extension methods remain in Source/.
- Binary-compatible by construction: methods stay methods, containing static class names and namespaces unchanged, so the lowered static surface consumed by Store/ADC/Helpdesk is identical. No release or consumer sweep needed.
- Internal-only modernization in `MMCA.Common.Testing.Architecture/RuleHelpers.cs`: 7 parameterless helpers become extension properties (`GetLoadableTypes()` -> `LoadableTypes`, `SimpleName()` -> `SimpleName`, ...), 70 call sites updated across the project. Internal class, so no public API change.
- Converts the last test-local `lock (object)` idiom to `System.Threading.Lock` in `OutboxProcessorTests`.

## Analyzer notes
- `CA1708` suppressed at class level where a class now holds multiple extension blocks: false positive against the compiler-generated grouping members; no user-visible identifiers differ by case.
- `IDE0051` suppressed once in `PageExtensions.cs` (private helper called from inside a block), reusing the justification pattern already established in `Infrastructure/DependencyInjection.cs`.

## Verification
- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors
- `dotnet test --solution MMCA.Common.slnx -c Release`: 2303/2303 passed
- `dotnet pack MMCA.Common.slnx -c Release`: all packages pack cleanly
- CRLF preserved on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bdyYRfwmMqytqKMwbkgMX