### PR TITLE
ci: stop dependabot rebasing open PRs; ignore Microsoft.OpenApi majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Do NOT let Dependabot rebase open PRs when main moves. With the default ("auto") it
+    # re-resolves every open PR after each merge, and on 2026-07-21 that pass closed two
+    # valid PRs as "no longer updatable" (#90 and #92) and deleted their branches seconds
+    # apart; #92 was fully green and could not be reopened. Because main requires an
+    # up-to-date branch anyway, refresh stale PRs deliberately with `gh pr update-branch`.
+    rebase-strategy: "disabled"
     # Scoped Commits (scope-first, see CONTRIBUTING.md), not the conventional-commits default.
     commit-message:
       prefix: "deps"
@@ -34,6 +40,14 @@ updates:
       # VS.Threading.Analyzers v18 adds stricter rules (e.g. VSTHRD103) that error under
       # TreatWarningsAsErrors; held at v17 until the flagged call sites are reworked.
       - dependency-name: "Microsoft.VisualStudio.Threading.Analyzers"
+        update-types: ["version-update:semver-major"]
+      # Microsoft.OpenApi is held at 2.x by a build constraint, not by preference. The
+      # Microsoft.AspNetCore.OpenApi XML-comment source generator (pinned to the SDK band) is
+      # written against 2.x, where IOpenApiMediaType.Example is settable; 3.x made it read only,
+      # so the generated OpenApiXmlCommentSupport.generated.cs fails with CS0200 and takes the
+      # consumer jobs down with it. Nothing here can override generated code. Revisit when
+      # ASP.NET Core ships a generator targeting 3.x. See Directory.Packages.props.
+      - dependency-name: "Microsoft.OpenApi"
         update-types: ["version-update:semver-major"]
       # Breaking majors held back deliberately. MessagePack is also pinned to a patched 2.x to
       # override a vulnerable transitive (see Directory.Packages.props).


### PR DESCRIPTION
Follow-up to the dependabot incident that cost us #92.

## What happened

| Time (UTC, 2026-07-21) | Event |
| --- | --- |
| 12:25:43 | #89 merged, `main` moves |
| 12:26:08 | #91 merged, `main` moves again |
| 12:32:03 | dependabot closes #92, "no longer updatable" |
| 12:32:04 | dependabot force-pushes #90's branch |
| 12:32:05 | dependabot closes #90, same message |
| 12:32:07 | both branches deleted |

Merging the first two PRs triggered dependabot's automatic rebase pass over the remaining open ones. During that pass it decided both were unupdatable, closed them, and deleted their branches. #92 (SQLitePCLRaw 3.0.4) had just been brought up to date and its full check suite went green minutes later, but the PR was already closed and GitHub will not reopen a PR whose branch is gone. That work had to be redone by hand in #93.

## Changes

**1. `rebase-strategy: "disabled"` on the nuget ecosystem.** The config never set this, so it defaulted to `auto`. Disabling it stops dependabot mutating open PRs when `main` moves. Since `main` requires an up-to-date branch anyway, stale PRs get refreshed deliberately with `gh pr update-branch`, which the flow already does by hand.

**2. Ignore `Microsoft.OpenApi` semver-major.** Separate and permanent: `Microsoft.AspNetCore.OpenApi` (pinned to the SDK band) ships an XML-comment source generator written against Microsoft.OpenApi 2.x, where `IOpenApiMediaType.Example` is settable. 3.x made it read only, so the generated `OpenApiXmlCommentSupport.generated.cs` fails with CS0200 and takes the Helpdesk consumer and package-mode consumer jobs down too. Nothing in this repo can override generated code. Placed alongside the existing MassTransit / ImageSharp / VS.Threading / Redis / MessagePack policy pins. Revisit when ASP.NET Core ships a generator targeting 3.x.

Deliberately **not** ignoring SQLitePCLRaw majors: 3.0.4 builds and tests clean, and #93 takes it.

## Scope

Common is the only repo with a NuGet dependabot config. ADC has github-actions only; Store, Helpdesk and Website have none. The github-actions ecosystem here is left on the default, since its updates resolve trivially and the observed failure was in NuGet dependency resolution.

## Not determined

Dependabot's internal reason for "no longer updatable" is not recoverable: its job logs are not exposed through the REST API (`dependabot/jobs` and `dependabot/updates` both 404). The obvious candidate is ruled out, though: `Microsoft.AspNetCore.OpenApi` 10.0.10 declares `Microsoft.OpenApi >= 2.0.0`, an open range with no upper bound, which is why #90 restored fine and only failed at compile time. This PR fixes the blast radius rather than that root cause.

## Verification

YAML parses; the nuget entry carries `rebase-strategy: disabled` and six ignore rules, with `SQLitePCLRaw` correctly absent. Config-only change, 14 added lines, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
