### PR TITLE
fix: honor Jwt lifetime settings for issued token expiries

### DIFF
--- a/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
+++ b/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
@@ -53,11 +53,21 @@ public abstract class AuthenticationServiceBase<TUser>(
     protected IRepository<TUser, UserIdentifierType> Repository =>
         unitOfWork.GetRepository<TUser, UserIdentifierType>();
 
-    /// <summary>Access-token lifetime (BR-205 default: 15 minutes).</summary>
-    protected virtual TimeSpan AccessTokenLifetime => TimeSpan.FromMinutes(15);
+    /// <summary>
+    /// Access-token lifetime, from the token service (<c>Jwt:AccessTokenExpirationMinutes</c>) so the
+    /// expiry reported to clients matches the JWT's actual <c>exp</c>. A non-positive value (a test
+    /// double or a misconfigured host) falls back to the BR-205 default of 15 minutes.
+    /// </summary>
+    protected virtual TimeSpan AccessTokenLifetime =>
+        tokenService.AccessTokenLifetime > TimeSpan.Zero ? tokenService.AccessTokenLifetime : TimeSpan.FromMinutes(15);
 
-    /// <summary>Refresh-token lifetime (BR-205 default: 7 days).</summary>
-    protected virtual TimeSpan RefreshTokenLifetime => TimeSpan.FromDays(7);
+    /// <summary>
+    /// Absolute refresh-token lifetime, from the token service (<c>Jwt:RefreshTokenExpirationDays</c>).
+    /// A non-positive value (a test double or a misconfigured host) falls back to the BR-205 default
+    /// of 7 days.
+    /// </summary>
+    protected virtual TimeSpan RefreshTokenLifetime =>
+        tokenService.RefreshTokenLifetime > TimeSpan.Zero ? tokenService.RefreshTokenLifetime : TimeSpan.FromDays(7);
 
     /// <inheritdoc />
     public async Task<Result<AuthenticationResponse>> LoginAsync(

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/ITokenService.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/ITokenService.cs
@@ -26,6 +26,20 @@ public interface ITokenService
     string GenerateRefreshToken();
 
     /// <summary>
+    /// Lifetime of issued access tokens. The concrete implementation derives it from the bound
+    /// JWT settings so the expiry reported to clients matches the token's actual <c>exp</c>;
+    /// the default keeps hand-written test doubles on the BR-205 baseline (15 minutes).
+    /// </summary>
+    TimeSpan AccessTokenLifetime => TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Absolute lifetime of issued refresh tokens (BR-205). The concrete implementation derives
+    /// it from the bound JWT settings; the default keeps hand-written test doubles on the
+    /// BR-205 baseline (7 days).
+    /// </summary>
+    TimeSpan RefreshTokenLifetime => TimeSpan.FromDays(7);
+
+    /// <summary>
     /// Extracts claims from an expired access token without validating its lifetime.
     /// Used during token refresh to identify the user.
     /// </summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Services/TokenService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/TokenService.cs
@@ -108,6 +108,12 @@ public sealed class TokenService : ITokenService, IDisposable
     }
 
     /// <inheritdoc />
+    public TimeSpan AccessTokenLifetime => TimeSpan.FromMinutes(_jwtSettings.AccessTokenExpirationMinutes);
+
+    /// <inheritdoc />
+    public TimeSpan RefreshTokenLifetime => TimeSpan.FromDays(_jwtSettings.RefreshTokenExpirationDays);
+
+    /// <inheritdoc />
     /// <remarks>
     /// Validates everything except lifetime — this is intentional because the method's purpose
     /// is to extract claims from an expired access token during the refresh flow.

--- a/Tests/Core/MMCA.Common.Application.Tests/Auth/AuthenticationServiceBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Auth/AuthenticationServiceBaseTests.cs
@@ -156,6 +156,29 @@ public sealed class AuthenticationServiceBaseTests
     }
 
     [Fact]
+    public async Task LoginAsync_WhenTokenServiceReportsConfiguredLifetimes_UsesThemForExpiries()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.TokenService.Setup(x => x.AccessTokenLifetime).Returns(TimeSpan.FromMinutes(30));
+        mocks.TokenService.Setup(x => x.RefreshTokenLifetime).Returns(TimeSpan.FromDays(14));
+        sut.UntrackedUser = CreateTestUser(id: 1);
+        var tracked = CreateTestUser(id: 1);
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tracked);
+
+        Result<AuthenticationResponse> result = await sut.LoginAsync(new LoginRequest("user@example.com", "pw"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AccessTokenExpiry.Should().Be(
+            FixedNow.UtcDateTime.AddMinutes(30),
+            "Jwt:AccessTokenExpirationMinutes drives the reported expiry");
+        tracked.RefreshTokenExpiry.Should().Be(
+            FixedNow.UtcDateTime.AddDays(14),
+            "Jwt:RefreshTokenExpirationDays drives the stored refresh expiry");
+    }
+
+    [Fact]
     public async Task LoginAsync_NormalizesEmailToValueObjectBeforeLookup()
     {
         var (sut, mocks) = CreateSut();

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/TokenServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/TokenServiceTests.cs
@@ -97,6 +97,24 @@ public sealed class TokenServiceTests : IDisposable
         token1.Should().NotBe(token2);
     }
 
+    // ── Token lifetimes ──
+    [Fact]
+    public void Lifetimes_DeriveFromJwtSettings()
+    {
+        var settings = new JwtSettings
+        {
+            SecretForKey = Base64Secret,
+            Issuer = "https://test-issuer",
+            Audience = "test-audience",
+            AccessTokenExpirationMinutes = 45,
+            RefreshTokenExpirationDays = 10
+        };
+        using var service = new TokenService(settings);
+
+        service.AccessTokenLifetime.Should().Be(TimeSpan.FromMinutes(45));
+        service.RefreshTokenLifetime.Should().Be(TimeSpan.FromDays(10));
+    }
+
     // ── GetPrincipalFromExpiredToken ──
     [Fact]
     public void GetPrincipalFromExpiredToken_ValidToken_ReturnsPrincipal()


### PR DESCRIPTION
## Problem

Found during the 2026-07-21 ADR audit (recorded in ADR-050): `Jwt:RefreshTokenExpirationDays` binds from configuration but was never read anywhere; the refresh expiry stamped on the user row came from the hardcoded 7-day `RefreshTokenLifetime` property on `AuthenticationServiceBase`. The reported access-token expiry had the twin bug: `AuthenticationResponse` expiry used a hardcoded 15 minutes while the JWT's actual `exp` reads `Jwt:AccessTokenExpirationMinutes`, so a host changing that setting got a response timestamp that no longer matched the token.

## Fix

- `ITokenService` exposes `AccessTokenLifetime` / `RefreshTokenLifetime` as default interface members (the DIM pattern `IAuthenticationService.ExternalLoginAsync` already establishes), defaulting to the BR-205 baselines so hand-written fakes keep today's behavior.
- `TokenService` implements both from the bound `JwtSettings`.
- `AuthenticationServiceBase`'s virtual lifetime properties delegate to the token service with a positive-value guard falling back to the BR-205 defaults (15 min / 7 days), which keeps Moq-based test doubles (whose proxies return `TimeSpan.Zero` for the DIMs) and misconfigured hosts on the previous behavior.

No behavior change for hosts on the default values; the settings are now honored when changed.

## Tests

- `TokenServiceTests.Lifetimes_DeriveFromJwtSettings` (settings -> lifetimes).
- `AuthenticationServiceBaseTests.LoginAsync_WhenTokenServiceReportsConfiguredLifetimes_UsesThemForExpiries` (configured lifetimes drive both the reported access expiry and the stored refresh expiry).
- Existing default-lifetime assertions unchanged and passing (fallback path). Full suite: 2305/2305 green locally in Release.

## Consumer note (next release sweep)

ADC/Store/Helpdesk have no `ITokenService` implementors (verified workspace-wide grep), so the sweep needs no fake updates; Moq mocks of `ITokenService` fall back to defaults via the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)