### PR TITLE
feat(filtering,caching): complete filter DSL operator matrix, add paging backstop, make cache invalidation observable

### DIFF
--- a/Source/Core/MMCA.Common.Application/Services/Filtering/BoolFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/BoolFilterStrategy.cs
@@ -5,25 +5,24 @@ namespace MMCA.Common.Application.Services.Filtering;
 
 /// <summary>
 /// Filter strategy for <see cref="bool"/> and <see cref="Nullable{Boolean}"/> properties.
-/// Supports only the "IS" operator. Silently returns the unfiltered query if the value
-/// cannot be parsed as a boolean, preventing runtime exceptions from invalid input.
+/// Supports the "IS" equality operator plus the "IS EMPTY" / "IS NOT EMPTY" null checks
+/// (meaningful for <see cref="Nullable{Boolean}"/> columns). Silently returns the unfiltered
+/// query if the value cannot be parsed as a boolean, preventing runtime exceptions from invalid input.
 /// </summary>
 internal sealed class BoolFilterStrategy : IFilterStrategy
 {
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
-        "IS"
+        "IS", "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
-    {
-        if (!bool.TryParse(value, out var boolValue))
-            return query;
-
-        return op switch
+        => op switch
         {
-            "IS" => query.Where($"{property} == @0", boolValue),
+            // Presence checks are value-independent, so they precede the bool parse.
+            "IS EMPTY" => query.Where($"{property} == null"),
+            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            "IS" when bool.TryParse(value, out var boolValue) => query.Where($"{property} == @0", boolValue),
             _ => query
         };
-    }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/DateTimeFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/DateTimeFilterStrategy.cs
@@ -6,9 +6,9 @@ namespace MMCA.Common.Application.Services.Filtering;
 
 /// <summary>
 /// Filter strategy for <see cref="DateTime"/> and <see cref="Nullable{DateTime}"/> properties.
-/// Supports temporal comparison operators (IS, IS AFTER, IS BEFORE, etc.) and null checks.
-/// All date parsing uses <see cref="CultureInfo.InvariantCulture"/> to ensure consistent
-/// behavior across server locales.
+/// Supports temporal comparison operators (IS, IS AFTER, IS BEFORE, etc.), null checks, the
+/// comma-separated IN set, and an inclusive BETWEEN range. All date parsing uses
+/// <see cref="CultureInfo.InvariantCulture"/> to ensure consistent behavior across server locales.
 /// </summary>
 internal sealed class DateTimeFilterStrategy : IFilterStrategy
 {
@@ -17,7 +17,8 @@ internal sealed class DateTimeFilterStrategy : IFilterStrategy
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
         "IS", "IS NOT", "IS AFTER", "IS ON OR AFTER",
-        "IS BEFORE", "IS ON OR BEFORE", "IS EMPTY", "IS NOT EMPTY"
+        "IS BEFORE", "IS ON OR BEFORE", "IS EMPTY", "IS NOT EMPTY",
+        "IN", "BETWEEN"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
@@ -37,6 +38,33 @@ internal sealed class DateTimeFilterStrategy : IFilterStrategy
                 => query.Where($"{property} <= @0", dt),
             "IS EMPTY" => query.Where($"{property} == null"),
             "IS NOT EMPTY" => query.Where($"{property} != null"),
+            // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
+            _ => ApplyInOrRange(query, property, op, value)
+        };
+
+    private static IQueryable<T> ApplyInOrRange<T>(IQueryable<T> query, string property, string op, string value)
+        => op switch
+        {
+            "IN" => ApplyIn(query, property, value),
+            "BETWEEN" => ApplyBetween(query, property, value),
             _ => query
         };
+
+    private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
+    {
+        var values = FilterValueParser.ParseList(value, ParseDateTime);
+        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+    }
+
+    private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
+    {
+        // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
+        var bounds = FilterValueParser.ParseList(value, ParseDateTime);
+        return bounds.Count == 2
+            ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
+            : query;
+    }
+
+    private static DateTime? ParseDateTime(string s) =>
+        DateTime.TryParse(s, FormatProvider, DateTimeStyles.None, out var dt) ? dt : null;
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
@@ -5,31 +5,29 @@ namespace MMCA.Common.Application.Services.Filtering;
 
 /// <summary>
 /// Filter strategy for <see cref="Guid"/> and <see cref="Nullable{Guid}"/> properties.
-/// Supports equality operators. Silently returns the unfiltered query if the value
-/// cannot be parsed as a GUID.
+/// Supports equality operators, the comma-separated IN set, and the IS EMPTY / IS NOT EMPTY null
+/// checks (meaningful for <see cref="Nullable{Guid}"/> columns). GUIDs have no meaningful ordering,
+/// so no comparison or range operators are provided. Silently returns the unfiltered query if the
+/// value cannot be parsed as a GUID.
 /// </summary>
 internal sealed class GuidFilterStrategy : IFilterStrategy
 {
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
-        "EQUALS", "NOT EQUALS", "IN"
+        "EQUALS", "NOT EQUALS", "IN", "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
-    {
-        if (op == "IN")
-            return ApplyIn(query, property, value);
-
-        if (!Guid.TryParse(value, out var guidValue))
-            return query;
-
-        return op switch
+        => op switch
         {
-            "EQUALS" => query.Where($"{property} == @0", guidValue),
-            "NOT EQUALS" => query.Where($"{property} != @0", guidValue),
+            "EQUALS" when Guid.TryParse(value, out var g) => query.Where($"{property} == @0", g),
+            "NOT EQUALS" when Guid.TryParse(value, out var g) => query.Where($"{property} != @0", g),
+            "IS EMPTY" => query.Where($"{property} == null"),
+            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            // IN parses a comma-separated set rather than a single scalar.
+            "IN" => ApplyIn(query, property, value),
             _ => query
         };
-    }
 
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
@@ -5,7 +5,8 @@ namespace MMCA.Common.Application.Services.Filtering;
 
 /// <summary>
 /// Filter strategy for <see cref="int"/> and <see cref="Nullable{Int32}"/> properties.
-/// Supports equality and numeric comparison operators. Silently returns the unfiltered
+/// Supports equality and numeric comparison operators, the comma-separated IN set, an inclusive
+/// BETWEEN range, and the IS EMPTY / IS NOT EMPTY null checks. Silently returns the unfiltered
 /// query if the value cannot be parsed as an integer.
 /// </summary>
 internal sealed class IntFilterStrategy : IFilterStrategy
@@ -13,33 +14,45 @@ internal sealed class IntFilterStrategy : IFilterStrategy
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
         "EQUALS", "NOT EQUALS", "GREATER THAN", "LESS THAN",
-        "GREATER THAN OR EQUAL", "LESS THAN OR EQUAL", "IN"
+        "GREATER THAN OR EQUAL", "LESS THAN OR EQUAL", "IN", "BETWEEN",
+        "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
-    {
-        // IN takes a comma-separated set; every other operator takes a single value.
-        if (op == "IN")
-            return ApplyIn(query, property, value);
-
-        if (!int.TryParse(value, out var intValue))
-            return query;
-
-        return op switch
+        => op switch
         {
-            "EQUALS" => query.Where($"{property} == @0", intValue),
-            "NOT EQUALS" => query.Where($"{property} != @0", intValue),
-            "GREATER THAN" => query.Where($"{property} > @0", intValue),
-            "LESS THAN" => query.Where($"{property} < @0", intValue),
-            "GREATER THAN OR EQUAL" => query.Where($"{property} >= @0", intValue),
-            "LESS THAN OR EQUAL" => query.Where($"{property} <= @0", intValue),
+            "EQUALS" when int.TryParse(value, out var v) => query.Where($"{property} == @0", v),
+            "NOT EQUALS" when int.TryParse(value, out var v) => query.Where($"{property} != @0", v),
+            "GREATER THAN" when int.TryParse(value, out var v) => query.Where($"{property} > @0", v),
+            "LESS THAN" when int.TryParse(value, out var v) => query.Where($"{property} < @0", v),
+            "GREATER THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where($"{property} >= @0", v),
+            "LESS THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where($"{property} <= @0", v),
+            "IS EMPTY" => query.Where($"{property} == null"),
+            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
+            _ => ApplyInOrRange(query, property, op, value)
+        };
+
+    private static IQueryable<T> ApplyInOrRange<T>(IQueryable<T> query, string property, string op, string value)
+        => op switch
+        {
+            "IN" => ApplyIn(query, property, value),
+            "BETWEEN" => ApplyBetween(query, property, value),
             _ => query
         };
-    }
 
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseList(value, static s => int.TryParse(s, out var v) ? v : (int?)null);
         return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+    }
+
+    private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
+    {
+        // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
+        var bounds = FilterValueParser.ParseList(value, static s => int.TryParse(s, out var v) ? v : (int?)null);
+        return bounds.Count == 2
+            ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
+            : query;
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/LongFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/LongFilterStrategy.cs
@@ -5,13 +5,13 @@ using System.Linq.Dynamic.Core;
 namespace MMCA.Common.Application.Services.Filtering;
 
 /// <summary>
-/// Filter strategy for <see cref="decimal"/> and <see cref="Nullable{Decimal}"/> properties.
+/// Filter strategy for <see cref="long"/> and <see cref="Nullable{Int64}"/> properties.
 /// Supports equality and numeric comparison operators, the comma-separated IN set, an inclusive
-/// BETWEEN range, and the IS EMPTY / IS NOT EMPTY null checks. Uses
-/// <see cref="CultureInfo.InvariantCulture"/> for parsing to ensure consistent decimal separator
-/// handling across locales.
+/// BETWEEN range, and the IS EMPTY / IS NOT EMPTY null checks. Silently returns the unfiltered
+/// query if the value cannot be parsed as a 64-bit integer. Registered by default so long-keyed
+/// entities filter without a startup <see cref="QueryFilterService.RegisterStrategy"/> call.
 /// </summary>
-internal sealed class DecimalFilterStrategy : IFilterStrategy
+internal sealed class LongFilterStrategy : IFilterStrategy
 {
     public IReadOnlySet<string> SupportedOperators { get; } = new HashSet<string>(StringComparer.Ordinal)
     {
@@ -35,8 +35,8 @@ internal sealed class DecimalFilterStrategy : IFilterStrategy
             _ => ApplyInOrRange(query, property, op, value)
         };
 
-    private static bool TryParse(string value, out decimal result) =>
-        decimal.TryParse(value, CultureInfo.InvariantCulture, out result);
+    private static bool TryParse(string value, out long result) =>
+        long.TryParse(value, CultureInfo.InvariantCulture, out result);
 
     private static IQueryable<T> ApplyInOrRange<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
@@ -48,19 +48,19 @@ internal sealed class DecimalFilterStrategy : IFilterStrategy
 
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
-        var values = FilterValueParser.ParseList(value, ParseDecimal);
+        var values = FilterValueParser.ParseList(value, ParseLong);
         return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
     }
 
     private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
     {
         // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
-        var bounds = FilterValueParser.ParseList(value, ParseDecimal);
+        var bounds = FilterValueParser.ParseList(value, ParseLong);
         return bounds.Count == 2
             ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
             : query;
     }
 
-    private static decimal? ParseDecimal(string s) =>
-        decimal.TryParse(s, CultureInfo.InvariantCulture, out var v) ? v : null;
+    private static long? ParseLong(string s) =>
+        long.TryParse(s, CultureInfo.InvariantCulture, out var v) ? v : null;
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/QueryFilterService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/QueryFilterService.cs
@@ -31,6 +31,8 @@ public static class QueryFilterService
             [typeof(bool?)] = new BoolFilterStrategy(),
             [typeof(int)] = new IntFilterStrategy(),
             [typeof(int?)] = new IntFilterStrategy(),
+            [typeof(long)] = new LongFilterStrategy(),
+            [typeof(long?)] = new LongFilterStrategy(),
             [typeof(DateTime)] = new DateTimeFilterStrategy(),
             [typeof(DateTime?)] = new DateTimeFilterStrategy(),
             [typeof(decimal)] = new DecimalFilterStrategy(),

--- a/Source/Core/MMCA.Common.Application/Services/Query/EntityQueryPipeline.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Query/EntityQueryPipeline.cs
@@ -14,9 +14,10 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
 {
     /// <summary>
     /// Framework safety ceiling (rubric §12): the maximum number of rows the pipeline will
-    /// materialize for a query that omits pagination. The per-request page size is separately
-    /// clamped to <c>ApplicationSettings.MaxPageSize</c> at the API boundary; this is the
-    /// last-resort guard so a direct service caller that forgets pagination can never trigger
+    /// materialize. A query that omits pagination is capped at this ceiling; a paginated query
+    /// has its page size clamped to this ceiling as well (defense in depth). The per-request page
+    /// size is also clamped to <c>ApplicationSettings.MaxPageSize</c> at the API boundary, but this
+    /// in-pipeline guard means a direct service caller that bypasses that boundary can never trigger
     /// an unbounded full-table load.
     /// </summary>
     public const int MaxUnboundedResultLimit = 1000;
@@ -90,8 +91,11 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
         if (isPaginated)
         {
             totalCount = await queryableExecutor.CountAsync(query, cancellationToken).ConfigureAwait(false);
-            int skip = checked(parameters.PageSize!.Value * (parameters.PageNumber!.Value - 1));
-            query = query.Skip(skip).Take(parameters.PageSize.Value);
+            // Defense-in-depth (rubric §12): clamp the caller's page size to the framework ceiling so a
+            // direct Application-layer caller that bypasses the API boundary cannot request an unbounded page.
+            int pageSize = Math.Min(parameters.PageSize!.Value, MaxUnboundedResultLimit);
+            int skip = checked(pageSize * (parameters.PageNumber!.Value - 1));
+            query = query.Skip(skip).Take(pageSize);
         }
         else
         {
@@ -134,8 +138,11 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
         {
             // Count must be taken before Skip/Take to get the total matching record count
             totalCount = await queryableExecutor.CountAsync(query, cancellationToken).ConfigureAwait(false);
-            int skip = checked(parameters.PageSize!.Value * (parameters.PageNumber!.Value - 1));
-            query = query.Skip(skip).Take(parameters.PageSize.Value);
+            // Defense-in-depth (rubric §12): clamp the caller's page size to the framework ceiling so a
+            // direct Application-layer caller that bypasses the API boundary cannot request an unbounded page.
+            int pageSize = Math.Min(parameters.PageSize!.Value, MaxUnboundedResultLimit);
+            int skip = checked(pageSize * (parameters.PageNumber!.Value - 1));
+            query = query.Skip(skip).Take(pageSize);
         }
         else
         {

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using MMCA.Common.Application.Interfaces;
 using StackExchange.Redis;
 
@@ -9,10 +10,13 @@ namespace MMCA.Common.Infrastructure.Caching;
 /// Cache backed by <see cref="IDistributedCache"/> (e.g., Redis, SQL Server).
 /// Serializes values as UTF-8 JSON via <see cref="System.Text.Json.JsonSerializer"/>.
 /// When an <see cref="IConnectionMultiplexer"/> is available (Redis), <see cref="RemoveByPrefixAsync"/>
-/// uses SCAN to enumerate and delete matching keys. Otherwise it is a no-op.
+/// uses SCAN to enumerate and delete matching keys. Otherwise prefix invalidation is a no-op and is
+/// logged (once for the missing-multiplexer case, which is a steady state; every time for the
+/// anomalous no-server case) so a silently-dead invalidation is observable instead of invisible.
 /// </summary>
-internal sealed class DistributedCacheService(
+internal sealed partial class DistributedCacheService(
     IDistributedCache cache,
+    ILogger<DistributedCacheService> logger,
     IConnectionMultiplexer? connectionMultiplexer = null) : ICacheService
 {
     /// <inheritdoc />
@@ -42,6 +46,9 @@ internal sealed class DistributedCacheService(
     /// <summary>Keys per delete round trip during prefix invalidation.</summary>
     private const int DeleteBatchSize = 512;
 
+    /// <summary>Set once (via <see cref="Interlocked"/>) after the missing-multiplexer no-op is logged, so the steady state warns once rather than on every command.</summary>
+    private int _noMultiplexerWarned;
+
     /// <inheritdoc />
     /// <remarks>
     /// SCAN enumerates matching keys incrementally; deletes are issued in batches of
@@ -51,11 +58,21 @@ internal sealed class DistributedCacheService(
     public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
     {
         if (connectionMultiplexer is null)
+        {
+            // No multiplexer (e.g. a SQL-Server-backed IDistributedCache, or Redis registered without
+            // AddRedisClient): prefix eviction cannot run, so cached entries expire on TTL alone. Warn once
+            // so this dead invalidation is visible without flooding the log on every mutating command.
+            if (Interlocked.Exchange(ref _noMultiplexerWarned, 1) == 0)
+                LogPrefixEvictionNoMultiplexer(logger);
             return;
+        }
 
         var server = connectionMultiplexer.GetServers().FirstOrDefault();
         if (server is null)
+        {
+            LogPrefixEvictionNoServer(logger, prefix);
             return;
+        }
 
         var keys = server.KeysAsync(pattern: $"{prefix}*");
         var db = connectionMultiplexer.GetDatabase();
@@ -80,4 +97,10 @@ internal sealed class DistributedCacheService(
 
     private static byte[] Serialize<T>(T value)
         => JsonSerializer.SerializeToUtf8Bytes(value);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation is a no-op: no IConnectionMultiplexer is registered, so cached entries are bounded only by their TTL. Register a Redis client (AddRedisClient) to enable prefix eviction.")]
+    private static partial void LogPrefixEvictionNoMultiplexer(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation skipped for prefix '{Prefix}': the connection multiplexer reports no servers.")]
+    private static partial void LogPrefixEvictionNoServer(ILogger logger, string prefix);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/MemoryCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/MemoryCacheService.cs
@@ -21,9 +21,12 @@ internal sealed class MemoryCacheService(IMemoryCache cache) : ICacheService
     /// <inheritdoc />
     public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        if (cache.TryGetValue(key, out T? value))
+        // Guard the cast: the generic TryGetValue<T> overload performs an unchecked (T)stored cast and
+        // throws InvalidCastException when a key is reused under a different T. Match on the stored object
+        // instead so a type mismatch (or a stored null) surfaces as a clean miss.
+        if (cache.TryGetValue(key, out var stored) && stored is T typed)
         {
-            return Task.FromResult(value);
+            return Task.FromResult<T?>(typed);
         }
 
         return Task.FromResult<T?>(default);

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -154,7 +156,9 @@ public static class DependencyInjection
                 if (distributedCache is not null and not MemoryDistributedCache)
                 {
                     var multiplexer = sp.GetService<IConnectionMultiplexer>();
-                    return new DistributedCacheService(distributedCache, multiplexer);
+                    var logger = sp.GetService<ILogger<DistributedCacheService>>()
+                        ?? NullLogger<DistributedCacheService>.Instance;
+                    return new DistributedCacheService(distributedCache, logger, multiplexer);
                 }
 
                 return new MemoryCacheService(sp.GetRequiredService<IMemoryCache>());

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryPipelineTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryPipelineTests.cs
@@ -250,6 +250,41 @@ public sealed class EntityQueryPipelineTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithOversizedPageSize_ClampsToUnboundedLimit()
+    {
+        // Defense in depth (rubric §12): a direct caller that bypasses the API boundary and requests an
+        // oversized page must still be capped at the framework ceiling rather than materialize the lot.
+        var entities = Enumerable.Range(1, EntityQueryPipeline.MaxUnboundedResultLimit + 50)
+            .Select(i => new TestEntity { Id = i, Name = string.Create(CultureInfo.InvariantCulture, $"E{i}") })
+            .ToList();
+        var query = entities.AsQueryable();
+
+        _executorMock
+            .Setup(e => e.CountAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entities.Count);
+        // Materialize the ACTUAL query so the pipeline's Take() is honored.
+        _executorMock
+            .Setup(e => e.ToListAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .Returns<IQueryable<TestEntity>, CancellationToken>((q, _) => Task.FromResult(q.ToList()));
+
+        var parameters = new EntityQueryParameters<TestEntity>
+        {
+            PageNumber = 1,
+            PageSize = EntityQueryPipeline.MaxUnboundedResultLimit + 500,
+            DTOToEntityPropertyMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+
+        var (items, _) = await _sut.ExecuteAsync<TestEntity, int>(
+            query,
+            EmptyNavigation(),
+            parameters,
+            (_, _, _, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        items.Should().HaveCount(EntityQueryPipeline.MaxUnboundedResultLimit);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithCriteria_FiltersResults()
     {
         var entities = new List<TestEntity>

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/BoolFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/BoolFilterStrategyTests.cs
@@ -8,15 +8,17 @@ public sealed class BoolFilterStrategyTests
     private sealed class Item
     {
         public bool IsActive { get; set; }
+
+        public bool? Flag { get; set; }
     }
 
     private static IQueryable<Item> Items() =>
         new List<Item>
         {
-            new() { IsActive = true },
-            new() { IsActive = false },
-            new() { IsActive = true },
-            new() { IsActive = false },
+            new() { IsActive = true, Flag = true },
+            new() { IsActive = false, Flag = false },
+            new() { IsActive = true, Flag = null },
+            new() { IsActive = false, Flag = null },
         }.AsQueryable();
 
     private static readonly Dictionary<string, string> EmptyMap = [];
@@ -25,6 +27,12 @@ public sealed class BoolFilterStrategyTests
         QueryFilterService.ApplyFilters(
             Items(),
             new Dictionary<string, (string, string)> { ["IsActive"] = (op, value) },
+            EmptyMap);
+
+    private static IQueryable<Item> FilterFlag(string op, string value) =>
+        QueryFilterService.ApplyFilters(
+            Items(),
+            new Dictionary<string, (string, string)> { ["Flag"] = (op, value) },
             EmptyMap);
 
     // ── IS true ──
@@ -41,6 +49,16 @@ public sealed class BoolFilterStrategyTests
     [Fact]
     public void InvalidValue_ReturnsAll() =>
         Filter("IS", "maybe").Should().HaveCount(4);
+
+    // ── IS EMPTY ──
+    [Fact]
+    public void IsEmpty_ReturnsNullFlags() =>
+        FilterFlag("IS EMPTY", string.Empty).Should().HaveCount(2);
+
+    // ── IS NOT EMPTY ──
+    [Fact]
+    public void IsNotEmpty_ReturnsNonNullFlags() =>
+        FilterFlag("IS NOT EMPTY", string.Empty).Should().HaveCount(2);
 
     // ── Unknown operator ──
     [Fact]

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/DateTimeFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/DateTimeFilterStrategyTests.cs
@@ -8,16 +8,18 @@ public sealed class DateTimeFilterStrategyTests
     private sealed class Item
     {
         public DateTime? Created { get; set; }
+
+        public DateTime Occurred { get; set; }
     }
 
     private static IQueryable<Item> Items() =>
         new List<Item>
         {
-            new() { Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
-            new() { Created = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc) },
-            new() { Created = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc) },
-            new() { Created = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc) },
-            new() { Created = null },
+            new() { Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), Occurred = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new() { Created = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc), Occurred = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new() { Created = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), Occurred = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new() { Created = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc), Occurred = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new() { Created = null, Occurred = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc) },
         }.AsQueryable();
 
     private static readonly Dictionary<string, string> EmptyMap = [];
@@ -26,6 +28,12 @@ public sealed class DateTimeFilterStrategyTests
         QueryFilterService.ApplyFilters(
             Items(),
             new Dictionary<string, (string, string)> { ["Created"] = (op, value) },
+            EmptyMap);
+
+    private static IQueryable<Item> FilterOccurred(string op, string value) =>
+        QueryFilterService.ApplyFilters(
+            Items(),
+            new Dictionary<string, (string, string)> { ["Occurred"] = (op, value) },
             EmptyMap);
 
     // ── IS ──
@@ -73,8 +81,26 @@ public sealed class DateTimeFilterStrategyTests
     public void InvalidDate_ReturnsAll() =>
         Filter("IS", "not-a-date").Should().HaveCount(5);
 
+    // ── IN (non-nullable column; matches EF IN-translation, LINQ Dynamic binds the set to a non-null type) ──
+    [Fact]
+    public void In_ReturnsItemsMatchingAnyListedValue() =>
+        FilterOccurred("IN", "2026-01-01,2026-03-01").Should().HaveCount(2);
+
+    [Fact]
+    public void In_SkipsUnparseableValues() =>
+        FilterOccurred("IN", "2026-01-01,not-a-date").Should().ContainSingle();
+
+    // ── BETWEEN ──
+    [Fact]
+    public void Between_ReturnsInclusiveRange() =>
+        Filter("BETWEEN", "2026-02-01,2026-03-01").Should().HaveCount(2);
+
+    [Fact]
+    public void Between_WithSingleValue_ReturnsAll() =>
+        Filter("BETWEEN", "2026-02-01").Should().HaveCount(5);
+
     // ── Unknown operator ──
     [Fact]
     public void UnknownOperator_ReturnsAll() =>
-        Filter("BETWEEN", "2026-02-01").Should().HaveCount(5);
+        Filter("IS WITHIN", "2026-02-01").Should().HaveCount(5);
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/DecimalFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/DecimalFilterStrategyTests.cs
@@ -8,15 +8,17 @@ public sealed class DecimalFilterStrategyTests
     private sealed class Item
     {
         public decimal Price { get; set; }
+
+        public decimal? Discount { get; set; }
     }
 
     private static IQueryable<Item> Items() =>
         new List<Item>
         {
-            new() { Price = 9.99m },
-            new() { Price = 19.99m },
-            new() { Price = 29.99m },
-            new() { Price = 49.99m },
+            new() { Price = 9.99m, Discount = 1.00m },
+            new() { Price = 19.99m, Discount = null },
+            new() { Price = 29.99m, Discount = 5.00m },
+            new() { Price = 49.99m, Discount = null },
         }.AsQueryable();
 
     private static readonly Dictionary<string, string> EmptyMap = [];
@@ -25,6 +27,12 @@ public sealed class DecimalFilterStrategyTests
         QueryFilterService.ApplyFilters(
             Items(),
             new Dictionary<string, (string, string)> { ["Price"] = (op, value) },
+            EmptyMap);
+
+    private static IQueryable<Item> FilterDiscount(string op, string value) =>
+        QueryFilterService.ApplyFilters(
+            Items(),
+            new Dictionary<string, (string, string)> { ["Discount"] = (op, value) },
             EmptyMap);
 
     // ── EQUALS ──
@@ -61,6 +69,37 @@ public sealed class DecimalFilterStrategyTests
     [Fact]
     public void InvalidDecimalValue_ReturnsAll() =>
         Filter("EQUALS", "not-a-number").Should().HaveCount(4);
+
+    // ── IN ──
+    [Fact]
+    public void In_ReturnsItemsMatchingAnyListedValue() =>
+        Filter("IN", "9.99,29.99").Select(i => i.Price).Should().BeEquivalentTo([9.99m, 29.99m]);
+
+    [Fact]
+    public void In_SkipsUnparseableValues() =>
+        Filter("IN", "9.99,not-a-number,49.99").Should().HaveCount(2);
+
+    [Fact]
+    public void In_WithNoParseableValues_ReturnsAll() =>
+        Filter("IN", "a,b").Should().HaveCount(4);
+
+    // ── BETWEEN ──
+    [Fact]
+    public void Between_ReturnsInclusiveRange() =>
+        Filter("BETWEEN", "19.99,29.99").Select(i => i.Price).Should().BeEquivalentTo([19.99m, 29.99m]);
+
+    [Fact]
+    public void Between_WithSingleValue_ReturnsAll() =>
+        Filter("BETWEEN", "19.99").Should().HaveCount(4);
+
+    // ── IS EMPTY / IS NOT EMPTY (nullable) ──
+    [Fact]
+    public void IsEmpty_ReturnsNullDiscounts() =>
+        FilterDiscount("IS EMPTY", string.Empty).Should().HaveCount(2);
+
+    [Fact]
+    public void IsNotEmpty_ReturnsNonNullDiscounts() =>
+        FilterDiscount("IS NOT EMPTY", string.Empty).Should().HaveCount(2);
 
     // ── Unknown operator ──
     [Fact]

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/GuidFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/GuidFilterStrategyTests.cs
@@ -8,6 +8,8 @@ public sealed class GuidFilterStrategyTests
     private sealed class Item
     {
         public Guid Tag { get; set; }
+
+        public Guid? OptionalTag { get; set; }
     }
 
     private const string Guid1String = "11111111-1111-1111-1111-111111111111";
@@ -16,10 +18,10 @@ public sealed class GuidFilterStrategyTests
     private static IQueryable<Item> Items() =>
         new List<Item>
         {
-            new() { Tag = new Guid(0x11111111, 0x1111, 0x1111, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11) },
-            new() { Tag = new Guid(0x22222222, 0x2222, 0x2222, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22) },
-            new() { Tag = new Guid(0x33333333, 0x3333, 0x3333, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33) },
-            new() { Tag = new Guid(0x44444444, 0x4444, 0x4444, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44) },
+            new() { Tag = new Guid(0x11111111, 0x1111, 0x1111, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11), OptionalTag = Guid.NewGuid() },
+            new() { Tag = new Guid(0x22222222, 0x2222, 0x2222, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22), OptionalTag = null },
+            new() { Tag = new Guid(0x33333333, 0x3333, 0x3333, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33), OptionalTag = null },
+            new() { Tag = new Guid(0x44444444, 0x4444, 0x4444, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44), OptionalTag = null },
         }.AsQueryable();
 
     private static readonly Dictionary<string, string> EmptyMap = [];
@@ -28,6 +30,12 @@ public sealed class GuidFilterStrategyTests
         QueryFilterService.ApplyFilters(
             Items(),
             new Dictionary<string, (string, string)> { ["Tag"] = (op, value) },
+            EmptyMap);
+
+    private static IQueryable<Item> FilterOptional(string op, string value) =>
+        QueryFilterService.ApplyFilters(
+            Items(),
+            new Dictionary<string, (string, string)> { ["OptionalTag"] = (op, value) },
             EmptyMap);
 
     // ── EQUALS ──
@@ -62,4 +70,13 @@ public sealed class GuidFilterStrategyTests
     [Fact]
     public void In_WithNoParseableValues_ReturnsAll() =>
         Filter("IN", "nope").Should().HaveCount(4);
+
+    // ── IS EMPTY / IS NOT EMPTY (nullable) ──
+    [Fact]
+    public void IsEmpty_ReturnsNullTags() =>
+        FilterOptional("IS EMPTY", string.Empty).Should().HaveCount(3);
+
+    [Fact]
+    public void IsNotEmpty_ReturnsNonNullTags() =>
+        FilterOptional("IS NOT EMPTY", string.Empty).Should().ContainSingle();
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/LongFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/LongFilterStrategyTests.cs
@@ -3,22 +3,22 @@ using MMCA.Common.Application.Services.Filtering;
 
 namespace MMCA.Common.Application.Tests.Services.Filtering;
 
-public sealed class IntFilterStrategyTests
+public sealed class LongFilterStrategyTests
 {
     private sealed class Item
     {
-        public int Count { get; set; }
+        public long Count { get; set; }
 
-        public int? Score { get; set; }
+        public long? Score { get; set; }
     }
 
     private static IQueryable<Item> Items() =>
         new List<Item>
         {
-            new() { Count = 5, Score = 5 },
-            new() { Count = 10, Score = null },
-            new() { Count = 15, Score = 15 },
-            new() { Count = 20, Score = null },
+            new() { Count = 5_000_000_000L, Score = 5_000_000_000L },
+            new() { Count = 10_000_000_000L, Score = null },
+            new() { Count = 15_000_000_000L, Score = 15_000_000_000L },
+            new() { Count = 20_000_000_000L, Score = null },
         }.AsQueryable();
 
     private static readonly Dictionary<string, string> EmptyMap = [];
@@ -38,32 +38,21 @@ public sealed class IntFilterStrategyTests
     // ── EQUALS ──
     [Fact]
     public void Equals_ReturnsExactMatch() =>
-        Filter("EQUALS", "10").Should().ContainSingle(i => i.Count == 10);
+        Filter("EQUALS", "10000000000").Should().ContainSingle(i => i.Count == 10_000_000_000L);
 
     // ── NOT EQUALS ──
     [Fact]
     public void NotEquals_ExcludesMatch() =>
-        Filter("NOT EQUALS", "10").Should().HaveCount(3);
+        Filter("NOT EQUALS", "10000000000").Should().HaveCount(3);
 
-    // ── GREATER THAN ──
+    // ── Comparisons ──
     [Fact]
     public void GreaterThan_ReturnsItemsAboveValue() =>
-        Filter("GREATER THAN", "10").Should().HaveCount(2);
+        Filter("GREATER THAN", "10000000000").Should().HaveCount(2);
 
-    // ── LESS THAN ──
-    [Fact]
-    public void LessThan_ReturnsItemsBelowValue() =>
-        Filter("LESS THAN", "10").Should().ContainSingle(i => i.Count == 5);
-
-    // ── GREATER THAN OR EQUAL ──
-    [Fact]
-    public void GreaterThanOrEqual_IncludesBoundary() =>
-        Filter("GREATER THAN OR EQUAL", "10").Should().HaveCount(3);
-
-    // ── LESS THAN OR EQUAL ──
     [Fact]
     public void LessThanOrEqual_IncludesBoundary() =>
-        Filter("LESS THAN OR EQUAL", "10").Should().HaveCount(2);
+        Filter("LESS THAN OR EQUAL", "10000000000").Should().HaveCount(2);
 
     // ── Invalid value ──
     [Fact]
@@ -73,45 +62,27 @@ public sealed class IntFilterStrategyTests
     // ── Unknown operator ──
     [Fact]
     public void UnknownOperator_ReturnsAll() =>
-        Filter("CONTAINS", "10").Should().HaveCount(4);
+        Filter("CONTAINS", "10000000000").Should().HaveCount(4);
 
     // ── IN ──
     [Fact]
     public void In_ReturnsItemsMatchingAnyListedValue() =>
-        Filter("IN", "5,15").Select(i => i.Count).Should().BeEquivalentTo([5, 15]);
-
-    [Fact]
-    public void In_TrimsWhitespaceAroundValues() =>
-        Filter("IN", " 10 , 20 ").Should().HaveCount(2);
+        Filter("IN", "5000000000,15000000000").Select(i => i.Count)
+            .Should().BeEquivalentTo([5_000_000_000L, 15_000_000_000L]);
 
     [Fact]
     public void In_SkipsUnparseableValues() =>
-        Filter("IN", "5,not-a-number,20").Select(i => i.Count).Should().BeEquivalentTo([5, 20]);
-
-    [Fact]
-    public void In_WithNoParseableValues_ReturnsAll() =>
-        Filter("IN", "a,b,c").Should().HaveCount(4);
-
-    [Fact]
-    public void In_WithEmptyValue_ReturnsAll() =>
-        Filter("IN", string.Empty).Should().HaveCount(4);
+        Filter("IN", "5000000000,not-a-number,20000000000").Should().HaveCount(2);
 
     // ── BETWEEN ──
     [Fact]
     public void Between_ReturnsInclusiveRange() =>
-        Filter("BETWEEN", "10,15").Select(i => i.Count).Should().BeEquivalentTo([10, 15]);
-
-    [Fact]
-    public void Between_IncludesBothBounds() =>
-        Filter("BETWEEN", "5,20").Should().HaveCount(4);
+        Filter("BETWEEN", "10000000000,15000000000").Select(i => i.Count)
+            .Should().BeEquivalentTo([10_000_000_000L, 15_000_000_000L]);
 
     [Fact]
     public void Between_WithSingleValue_ReturnsAll() =>
-        Filter("BETWEEN", "10").Should().HaveCount(4);
-
-    [Fact]
-    public void Between_WithUnparseableBound_ReturnsAll() =>
-        Filter("BETWEEN", "10,not-a-number").Should().HaveCount(4);
+        Filter("BETWEEN", "10000000000").Should().HaveCount(4);
 
     // ── IS EMPTY / IS NOT EMPTY (nullable) ──
     [Fact]

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceTests.cs
@@ -160,7 +160,20 @@ public class QueryFilterServiceTests
 
     [Fact]
     public void DateTime_UnknownOp_ReturnsAll() =>
-        Filter("CreatedOn", "BETWEEN", "2024-01-01").Should().HaveCount(4);
+        Filter("CreatedOn", "IS WITHIN", "2024-01-01").Should().HaveCount(4);
+
+    [Fact]
+    public void DateTime_Between_ReturnsInclusiveRange() =>
+        Filter("CreatedOn", "BETWEEN", "2024-03-01,2024-06-15").Should().HaveCount(2);
+
+    // ── Nullable int strategy (IS EMPTY / BETWEEN) via ApplyFilters ──
+    [Fact]
+    public void NullableInt_IsEmpty_ReturnsNulls() =>
+        Filter("NullablePrice", "IS EMPTY", string.Empty).Should().HaveCount(2);
+
+    [Fact]
+    public void NullableInt_Between_ReturnsInclusiveRange() =>
+        Filter("NullablePrice", "BETWEEN", "10,50").Should().HaveCount(2);
 
     // ── Multiple filters ──
     [Fact]

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/DistributedCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/DistributedCacheServiceTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Infrastructure.Caching;
 using Moq;
 using StackExchange.Redis;
@@ -9,11 +11,13 @@ namespace MMCA.Common.Infrastructure.Tests.Caching;
 
 public class DistributedCacheServiceTests
 {
+    private static readonly ILogger<DistributedCacheService> NullLog = NullLogger<DistributedCacheService>.Instance;
+
     private readonly Mock<IDistributedCache> _cacheMock = new();
     private readonly DistributedCacheService _sut;
 
     public DistributedCacheServiceTests() =>
-        _sut = new DistributedCacheService(_cacheMock.Object);
+        _sut = new DistributedCacheService(_cacheMock.Object, NullLog);
 
     // ── GetAsync ──
     [Fact]
@@ -96,6 +100,36 @@ public class DistributedCacheServiceTests
     }
 
     [Fact]
+    public async Task RemoveByPrefixAsync_WithoutRedis_LogsWarningOnceAcrossCalls()
+    {
+        // Moq cannot proxy ILogger<T> of an internal T (strong-named abstractions), so use a small fake.
+        var logger = new WarningCountingLogger();
+        var sut = new DistributedCacheService(_cacheMock.Object, logger);
+
+        // The dead no-op should be observable, but warn once (steady state) rather than on every command.
+        await sut.RemoveByPrefixAsync("prefix:");
+        await sut.RemoveByPrefixAsync("other:");
+
+        logger.WarningCount.Should().Be(1);
+    }
+
+    private sealed class WarningCountingLogger : ILogger<DistributedCacheService>
+    {
+        public int WarningCount { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+                WarningCount++;
+        }
+    }
+
+    [Fact]
     public async Task RemoveByPrefixAsync_WithRedis_DeletesMatchingKeys()
     {
         var cacheMock = new Mock<IDistributedCache>();
@@ -119,7 +153,7 @@ public class DistributedCacheServiceTests
         dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey[]>(), It.IsAny<CommandFlags>()))
             .ReturnsAsync(2);
 
-        var sut = new DistributedCacheService(cacheMock.Object, connectionMock.Object);
+        var sut = new DistributedCacheService(cacheMock.Object, NullLog, connectionMock.Object);
 
         await sut.RemoveByPrefixAsync("prefix:");
 
@@ -139,7 +173,7 @@ public class DistributedCacheServiceTests
         var connectionMock = new Mock<IConnectionMultiplexer>();
         connectionMock.Setup(c => c.GetServers()).Returns([]);
 
-        var sut = new DistributedCacheService(cacheMock.Object, connectionMock.Object);
+        var sut = new DistributedCacheService(cacheMock.Object, NullLog, connectionMock.Object);
 
         await sut.RemoveByPrefixAsync("prefix:");
 
@@ -166,7 +200,7 @@ public class DistributedCacheServiceTests
                 It.IsAny<CommandFlags>()))
             .Returns(AsyncEnumerable.Empty<RedisKey>());
 
-        var sut = new DistributedCacheService(cacheMock.Object, connectionMock.Object);
+        var sut = new DistributedCacheService(cacheMock.Object, NullLog, connectionMock.Object);
 
         await sut.RemoveByPrefixAsync("prefix:");
 

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/MemoryCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/MemoryCacheServiceTests.cs
@@ -38,6 +38,18 @@ public sealed class MemoryCacheServiceTests : IDisposable
         result.Should().Be(42);
     }
 
+    [Fact]
+    public async Task GetAsync_WhenKeyStoredUnderDifferentType_ReturnsCleanMissWithoutThrowing()
+    {
+        await _sut.SetAsync("reused-key", 42);
+
+        // A key reused under a mismatched T must surface as a clean miss, not an InvalidCastException.
+        var result = await FluentActions.Invoking(() => _sut.GetAsync<string>("reused-key"))
+            .Should().NotThrowAsync();
+
+        result.Subject.Should().BeNull();
+    }
+
     // ── SetAsync ──
     [Fact]
     public async Task SetAsync_WithExpiration_StoresValue()


### PR DESCRIPTION
Closes several onboarding **Caveats / not-in-source** gaps in group-03 (querying/filtering) and group-09 (caching) with real framework improvements. Self-contained; no public API removed; existing behavior unchanged.

## Filtering DSL (group-03)
- **IS EMPTY / IS NOT EMPTY** null-checks added to `Bool`, `Int`, `Decimal`, `Guid` strategies. Nullable value-type columns (`bool?`/`int?`/`decimal?`/`Guid?`) could not be filtered for null before; `DateTime?` already could.
- **IN** added to `Decimal` and `DateTime` (parity with the existing `Int`/`Guid`/`String` IN).
- **BETWEEN** inclusive range added to `Int`, `Decimal`, `DateTime`, `Long` (previously a range needed two filters).
- New **`LongFilterStrategy`** + `long`/`long?` registration. A `long`-keyed entity previously failed filter validation with "No filter strategy registered".

## Paging backstop (group-03)
`EntityQueryPipeline` now clamps the caller's page size to `MaxUnboundedResultLimit` in both paginated branches, so a direct Application-layer caller (gRPC handler, cross-module call) that bypasses the API-boundary `MaxPageSize` clamp cannot request an unbounded page.

## Caching observability + robustness (group-09)
- `DistributedCacheService` now **warns** when prefix eviction is a no-op (once for the steady-state missing-`IConnectionMultiplexer` case, every time for the anomalous no-server case) instead of silently skipping. `ILogger` is injected via the DI factory with a `NullLogger` fallback for minimal containers.
- `MemoryCacheService.GetAsync<T>` returns a **clean miss** instead of throwing `InvalidCastException` when a key is reused under a different `T`.

## Tests
Unit tests added for every new operator, the new strategy, the page-size clamp, and both caching behaviors. Full suite green locally: **2,344/2,344**, Release build clean, FACTS gate clean.

## Follow-ups (not in this PR)
- ADC hosts register `AddRedisDistributedCache` without `IConnectionMultiplexer`, so their 38 wired `ICacheInvalidating` prefixes evict nothing today (TTL-bound). Registering `AddRedisClient("redis")` there (a prod deploy) is a deferred follow-up, to land after this releases and sweeps into ADC.
- Onboarding caveat closure (`/update-onboarding` on group-03/05/09) to follow the release + sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)