### PR TITLE
§4: add DomainFactoriesReturnResult DDD fitness function

### DIFF
--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-07-22 (framework v1.123.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-07-23 (framework v1.123.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -41,10 +41,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **91 test methods across 30 abstract `*TestsBase` classes**, shipped once in the
+- **93 test methods across 30 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **55** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **56** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Entities.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Entities.cs
@@ -41,6 +41,45 @@ public static partial class ArchitectureRules
     }
 
     /// <summary>
+    /// The factory convention holds across the WHOLE domain model, not just aggregate roots: any concrete
+    /// type in the Domain or Shared layer that exposes a public static <c>Create(...)</c> must have at least
+    /// one <c>Create</c> overload returning <c>Result&lt;TSelf&gt;</c>. This generalizes
+    /// <see cref="AggregateRootsHaveResultFactory"/> from aggregate roots to value objects (e.g. <c>Money</c>,
+    /// <c>Email</c>, <c>DateRange</c>), locking in the "factories always return Result&lt;T&gt;" convention so a
+    /// future bare-entity/bare-value-object factory fails the build. Types that expose no <c>Create</c> are
+    /// unaffected (construction sugar such as <c>Money.Zero()</c> / arithmetic operators is out of scope: only
+    /// the <c>Create</c> factory name is governed).
+    /// </summary>
+    public static void DomainFactoriesReturnResult(IArchitectureMap map)
+    {
+        var violations = new List<string>();
+
+        var factoryTypes = map.OfLayer(Layer.Domain)
+            .Concat(map.OfLayer(Layer.Shared))
+            .SelectMany(a => a.ConcreteClasses);
+
+        foreach (var type in factoryTypes)
+        {
+            var createMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => string.Equals(m.Name, "Create", StringComparison.Ordinal))
+                .ToList();
+
+            if (createMethods.Count == 0)
+            {
+                continue;
+            }
+
+            if (!createMethods.Exists(m => ReturnsResultOf(m.ReturnType, type)))
+            {
+                violations.Add($"  - {type.FullName}: Create(...) must return Result<{type.Name}>");
+            }
+        }
+
+        ArchitectureAssert.NoViolations(violations,
+            "every domain/value-object factory named Create must return Result<T> (factory convention normalized across the model)");
+    }
+
+    /// <summary>
     /// Aggregate roots across the WHOLE Domain layer (framework + module) expose no public constructor —
     /// construction goes through the static <c>Create(...)</c> factory. This is the minimal-base
     /// counterpart to <see cref="AggregateRootsHaveNoPublicConstructors"/>, which scopes to per-module

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/AggregateConventionTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/AggregateConventionTestsBase.cs
@@ -2,8 +2,10 @@ namespace MMCA.Common.Testing.Architecture;
 
 /// <summary>
 /// Minimal DDD aggregate fitness functions for repos that have no business modules (e.g. MMCA.Common):
-/// the Domain layer exposes aggregate roots, and each is built via a static <c>Create(...)</c> factory
-/// returning <c>Result&lt;T&gt;</c>. Module-bearing repos use the fuller <see cref="EntityConventionTestsBase"/>.
+/// the Domain layer exposes aggregate roots, each is built via a static <c>Create(...)</c> factory
+/// returning <c>Result&lt;T&gt;</c> with no public constructor, and the same Result-returning factory
+/// convention holds for every domain/value-object <c>Create</c>. Module-bearing repos use the fuller
+/// <see cref="EntityConventionTestsBase"/>.
 /// </summary>
 public abstract class AggregateConventionTestsBase
 {
@@ -17,4 +19,7 @@ public abstract class AggregateConventionTestsBase
 
     [Fact]
     public void AggregateRoots_ShouldHave_NoPublicConstructors() => ArchitectureRules.DomainAggregateRootsHaveNoPublicConstructors(Map);
+
+    [Fact]
+    public void DomainFactories_ShouldReturn_Result() => ArchitectureRules.DomainFactoriesReturnResult(Map);
 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/EntityConventionTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/EntityConventionTestsBase.cs
@@ -3,7 +3,8 @@ namespace MMCA.Common.Testing.Architecture;
 /// <summary>
 /// DDD entity/aggregate fitness functions: entities are sealed and live only in Domain, aggregate roots
 /// are built through a static <c>Create(...)</c> factory returning <c>Result&lt;T&gt;</c> with no public
-/// constructor, and DTOs/requests stay out of Domain and Infrastructure.
+/// constructor, every domain/value-object <c>Create</c> factory returns <c>Result&lt;T&gt;</c>, and
+/// DTOs/requests stay out of Domain and Infrastructure.
 /// </summary>
 public abstract class EntityConventionTestsBase
 {
@@ -17,6 +18,9 @@ public abstract class EntityConventionTestsBase
 
     [Fact]
     public void AggregateRoots_ShouldHave_NoPublicConstructors() => ArchitectureRules.AggregateRootsHaveNoPublicConstructors(Map);
+
+    [Fact]
+    public void DomainFactories_ShouldReturn_Result() => ArchitectureRules.DomainFactoriesReturnResult(Map);
 
     [Fact]
     public void DomainEntities_ShouldBe_Sealed() => ArchitectureRules.DomainEntitiesAreSealed(Map);


### PR DESCRIPTION
## Summary

Closes the remaining actionable work on backlog **#4 (Domain-Driven Design)**. Most of this item was already implemented (aggregate private-ctor + `Result<T>` factory fitness functions already exist; `UserNotification.Create` already returns `Result<T>`; all 8 `Create` factories already return `Result<T>`). This PR locks in the "factories always return `Result<T>`" convention model-wide.

## Changes

- **New fitness function `DomainFactoriesReturnResult`** (`ArchitectureRules.Entities.cs`): any concrete type in the Domain or Shared layer exposing a public static `Create(...)` must have a `Create` overload returning `Result<TSelf>`. Generalizes the aggregate-only `AggregateRootsHaveResultFactory` to value objects (`Money`, `Email`, `DateRange`, ...).
- Wired into **both** shared bases (`AggregateConventionTestsBase`, `EntityConventionTestsBase`), so it runs across Common, ADC, Store, and Helpdesk.
- Regenerated `FACTS.md`: fitness methods **91 -> 93** (one `[Fact]` in each of the two bases), Common executes **55 -> 56**.

## Deliberately NOT added
- **No cross-aggregate navigation rule.** Cross-aggregate object navigation is an accepted design feature: aggregate roots reference other roots via `[Navigation]` FK references loaded by the navigation populators (**ADR-002**), e.g. `Session.Event` / `Session.Room` in ADC. A strict rule would contradict ADR-002 and break the consumers' 15 aggregates.
- **`Money.operator+` keeps throwing** by design (a C# operator cannot return `Result<T>`); `Money.Add(...)` is the documented Result path.

## Verification
- Release build: 0 warnings / 0 errors.
- Architecture tests: 56 pass (new test verified non-vacuous over the 8 factory types).
- Shared tests: 196 pass. FACTS `--check`: up to date.
- Helpdesk/ADC/Store confirmed compliant; Helpdesk exercises the new rule in the `consumer-source-build` gate.

Backlog reconciliation lands in a companion Website PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)