### PR TITLE
Repository ExecuteUpdateAsync, shared ConcurrencyTokenRequest, and PeriodicBackgroundService base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+Additive feature work extracted from the MMCA.Store Sales consistency-guards PR (Store #39). No
+breaking changes and no public API removed.
+
+### Added
+- **`IWriteRepository.ExecuteUpdateAsync` set-based conditional update (Application + Infrastructure).**
+  Symmetric counterpart to `ExecuteDeleteAsync`: one atomic `UPDATE ... SET ... WHERE ...` through the
+  repository abstraction, intended for contention-proof conditional updates (stock decrements, quota
+  claims) where zero rows affected means the guard did not hold and the database arbitrates races. The
+  SET clause is described through the new EF-free `IUpdatePropertySetter<TEntity>` builder (fixed
+  values or expressions over the current row), translated to EF Core `SetPropertyCalls` by the new
+  `UpdatePropertySetterBuilder`. Global query filters (soft delete) apply to the WHERE; domain events
+  are bypassed (as with `ExecuteDeleteAsync`); `LastModifiedOn`/`LastModifiedBy` are stamped
+  automatically (TimeProvider clock + `ICurrentUserService` when available) unless set explicitly.
+- **`ConcurrencyTokenRequest` (Shared).** Reusable request body for lifecycle/state-transition
+  endpoints whose only payload is the ADR-035 optimistic-concurrency token: bind as an optional body
+  (`EmptyBodyBehavior.Allow`) so body-less callers skip the stale-view check. Replaces per-app copies
+  (Store's `OrderTransitionRequest`, ADC's lifecycle equivalents) at the next consumer sweep.
+- **`PeriodicBackgroundService` (Infrastructure).** Base class for fixed-interval background sweeps:
+  enablement gate, TimeProvider-driven startup delay + interval waits (deterministic in tests via
+  `FakeTimeProvider`), and a failing cycle that is logged without killing the loop. For reconciliation
+  and cleanup work (e.g. Store's stuck-payment sweep); deliberately not used by the signal-driven
+  outbox processor.
+
 ## [1.124.0] - 2026-07-23
 
 Maintenance release strengthening the architecture-test rule library. No breaking changes and no

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
@@ -196,6 +196,30 @@ public interface IWriteRepository<TEntity, TIdentifierType>
         Expression<Func<TEntity, bool>> where,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Executes a set-based UPDATE directly in the database, bypassing change tracking:
+    /// <c>UPDATE ... SET ... WHERE ...</c> as one atomic statement. The intended use is
+    /// contention-proof conditional updates (e.g. a stock decrement guarded by
+    /// <c>AvailableQuantity &gt;= @qty</c> in <paramref name="where"/>): zero rows affected
+    /// means the condition did not hold, and two racing callers can never both win, with no
+    /// rowversion retry loop, because the database itself arbitrates.
+    /// <para>
+    /// WARNING: bypasses domain events. Global query filters (soft delete) DO apply to
+    /// <paramref name="where"/>. Audit fields are NOT bypassed: <c>LastModifiedOn</c> and
+    /// <c>LastModifiedBy</c> are stamped automatically unless the caller sets them explicitly.
+    /// Runs on the ambient transaction when one is active (see
+    /// <c>IUnitOfWork.ExecuteInTransactionAsync</c>), so decrements roll back with the caller.
+    /// </para>
+    /// </summary>
+    /// <param name="where">A predicate selecting (and guarding) the rows to update.</param>
+    /// <param name="setProperties">Builder describing the properties to set.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of rows updated (0 = the guard condition matched no row).</returns>
+    Task<int> ExecuteUpdateAsync(
+        Expression<Func<TEntity, bool>> where,
+        Action<IUpdatePropertySetter<TEntity>> setProperties,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Synchronous save. Prefer <see cref="SaveChangesAsync"/> in async code paths.</summary>
     /// <returns>The number of state entries written.</returns>
     int Save();

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IUpdatePropertySetter.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IUpdatePropertySetter.cs
@@ -1,0 +1,36 @@
+using System.Linq.Expressions;
+
+namespace MMCA.Common.Application.Interfaces.Infrastructure;
+
+/// <summary>
+/// Persistence-agnostic builder for the SET clause of a bulk update
+/// (<see cref="IWriteRepository{TEntity,TIdentifierType}.ExecuteUpdateAsync"/>).
+/// Mirrors the shape of EF Core's <c>SetPropertyCalls</c> without leaking EF Core into the
+/// Application layer: handlers describe WHICH properties change and to WHAT, and the
+/// Infrastructure implementation translates the calls into the provider's set-based UPDATE.
+/// </summary>
+/// <typeparam name="TEntity">The entity type being updated.</typeparam>
+public interface IUpdatePropertySetter<TEntity>
+{
+    /// <summary>Sets a property to a fixed value (e.g. a status, a timestamp).</summary>
+    /// <typeparam name="TProperty">The property type.</typeparam>
+    /// <param name="property">The property to set.</param>
+    /// <param name="value">The value to assign.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IUpdatePropertySetter<TEntity> Set<TProperty>(
+        Expression<Func<TEntity, TProperty>> property,
+        TProperty value);
+
+    /// <summary>
+    /// Sets a property from an expression over the CURRENT database row (e.g.
+    /// <c>quantity => quantity.Amount - 5</c>), enabling atomic read-modify-write updates
+    /// such as conditional counter decrements where the database itself arbitrates races.
+    /// </summary>
+    /// <typeparam name="TProperty">The property type.</typeparam>
+    /// <param name="property">The property to set.</param>
+    /// <param name="valueFactory">An expression computing the new value from the current row.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IUpdatePropertySetter<TEntity> Set<TProperty>(
+        Expression<Func<TEntity, TProperty>> property,
+        Expression<Func<TEntity, TProperty>> valueFactory);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
@@ -12,8 +12,15 @@ namespace MMCA.Common.Infrastructure.Persistence.Repositories;
 /// </summary>
 /// <typeparam name="TEntity">The entity type.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
+/// <remarks>
+/// The optional <paramref name="timeProvider"/> and <paramref name="currentUserService"/> are
+/// used only by <see cref="ExecuteUpdateAsync"/> for automatic audit stamping; when absent
+/// (direct construction in tests) the system clock is used and the user stamp is skipped.
+/// </remarks>
 internal sealed class EFRepository<TEntity, TIdentifierType>(
-    DbContext context
+    DbContext context,
+    TimeProvider? timeProvider = null,
+    ICurrentUserService? currentUserService = null
 ) : EFReadRepository<TEntity, TIdentifierType>(context), IRepository<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull
@@ -99,6 +106,36 @@ internal sealed class EFRepository<TEntity, TIdentifierType>(
     {
         ArgumentNullException.ThrowIfNull(where);
         return await Entities.Where(where).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ExecuteUpdateAsync(
+        Expression<Func<TEntity, bool>> where,
+        Action<IUpdatePropertySetter<TEntity>> setProperties,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(where);
+        ArgumentNullException.ThrowIfNull(setProperties);
+
+        var builder = new UpdatePropertySetterBuilder<TEntity>();
+        setProperties(builder);
+        if (builder.IsEmpty)
+            throw new ArgumentException("At least one property assignment is required.", nameof(setProperties));
+
+        // ExecuteUpdate bypasses the save pipeline's audit interceptor, so stamp the
+        // modification audit fields here unless the caller assigned them explicitly.
+        if (!builder.SetsProperty(nameof(IAuditableEntity.LastModifiedOn)))
+        {
+            var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+            builder.Set(e => e.LastModifiedOn, (DateTime?)now);
+        }
+
+        if (currentUserService?.UserId is { } userId && !builder.SetsProperty(nameof(IAuditableEntity.LastModifiedBy)))
+        {
+            builder.Set(e => e.LastModifiedBy, userId);
+        }
+
+        return await Entities.Where(where).ExecuteUpdateAsync(builder.Apply, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepositoryDecorator.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepositoryDecorator.cs
@@ -51,6 +51,13 @@ internal sealed class EFRepositoryDecorator<TEntity, TIdentifierType>(IRepositor
         ProfilingHelper.ProfileAsync(ClassName, nameof(ExecuteDeleteAsync),
             () => _inner.ExecuteDeleteAsync(where, cancellationToken));
 
+    public Task<int> ExecuteUpdateAsync(
+        System.Linq.Expressions.Expression<Func<TEntity, bool>> where,
+        Action<IUpdatePropertySetter<TEntity>> setProperties,
+        CancellationToken cancellationToken = default) =>
+        ProfilingHelper.ProfileAsync(ClassName, nameof(ExecuteUpdateAsync),
+            () => _inner.ExecuteUpdateAsync(where, setProperties, cancellationToken));
+
     public int Save() =>
         ProfilingHelper.Profile(ClassName, nameof(Save), _inner.Save);
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/UpdatePropertySetterBuilder.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/UpdatePropertySetterBuilder.cs
@@ -1,0 +1,67 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Collects the property assignments described through the persistence-agnostic
+/// <see cref="IUpdatePropertySetter{TEntity}"/> surface and replays them onto EF Core 10's
+/// <see cref="UpdateSettersBuilder{TSource}"/> when <c>ExecuteUpdateAsync</c> runs. This is
+/// the bridge that keeps EF Core out of the Application layer.
+/// </summary>
+/// <typeparam name="TEntity">The entity type being updated.</typeparam>
+internal sealed class UpdatePropertySetterBuilder<TEntity> : IUpdatePropertySetter<TEntity>
+{
+    private readonly List<Action<UpdateSettersBuilder<TEntity>>> _assignments = [];
+    private readonly HashSet<string> _assignedProperties = [];
+
+    /// <inheritdoc />
+    public IUpdatePropertySetter<TEntity> Set<TProperty>(
+        Expression<Func<TEntity, TProperty>> property,
+        TProperty value)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+        TrackPropertyName(property);
+        _assignments.Add(builder => builder.SetProperty(property, value));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IUpdatePropertySetter<TEntity> Set<TProperty>(
+        Expression<Func<TEntity, TProperty>> property,
+        Expression<Func<TEntity, TProperty>> valueFactory)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+        ArgumentNullException.ThrowIfNull(valueFactory);
+        TrackPropertyName(property);
+        _assignments.Add(builder => builder.SetProperty(property, valueFactory));
+        return this;
+    }
+
+    /// <summary>Gets a value indicating whether any assignment was described.</summary>
+    public bool IsEmpty => _assignments.Count == 0;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the caller already assigned the named top-level
+    /// property, so automatic audit stamping does not overwrite an explicit value.
+    /// </summary>
+    public bool SetsProperty(string propertyName) => _assignedProperties.Contains(propertyName);
+
+    /// <summary>Replays every collected assignment onto EF Core's setters builder.</summary>
+    public void Apply(UpdateSettersBuilder<TEntity> builder)
+    {
+        foreach (var assignment in _assignments)
+        {
+            assignment(builder);
+        }
+    }
+
+    private void TrackPropertyName(LambdaExpression property)
+    {
+        if (property.Body is MemberExpression member)
+        {
+            _assignedProperties.Add(member.Member.Name);
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Services/PeriodicBackgroundService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/PeriodicBackgroundService.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MMCA.Common.Infrastructure.Services;
+
+/// <summary>
+/// Base class for fixed-interval background sweeps: an optional enablement gate, a short
+/// startup delay so the host finishes initializing, then a loop of
+/// <see cref="ExecuteCycleAsync"/> + interval wait until shutdown. A failing cycle is logged
+/// and NEVER kills the loop; the next interval retries. All waits go through the injected
+/// <see cref="TimeProvider"/> so tests can drive the loop deterministically with a fake clock.
+/// <para>
+/// Use this for periodic reconciliation/cleanup work (stuck-state sweeps, cache refreshes,
+/// external-system polling). It is deliberately NOT used by the outbox processor, whose
+/// signal-driven smart wait does not fit a fixed interval.
+/// </para>
+/// </summary>
+/// <param name="timeProvider">Clock used for the startup delay and interval waits.</param>
+/// <param name="logger">Logger receiving cycle failures and lifecycle messages.</param>
+public abstract partial class PeriodicBackgroundService(
+    TimeProvider timeProvider,
+    ILogger logger) : BackgroundService
+{
+    /// <summary>Gets the wait between cycles.</summary>
+    protected abstract TimeSpan Interval { get; }
+
+    /// <summary>
+    /// Gets the delay before the first cycle, so the application finishes initializing
+    /// before background work starts. Override to shorten in tests.
+    /// </summary>
+    protected virtual TimeSpan StartupDelay => TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Gets a value indicating whether the service should run at all. Evaluated once at
+    /// startup; when <see langword="false"/> the service logs and exits (e.g. a feature
+    /// toggle is off or a required credential is not configured).
+    /// </summary>
+    protected virtual bool IsEnabled => true;
+
+    /// <summary>Runs one sweep cycle. Exceptions are logged and do not stop the loop.</summary>
+    /// <param name="stoppingToken">Canceled when the host shuts down.</param>
+    protected abstract Task ExecuteCycleAsync(CancellationToken stoppingToken);
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!IsEnabled)
+        {
+            LogDisabled(logger, GetType().Name);
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(StartupDelay, timeProvider, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ExecuteCycleAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Normal shutdown mid-cycle.
+                break;
+            }
+            catch (Exception ex)
+            {
+                LogCycleError(logger, GetType().Name, ex);
+            }
+
+            try
+            {
+                await Task.Delay(Interval, timeProvider, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "{ServiceName} is disabled; the periodic sweep will not run")]
+    private static partial void LogDisabled(ILogger logger, string serviceName);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "{ServiceName} cycle failed; it will retry on the next interval")]
+    private static partial void LogCycleError(ILogger logger, string serviceName, Exception ex);
+}

--- a/Source/Core/MMCA.Common.Shared/DTOs/ConcurrencyTokenRequest.cs
+++ b/Source/Core/MMCA.Common.Shared/DTOs/ConcurrencyTokenRequest.cs
@@ -1,0 +1,16 @@
+namespace MMCA.Common.Shared.DTOs;
+
+/// <summary>
+/// Reusable request body for lifecycle/state-transition endpoints (publish, cancel, open,
+/// approve, ...) whose only payload is the optimistic-concurrency token (ADR-035). The client
+/// echoes the <see cref="RowVersion"/> from the DTO it acted on, so a transition decided
+/// against a stale view of the aggregate surfaces as 409 Conflict instead of applying
+/// silently. Bind it as an OPTIONAL body (ASP.NET Core <c>EmptyBodyBehavior.Allow</c>) so
+/// body-less legacy callers keep working and simply skip the stale-view check; a null
+/// <see cref="RowVersion"/> also skips it (see <c>IWriteRepository.SetOriginalRowVersion</c>).
+/// </summary>
+public sealed record class ConcurrencyTokenRequest : IConcurrencyAware
+{
+    /// <inheritdoc />
+    public byte[]? RowVersion { get; init; }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFRepositoryIntegrationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFRepositoryIntegrationTests.cs
@@ -1,8 +1,11 @@
 using AwesomeAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Infrastructure.Persistence.Repositories;
+using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
 
@@ -456,13 +459,104 @@ public sealed class EFRepositoryIntegrationTests : IDisposable
             .Should().BeSameAs(original, because: "legacy clients that send no token skip the concurrency check, matching the aggregate-typed overload's contract");
     }
 
+    // ── ExecuteUpdateAsync (set-based conditional update) ──
+    [Fact]
+    public async Task ExecuteUpdateAsync_UpdatesMatchingRows_AndAutoStampsAudit()
+    {
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.SetupGet(u => u.UserId).Returns(42);
+        var sut = new EFRepository<TestEntity, int>(_context, fakeTime, currentUser.Object);
+
+        _context.Add(TestEntity.Create(1, "before"));
+        _context.Add(TestEntity.Create(2, "untouched"));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var affected = await sut.ExecuteUpdateAsync(
+            e => e.Id == 1,
+            setters => setters.Set(e => e.Name, "after"));
+
+        affected.Should().Be(1);
+        var updated = await _context.TestEntities.AsNoTracking().SingleAsync(e => e.Id == 1);
+        updated.Name.Should().Be("after");
+        updated.LastModifiedOn.Should().Be(fakeTime.GetUtcNow().UtcDateTime,
+            because: "ExecuteUpdate bypasses the audit interceptor, so the repository stamps LastModifiedOn itself");
+        updated.LastModifiedBy.Should().Be(42,
+            because: "the current user is stamped when an ICurrentUserService is available");
+        (await _context.TestEntities.AsNoTracking().SingleAsync(e => e.Id == 2)).Name.Should().Be("untouched");
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_ConditionalCounterDecrement_ZeroRowsWhenGuardFails()
+    {
+        _context.Add(TestEntity.Create(1, "stock", counter: 1));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        // First conditional decrement wins.
+        var first = await _sut.ExecuteUpdateAsync(
+            e => e.Id == 1 && e.Counter >= 1,
+            setters => setters.Set(e => e.Counter, e => e.Counter - 1));
+
+        // Second decrement finds no row satisfying the guard: the database arbitrated the race.
+        var second = await _sut.ExecuteUpdateAsync(
+            e => e.Id == 1 && e.Counter >= 1,
+            setters => setters.Set(e => e.Counter, e => e.Counter - 1));
+
+        first.Should().Be(1);
+        second.Should().Be(0, because: "zero rows affected is the insufficient-stock signal");
+        (await _context.TestEntities.AsNoTracking().SingleAsync(e => e.Id == 1)).Counter
+            .Should().Be(0, because: "the counter must never go below the guard");
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_ExplicitAuditValue_IsNotOverwritten()
+    {
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var sut = new EFRepository<TestEntity, int>(_context, fakeTime);
+        var explicitStamp = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        _context.Add(TestEntity.Create(1, "x"));
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        await sut.ExecuteUpdateAsync(
+            e => e.Id == 1,
+            setters => setters
+                .Set(e => e.Name, "y")
+                .Set(e => e.LastModifiedOn, (DateTime?)explicitStamp));
+
+        (await _context.TestEntities.AsNoTracking().SingleAsync(e => e.Id == 1)).LastModifiedOn
+            .Should().Be(explicitStamp, because: "a caller-supplied audit value wins over the automatic stamp");
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_WithoutSetters_Throws()
+    {
+        var act = () => _sut.ExecuteUpdateAsync(e => e.Id == 1, _ => { });
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_NullArguments_Throw()
+    {
+        var actWhere = () => _sut.ExecuteUpdateAsync(null!, s => s.Set(e => e.Name, "x"));
+        var actSetters = () => _sut.ExecuteUpdateAsync(e => true, null!);
+
+        await actWhere.Should().ThrowAsync<ArgumentNullException>();
+        await actSetters.Should().ThrowAsync<ArgumentNullException>();
+    }
+
     // ── Test entity & context ──
     public sealed class TestEntity : AuditableAggregateRootEntity<int>
     {
         public string Name { get; set; } = string.Empty;
 
-        public static TestEntity Create(int id, string name) =>
-            new() { Id = id, Name = name };
+        public int Counter { get; set; }
+
+        public static TestEntity Create(int id, string name, int counter = 0) =>
+            new() { Id = id, Name = name, Counter = counter };
     }
 
     /// <summary>A NON-aggregate child entity (a different CLR type than the repository's TEntity).</summary>

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PeriodicBackgroundServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PeriodicBackgroundServiceTests.cs
@@ -1,0 +1,129 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Infrastructure.Services;
+
+namespace MMCA.Common.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Coverage for <see cref="PeriodicBackgroundService"/>: the enablement gate, the startup
+/// delay, interval-driven cycles, and the failing-cycle-never-kills-the-loop contract, all
+/// driven deterministically through the <see cref="FakeTimeProvider"/> clock using the same
+/// advance-until idiom as <c>OutboxCleanupServiceTests</c> (Advance only completes a Delay
+/// whose timer already exists, so a single Advance can race the loop's registration).
+/// </summary>
+public sealed class PeriodicBackgroundServiceTests
+{
+    private static readonly TimeSpan SweepStartup = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(10);
+
+    [Fact]
+    public async Task ExecuteAsync_RunsCyclesOnTheIntervalClock_AndOnlyWhenTimeAdvances()
+    {
+        var time = new FakeTimeProvider();
+        using var sut = new CountingSweep(time);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        (await AdvanceUntilCyclesAsync(time, sut, expected: 1)).Should().BeGreaterThanOrEqualTo(1,
+            because: "advancing past the startup delay must run the first cycle");
+
+        // With the clock frozen, no further cycles may sneak in: the loop is clock-driven.
+        var frozen = sut.Cycles;
+        await Task.Delay(TimeSpan.FromMilliseconds(100), TimeProvider.System, CancellationToken.None);
+        sut.Cycles.Should().Be(frozen, because: "cycles only run when the interval elapses");
+
+        (await AdvanceUntilCyclesAsync(time, sut, expected: frozen + 1)).Should().BeGreaterThanOrEqualTo(frozen + 1,
+            because: "each elapsed interval produces a further cycle");
+
+        await sut.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CycleFailure_DoesNotStopTheLoop()
+    {
+        var time = new FakeTimeProvider();
+        using var sut = new CountingSweep(time) { FailOnCycle = 1 };
+
+        await sut.StartAsync(CancellationToken.None);
+
+        (await AdvanceUntilCyclesAsync(time, sut, expected: 2)).Should().BeGreaterThanOrEqualTo(2,
+            because: "the throwing first cycle is logged and the loop keeps sweeping");
+
+        await sut.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDisabled_NeverRunsACycle()
+    {
+        var time = new FakeTimeProvider();
+        using var sut = new CountingSweep(time) { Enabled = false };
+
+        await sut.StartAsync(CancellationToken.None);
+        sut.ExecuteTask.Should().NotBeNull();
+        await sut.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(5), TimeProvider.System);
+
+        time.Advance(SweepStartup + SweepInterval + SweepInterval);
+        sut.Cycles.Should().Be(0, because: "the enablement gate exits before the loop starts");
+
+        await sut.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_DuringStartupDelay_ExitsCleanly()
+    {
+        var time = new FakeTimeProvider();
+        using var sut = new CountingSweep(time);
+
+        await sut.StartAsync(CancellationToken.None);
+        await sut.StopAsync(CancellationToken.None);
+
+        sut.Cycles.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Advances the fake clock one interval at a time, yielding a few real milliseconds after
+    /// each step so the loop's continuations run, until the cycle count reaches
+    /// <paramref name="expected"/> or a bounded deadline passes (mirrors
+    /// <c>OutboxCleanupServiceTests.AdvanceUntilSweepAsync</c>).
+    /// </summary>
+    private static async Task<int> AdvanceUntilCyclesAsync(FakeTimeProvider time, CountingSweep sut, int expected)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (sut.Cycles < expected && DateTime.UtcNow < deadline)
+        {
+            time.Advance(SweepInterval);
+            await Task.Delay(TimeSpan.FromMilliseconds(10), TimeProvider.System, CancellationToken.None);
+        }
+
+        return sut.Cycles;
+    }
+
+    /// <summary>Test double counting cycles, optionally failing one of them.</summary>
+    private sealed class CountingSweep(FakeTimeProvider time)
+        : PeriodicBackgroundService(time, NullLogger<CountingSweep>.Instance)
+    {
+        private int _cycles;
+
+        public bool Enabled { get; init; } = true;
+
+        /// <summary>1-based index of a cycle that should throw; 0 = never.</summary>
+        public int FailOnCycle { get; init; }
+
+        public int Cycles => Volatile.Read(ref _cycles);
+
+        protected override TimeSpan Interval => SweepInterval;
+
+        protected override TimeSpan StartupDelay => SweepStartup;
+
+        protected override bool IsEnabled => Enabled;
+
+        protected override Task ExecuteCycleAsync(CancellationToken stoppingToken)
+        {
+            var cycle = Interlocked.Increment(ref _cycles);
+            return cycle == FailOnCycle
+                ? Task.FromException(new InvalidOperationException("simulated cycle failure"))
+                : Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Extracts three reusable pieces identified while landing the MMCA.Store Sales consistency guards (ivanball/MMCA#39), so consumers stop hand-rolling them. All additive; no public API removed or changed.

## 1. `IWriteRepository.ExecuteUpdateAsync`
Set-based conditional UPDATE through the repository abstraction, symmetric to the existing `ExecuteDeleteAsync`:
- SET clause described via the new EF-free `IUpdatePropertySetter<TEntity>` (Application layer stays EF-clean; the internal `UpdatePropertySetterBuilder` replays onto EF Core 10's `UpdateSettersBuilder`).
- Intended use: contention-proof conditional updates (stock decrements, quota claims) where `WHERE guard` + 0-rows-affected = the database arbitrated the race. Store's `InventoryAllocationService` collapses onto this at the next sweep; the outbox lease-claim/finalizer sites can follow.
- Semantics: soft-delete query filters apply to the WHERE; domain events bypassed (as with `ExecuteDeleteAsync`); `LastModifiedOn`/`LastModifiedBy` auto-stamped via optional `TimeProvider`/`ICurrentUserService` ctor deps unless the caller sets them explicitly. Decorator passthrough included.

## 2. `ConcurrencyTokenRequest` (Shared.DTOs)
Reusable optional request body for lifecycle/state-transition endpoints whose only payload is the ADR-035 rowversion echo (bind with `EmptyBodyBehavior.Allow`). Replaces Store's `OrderTransitionRequest` and the ADC lifecycle equivalents at the next consumer sweep.

## 3. `PeriodicBackgroundService` (Infrastructure.Services)
Base class for fixed-interval background sweeps: enablement gate, TimeProvider-driven startup delay and interval waits (deterministic under `FakeTimeProvider`), and log-and-continue cycle failures. First consumer: Store's `PaymentReconciliationService` at the next sweep. Deliberately NOT adopted by the outbox processor (signal-driven smart wait does not fit a fixed interval).

## Verification
- Release build + full suite green: 2351 passed, 0 failed.
- New coverage: conditional counter decrement (0-rows guard), automatic + explicit audit stamping, argument guards, and four sweep-lifecycle tests using the `OutboxCleanupServiceTests` advance-until idiom.
- FACTS drift gate clean (`build/facts --check`).
- CHANGELOG updated under Unreleased.

Consumer note: ships with the next release train (v1.125.0) and the standard lockstep sweep; nothing here is consumed by Store/ADC/Helpdesk until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)