### PR TITLE
fix(security): scope idempotency keys, normalize lockout keys, deny-by-default ownership

### DIFF
--- a/Source/Core/MMCA.Common.Application/Interfaces/ICacheService.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/ICacheService.cs
@@ -38,4 +38,27 @@ public interface ICacheService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically increments a counter and returns its new value, setting <paramref name="expiration"/>
+    /// when the counter is created. Used by rate-limit and brute-force counters (ADR-029), where the
+    /// read-modify-write shape of <see cref="GetAsync{T}"/> + <see cref="SetAsync{T}"/> lets
+    /// concurrent requests overwrite each other's increments and undercount.
+    /// </summary>
+    /// <param name="key">The counter key.</param>
+    /// <param name="expiration">Time-to-live applied when the counter is first created.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The counter value after the increment.</returns>
+    /// <remarks>
+    /// The default implementation is the non-atomic read-modify-write, preserving behavior for
+    /// implementations with no native counter primitive (and keeping this a non-breaking addition).
+    /// Backing stores that can do better (Redis <c>INCR</c>) override it.
+    /// </remarks>
+    async Task<long> IncrementAsync(string key, TimeSpan expiration, CancellationToken cancellationToken = default)
+    {
+        var current = await GetAsync<long?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
+        var next = current + 1;
+        await SetAsync(key, next, expiration, cancellationToken).ConfigureAwait(false);
+        return next;
+    }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Auth/LoginProtectionService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Auth/LoginProtectionService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Auth;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.ValueObjects;
 
 namespace MMCA.Common.Infrastructure.Auth;
 
@@ -21,10 +22,34 @@ public sealed class LoginProtectionService(
 {
     private readonly LoginProtectionSettings _settings = settings.Value;
 
+    /// <summary>
+    /// Normalizes the supplied address the same way <see cref="Email"/> does before it is used in a
+    /// counter key. Without this the keys are built from raw request input while the user lookup
+    /// runs against the normalized value object, so <c>User@x.com</c>, <c>user@x.com</c> and
+    /// <c>" user@x.com "</c> resolve to one account but get independent attempt counters and
+    /// lockouts: an attacker defeats the ADR-029 backoff just by varying capitalization.
+    /// A malformed address (which never matches a user, but still increments a counter) falls back
+    /// to the same trim-and-lowercase shape so its attempts collapse onto one key too.
+    /// </summary>
+    private static string NormalizeIdentity(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            return string.Empty;
+
+        var result = Email.Create(email);
+#pragma warning disable CA1308 // Matches Email's own RFC 5321 lowercase normalization.
+        return result.IsSuccess ? result.Value!.Value : email.Trim().ToLowerInvariant();
+#pragma warning restore CA1308
+    }
+
+    private static string LockoutKey(string email) => $"login:lockout:{NormalizeIdentity(email)}";
+
+    private static string AttemptsKey(string email) => $"login:attempts:{NormalizeIdentity(email)}";
+
     /// <inheritdoc />
     public async Task<Result> CheckLockoutAsync(string email, CancellationToken cancellationToken = default)
     {
-        var lockoutKey = $"login:lockout:{email}";
+        var lockoutKey = LockoutKey(email);
         var isLockedOut = await cacheService.GetAsync<bool?>(lockoutKey, cancellationToken).ConfigureAwait(false) ?? false;
 
         return isLockedOut
@@ -38,34 +63,31 @@ public sealed class LoginProtectionService(
     /// <inheritdoc />
     public async Task IncrementFailedAttemptsAsync(string email, CancellationToken cancellationToken = default)
     {
-        var attemptsKey = $"login:attempts:{email}";
-        var currentCount = await cacheService.GetAsync<int?>(attemptsKey, cancellationToken).ConfigureAwait(false) ?? 0;
-        var newCount = currentCount + 1;
-        await cacheService.SetAsync(
-            attemptsKey,
-            newCount,
+        // Atomic: a read-modify-write lets parallel attempts overwrite each other's increments, so
+        // a burst of concurrent guesses could stay below MaxFailedAttempts indefinitely.
+        var newCount = await cacheService.IncrementAsync(
+            AttemptsKey(email),
             TimeSpan.FromMinutes(_settings.FailedAttemptWindowMinutes),
             cancellationToken).ConfigureAwait(false);
 
         if (newCount >= _settings.MaxFailedAttempts)
         {
-            var excessAttempts = newCount - _settings.MaxFailedAttempts;
+            var excessAttempts = (int)Math.Min(newCount - _settings.MaxFailedAttempts, int.MaxValue);
 
             // Clamp the shift exponent: C# masks int shift counts to 5 bits, so 1 << 31 is negative
             // and 1 << 32 wraps back to 1, silently shrinking (or negating) the lockout TTL for a
             // sufficiently persistent attacker. 1 << 30 already exceeds any permitted
             // MaxLockoutSeconds (range caps at 3600), so deep excess always lands on the cap.
             var lockoutSeconds = Math.Min(1 << Math.Min(excessAttempts, 30), _settings.MaxLockoutSeconds);
-            var lockoutKey = $"login:lockout:{email}";
-            await cacheService.SetAsync(lockoutKey, true, TimeSpan.FromSeconds(lockoutSeconds), cancellationToken).ConfigureAwait(false);
+            await cacheService.SetAsync(LockoutKey(email), true, TimeSpan.FromSeconds(lockoutSeconds), cancellationToken).ConfigureAwait(false);
         }
     }
 
     /// <inheritdoc />
     public async Task ResetFailedAttemptsAsync(string email, CancellationToken cancellationToken = default)
     {
-        await cacheService.RemoveAsync($"login:attempts:{email}", cancellationToken).ConfigureAwait(false);
-        await cacheService.RemoveAsync($"login:lockout:{email}", cancellationToken).ConfigureAwait(false);
+        await cacheService.RemoveAsync(AttemptsKey(email), cancellationToken).ConfigureAwait(false);
+        await cacheService.RemoveAsync(LockoutKey(email), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -76,8 +98,8 @@ public sealed class LoginProtectionService(
             return Result.Success();
         }
 
-        var key = $"registration:ip:{ipAddress}";
-        var registrationCount = await cacheService.GetAsync<int?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
+        var key = RegistrationKey(ipAddress);
+        var registrationCount = await cacheService.GetAsync<long?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
 
         return registrationCount >= _settings.MaxRegistrationsPerIpPerHour
             ? Result.Failure(Error.Unauthorized(
@@ -95,12 +117,15 @@ public sealed class LoginProtectionService(
             return;
         }
 
-        var key = $"registration:ip:{ipAddress}";
-        var currentCount = await cacheService.GetAsync<int?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
-        await cacheService.SetAsync(
-            key,
-            currentCount + 1,
+        // Atomic. On a store with a native counter (Redis) the TTL is also anchored to the first
+        // registration in the window; the read-modify-write fallback keeps the previous
+        // refresh-on-every-write behavior, which makes the window slide but only ever tightens
+        // the limit.
+        await cacheService.IncrementAsync(
+            RegistrationKey(ipAddress),
             TimeSpan.FromMinutes(_settings.RegistrationRateLimitWindowMinutes),
             cancellationToken).ConfigureAwait(false);
     }
+
+    private static string RegistrationKey(string ipAddress) => $"registration:ip:{ipAddress}";
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
@@ -92,6 +92,34 @@ internal sealed partial class DistributedCacheService(
             await db.KeyDeleteAsync([.. batch]).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Uses Redis <c>INCR</c> when a multiplexer is available, so concurrent increments cannot
+    /// overwrite each other (the interface default is a read-modify-write and undercounts under
+    /// load, which for a brute-force counter means attempts that never reach the lockout
+    /// threshold). The TTL is applied only when the counter is created, so the window stays
+    /// anchored to the first attempt rather than sliding on every increment. Without a
+    /// multiplexer, falls back to the interface default.
+    /// </remarks>
+    public async Task<long> IncrementAsync(string key, TimeSpan expiration, CancellationToken cancellationToken = default)
+    {
+        if (connectionMultiplexer is null)
+        {
+            var current = await GetAsync<long?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
+            var fallback = current + 1;
+            await SetAsync(key, fallback, expiration, cancellationToken).ConfigureAwait(false);
+            return fallback;
+        }
+
+        var db = connectionMultiplexer.GetDatabase();
+        var value = await db.StringIncrementAsync(key).ConfigureAwait(false);
+
+        if (value == 1)
+            await db.KeyExpireAsync(key, expiration).ConfigureAwait(false);
+
+        return value;
+    }
+
     private static T Deserialize<T>(byte[] bytes)
         => JsonSerializer.Deserialize<T>(bytes)!;
 

--- a/Source/Core/MMCA.Common.Shared/Concurrency/KeyedSemaphoreStripe.cs
+++ b/Source/Core/MMCA.Common.Shared/Concurrency/KeyedSemaphoreStripe.cs
@@ -1,0 +1,87 @@
+namespace MMCA.Common.Shared.Concurrency;
+
+/// <summary>
+/// Serializes work per logical key across a fixed set of <see cref="SemaphoreSlim"/> stripes.
+/// A key is mapped to a stripe by its hash, so the table size is bounded by
+/// <see cref="Width"/> regardless of how many distinct keys the process sees.
+/// <para>
+/// This deliberately replaces the "one semaphore per key in a ConcurrentDictionary" shape, which
+/// forces a choice between two defects: removing the entry when the last holder releases opens a
+/// window where one caller waits on a semaphore that is no longer in the table while a second
+/// caller creates a fresh one (both then run concurrently), and never removing it lets a
+/// caller-supplied key (an idempotency key, a parameterized cache key) grow the table without
+/// bound. Striping has neither problem. The cost is that two unrelated keys can share a stripe and
+/// briefly serialize against each other, which is harmless for the double-check-locking callers
+/// this exists for: they re-check their own key's state after acquiring.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Instances are thread-safe and intended to be held in a static field for the process lifetime.
+/// Stripes are never disposed because the instance outlives every caller.
+/// </remarks>
+public sealed class KeyedSemaphoreStripe
+{
+    /// <summary>Default number of stripes: ample concurrency without a meaningful memory cost.</summary>
+    public const int DefaultWidth = 256;
+
+    private readonly SemaphoreSlim[] _stripes;
+
+    /// <summary>Initializes a stripe set with <see cref="DefaultWidth"/> stripes.</summary>
+    public KeyedSemaphoreStripe()
+        : this(DefaultWidth)
+    {
+    }
+
+    /// <summary>Initializes a stripe set with the given width.</summary>
+    /// <param name="width">Number of stripes. Must be greater than zero.</param>
+    public KeyedSemaphoreStripe(int width)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(width, 0);
+
+        Width = width;
+        _stripes = new SemaphoreSlim[width];
+        for (var i = 0; i < width; i++)
+        {
+            _stripes[i] = new SemaphoreSlim(1, 1);
+        }
+    }
+
+    /// <summary>Gets the number of stripes.</summary>
+    public int Width { get; }
+
+    /// <summary>
+    /// Acquires the stripe guarding <paramref name="key"/>, returning a handle that releases it on
+    /// disposal. Await the call inside a <see langword="using"/> statement so the release happens
+    /// even when the guarded work throws.
+    /// </summary>
+    /// <param name="key">The logical key to serialize on.</param>
+    /// <param name="cancellationToken">Cancels the wait, not the work that follows it.</param>
+    /// <returns>A handle whose disposal releases the stripe.</returns>
+    public async Task<Releaser> AcquireAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var stripe = GetStripe(key);
+        await stripe.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(stripe);
+    }
+
+    private SemaphoreSlim GetStripe(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        // Ordinal hash, folded to a non-negative index. int.MinValue has no positive counterpart,
+        // so mask the sign bit rather than calling Math.Abs.
+        var index = (uint)string.GetHashCode(key, StringComparison.Ordinal) % (uint)Width;
+        return _stripes[index];
+    }
+
+    /// <summary>Releases the acquired stripe when disposed.</summary>
+    public readonly record struct Releaser : IDisposable
+    {
+        private readonly SemaphoreSlim? _stripe;
+
+        internal Releaser(SemaphoreSlim stripe) => _stripe = stripe;
+
+        /// <summary>Releases the stripe. Safe to call on a default-constructed instance.</summary>
+        public void Dispose() => _stripe?.Release();
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Authorization/AllowMissingOwnerAttribute.cs
+++ b/Source/Presentation/MMCA.Common.API/Authorization/AllowMissingOwnerAttribute.cs
@@ -1,0 +1,23 @@
+namespace MMCA.Common.API.Authorization;
+
+/// <summary>
+/// Marks an action (or an entire controller) as exempt from <see cref="OwnerOrAdminFilter"/>'s
+/// requirement that the request carry a resolvable owner identifier.
+/// <para>
+/// The filter denies by default: an action it guards whose owner parameter is absent or
+/// unparseable is rejected, because "no owner to compare" must not read as "no restriction". Some
+/// actions legitimately have no owner parameter and are guarded another way, typically a
+/// collection endpoint whose rows are already narrowed to the caller by an ownership
+/// specification, or one restricted to administrators by its own authorization policy. Those
+/// actions carry this attribute.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Applying this attribute is an assertion that the action is guarded elsewhere. Always state
+/// which guard replaces the parameter check in a comment at the application site, so a later
+/// reader can verify the claim instead of trusting it.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class AllowMissingOwnerAttribute : Attribute
+{
+}

--- a/Source/Presentation/MMCA.Common.API/Authorization/OwnerOrAdminFilter.cs
+++ b/Source/Presentation/MMCA.Common.API/Authorization/OwnerOrAdminFilter.cs
@@ -12,10 +12,20 @@ namespace MMCA.Common.API.Authorization;
 /// privileged nor the resource owner. The vocabulary (claim type, bypass role, route parameter) comes
 /// from <see cref="OwnerOrAdminFilterOptions"/>, whose defaults preserve the original
 /// <c>customer_id</c> / <c>Admin</c> / <c>id</c> behavior (ADR-033).
+/// <para>
+/// The filter denies by default. When the owner parameter cannot be resolved from the route or the
+/// bound action arguments, the request is rejected rather than allowed through: an ownership gate
+/// that treats "nothing to compare" as "nothing to enforce" silently stops guarding any action
+/// whose parameter is optional, non-integer, or carried inside a bound model. Actions that
+/// legitimately have no owner parameter opt out explicitly with
+/// <see cref="AllowMissingOwnerAttribute"/>.
+/// </para>
 /// </summary>
 /// <remarks>
 /// Register as a scoped service and apply via <c>[ServiceFilter(typeof(OwnerOrAdminFilter))]</c>
 /// on controllers that mix admin and owner access (e.g., shopping carts, orders, customers, bookmarks).
+/// Applying it at controller level covers every action, so audit the collection and lookup actions
+/// on that controller and mark the ones guarded another way with <see cref="AllowMissingOwnerAttribute"/>.
 /// </remarks>
 public sealed class OwnerOrAdminFilter(
     ICurrentUserService currentUserService,
@@ -43,8 +53,23 @@ public sealed class OwnerOrAdminFilter(
             return;
         }
 
-        if (TryGetOwnerParameter(context, settings.OwnerParameterName, out var requestedId)
-            && requestedId != ownerId.Value)
+        if (!TryGetOwnerParameter(context, settings.OwnerParameterName, out var requestedId))
+        {
+            // Deny by default. An action that genuinely has no owner parameter declares that with
+            // [AllowMissingOwner] and names the guard that replaces this check.
+            if (!HasAllowMissingOwner(context))
+            {
+                context.Result = new ForbidResult();
+            }
+            else
+            {
+                await next().ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        if (requestedId != ownerId.Value)
         {
             context.Result = new ForbidResult();
             return;
@@ -52,6 +77,11 @@ public sealed class OwnerOrAdminFilter(
 
         await next().ConfigureAwait(false);
     }
+
+    // Honors the attribute on the action itself or on its declaring controller. Endpoint metadata
+    // already carries both, in the order MVC composed them.
+    private static bool HasAllowMissingOwner(ActionExecutingContext context) =>
+        context.ActionDescriptor.EndpointMetadata.OfType<AllowMissingOwnerAttribute>().Any();
 
     // The owner identifier can arrive as a route value (/customers/{id}) or as a model-bound
     // query/body argument (/bookmarks?userId=42); check the route first, then the bound arguments.

--- a/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyFilter.cs
+++ b/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyFilter.cs
@@ -1,4 +1,5 @@
-using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -6,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Shared.Concurrency;
 
 namespace MMCA.Common.API.Idempotency;
 
@@ -30,6 +32,13 @@ namespace MMCA.Common.API.Idempotency;
 /// Replayed responses include the <c>X-Idempotent-Replay: true</c> header so clients can
 /// distinguish cached responses from original executions.
 /// </para>
+/// <para>
+/// SECURITY: the cache key is derived from the caller's identity, the HTTP method and the route
+/// template in addition to the client-supplied key, so a key value is only ever replayed to the
+/// caller that produced it, on the same endpoint. Keying on the bare client value would let two
+/// callers who happen to choose the same key share an entry, replaying one user's serialized
+/// response body to another.
+/// </para>
 /// </remarks>
 public sealed class IdempotencyFilter : IAsyncActionFilter
 {
@@ -40,16 +49,22 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
 
     private static string CacheKeyPrefix => "idempotency:";
 
+    /// <summary>Claim carrying the caller's identity, matching the one <c>TokenService</c> emits.</summary>
+    private const string UserIdClaimType = "user_id";
+
     /// <summary>
     /// Default cache expiration when <see cref="IdempotencySettings"/> is not registered.
     /// </summary>
     private static readonly TimeSpan DefaultExpiration = TimeSpan.FromHours(24);
 
     /// <summary>
-    /// Per-key semaphores prevent concurrent duplicate execution. Keys are cleaned up when
-    /// no waiters remain, preventing unbounded memory growth.
+    /// Serializes concurrent requests that map to the same cache key. Striped rather than
+    /// one-semaphore-per-key: the key embeds a caller-supplied value, so a per-key table would
+    /// either grow without bound or need an eager removal that races (a removal between another
+    /// request's lookup and its wait lets a third request create a fresh semaphore, and both
+    /// then execute concurrently, which is exactly what this lock exists to prevent).
     /// </summary>
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> KeyLocks = new();
+    private static readonly KeyedSemaphoreStripe KeyLocks = new();
 
     /// <inheritdoc />
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -62,70 +77,104 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
             return;
         }
 
-        var idempotencyKey = keyValues.ToString();
-        var cacheKey = $"{CacheKeyPrefix}{idempotencyKey}";
+        var cacheKey = BuildCacheKey(context, keyValues.ToString());
         var cache = context.HttpContext.RequestServices.GetRequiredService<ICacheService>();
 
         // Fast path: return cached response without acquiring a lock
-        var cached = await cache.GetAsync<IdempotencyRecord>(cacheKey).ConfigureAwait(false);
-        if (cached is not null)
-        {
-            context.HttpContext.Response.Headers.Append("X-Idempotent-Replay", "true");
-            context.Result = new ContentResult
-            {
-                StatusCode = cached.StatusCode,
-                Content = cached.ResponseBody,
-                ContentType = "application/json"
-            };
+        if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
             return;
-        }
 
-        // Slow path: acquire per-key lock to serialize concurrent duplicates
-        var keyLock = KeyLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
-        await keyLock.WaitAsync(context.HttpContext.RequestAborted).ConfigureAwait(false);
-        try
+        // Slow path: acquire the key's stripe to serialize concurrent duplicates
+        using (await KeyLocks.AcquireAsync(cacheKey, context.HttpContext.RequestAborted).ConfigureAwait(false))
         {
             // Double-check: another request may have completed and cached while we waited
-            cached = await cache.GetAsync<IdempotencyRecord>(cacheKey).ConfigureAwait(false);
-            if (cached is not null)
-            {
-                context.HttpContext.Response.Headers.Append("X-Idempotent-Replay", "true");
-                context.Result = new ContentResult
-                {
-                    StatusCode = cached.StatusCode,
-                    Content = cached.ResponseBody,
-                    ContentType = "application/json"
-                };
+            if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
                 return;
-            }
 
             var executedContext = await next().ConfigureAwait(false);
+            await TryStoreAsync(context, cache, cacheKey, executedContext).ConfigureAwait(false);
+        }
+    }
 
-            // Only cache ObjectResult responses (not redirects, file results, etc.)
-            if (executedContext.Result is ObjectResult objectResult)
-            {
+    /// <summary>
+    /// Serves the cached response for <paramref name="cacheKey"/> when one exists, returning
+    /// whether the request was short-circuited.
+    /// </summary>
+    private static async Task<bool> TryReplayAsync(
+        ActionExecutingContext context,
+        ICacheService cache,
+        string cacheKey)
+    {
+        var cached = await cache.GetAsync<IdempotencyRecord>(cacheKey).ConfigureAwait(false);
+        if (cached is null)
+            return false;
+
+        context.HttpContext.Response.Headers.Append("X-Idempotent-Replay", "true");
+        context.Result = new ContentResult
+        {
+            StatusCode = cached.StatusCode,
+            Content = cached.ResponseBody,
+            ContentType = "application/json"
+        };
+
+        return true;
+    }
+
+    /// <summary>
+    /// Caches the executed response when it is a successful <see cref="ObjectResult"/>.
+    /// Non-2xx results are deliberately not stored: replaying a failure for the whole retention
+    /// window would mean a client retrying the same key after a transient 500 keeps receiving that
+    /// 500 for 24 hours instead of the retry actually executing. Redirects and file results are
+    /// skipped because the record carries only a status code and a JSON body.
+    /// </summary>
+    private static async Task TryStoreAsync(
+        ActionExecutingContext context,
+        ICacheService cache,
+        string cacheKey,
+        ActionExecutedContext executedContext)
+    {
+        if (executedContext.Result is not ObjectResult objectResult)
+            return;
+
+        var statusCode = objectResult.StatusCode ?? StatusCodes.Status200OK;
+        if (statusCode is < 200 or >= 300)
+            return;
+
 #pragma warning disable VSTHRD103 // JsonSerializer.Serialize to a string is correctly synchronous; SerializeAsync is only for writing to a stream.
-                var record = new IdempotencyRecord(
-                    objectResult.StatusCode ?? StatusCodes.Status200OK,
-                    JsonSerializer.Serialize(objectResult.Value, JsonSerializerOptions.Web));
+        var record = new IdempotencyRecord(
+            statusCode,
+            JsonSerializer.Serialize(objectResult.Value, JsonSerializerOptions.Web));
 #pragma warning restore VSTHRD103
 
-                var idempotencySettings = context.HttpContext.RequestServices
-                    .GetService<IOptions<IdempotencySettings>>();
-                var expiration = idempotencySettings is not null
-                    ? TimeSpan.FromHours(idempotencySettings.Value.CacheExpirationHours)
-                    : DefaultExpiration;
+        var idempotencySettings = context.HttpContext.RequestServices
+            .GetService<IOptions<IdempotencySettings>>();
+        var expiration = idempotencySettings is not null
+            ? TimeSpan.FromHours(idempotencySettings.Value.CacheExpirationHours)
+            : DefaultExpiration;
 
-                await cache.SetAsync(cacheKey, record, expiration).ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            keyLock.Release();
+        await cache.SetAsync(cacheKey, record, expiration).ConfigureAwait(false);
+    }
 
-            // Eagerly remove the semaphore when no other requests are waiting on it
-            if (keyLock.CurrentCount == 1)
-                KeyLocks.TryRemove(cacheKey, out _);
-        }
+    /// <summary>
+    /// Derives the cache key from the caller's identity, the HTTP method, the route template and
+    /// the client-supplied key, hashed so the key length stays bounded regardless of what the
+    /// client sends. Scoping to the caller stops one user's cached response from being replayed to
+    /// another; scoping to method plus route stops the same key from colliding across endpoints
+    /// (which, with services sharing one cache instance, would otherwise reach across services).
+    /// </summary>
+    private static string BuildCacheKey(ActionExecutingContext context, string idempotencyKey)
+    {
+        var subject = context.HttpContext.User?.FindFirst(UserIdClaimType)?.Value
+            ?? string.Concat("anon:", context.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown");
+
+        var route = context.ActionDescriptor.AttributeRouteInfo?.Template
+            ?? context.HttpContext.Request.Path.Value
+            ?? string.Empty;
+
+        // \n is not valid in any component, so it cannot be used to forge a different tuple.
+        var material = string.Join('\n', subject, context.HttpContext.Request.Method, route, idempotencyKey);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(material));
+
+        return string.Concat(CacheKeyPrefix, Convert.ToHexStringLower(hash));
     }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Auth/LoginProtectionServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Auth/LoginProtectionServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class LoginProtectionServiceTests
 
         await sut.IncrementFailedAttemptsAsync(TestEmail);
 
-        cache.Values[AttemptsKey].Should().Be(1);
+        cache.Values[AttemptsKey].Should().Be(1L);
         cache.Ttls[AttemptsKey].Should().Be(TimeSpan.FromMinutes(30));
         cache.Values.Should().NotContainKey(LockoutKey, "below the threshold no lockout is applied");
     }
@@ -60,11 +60,11 @@ public sealed class LoginProtectionServiceTests
     public async Task IncrementFailedAttemptsAsync_BelowThreshold_DoesNotApplyLockout()
     {
         var (sut, cache) = CreateSut(maxFailedAttempts: 5);
-        cache.Seed(AttemptsKey, 3);
+        cache.Seed(AttemptsKey, 3L);
 
         await sut.IncrementFailedAttemptsAsync(TestEmail);
 
-        cache.Values[AttemptsKey].Should().Be(4);
+        cache.Values[AttemptsKey].Should().Be(4L);
         cache.Values.Should().NotContainKey(LockoutKey);
     }
 
@@ -73,7 +73,7 @@ public sealed class LoginProtectionServiceTests
     {
         // newCount == MaxFailedAttempts means zero excess attempts: min(1 << 0, cap) == 1 second.
         var (sut, cache) = CreateSut(maxFailedAttempts: 5, maxLockoutSeconds: 300);
-        cache.Seed(AttemptsKey, 4);
+        cache.Seed(AttemptsKey, 4L);
 
         await sut.IncrementFailedAttemptsAsync(TestEmail);
 
@@ -97,7 +97,7 @@ public sealed class LoginProtectionServiceTests
         int expectedLockoutSeconds)
     {
         var (sut, cache) = CreateSut(maxFailedAttempts: 5, maxLockoutSeconds: 300);
-        cache.Seed(AttemptsKey, previousAttempts);
+        cache.Seed(AttemptsKey, (long)previousAttempts);
 
         await sut.IncrementFailedAttemptsAsync(TestEmail);
 
@@ -109,11 +109,11 @@ public sealed class LoginProtectionServiceTests
     public async Task IncrementFailedAttemptsAsync_EveryAttempt_RefreshesAttemptWindowTtl()
     {
         var (sut, cache) = CreateSut(maxFailedAttempts: 5, failedAttemptWindowMinutes: 15);
-        cache.Seed(AttemptsKey, 7);
+        cache.Seed(AttemptsKey, 7L);
 
         await sut.IncrementFailedAttemptsAsync(TestEmail);
 
-        cache.Values[AttemptsKey].Should().Be(8);
+        cache.Values[AttemptsKey].Should().Be(8L);
         cache.Ttls[AttemptsKey].Should().Be(TimeSpan.FromMinutes(15));
     }
 
@@ -122,7 +122,7 @@ public sealed class LoginProtectionServiceTests
     public async Task ResetFailedAttemptsAsync_RemovesAttemptCounterAndLockout()
     {
         var (sut, cache) = CreateSut();
-        cache.Seed(AttemptsKey, 6);
+        cache.Seed(AttemptsKey, 6L);
         cache.Seed(LockoutKey, true);
 
         await sut.ResetFailedAttemptsAsync(TestEmail);
@@ -148,7 +148,7 @@ public sealed class LoginProtectionServiceTests
     public async Task CheckRegistrationRateLimitAsync_BelowLimit_ReturnsSuccess()
     {
         var (sut, cache) = CreateSut(maxRegistrationsPerIpPerHour: 10);
-        cache.Seed(RegistrationKey, 9);
+        cache.Seed(RegistrationKey, 9L);
 
         Result result = await sut.CheckRegistrationRateLimitAsync(TestIp);
 
@@ -159,7 +159,7 @@ public sealed class LoginProtectionServiceTests
     public async Task CheckRegistrationRateLimitAsync_AtLimit_ReturnsUnauthorizedFailure()
     {
         var (sut, cache) = CreateSut(maxRegistrationsPerIpPerHour: 10);
-        cache.Seed(RegistrationKey, 10);
+        cache.Seed(RegistrationKey, 10L);
 
         Result result = await sut.CheckRegistrationRateLimitAsync(TestIp);
 
@@ -188,7 +188,7 @@ public sealed class LoginProtectionServiceTests
 
         await sut.IncrementRegistrationCountAsync(TestIp);
 
-        cache.Values[RegistrationKey].Should().Be(1);
+        cache.Values[RegistrationKey].Should().Be(1L);
         cache.Ttls[RegistrationKey].Should().Be(TimeSpan.FromMinutes(60));
     }
 
@@ -196,12 +196,73 @@ public sealed class LoginProtectionServiceTests
     public async Task IncrementRegistrationCountAsync_ExistingCount_IncrementsAndRefreshesWindow()
     {
         var (sut, cache) = CreateSut(registrationRateLimitWindowMinutes: 45);
-        cache.Seed(RegistrationKey, 2);
+        cache.Seed(RegistrationKey, 2L);
 
         await sut.IncrementRegistrationCountAsync(TestIp);
 
-        cache.Values[RegistrationKey].Should().Be(3);
+        cache.Values[RegistrationKey].Should().Be(3L);
         cache.Ttls[RegistrationKey].Should().Be(TimeSpan.FromMinutes(45));
+    }
+
+    // ── Identity normalization ──
+    // The counters must key off the same normalized address the user lookup resolves against.
+    // Keying off raw request input let an attacker reset the ADR-029 backoff by varying case or
+    // padding the address with whitespace: every variant got its own counter and lockout while
+    // still targeting one account.
+    [Theory]
+    [InlineData("User@Example.com")]
+    [InlineData("USER@EXAMPLE.COM")]
+    [InlineData("  user@example.com  ")]
+    public async Task IncrementFailedAttemptsAsync_EmailVariants_ShareOneAttemptCounter(string variant)
+    {
+        var (sut, cache) = CreateSut(maxFailedAttempts: 5);
+        cache.Seed(AttemptsKey, 3L);
+
+        await sut.IncrementFailedAttemptsAsync(variant);
+
+        cache.Values[AttemptsKey].Should().Be(4L, "the variant must not get its own counter");
+        cache.Values.Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData("User@Example.com")]
+    [InlineData("USER@EXAMPLE.COM")]
+    [InlineData("  user@example.com  ")]
+    public async Task CheckLockoutAsync_EmailVariants_SeeTheSameLockout(string variant)
+    {
+        var (sut, cache) = CreateSut();
+        cache.Seed(LockoutKey, true);
+
+        Result result = await sut.CheckLockoutAsync(variant);
+
+        result.IsFailure.Should().BeTrue("a lockout recorded for the normalized address applies to every variant");
+    }
+
+    [Fact]
+    public async Task ResetFailedAttemptsAsync_EmailVariant_ClearsTheNormalizedKeys()
+    {
+        var (sut, cache) = CreateSut();
+        cache.Seed(AttemptsKey, 6L);
+        cache.Seed(LockoutKey, true);
+
+        await sut.ResetFailedAttemptsAsync("User@Example.COM");
+
+        cache.Values.Should().NotContainKey(AttemptsKey);
+        cache.Values.Should().NotContainKey(LockoutKey);
+    }
+
+    [Fact]
+    public async Task IncrementFailedAttemptsAsync_MalformedEmail_StillCollapsesVariantsOntoOneKey()
+    {
+        // A malformed address never matches a user, but it still increments a counter; the
+        // trim-and-lowercase fallback keeps its variants on one key rather than one key each.
+        var (sut, cache) = CreateSut();
+
+        await sut.IncrementFailedAttemptsAsync("Not-An-Email");
+        await sut.IncrementFailedAttemptsAsync("  not-an-email  ");
+
+        cache.Values["login:attempts:not-an-email"].Should().Be(2L);
+        cache.Values.Should().HaveCount(1);
     }
 
     // ── Helpers ──

--- a/Tests/Core/MMCA.Common.Shared.Tests/Concurrency/KeyedSemaphoreStripeTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Concurrency/KeyedSemaphoreStripeTests.cs
@@ -1,0 +1,144 @@
+using System.Globalization;
+using AwesomeAssertions;
+using MMCA.Common.Shared.Concurrency;
+
+namespace MMCA.Common.Shared.Tests.Concurrency;
+
+/// <summary>
+/// Verifies the striped keyed lock: mutual exclusion for one key, independent progress across
+/// stripes, correct release on the exception path, and a bounded table size regardless of how many
+/// distinct (potentially caller-supplied) keys arrive.
+/// </summary>
+public sealed class KeyedSemaphoreStripeTests
+{
+    [Fact]
+    public async Task AcquireAsync_SameKey_SerializesCallers()
+    {
+        var sut = new KeyedSemaphoreStripe();
+        var inFlight = 0;
+        var observedMaxInFlight = 0;
+
+        async Task ContendAsync()
+        {
+            using (await sut.AcquireAsync("key"))
+            {
+                var current = Interlocked.Increment(ref inFlight);
+                InterlockedMax(ref observedMaxInFlight, current);
+                await Task.Delay(5);
+                Interlocked.Decrement(ref inFlight);
+            }
+        }
+
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => ContendAsync()));
+
+        observedMaxInFlight.Should().Be(1, "callers holding the same key must never overlap");
+    }
+
+    [Fact]
+    public async Task AcquireAsync_HeldKey_BlocksASecondCallerUntilRelease()
+    {
+        var sut = new KeyedSemaphoreStripe(width: 1);
+
+        var first = await sut.AcquireAsync("key");
+        var second = sut.AcquireAsync("key");
+
+        second.IsCompleted.Should().BeFalse("the stripe is held");
+
+        first.Dispose();
+
+        var acquired = await second.WaitAsync(TimeSpan.FromSeconds(5));
+        acquired.Dispose();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ReleasesWhenTheGuardedWorkThrows()
+    {
+        var sut = new KeyedSemaphoreStripe(width: 1);
+
+        var act = async () =>
+        {
+            using (await sut.AcquireAsync("key"))
+            {
+                throw new InvalidOperationException("boom");
+            }
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // A leaked stripe would leave this waiting forever.
+        var reacquire = sut.AcquireAsync("key");
+        var releaser = await reacquire.WaitAsync(TimeSpan.FromSeconds(5));
+        releaser.Dispose();
+    }
+
+    [Fact]
+    public async Task AcquireAsync_DifferentStripes_ProceedIndependently()
+    {
+        // Width 2 with keys that land on different stripes: holding one must not block the other.
+        var sut = new KeyedSemaphoreStripe(width: 2);
+        var keys = Enumerable.Range(0, 64).Select(i => string.Create(CultureInfo.InvariantCulture, $"key-{i}")).ToList();
+
+        var held = await sut.AcquireAsync(keys[0]);
+        try
+        {
+            var other = keys.Select(k => sut.AcquireAsync(k)).FirstOrDefault(t => t.IsCompleted);
+            other.Should().NotBeNull("with more than one stripe some key must map to a free stripe");
+            (await other!).Dispose();
+        }
+        finally
+        {
+            held.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ManyDistinctKeys_DoesNotGrowBeyondTheConfiguredWidth()
+    {
+        // The point of striping: a caller-supplied key space cannot grow the lock table.
+        var sut = new KeyedSemaphoreStripe(width: 4);
+
+        foreach (var i in Enumerable.Range(0, 10_000))
+        {
+            using (await sut.AcquireAsync(string.Create(CultureInfo.InvariantCulture, $"key-{i}")))
+            {
+                // No-op: exercising allocation behavior, not the guarded work.
+            }
+        }
+
+        sut.Width.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_AlreadyCanceledToken_Throws()
+    {
+        var sut = new KeyedSemaphoreStripe();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = async () => await sut.AcquireAsync("key", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_NonPositiveWidth_Throws(int width)
+    {
+        var act = () => new KeyedSemaphoreStripe(width);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static void InterlockedMax(ref int target, int candidate)
+    {
+        int observed;
+        do
+        {
+            observed = Volatile.Read(ref target);
+            if (candidate <= observed)
+                return;
+        }
+        while (Interlocked.CompareExchange(ref target, candidate, observed) != observed);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Authorization/OwnerOrAdminFilterTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Authorization/OwnerOrAdminFilterTests.cs
@@ -15,11 +15,20 @@ public sealed class OwnerOrAdminFilterTests
 {
     private readonly Mock<ICurrentUserService> _currentUserService = new();
 
-    private static (ActionExecutingContext Context, bool NextCalled) CreateContext(RouteValueDictionary? routeData = null)
+    private static (ActionExecutingContext Context, bool NextCalled) CreateContext(
+        RouteValueDictionary? routeData = null,
+        bool allowMissingOwner = false,
+        Dictionary<string, object?>? actionArguments = null)
     {
         var httpContext = new DefaultHttpContext();
-        var actionContext = new ActionContext(httpContext, routeData is null ? new RouteData() : new RouteData(routeData), new ActionDescriptor());
-        var context = new ActionExecutingContext(actionContext, [], new Dictionary<string, object?>(), null!);
+        var descriptor = new ActionDescriptor();
+        if (allowMissingOwner)
+        {
+            descriptor.EndpointMetadata = [new AllowMissingOwnerAttribute()];
+        }
+
+        var actionContext = new ActionContext(httpContext, routeData is null ? new RouteData() : new RouteData(routeData), descriptor);
+        var context = new ActionExecutingContext(actionContext, [], actionArguments ?? new Dictionary<string, object?>(), null!);
         return (context, false);
     }
 
@@ -155,5 +164,118 @@ public sealed class OwnerOrAdminFilterTests
             Task.FromResult(new ActionExecutedContext(
                 new ActionContext(foreignContext.HttpContext, foreignContext.RouteData, foreignContext.ActionDescriptor), [], null!)));
         foreignContext.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    // ── Deny by default when the owner parameter cannot be resolved ──
+    // The filter used to call next() whenever TryGetOwnerParameter failed, so it stopped guarding
+    // any action whose owner parameter was absent, non-integer, or carried inside a bound model.
+    // "Nothing to compare" must read as deny, not as allow.
+    [Fact]
+    public async Task OnActionExecutionAsync_OwnerParameterMissing_ReturnsForbid()
+    {
+        _currentUserService.Setup(s => s.Role).Returns("Customer");
+        _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(42);
+        var (context, _) = CreateContext();
+        var nextCalled = false;
+        var sut = CreateFilter();
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!));
+        });
+
+        context.Result.Should().BeOfType<ForbidResult>();
+        nextCalled.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("42abc")]
+    [InlineData("")]
+    public async Task OnActionExecutionAsync_OwnerParameterUnparseable_ReturnsForbid(string routeValue)
+    {
+        _currentUserService.Setup(s => s.Role).Returns("Customer");
+        _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(42);
+        var (context, _) = CreateContext(new RouteValueDictionary { ["id"] = routeValue });
+        var sut = CreateFilter();
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!)));
+
+        context.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_ComplexBoundArgument_ReturnsForbid()
+    {
+        // A model-bound object whose ToString() is the type name must not read as a match.
+        _currentUserService.Setup(s => s.Role).Returns("Customer");
+        _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(42);
+        var (context, _) = CreateContext(
+            actionArguments: new Dictionary<string, object?> { ["id"] = new object() });
+        var sut = CreateFilter();
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!)));
+
+        context.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    // ── Explicit opt-out ──
+    [Fact]
+    public async Task OnActionExecutionAsync_AllowMissingOwner_PassesThroughWithoutOwnerParameter()
+    {
+        _currentUserService.Setup(s => s.Role).Returns("Customer");
+        _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(42);
+        var (context, _) = CreateContext(allowMissingOwner: true);
+        var nextCalled = false;
+        var sut = CreateFilter();
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!));
+        });
+
+        nextCalled.Should().BeTrue();
+        context.Result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_AllowMissingOwner_StillEnforcesAResolvableOwnerParameter()
+    {
+        // The opt-out excuses a missing parameter, not a foreign one: an action that does carry an
+        // owner id is still checked against the caller's claim.
+        _currentUserService.Setup(s => s.Role).Returns("Customer");
+        _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(42);
+        var (context, _) = CreateContext(new RouteValueDictionary { ["id"] = "99" }, allowMissingOwner: true);
+        var sut = CreateFilter();
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!)));
+
+        context.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_AllowMissingOwner_DoesNotExcuseAMissingOwnerClaim()
+    {
+        // The claim check runs before the parameter check and is unaffected by the opt-out.
+        _currentUserService.Setup(s => s.Role).Returns("Customer");
+        _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns((int?)null);
+        var (context, _) = CreateContext(allowMissingOwner: true);
+        var sut = CreateFilter();
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!)));
+
+        context.Result.Should().BeOfType<ForbidResult>();
     }
 }

--- a/Tests/Presentation/MMCA.Common.API.Tests/Idempotency/IdempotencyFilterTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Idempotency/IdempotencyFilterTests.cs
@@ -1,8 +1,11 @@
+using System.Globalization;
+using System.Security.Claims;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.API.Idempotency;
@@ -14,20 +17,52 @@ namespace MMCA.Common.API.Tests.Idempotency;
 public sealed class IdempotencyFilterTests
 {
     private static (ActionExecutingContext Context, Mock<ICacheService> Cache) CreateContext(
-        string? idempotencyKey = null)
+        string? idempotencyKey = null,
+        string? userId = null,
+        string method = "POST",
+        string? routeTemplate = null,
+        Mock<ICacheService>? sharedCache = null)
     {
-        var cache = new Mock<ICacheService>();
+        var cache = sharedCache ?? new Mock<ICacheService>();
         var services = new ServiceCollection();
         services.AddSingleton(cache.Object);
         var serviceProvider = services.BuildServiceProvider();
 
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
+        httpContext.Request.Method = method;
         if (idempotencyKey is not null)
             httpContext.Request.Headers[IdempotencyFilter.IdempotencyKeyHeader] = idempotencyKey;
 
-        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        if (userId is not null)
+        {
+            httpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity([new Claim("user_id", userId)], "TestAuth"));
+        }
+
+        var descriptor = new ActionDescriptor();
+        if (routeTemplate is not null)
+            descriptor.AttributeRouteInfo = new AttributeRouteInfo { Template = routeTemplate };
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), descriptor);
         var context = new ActionExecutingContext(actionContext, [], new Dictionary<string, object?>(), null!);
         return (context, cache);
+    }
+
+    /// <summary>Runs the filter and returns the cache key it looked the record up under.</summary>
+    private static async Task<string> CaptureCacheKeyAsync(ActionExecutingContext context, Mock<ICacheService> cache)
+    {
+        string? observedKey = null;
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((key, _) => observedKey ??= key)
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        await new IdempotencyFilter().OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)));
+
+        observedKey.Should().NotBeNull();
+        return observedKey!;
     }
 
     [Fact]
@@ -272,5 +307,146 @@ public sealed class IdempotencyFilterTests
         contentResult.Content.Should().Be("{\"replayed\":true}");
         context.HttpContext.Response.Headers["X-Idempotent-Replay"].ToString()
             .Should().Be("true", "replayed responses from the double-check path must include the replay header");
+    }
+
+    // ── Cache-key scoping ──
+    // The key used to be the bare client-supplied header value, so two callers who chose the same
+    // value shared an entry and one user's serialized response body was replayed to the other. The
+    // key now folds in the caller, the HTTP method and the route template.
+    [Fact]
+    public async Task CacheKey_DiffersPerCaller_ForTheSameClientKey()
+    {
+        const string clientKey = "shared-client-key";
+        var (alice, aliceCache) = CreateContext(clientKey, userId: "1", routeTemplate: "Orders");
+        var (bob, bobCache) = CreateContext(clientKey, userId: "2", routeTemplate: "Orders");
+
+        var aliceKey = await CaptureCacheKeyAsync(alice, aliceCache);
+        var bobKey = await CaptureCacheKeyAsync(bob, bobCache);
+
+        aliceKey.Should().NotBe(bobKey, "one caller's cached response must never be replayed to another");
+    }
+
+    [Fact]
+    public async Task CacheKey_IsStable_ForTheSameCallerEndpointAndClientKey()
+    {
+        const string clientKey = "retry-key";
+        var (first, firstCache) = CreateContext(clientKey, userId: "1", routeTemplate: "Orders");
+        var (second, secondCache) = CreateContext(clientKey, userId: "1", routeTemplate: "Orders");
+
+        var firstKey = await CaptureCacheKeyAsync(first, firstCache);
+        var secondKey = await CaptureCacheKeyAsync(second, secondCache);
+
+        firstKey.Should().Be(secondKey, "a genuine retry must still hit the same entry");
+    }
+
+    [Fact]
+    public async Task CacheKey_DiffersPerEndpoint_ForTheSameCallerAndClientKey()
+    {
+        const string clientKey = "shared-client-key";
+        var (orders, ordersCache) = CreateContext(clientKey, userId: "1", routeTemplate: "Orders");
+        var (carts, cartsCache) = CreateContext(clientKey, userId: "1", routeTemplate: "ShoppingCarts");
+
+        var ordersKey = await CaptureCacheKeyAsync(orders, ordersCache);
+        var cartsKey = await CaptureCacheKeyAsync(carts, cartsCache);
+
+        ordersKey.Should().NotBe(cartsKey, "services sharing one cache instance must not collide across endpoints");
+    }
+
+    [Fact]
+    public async Task CacheKey_DiffersPerHttpMethod_ForTheSameCallerAndClientKey()
+    {
+        const string clientKey = "shared-client-key";
+        var (post, postCache) = CreateContext(clientKey, userId: "1", method: "POST", routeTemplate: "Orders/{id}");
+        var (put, putCache) = CreateContext(clientKey, userId: "1", method: "PUT", routeTemplate: "Orders/{id}");
+
+        var postKey = await CaptureCacheKeyAsync(post, postCache);
+        var putKey = await CaptureCacheKeyAsync(put, putCache);
+
+        postKey.Should().NotBe(putKey);
+    }
+
+    [Fact]
+    public async Task CacheKey_DiffersPerAnonymousCaller()
+    {
+        const string clientKey = "shared-client-key";
+        var (first, firstCache) = CreateContext(clientKey, routeTemplate: "Orders");
+        first.HttpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.1");
+        var (second, secondCache) = CreateContext(clientKey, routeTemplate: "Orders");
+        second.HttpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.2");
+
+        var firstKey = await CaptureCacheKeyAsync(first, firstCache);
+        var secondKey = await CaptureCacheKeyAsync(second, secondCache);
+
+        firstKey.Should().NotBe(secondKey, "unauthenticated callers fall back to remote address scoping");
+    }
+
+    // ── Only successful responses are cached ──
+    // Caching a failure replayed it for the whole 24-hour window, so a client retrying the same key
+    // after a transient 500 kept receiving that 500 instead of the retry executing.
+    [Theory]
+    [InlineData(400)]
+    [InlineData(401)]
+    [InlineData(409)]
+    [InlineData(422)]
+    [InlineData(500)]
+    public async Task FailureResponse_NotCached(int statusCode)
+    {
+        var sut = new IdempotencyFilter();
+        var (context, cache) = CreateContext(string.Create(CultureInfo.InvariantCulture, $"failure-{statusCode}-{Guid.NewGuid()}"));
+
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            var executedContext = new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = new ObjectResult(new ProblemDetails { Status = statusCode }) { StatusCode = statusCode }
+            };
+            return Task.FromResult(executedContext);
+        });
+
+        cache.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a failed response must not be replayed for the retention window");
+    }
+
+    [Theory]
+    [InlineData(200)]
+    [InlineData(201)]
+    [InlineData(202)]
+    public async Task SuccessResponse_IsCached(int statusCode)
+    {
+        var sut = new IdempotencyFilter();
+        var (context, cache) = CreateContext(string.Create(CultureInfo.InvariantCulture, $"success-{statusCode}-{Guid.NewGuid()}"));
+
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            var executedContext = new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = new ObjectResult(new { id = 42 }) { StatusCode = statusCode }
+            };
+            return Task.FromResult(executedContext);
+        });
+
+        cache.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.Is<IdempotencyRecord>(r => r.StatusCode == statusCode),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }


### PR DESCRIPTION
First of three PRs from a review of MMCA.Common and MMCA.ADC. This one carries the three findings with direct security impact.

## 1. Login lockout bypass via email casing (ADR-029)

`LoginProtectionService` built `login:lockout:{email}` and `login:attempts:{email}` from the **raw request string**, while `AuthenticationServiceBase` resolves the user through `Email.Create`, which trims and lowercases. So `User@x.com`, `user@x.com` and `"  user@x.com  "` all hit one account but got three independent attempt counters and three independent lockouts: cycling capitalization reset the exponential backoff indefinitely.

- Keys now route through the same normalization. A malformed address (which never matches a user, but still increments a counter) falls back to trim-and-lowercase so its variants also collapse onto one key.
- The counter was a read-modify-write, so concurrent attempts could overwrite each other's increments and stay under the threshold. Added `ICacheService.IncrementAsync` as a **default interface member** (non-breaking; the default is the old read-modify-write) with a Redis `INCR` override in `DistributedCacheService`.

## 2. Cross-user idempotency replay (ADR-017)

`IdempotencyFilter` keyed the cache on `"idempotency:" + <client-supplied header>` and nothing else. Two callers who picked the same key value shared an entry, so one user's serialized response body was replayed to the other. Because ADC's four services share one Redis instance with no key namespace, the collision also reached across endpoints and services.

- The key now folds in the caller (`user_id` claim, or `anon:<remote IP>`), the HTTP method and the route template, SHA-256 hashed so length stays bounded regardless of what the client sends.
- Only 2xx `ObjectResult`s are cached. Previously any `ObjectResult` was, including ProblemDetails failures, so one transient 500 was replayed under that key for the full 24-hour window instead of the retry executing.
- The per-key `ConcurrentDictionary<string, SemaphoreSlim>` had the eager-removal race that `CachingQueryDecorator`'s comment explicitly describes and avoids: a removal between another request's `GetOrAdd` and its `WaitAsync` let a third request create a fresh semaphore, and both then executed concurrently. Replaced with a fixed-width striped lock, which is both bounded and race-free.

## 3. Ownership filter failed open (ADR-033)

`OwnerOrAdminFilter.TryGetOwnerParameter` returns false for an absent route value, a non-integer value, or a model-bound complex argument, and the filter then called `next()` and allowed the request. An ownership gate that reads "nothing to compare" as "nothing to enforce" silently stops guarding any endpoint whose parameter is optional or non-integer.

- Now denies by default.
- Added `[AllowMissingOwner]` for actions that legitimately have no owner parameter. The Store audit (landing in the Store PR) covers the six such actions; each is guarded either by an ownership specification that scopes rows to the caller, or by `RequireAdmin`. ADC's `BookmarksController` needs no annotation: `userId` is `[Required]` and non-nullable, so model validation rejects a missing value before the filter runs.

## New shared helper

`MMCA.Common.Shared/Concurrency/KeyedSemaphoreStripe` - a fixed-width semaphore array selected by key hash. Lives in Shared because both `MMCA.Common.API` (idempotency) and `MMCA.Common.Application` (query caching, PR 3) need it.

## Compatibility

No public API removals. `ICacheService.IncrementAsync` is a default interface member, so existing implementers (including test fakes) compile unchanged.

## Verification

- `dotnet build MMCA.Common.slnx -c Release` clean.
- `dotnet test --solution MMCA.Common.slnx -c Release` -> **2388 passed, 0 failed** (up from 2340; +48 new tests).
- New coverage: lockout key normalization across casing/whitespace/malformed variants, idempotency key scoping per caller / endpoint / method / anonymous IP plus key stability for a genuine retry, 2xx-only caching, ownership deny-by-default for missing / unparseable / complex-bound parameters, `[AllowMissingOwner]` opt-out semantics (and that it does not excuse a foreign owner id or a missing claim), and the striped lock's mutual exclusion, exception-path release, and bounded width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)