### PR TITLE
fix(persistence): stop dropping handler-raised events and make retries idempotent

### DIFF
--- a/Source/Core/MMCA.Common.Domain/Entities/AuditableAggregateRootEntity.cs
+++ b/Source/Core/MMCA.Common.Domain/Entities/AuditableAggregateRootEntity.cs
@@ -33,6 +33,22 @@ public abstract class AuditableAggregateRootEntity<TIdentifierType> : AuditableB
     /// </summary>
     public void ClearDomainEvents() => _domainEvents.Clear();
 
+    /// <inheritdoc />
+    public void RemoveDomainEvents(IEnumerable<IDomainEvent> domainEvents)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvents);
+
+        // Reference equality: two structurally equal events raised separately are still two
+        // distinct occurrences, and only the captured instances have been delivered.
+        var captured = new HashSet<IDomainEvent>(domainEvents, ReferenceEqualityComparer.Instance);
+        if (captured.Count == 0)
+        {
+            return;
+        }
+
+        _domainEvents.RemoveAll(captured.Contains);
+    }
+
     /// <summary>
     /// Replaces a child entity collection with a new set of items, invoking
     /// <see cref="ValidateSetItems{TChildEntity}"/> before mutation so aggregates can

--- a/Source/Core/MMCA.Common.Domain/Interfaces/IAggregateRoot.cs
+++ b/Source/Core/MMCA.Common.Domain/Interfaces/IAggregateRoot.cs
@@ -17,4 +17,17 @@ public interface IAggregateRoot
 
     /// <summary>Clears all pending domain events after they have been dispatched.</summary>
     void ClearDomainEvents();
+
+    /// <summary>
+    /// Removes only the specified events, leaving any raised since they were captured.
+    /// </summary>
+    /// <param name="domainEvents">The events to remove.</param>
+    /// <remarks>
+    /// The persistence pipeline captures an aggregate's events before saving and clears them
+    /// afterwards. Clearing wholesale discards anything a handler raised on the same aggregate
+    /// during in-process dispatch, because those events arrive after the capture and are wiped
+    /// before any later capture can see them: they never dispatch and never reach the outbox.
+    /// Removing exactly what was captured leaves them pending for the next save instead.
+    /// </remarks>
+    void RemoveDomainEvents(IEnumerable<IDomainEvent> domainEvents);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/MemoryCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/MemoryCacheService.cs
@@ -46,12 +46,22 @@ internal sealed class MemoryCacheService(IMemoryCache cache) : ICacheService
             options.AbsoluteExpirationRelativeToNow = expiration;
         }
 
-        // Keep _keys in sync: remove the key when evicted (expiration, capacity pressure, or manual removal).
-        options.RegisterPostEvictionCallback((evictedKey, _, _, _) =>
-            _keys.TryRemove(evictedKey.ToString()!, out _));
+        // Keep _keys in sync: remove the key when evicted (expiration, capacity pressure, or manual
+        // removal). Replacement is deliberately excluded. IMemoryCache queues post-eviction
+        // callbacks to the thread pool, so overwriting a live key fires the OLD entry's callback
+        // asynchronously; it could land after the TryAdd below and delete the tracking record for
+        // the entry that just replaced it. The entry would then be live in the cache but invisible
+        // to RemoveByPrefixAsync, leaving a stale value that only its TTL could clear.
+        options.RegisterPostEvictionCallback((evictedKey, _, reason, _) =>
+        {
+            if (reason != EvictionReason.Replaced)
+                _keys.TryRemove(evictedKey.ToString()!, out _);
+        });
 
-        cache.Set(key, value, options);
+        // Track before writing so a concurrent RemoveByPrefixAsync cannot observe a cached entry
+        // that is not yet in the table.
         _keys.TryAdd(key, 0);
+        cache.Set(key, value, options);
 
         return Task.CompletedTask;
     }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -22,6 +22,13 @@ public sealed class DbContextFactory(
     ICurrentUserService currentUserService
 ) : IDbContextFactory
 {
+    /// <summary>
+    /// Bound on the save re-loop in <see cref="SaveChangesAsync"/>. Two passes cover the realistic
+    /// case (a handler touching one further source); the third is slack before giving up rather
+    /// than spinning.
+    /// </summary>
+    private const int MaxSavePasses = 3;
+
     private readonly IPhysicalDbContextFactory _physicalDbContextFactory = physicalDbContextFactory ?? throw new ArgumentNullException(nameof(physicalDbContextFactory));
     private readonly IEntityDataSourceRegistry _entityDataSourceRegistry = entityDataSourceRegistry ?? throw new ArgumentNullException(nameof(entityDataSourceRegistry));
     private readonly IDataSourceResolver _dataSourceResolver = dataSourceResolver ?? throw new ArgumentNullException(nameof(dataSourceResolver));
@@ -105,15 +112,26 @@ public sealed class DbContextFactory(
         _identityInsertRequested = false;
 
         var result = 0;
-        foreach (var context in _dbContexts.Values)
-        {
-            if (!identityInsertRequested || context is not SQLServerDbContext)
-            {
-                result += await context.SaveChangesAsync(_currentUserService.UserId, cancellationToken).ConfigureAwait(false);
-                continue;
-            }
+        var saved = new HashSet<ApplicationDbContext>();
 
-            result += await SaveWithIdentityInsertAsync(context, cancellationToken).ConfigureAwait(false);
+        // Snapshot before iterating: saving dispatches domain events in-process, and a handler that
+        // resolves a repository for a source not yet materialized calls GetDbContext, which adds to
+        // _dbContexts mid-enumeration. Re-loop so a context created that way is still saved; the
+        // bound stops a handler that keeps creating work from looping forever.
+        for (var pass = 0; pass < MaxSavePasses; pass++)
+        {
+            var pending = _dbContexts.Values.Where(c => !saved.Contains(c)).ToArray();
+            if (pending.Length == 0)
+                break;
+
+            foreach (var context in pending)
+            {
+                saved.Add(context);
+
+                result += !identityInsertRequested || context is not SQLServerDbContext
+                    ? await context.SaveChangesAsync(_currentUserService.UserId, cancellationToken).ConfigureAwait(false)
+                    : await SaveWithIdentityInsertAsync(context, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         return result;
@@ -243,7 +261,9 @@ public sealed class DbContextFactory(
     public int SaveChanges()
     {
         var result = 0;
-        foreach (var context in _dbContexts.Values)
+        // Snapshot: see the async overload. The sync path cannot dispatch in-process, but a
+        // handler is not the only thing that can materialize a context mid-loop.
+        foreach (var context in _dbContexts.Values.ToArray())
             result += context.SaveChanges(_currentUserService.UserId);
         return result;
     }
@@ -251,27 +271,27 @@ public sealed class DbContextFactory(
     public void BeginTransaction()
     {
         _transactionActive = true;
-        foreach (var context in _dbContexts.Values.Where(SupportsTransactions))
+        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).ToArray())
             context.Database.BeginTransaction();
     }
 
     public void CommitTransaction()
     {
         _transactionActive = false;
-        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).Where(HasActiveTransaction))
+        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).Where(HasActiveTransaction).ToArray())
             context.Database.CommitTransaction();
     }
 
     public void RollbackTransaction()
     {
         _transactionActive = false;
-        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).Where(HasActiveTransaction))
+        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).Where(HasActiveTransaction).ToArray())
             context.Database.RollbackTransaction();
 
         // The aggregate changes and their outbox rows just rolled back; any event dispatch
         // deferred for this transaction must never run (and must not survive into an
         // execution-strategy retry of the same operation).
-        foreach (var context in _dbContexts.Values)
+        foreach (var context in _dbContexts.Values.ToArray())
             DomainEventSaveChangesInterceptor.DropDeferred(context);
     }
 
@@ -292,6 +312,13 @@ public sealed class DbContextFactory(
     /// <paramref name="operation"/> wholesale on transient failures — cannot dispatch the same
     /// events once per attempt: rollback drops the aborted attempt's deferred work.
     /// </para>
+    /// <para>
+    /// Each retry also starts from a clean change tracker. The strategy re-runs the delegate
+    /// against the same cached context instances, so entities the failed attempt added are still
+    /// Added; without the reset the retry would add them a second time and insert duplicates
+    /// (along with a duplicate outbox row per event). Clearing is safe because the delegate
+    /// re-executes wholesale and re-reads whatever it needs.
+    /// </para>
     /// </remarks>
     public async Task<TResult> ExecuteInTransactionAsync<TResult>(
         Func<CancellationToken, Task<TResult>> operation,
@@ -303,9 +330,13 @@ public sealed class DbContextFactory(
         var context = _dbContexts.Values.FirstOrDefault(SupportsTransactions)
             ?? GetDbContext(DataSource.SQLServer);
 
+        var attempt = 0;
         var strategy = context.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async ct =>
         {
+            if (attempt++ > 0)
+                ResetForRetry();
+
             BeginTransaction();
             try
             {
@@ -323,8 +354,9 @@ public sealed class DbContextFactory(
                 CommitTransaction();
 
                 // Deliver events only now that the data is durable: in-process handlers must
-                // never act on state that could still roll back.
-                foreach (var committedContext in _dbContexts.Values)
+                // never act on state that could still roll back. Snapshot first: a handler that
+                // reaches a not-yet-materialized source adds to _dbContexts while we enumerate.
+                foreach (var committedContext in _dbContexts.Values.ToArray())
                 {
                     await DomainEventSaveChangesInterceptor.FlushDeferredAsync(committedContext, ct)
                         .ConfigureAwait(false);
@@ -343,7 +375,7 @@ public sealed class DbContextFactory(
                 catch
                 {
                     _transactionActive = false;
-                    foreach (var abortedContext in _dbContexts.Values)
+                    foreach (var abortedContext in _dbContexts.Values.ToArray())
                         DomainEventSaveChangesInterceptor.DropDeferred(abortedContext);
                 }
 
@@ -377,6 +409,20 @@ public sealed class DbContextFactory(
     }
 
     /// <summary>
+    /// Discards everything the previous, aborted attempt left behind before the execution strategy
+    /// re-runs the operation: tracked entity state (so Added entities are not inserted once per
+    /// attempt) and any deferred event dispatch.
+    /// </summary>
+    private void ResetForRetry()
+    {
+        foreach (var context in _dbContexts.Values.ToArray())
+        {
+            DomainEventSaveChangesInterceptor.DropDeferred(context);
+            context.ChangeTracker.Clear();
+        }
+    }
+
+    /// <summary>
     /// Cosmos DB does not support multi-document transactions via the EF provider;
     /// transaction operations are skipped for Cosmos contexts.
     /// </summary>
@@ -392,7 +438,7 @@ public sealed class DbContextFactory(
         {
             if (disposing)
             {
-                foreach (var context in _dbContexts.Values)
+                foreach (var context in _dbContexts.Values.ToArray())
                     context.Dispose();
                 _dbContexts.Clear();
             }
@@ -404,7 +450,7 @@ public sealed class DbContextFactory(
     {
         if (!_disposed)
         {
-            foreach (var context in _dbContexts.Values)
+            foreach (var context in _dbContexts.Values.ToArray())
                 await context.DisposeAsync().ConfigureAwait(false);
             _dbContexts.Clear();
             _disposed = true;

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/DomainEventSaveChangesInterceptor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/DomainEventSaveChangesInterceptor.cs
@@ -142,16 +142,23 @@ public sealed partial class DomainEventSaveChangesInterceptor(
     /// </summary>
     private static void CaptureEventsAndPersistToOutbox(ApplicationDbContext context)
     {
-        var aggregateRootEntities = context.ChangeTracker.Entries<IAggregateRoot>()
+        // A previous SavingChanges that never reached SavedChanges (a failed save, then an
+        // execution-strategy retry of the same operation) left its outbox rows tracked as Added
+        // and its events still on the aggregates. Re-capturing on top of that would write a
+        // second row per event, so the retry would publish every integration event twice.
+        DiscardAbandonedCapture(context);
+
+        // Snapshot each aggregate's events now: the flush removes exactly these, so anything a
+        // handler raises during dispatch survives instead of being cleared along with them.
+        var captures = context.ChangeTracker.Entries<IAggregateRoot>()
             .Where(e => e.Entity.DomainEvents is { Count: > 0 })
+            .Select(e => new AggregateCapture(e, [.. e.Entity.DomainEvents]))
             .ToArray();
 
-        if (aggregateRootEntities.Length == 0)
+        if (captures.Length == 0)
             return;
 
-        var domainEvents = aggregateRootEntities
-            .SelectMany(e => e.Entity.DomainEvents)
-            .ToArray();
+        var domainEvents = captures.SelectMany(c => c.Events).ToArray();
 
         IDomainEvent[] localEvents;
         var hasIntegrationEvents = false;
@@ -190,8 +197,32 @@ public sealed partial class DomainEventSaveChangesInterceptor(
             localEvents = domainEvents;
         }
 
-        var state = new CapturedState(aggregateRootEntities, localEvents, localOutboxEntries, hasIntegrationEvents);
+        var state = new CapturedState(captures, localEvents, localOutboxEntries, hasIntegrationEvents);
         StateTable.AddOrUpdate(context, state);
+    }
+
+    /// <summary>
+    /// Detaches the outbox rows written by a capture whose save never completed, so the next
+    /// capture starts clean. Without this a retried operation accumulates one outbox row per
+    /// attempt for every event it raises.
+    /// </summary>
+    private static void DiscardAbandonedCapture(ApplicationDbContext context)
+    {
+        if (!StateTable.TryGetValue(context, out _))
+            return;
+
+        StateTable.Remove(context);
+
+        // Every Added OutboxMessage on this context came from that abandoned capture: this
+        // interceptor is the only writer of outbox rows, and a completed save leaves none Added.
+        // Detaching covers integration-event rows too, which the state does not list because they
+        // are deliberately never dispatched in-process.
+        foreach (var entry in context.ChangeTracker.Entries<OutboxMessage>()
+            .Where(e => e.State == EntityState.Added)
+            .ToArray())
+        {
+            entry.State = EntityState.Detached;
+        }
     }
 
     /// <summary>
@@ -251,22 +282,35 @@ public sealed partial class DomainEventSaveChangesInterceptor(
         }
     }
 
+    /// <summary>
+    /// Removes exactly the events this save captured. Clearing the aggregates wholesale would also
+    /// discard anything a handler raised on the same aggregate during in-process dispatch: those
+    /// events arrive after the capture and would be wiped before any later capture could see them,
+    /// so they would never dispatch and never reach the outbox.
+    /// </summary>
     private static void ClearDomainEvents(CapturedState state)
     {
-        foreach (var aggregateRootEntity in state.AggregateRootEntities)
-            aggregateRootEntity.Entity.ClearDomainEvents();
+        foreach (var capture in state.Captures)
+            capture.Entry.Entity.RemoveDomainEvents(capture.Events);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "In-process domain event dispatch failed; the outbox processor will retry")]
     private static partial void LogDispatchError(ILogger logger, Exception exception);
 
+    /// <summary>One tracked aggregate root and the exact events captured from it for this save.</summary>
+    /// <param name="Entry">The tracked aggregate root.</param>
+    /// <param name="Events">The events snapshotted at capture time, removed again after dispatch.</param>
+    private sealed record AggregateCapture(
+        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<IAggregateRoot> Entry,
+        IDomainEvent[] Events);
+
     /// <summary>Holds state captured before save that is consumed after save.</summary>
-    /// <param name="AggregateRootEntities">The tracked aggregate roots whose events were captured.</param>
+    /// <param name="Captures">The aggregate roots whose events were captured, each with its snapshot.</param>
     /// <param name="LocalEvents">Events to dispatch in-process (excludes integration events on outbox-enabled contexts).</param>
     /// <param name="LocalOutboxEntries">Outbox rows backing <paramref name="LocalEvents"/>, marked processed after successful dispatch.</param>
     /// <param name="HasIntegrationEvents">Whether any captured event routes through the outbox to <c>IMessageBus</c>.</param>
     private sealed record CapturedState(
-        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<IAggregateRoot>[] AggregateRootEntities,
+        AggregateCapture[] Captures,
         IDomainEvent[] LocalEvents,
         List<OutboxMessage> LocalOutboxEntries,
         bool HasIntegrationEvents);

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/MemoryCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/MemoryCacheServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AwesomeAssertions;
 using Microsoft.Extensions.Caching.Memory;
 using MMCA.Common.Infrastructure.Caching;
@@ -111,6 +112,58 @@ public sealed class MemoryCacheServiceTests : IDisposable
     {
         await _sut.SetAsync("other:1", "val");
         await FluentActions.Invoking(() => _sut.RemoveByPrefixAsync("missing:"))
+            .Should().NotThrowAsync();
+    }
+
+    // ── Overwriting a key must not lose its prefix-eviction tracking ──
+    // IMemoryCache queues post-eviction callbacks to the thread pool, so overwriting a live key
+    // fires the OLD entry's callback asynchronously. When that callback removed the key
+    // unconditionally it could land after the replacement was tracked, deleting the record for an
+    // entry that was still cached: live in the cache, invisible to RemoveByPrefixAsync, and
+    // clearable only by its TTL.
+    [Fact]
+    public async Task RemoveByPrefixAsync_AfterOverwritingAKey_StillEvictsIt()
+    {
+        await _sut.SetAsync("product:1", "first");
+        await _sut.SetAsync("product:1", "second");
+
+        // Give any queued post-eviction callback from the overwrite time to run.
+        await Task.Delay(100);
+
+        await _sut.RemoveByPrefixAsync("product:");
+
+        (await _sut.GetAsync<string>("product:1")).Should().BeNull(
+            "the replacement entry must remain tracked for prefix eviction");
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_AfterRepeatedOverwrites_StillEvictsEveryKey()
+    {
+        foreach (var round in Enumerable.Range(0, 20))
+        {
+            await _sut.SetAsync("product:1", $"value-{round.ToString(CultureInfo.InvariantCulture)}");
+            await _sut.SetAsync("product:2", $"value-{round.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        await Task.Delay(100);
+
+        await _sut.RemoveByPrefixAsync("product:");
+
+        (await _sut.GetAsync<string>("product:1")).Should().BeNull();
+        (await _sut.GetAsync<string>("product:2")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_AfterExpiry_DoesNotResurrectTracking()
+    {
+        // The callback must still clean up on a genuine eviction; only Replaced is exempt.
+        await _sut.SetAsync("product:1", "value", TimeSpan.FromMilliseconds(1));
+        await Task.Delay(150);
+
+        // Touch the cache so MemoryCache processes the expiry.
+        (await _sut.GetAsync<string>("product:1")).Should().BeNull();
+
+        await FluentActions.Invoking(() => _sut.RemoveByPrefixAsync("product:"))
             .Should().NotThrowAsync();
     }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryAdditionalTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryAdditionalTests.cs
@@ -1,7 +1,16 @@
 using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
 using Moq;
 
 namespace MMCA.Common.Infrastructure.Tests.Persistence;
@@ -107,6 +116,70 @@ public sealed class DbContextFactoryAdditionalTests
         result.Should().BeFalse();
     }
 
+    // -- Saving must tolerate a context being created mid-save --
+    // SaveChangesAsync dispatches domain events in-process, and a handler that reaches a data
+    // source not yet materialized calls GetDbContext, which adds to the factory's dictionary. The
+    // loop used to enumerate that dictionary directly, so the handler's call threw
+    // "Collection was modified" and took the whole save down with it.
+    [Fact]
+    public async Task SaveChangesAsync_WhenSavingMaterializesAnotherContext_DoesNotThrow()
+    {
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        DbContextFactory? sut = null;
+        var secondaryKey = new DataSourceKey(DataSource.Sqlite, "Secondary");
+
+        physicalFactory
+            .Setup(f => f.Create(It.IsAny<DataSourceKey>()))
+            .Returns<DataSourceKey>(key =>
+            {
+                if (key == secondaryKey)
+                {
+                    return MidSaveContextCreatingDbContext.CreateInert();
+                }
+
+                // The primary context reaches for a second source while it is being saved.
+                return MidSaveContextCreatingDbContext.CreateThatResolves(() => sut!.GetDbContext(secondaryKey));
+            });
+
+        await using var factory = CreateSut(physicalFactory);
+        sut = factory;
+        factory.GetDbContext(DataSource.Sqlite);
+
+        var act = async () => await factory.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ContextCreatedMidSave_IsAlsoSaved()
+    {
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        DbContextFactory? sut = null;
+        var secondaryKey = new DataSourceKey(DataSource.Sqlite, "Secondary");
+        var secondary = MidSaveContextCreatingDbContext.CreateInert();
+
+        physicalFactory
+            .Setup(f => f.Create(It.IsAny<DataSourceKey>()))
+            .Returns<DataSourceKey>(key =>
+            {
+                if (key == secondaryKey)
+                {
+                    return secondary;
+                }
+
+                return MidSaveContextCreatingDbContext.CreateThatResolves(() => sut!.GetDbContext(secondaryKey));
+            });
+
+        await using var factory = CreateSut(physicalFactory);
+        sut = factory;
+        factory.GetDbContext(DataSource.Sqlite);
+
+        await factory.SaveChangesAsync();
+
+        secondary.SaveCount.Should().Be(1,
+            "a context materialized during the save must still be saved in the same unit of work");
+    }
+
     private static DbContextFactory CreateSut(Mock<IPhysicalDbContextFactory>? physicalFactory = null)
     {
         var registry = new Mock<IEntityDataSourceRegistry>();
@@ -117,5 +190,73 @@ public sealed class DbContextFactoryAdditionalTests
             registry.Object,
             Mock.Of<IDataSourceResolver>(),
             Mock.Of<ICurrentUserService>());
+    }
+
+    /// <summary>
+    /// Stands in for a context whose save reaches back into the factory, the way in-process domain
+    /// event dispatch does when a handler touches a data source that has not been materialized yet.
+    /// The callback runs from a save interceptor, which is where that re-entrancy actually happens.
+    /// </summary>
+    private sealed class MidSaveContextCreatingDbContext : ApplicationDbContext
+    {
+        private Action? _onSave;
+
+        private MidSaveContextCreatingDbContext(DbContextOptions<MidSaveContextCreatingDbContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, Mock.Of<IEntityConfigurationAssemblyProvider>(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        public int SaveCount { get; private set; }
+
+        public static MidSaveContextCreatingDbContext CreateInert() => Create(onSave: null);
+
+        public static MidSaveContextCreatingDbContext CreateThatResolves(Action onSave) => Create(onSave);
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+            optionsBuilder.AddInterceptors(new ReentrantSaveInterceptor(this));
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Deliberately empty: the save has nothing to write, only the re-entrancy matters.
+        }
+
+        private static MidSaveContextCreatingDbContext Create(Action? onSave)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(new DomainEventSaveChangesInterceptor(
+                Mock.Of<IDomainEventDispatcher>(),
+                NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+                Mock.Of<IOutboxSignal>()));
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+
+            var options = new DbContextOptionsBuilder<MidSaveContextCreatingDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            var context = new MidSaveContextCreatingDbContext(options, services.BuildServiceProvider())
+            {
+                _onSave = onSave,
+            };
+            context.Database.OpenConnection();
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        private sealed class ReentrantSaveInterceptor(MidSaveContextCreatingDbContext owner) : SaveChangesInterceptor
+        {
+            public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+                DbContextEventData eventData,
+                InterceptionResult<int> result,
+                CancellationToken cancellationToken = default)
+            {
+                owner.SaveCount++;
+                owner._onSave?.Invoke();
+                return base.SavingChangesAsync(eventData, result, cancellationToken);
+            }
+        }
     }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DomainEventSaveChangesInterceptorOutboxRoutingTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DomainEventSaveChangesInterceptorOutboxRoutingTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Application.Interfaces;
@@ -154,6 +155,85 @@ public sealed class DomainEventSaveChangesInterceptorOutboxRoutingTests : IDispo
             Times.Never);
     }
 
+    // ── Events raised by a handler during dispatch survive ──
+    // The flush used to clear the aggregate wholesale, which also discarded anything a handler
+    // raised on that same aggregate mid-dispatch: those events arrived after the capture and were
+    // wiped before any later capture could see them, so they never dispatched and never reached
+    // the outbox. Only the captured events are removed now.
+    [Fact]
+    public async Task SaveChangesAsync_HandlerRaisesAnotherEvent_KeepsItPendingInsteadOfDiscardingIt()
+    {
+        var entity = new TestAggregate { Id = 1, Name = "Test" };
+        var captured = new TestLocalEvent("original");
+        entity.AddDomainEvent(captured);
+        _dbContext.TestAggregates.Add(entity);
+
+        var followUp = new TestLocalEvent("raised-by-handler");
+        _mockDispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => entity.AddDomainEvent(followUp))
+            .Returns(Task.CompletedTask);
+
+        await _dbContext.SaveChangesAsync();
+
+        entity.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeSameAs(followUp, "the captured event is removed, the handler's is not");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_EventRaisedDuringDispatch_ReachesTheOutboxOnTheNextSave()
+    {
+        var entity = new TestAggregate { Id = 1, Name = "Test" };
+        entity.AddDomainEvent(new TestLocalEvent("original"));
+        _dbContext.TestAggregates.Add(entity);
+
+        var raisedOnce = false;
+        _mockDispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                if (raisedOnce)
+                    return;
+                raisedOnce = true;
+                entity.AddDomainEvent(new TestIntegrationEvent());
+            })
+            .Returns(Task.CompletedTask);
+
+        await _dbContext.SaveChangesAsync();
+
+        entity.Name = "Changed";
+        await _dbContext.SaveChangesAsync();
+
+        var rows = await GetOutboxRowsAsync();
+        rows.Should().HaveCount(2, "the handler's integration event must be persisted, not silently dropped");
+        rows.Should().Contain(r => r.EventType.Contains(nameof(TestIntegrationEvent), StringComparison.Ordinal));
+    }
+
+    // ── A capture whose save never completed does not duplicate outbox rows ──
+    // The execution strategy re-runs the whole operation against the same context, so a failed
+    // attempt leaves its outbox rows tracked as Added and its events still on the aggregate.
+    // Re-capturing on top of that used to write a second row per event, so one transient failure
+    // published every integration event twice.
+    [Fact]
+    public async Task SaveChangesAsync_AfterAFailedSave_WritesOneOutboxRowPerEvent()
+    {
+        var entity = new TestAggregate { Id = 1, Name = "Test" };
+        entity.AddDomainEvent(new TestIntegrationEvent());
+        _dbContext.TestAggregates.Add(entity);
+
+        // Force the first save to fail after the interceptor captured and staged its outbox rows.
+        _dbContext.FailNextSave = true;
+        var firstAttempt = async () => await _dbContext.SaveChangesAsync();
+        await firstAttempt.Should().ThrowAsync<DbUpdateException>();
+
+        // The retry re-runs against the same context, with the previous attempt's state intact.
+        _dbContext.FailNextSave = false;
+        await _dbContext.SaveChangesAsync();
+
+        var rows = await GetOutboxRowsAsync();
+        rows.Should().ContainSingle("the abandoned attempt's row must be discarded, not duplicated");
+    }
+
     // ── Test doubles ──
     public sealed record TestLocalEvent(string Data) : BaseDomainEvent;
 
@@ -164,15 +244,45 @@ public sealed class DomainEventSaveChangesInterceptorOutboxRoutingTests : IDispo
         public string Name { get; set; } = string.Empty;
     }
 
+    /// <summary>
+    /// Aborts the save after the domain-event interceptor has captured events and staged their
+    /// outbox rows, reproducing the state an execution-strategy retry starts from: rows tracked as
+    /// Added, events still on the aggregate, and <c>SavedChanges</c> never reached.
+    /// </summary>
+    private sealed class FailingSaveInterceptor(OutboxRoutingTestDbContext owner) : SaveChangesInterceptor
+    {
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (owner.FailNextSave)
+                throw new DbUpdateException("Simulated transient save failure.");
+
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+
     public sealed class OutboxRoutingTestDbContext : ApplicationDbContext
     {
         public DbSet<TestAggregate> TestAggregates => Set<TestAggregate>();
 
         internal override bool SupportsOutbox => true;
 
+        /// <summary>When set, the next save aborts after event capture. See <see cref="FailingSaveInterceptor"/>.</summary>
+        public bool FailNextSave { get; set; }
+
         private OutboxRoutingTestDbContext(DbContextOptions<OutboxRoutingTestDbContext> options, IServiceProvider serviceProvider)
             : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
         {
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            // base registers the audit and domain-event interceptors; appending after it means
+            // this one runs last, so the capture has already happened when it throws.
+            base.OnConfiguring(optionsBuilder);
+            optionsBuilder.AddInterceptors(new FailingSaveInterceptor(this));
         }
 
         public static OutboxRoutingTestDbContext Create(DomainEventSaveChangesInterceptor domainEventInterceptor)


### PR DESCRIPTION
Second of three PRs from the MMCA.Common / MMCA.ADC review. Four data-integrity defects in the persistence and event pipeline. Independent of PR #111; both branch from `main`.

## 1. Domain events raised by an in-process handler were silently discarded

`DomainEventSaveChangesInterceptor.FlushStateAsync` dispatched the captured events and then called `ClearDomainEvents()` on each aggregate, which clears the **live** list. If a handler mutated one of those same aggregates and called `AddDomainEvent`, the new event was wiped before it was ever captured or written to the outbox. It never fired, never reached the broker, and nothing logged.

- Capture now snapshots each aggregate's events (`AggregateCapture`) and the flush removes exactly those, via a new `IAggregateRoot.RemoveDomainEvents(IEnumerable<IDomainEvent>)`. Removal is by reference: two structurally equal events raised separately are still two occurrences.
- An event raised during dispatch stays pending and is captured by the next save.

## 2. Execution-strategy retries duplicated inserts and outbox rows

`SQLServerDbContext` enables `EnableRetryOnFailure(maxRetryCount: 5)`, and `ExecuteInTransactionAsync` re-runs the delegate against the **same cached context instances**. Entities the failed attempt added were still `Added`, so the retry added them again. Worse, `CaptureEventsAndPersistToOutbox` runs on every `SavingChanges` pass while the aggregate's events are only cleared after a *successful* save, so each attempt appended another outbox row per event: one transient SQL failure published every integration event twice.

- `ResetForRetry()` clears the change tracker and drops deferred dispatch before attempts 2+.
- `DiscardAbandonedCapture` detaches the staged outbox rows of a capture whose save never completed, covering integration-event rows too (which `LocalOutboxEntries` deliberately does not list).

## 3. "Collection was modified" during in-process dispatch

`SaveChangesAsync` iterated `_dbContexts.Values` while each save dispatched domain events in-process. A handler resolving a repository for a not-yet-materialized data source calls `GetDbContext`, which writes into that dictionary mid-enumeration and throws, taking the whole save down. Same shape in `BeginTransaction` / `Commit` / `Rollback` / the post-commit flush / disposal.

- Every enumeration now works from a snapshot.
- `SaveChangesAsync` additionally re-loops (bounded at 3 passes) so a context materialized during the save is still saved in the same unit of work, rather than silently skipped.

## 4. MemoryCacheService lost prefix-eviction tracking on overwrite

The post-eviction callback removed the key for **every** eviction reason. `IMemoryCache` queues those callbacks to the thread pool, so overwriting a live key fires the old entry's callback asynchronously, and it could land after the replacement was tracked, deleting the record for an entry that was still cached. That entry was then live but invisible to `RemoveByPrefixAsync`, clearable only by its TTL.

- The callback now skips `EvictionReason.Replaced`; genuine evictions still clean up.
- Tracking is written before the cache write, so a concurrent prefix eviction cannot see an untracked live entry.

## Compatibility

`IAggregateRoot` gains a member. The only implementer across all four repos is `AuditableAggregateRootEntity`, so this is source-compatible for every aggregate; the Helpdesk `consumer-source-build` gate is the pre-merge check.

## Verification

- `dotnet build MMCA.Common.slnx -c Release` clean.
- `dotnet test --solution MMCA.Common.slnx -c Release` -> **2359 passed, 0 failed**.
- Each new test was confirmed to **fail against the unfixed source** (stash the source fix, run, restore):
  - 3 interceptor tests: handler-raised event kept pending, that event reaching the outbox on the next save, and one outbox row per event after a failed save.
  - 2 factory tests: no throw when a save materializes another context, and that context still being saved.
  - 3 cache tests covering overwrite, repeated overwrites, and that genuine expiry still cleans up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)