### PR TITLE
fix(query): fail closed on bad filters, fix mapped-property drop and paging edges

### DIFF
--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/ICurrentUserService.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/ICurrentUserService.cs
@@ -15,7 +15,27 @@ public interface ICurrentUserService
     UserIdentifierType? UserId { get; }
 
     /// <summary>Gets the current user's role (e.g. "Organizer", "Attendee"), or <see langword="null"/> if unauthenticated.</summary>
+    /// <remarks>
+    /// This is the <b>first</b> role claim only. Use <see cref="Roles"/> or <see cref="IsInRole"/>
+    /// for membership checks so a principal carrying more than one role is handled correctly.
+    /// </remarks>
     string? Role { get; }
+
+    /// <summary>
+    /// Gets every role the current user holds, empty when unauthenticated.
+    /// </summary>
+    /// <remarks>
+    /// Reads all role claims rather than the first, and accepts each of the claim types the JWT
+    /// middleware may produce: the standard <see cref="ClaimTypes.Role"/> URI when inbound claim
+    /// mapping is on, or the raw <c>role</c> / <c>roles</c> claim when it is off.
+    /// </remarks>
+    IEnumerable<string> Roles =>
+        User.Claims
+            .Where(claim =>
+                string.Equals(claim.Type, ClaimTypes.Role, StringComparison.Ordinal)
+                || string.Equals(claim.Type, "role", StringComparison.Ordinal)
+                || string.Equals(claim.Type, "roles", StringComparison.Ordinal))
+            .Select(claim => claim.Value);
 
     /// <summary>
     /// Extracts a typed claim value from the current user's claims.
@@ -28,10 +48,17 @@ public interface ICurrentUserService
         where T : struct, IParsable<T>;
 
     /// <summary>
-    /// Returns <see langword="true"/> if the current user's role matches <paramref name="roleName"/>
+    /// Returns <see langword="true"/> if the current user holds <paramref name="roleName"/>,
     /// using case-insensitive comparison.
     /// </summary>
     /// <param name="roleName">The role name to check (use <see cref="Common.Shared.Auth.RoleNames"/> constants).</param>
     /// <returns><see langword="true"/> if the user has the specified role; otherwise, <see langword="false"/>.</returns>
-    bool IsInRole(string roleName) => string.Equals(Role, roleName, StringComparison.OrdinalIgnoreCase);
+    /// <remarks>
+    /// Checks every role claim. Comparing against <see cref="Role"/> alone matched only the first
+    /// one, so a principal holding several roles failed the check for all but whichever happened to
+    /// be listed first. That is latent today (tokens carry a single role) and would have surfaced
+    /// silently, as an authorization denial, the moment a second was added.
+    /// </remarks>
+    bool IsInRole(string roleName) =>
+        Roles.Any(role => string.Equals(role, roleName, StringComparison.OrdinalIgnoreCase));
 }

--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -99,17 +99,41 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
             : Result.Success(entity);
     }
 
-    private static bool IsPrimaryKeyOnlyLookup(
+    /// <summary>
+    /// Whether the request is a plain primary-key lookup the fast path can serve.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="includeFKs"/> and <paramref name="includeChildren"/> only disqualify the
+    /// request when the entity actually has navigations to include. Treating the flags themselves
+    /// as disqualifying made the fast path unreachable from the REST layer, whose by-id action
+    /// defaults <c>includeFKs</c> to true: every by-id read fell back to the dynamic-filter
+    /// pipeline, which parses a string predicate and emits <c>TOP 1000</c> plus a client-side
+    /// <c>FirstOrDefault</c> where a keyed <c>TOP 1 WHERE Id = @id</c> would do.
+    /// </remarks>
+    private bool IsPrimaryKeyOnlyLookup(
         string? idField,
         bool includeFKs,
         bool includeChildren,
         Specification<TEntity, TIdentifierType>? specification,
         string? fields)
-        => fields is null
-            && !includeFKs
-            && !includeChildren
-            && specification is null
-            && (idField is null || string.Equals(idField, IdField, StringComparison.OrdinalIgnoreCase));
+    {
+        if (fields is not null
+            || specification is not null
+            || idField is not null && !string.Equals(idField, IdField, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!includeFKs && !includeChildren)
+        {
+            return true;
+        }
+
+        // Asking for includes on an entity that declares none is the same request as asking for
+        // none, so it stays on the fast path.
+        var metadata = NavigationMetadataProvider.BuildIncludes<TEntity>(includeFKs, includeChildren);
+        return metadata.SupportedIncludes.Count == 0 && metadata.UnsupportedIncludes.Count == 0;
+    }
 
     /// <summary>
     /// Converts the string id to <typeparamref name="TIdentifierType"/> for the keyed fast path.
@@ -419,7 +443,10 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
         return new PaginationMetadata
         {
             TotalItemCount = totalItemCount,
-            PageSize = pageSize.Value,
+            // Report the page size the pipeline actually applied, not the one requested: the
+            // pipeline clamps to the framework ceiling, so an over-large request previously
+            // advertised a page size the response never contained.
+            PageSize = Math.Min(pageSize.Value, Query.EntityQueryPipeline.MaxUnboundedResultLimit),
             CurrentPage = pageNumber.Value
         };
     }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/BoolFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/BoolFilterStrategy.cs
@@ -16,6 +16,10 @@ internal sealed class BoolFilterStrategy : IFilterStrategy
         "IS", "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
+    /// <inheritdoc />
+    public bool CanParseValue(string op, string value) =>
+        FilterValueParser.CanParse(op, value, static s => bool.TryParse(s, out var b) ? b : (bool?)null);
+
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/DateTimeFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/DateTimeFilterStrategy.cs
@@ -21,6 +21,10 @@ internal sealed class DateTimeFilterStrategy : IFilterStrategy
         "IN", "BETWEEN"
     }.ToFrozenSet(StringComparer.Ordinal);
 
+    /// <inheritdoc />
+    public bool CanParseValue(string op, string value) =>
+        FilterValueParser.CanParse(op, value, ParseDateTime);
+
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/DecimalFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/DecimalFilterStrategy.cs
@@ -20,6 +20,10 @@ internal sealed class DecimalFilterStrategy : IFilterStrategy
         "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
+    /// <inheritdoc />
+    public bool CanParseValue(string op, string value) =>
+        FilterValueParser.CanParse(op, value, ParseDecimal);
+
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/FilterValueParser.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/FilterValueParser.cs
@@ -38,4 +38,29 @@ internal static class FilterValueParser
 
         return [.. value.Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
     }
+
+    /// <summary>
+    /// Whether a value-type strategy can apply <paramref name="value"/> under <paramref name="op"/>,
+    /// following the shape every built-in strategy shares: presence checks ignore the value, IN needs
+    /// at least one parseable item, BETWEEN needs exactly two bounds, and every other operator needs
+    /// the single scalar to parse.
+    /// </summary>
+    /// <typeparam name="T">The value type each item parses to.</typeparam>
+    /// <param name="op">The operator, already uppercased by the caller.</param>
+    /// <param name="value">The raw filter value.</param>
+    /// <param name="parse">Parses one item, returning <see langword="null"/> when it is unparseable.</param>
+    /// <returns><see langword="true"/> when the value is usable for that operator.</returns>
+    public static bool CanParse<T>(string op, string value, Func<string, T?> parse)
+        where T : struct
+    {
+        ArgumentNullException.ThrowIfNull(parse);
+
+        return op switch
+        {
+            "IS EMPTY" or "IS NOT EMPTY" => true,
+            "IN" => ParseList(value, parse).Count > 0,
+            "BETWEEN" => ParseList(value, parse).Count == 2,
+            _ => parse(value) is not null,
+        };
+    }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
@@ -17,6 +17,10 @@ internal sealed class GuidFilterStrategy : IFilterStrategy
         "EQUALS", "NOT EQUALS", "IN", "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
+    /// <inheritdoc />
+    public bool CanParseValue(string op, string value) =>
+        FilterValueParser.CanParse(op, value, ParseGuid);
+
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
@@ -31,7 +35,9 @@ internal sealed class GuidFilterStrategy : IFilterStrategy
 
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
-        var values = FilterValueParser.ParseList(value, static s => Guid.TryParse(s, out var g) ? g : (Guid?)null);
+        var values = FilterValueParser.ParseList(value, ParseGuid);
         return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
     }
+
+    private static Guid? ParseGuid(string s) => Guid.TryParse(s, out var g) ? g : null;
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/IFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/IFilterStrategy.cs
@@ -22,4 +22,24 @@ public interface IFilterStrategy
     /// Built-in strategies override this to enable upstream validation.
     /// </summary>
     IReadOnlySet<string>? SupportedOperators => null;
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is usable for <paramref name="op"/> on this strategy's type.
+    /// </summary>
+    /// <param name="op">The operator, already uppercased by the caller.</param>
+    /// <param name="value">The raw filter value.</param>
+    /// <returns><see langword="true"/> when the value can be applied.</returns>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Apply{T}"/> silently returns the query unfiltered when it cannot parse a value,
+    /// which fails open: <c>?filter=id:equals:abc</c> returned the whole result set instead of no
+    /// matches. Validating up front turns that into a 400, so an unparseable value can never widen
+    /// a response.
+    /// </para>
+    /// <para>
+    /// Defaults to <see langword="true"/>, so a custom strategy keeps its existing behavior until
+    /// it opts in.
+    /// </para>
+    /// </remarks>
+    bool CanParseValue(string op, string value) => true;
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
@@ -18,6 +18,10 @@ internal sealed class IntFilterStrategy : IFilterStrategy
         "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
+    /// <inheritdoc />
+    public bool CanParseValue(string op, string value) =>
+        FilterValueParser.CanParse(op, value, ParseInt);
+
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
@@ -43,16 +47,18 @@ internal sealed class IntFilterStrategy : IFilterStrategy
 
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
-        var values = FilterValueParser.ParseList(value, static s => int.TryParse(s, out var v) ? v : (int?)null);
+        var values = FilterValueParser.ParseList(value, ParseInt);
         return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
     }
 
     private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
     {
         // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
-        var bounds = FilterValueParser.ParseList(value, static s => int.TryParse(s, out var v) ? v : (int?)null);
+        var bounds = FilterValueParser.ParseList(value, ParseInt);
         return bounds.Count == 2
             ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
             : query;
     }
+
+    private static int? ParseInt(string s) => int.TryParse(s, out var v) ? v : null;
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/LongFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/LongFilterStrategy.cs
@@ -20,6 +20,10 @@ internal sealed class LongFilterStrategy : IFilterStrategy
         "IS EMPTY", "IS NOT EMPTY"
     }.ToFrozenSet(StringComparer.Ordinal);
 
+    /// <inheritdoc />
+    public bool CanParseValue(string op, string value) =>
+        FilterValueParser.CanParse(op, value, ParseLong);
+
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/QueryFilterService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/QueryFilterService.cs
@@ -82,17 +82,7 @@ public static class QueryFilterService
                 ? mapped
                 : property;
 
-            // For nested paths like "Category.Name", resolve the root property to validate existence
-            var rootPropertyName = entityProperty.Contains('.', StringComparison.Ordinal)
-                ? entityProperty.Split('.')[0]
-                : property;
-
-            var propertyInfo = PropertyCache.GetOrAdd(
-                (typeof(TEntity), property),
-                static key => key.EntityType.GetProperty(key.PropertyName, BindingFlags.Public | BindingFlags.Instance))
-                ?? PropertyCache.GetOrAdd(
-                    (typeof(TEntity), rootPropertyName),
-                    static key => key.EntityType.GetProperty(key.PropertyName, BindingFlags.Public | BindingFlags.Instance));
+            var propertyInfo = ResolvePropertyInfo<TEntity>(property, entityProperty);
 
             if (propertyInfo is null)
                 continue;
@@ -132,8 +122,8 @@ public static class QueryFilterService
 
         List<Error> errors = [];
 
-        foreach (var (property, (op, _)) in filters)
-            ValidateSingleFilter<TEntity>(property, op, dtoToEntityPropertyMap, errors);
+        foreach (var (property, (op, value)) in filters)
+            ValidateSingleFilter<TEntity>(property, op, value, dtoToEntityPropertyMap, errors);
 
         return errors.Count == 0
             ? Result.Success()
@@ -143,6 +133,7 @@ public static class QueryFilterService
     private static void ValidateSingleFilter<TEntity>(
         string property,
         string op,
+        string value,
         IReadOnlyDictionary<string, string> dtoToEntityPropertyMap,
         List<Error> errors)
     {
@@ -168,6 +159,7 @@ public static class QueryFilterService
         if (entityProperty.Contains('.', StringComparison.Ordinal))
         {
             ValidateOperatorSupported(StringStrategy, opUpper, op, property, "string", errors);
+            ValidateValueParseable(StringStrategy, opUpper, value, property, "string", errors);
             return;
         }
 
@@ -184,8 +176,48 @@ public static class QueryFilterService
         }
 
         ValidateOperatorSupported(strategy, opUpper, op, property, propertyInfo.PropertyType.Name, errors);
+        ValidateValueParseable(strategy, opUpper, value, property, propertyInfo.PropertyType.Name, errors);
     }
 
+    /// <summary>
+    /// Rejects a filter whose value the strategy cannot apply. Without this the strategy returns the
+    /// query unfiltered, so a malformed value widened the response to the full result set instead of
+    /// narrowing it to no matches.
+    /// </summary>
+    private static void ValidateValueParseable(
+        IFilterStrategy strategy,
+        string opUpper,
+        string value,
+        string property,
+        string typeName,
+        List<Error> errors)
+    {
+        // Only complain about the value once the operator itself is valid, so one bad filter does
+        // not produce two errors describing the same mistake.
+        if (strategy.SupportedOperators is not null && !strategy.SupportedOperators.Contains(opUpper))
+            return;
+
+        if (!strategy.CanParseValue(opUpper, value))
+        {
+            errors.Add(Error.Validation(
+                "Filter.Value.Invalid",
+                $"Filter value '{value}' is not valid for property '{property}' (type: {typeName}) with operator '{opUpper}'.",
+                source: nameof(ValidateFilters),
+                target: property));
+        }
+    }
+
+    /// <summary>
+    /// Resolves the <see cref="PropertyInfo"/> backing a filter: the DTO-facing name first, then the
+    /// mapped entity name (its root segment for a nested path like <c>"Category.Name"</c>).
+    /// <para>
+    /// Shared by <see cref="ApplyFilters"/> and <see cref="ValidateFilters"/> so both agree on what
+    /// resolves. They used to disagree on the fallback: validation tried the mapped entity name
+    /// while application retried the DTO name, so a plain rename entry (for example
+    /// <c>["Name"] = "Title"</c>) passed validation and was then silently dropped, returning an
+    /// unfiltered result set with a 200.
+    /// </para>
+    /// </summary>
     private static PropertyInfo? ResolvePropertyInfo<TEntity>(string property, string entityProperty)
     {
         var propertyName = entityProperty.Contains('.', StringComparison.Ordinal)

--- a/Source/Core/MMCA.Common.Application/Services/Query/EntityQueryPipeline.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Query/EntityQueryPipeline.cs
@@ -88,14 +88,12 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
         // Sort at the DB level before materialization
         query = QueryFieldService.ApplySorting(query, parameters.SortColumn, parameters.SortDirection, parameters.DTOToEntityPropertyMap);
 
+        var unpagedQuery = query;
+
         if (isPaginated)
         {
             totalCount = await queryableExecutor.CountAsync(query, cancellationToken).ConfigureAwait(false);
-            // Defense-in-depth (rubric §12): clamp the caller's page size to the framework ceiling so a
-            // direct Application-layer caller that bypasses the API boundary cannot request an unbounded page.
-            int pageSize = Math.Min(parameters.PageSize!.Value, MaxUnboundedResultLimit);
-            int skip = checked(pageSize * (parameters.PageNumber!.Value - 1));
-            query = query.Skip(skip).Take(pageSize);
+            query = ApplyPaging(query, parameters);
         }
         else
         {
@@ -111,7 +109,9 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
         }
 
         if (!isPaginated)
-            totalCount = entities.Count;
+        {
+            totalCount = await CountUnpaginatedAsync(unpagedQuery, entities.Count, cancellationToken).ConfigureAwait(false);
+        }
 
         var pagedQuery = entities.AsQueryable();
         pagedQuery = QueryFieldService.ApplyFieldSelection(pagedQuery, parameters.Fields);
@@ -133,16 +133,13 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
 
         bool isPaginated = parameters.PageNumber.HasValue && parameters.PageSize.HasValue;
         int totalCount = 0;
+        var unpagedQuery = query;
 
         if (isPaginated)
         {
             // Count must be taken before Skip/Take to get the total matching record count
             totalCount = await queryableExecutor.CountAsync(query, cancellationToken).ConfigureAwait(false);
-            // Defense-in-depth (rubric §12): clamp the caller's page size to the framework ceiling so a
-            // direct Application-layer caller that bypasses the API boundary cannot request an unbounded page.
-            int pageSize = Math.Min(parameters.PageSize!.Value, MaxUnboundedResultLimit);
-            int skip = checked(pageSize * (parameters.PageNumber!.Value - 1));
-            query = query.Skip(skip).Take(pageSize);
+            query = ApplyPaging(query, parameters);
         }
         else
         {
@@ -156,8 +153,45 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
         var result = await queryableExecutor.ToListAsync(query, cancellationToken).ConfigureAwait(false);
 
         if (!isPaginated)
-            totalCount = result.Count;
+        {
+            totalCount = await CountUnpaginatedAsync(unpagedQuery, result.Count, cancellationToken).ConfigureAwait(false);
+        }
 
         return (result, totalCount);
     }
+
+    /// <summary>
+    /// Applies Skip/Take for a paginated request, clamping the page size to
+    /// <see cref="MaxUnboundedResultLimit"/> (defense in depth, rubric §12: a direct
+    /// Application-layer caller that bypasses the API boundary cannot request an unbounded page).
+    /// </summary>
+    /// <remarks>
+    /// The offset is computed in 64-bit and range-checked rather than left to <see langword="checked"/>
+    /// arithmetic: a page number near <see cref="int.MaxValue"/> overflowed and surfaced as a 500
+    /// instead of the empty page that page genuinely holds.
+    /// </remarks>
+    private static IQueryable<TEntity> ApplyPaging<TEntity>(
+        IQueryable<TEntity> query,
+        EntityQueryParameters<TEntity> parameters)
+    {
+        int pageSize = Math.Min(parameters.PageSize!.Value, MaxUnboundedResultLimit);
+        long skip = (long)pageSize * (parameters.PageNumber!.Value - 1);
+
+        return skip > int.MaxValue
+            ? query.Take(0)
+            : query.Skip((int)skip).Take(pageSize);
+    }
+
+    /// <summary>
+    /// Reports the true total for an unpaginated read. The materialized count is only the truth
+    /// while it stays under <see cref="MaxUnboundedResultLimit"/>; at the ceiling it is the cap
+    /// itself, and returning it as the total told callers the set was exactly 1000 rows.
+    /// </summary>
+    private async Task<int> CountUnpaginatedAsync<TEntity>(
+        IQueryable<TEntity> unpagedQuery,
+        int materializedCount,
+        CancellationToken cancellationToken)
+        => materializedCount < MaxUnboundedResultLimit
+            ? materializedCount
+            : await queryableExecutor.CountAsync(unpagedQuery, cancellationToken).ConfigureAwait(false);
 }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingQueryDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingQueryDecorator.cs
@@ -1,5 +1,5 @@
-using System.Collections.Concurrent;
 using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Shared.Concurrency;
 
 namespace MMCA.Common.Application.UseCases.Decorators;
 
@@ -32,9 +32,7 @@ public sealed class CachingQueryDecorator<TQuery, TResult>(
         // Slow path: per-key double-check locking (same pattern as IdempotencyFilter). On
         // expiry of a hot key only one concurrent request runs the handler; the rest wait
         // and are served the freshly cached entry.
-        var keyLock = QueryCacheKeyLocks.Locks.GetOrAdd(cacheable.CacheKey, static _ => new SemaphoreSlim(1, 1));
-        await keyLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        using (await QueryCacheKeyLocks.Locks.AcquireAsync(cacheable.CacheKey, cancellationToken).ConfigureAwait(false))
         {
             cached = await cacheService.GetAsync<TResult>(cacheable.CacheKey, cancellationToken)
                 .ConfigureAwait(false);
@@ -52,16 +50,6 @@ public sealed class CachingQueryDecorator<TQuery, TResult>(
 
             return result;
         }
-        finally
-        {
-            keyLock.Release();
-
-            // No eager removal: a remove between another request's GetOrAdd and WaitAsync
-            // would leave that request holding a semaphore no longer in the table, so a third
-            // request would create a fresh one and both would execute concurrently. Entries
-            // are bounded by the set of distinct cache keys and SemaphoreSlim holds no OS
-            // handle here, so the table's steady-state footprint is negligible.
-        }
     }
 }
 
@@ -71,14 +59,23 @@ public sealed class CachingQueryDecorator<TQuery, TResult>(
 /// (statics on a generic type would be per closed type).
 /// </summary>
 /// <remarks>
+/// <para>
+/// Striped rather than one semaphore per key. A per-key table forces a choice between two
+/// defects: removing the entry when the last holder releases opens a window where one caller
+/// waits on a semaphore no longer in the table while a second creates a fresh one (both then
+/// execute concurrently, defeating the lock), and never removing it lets a cache key that embeds
+/// request parameters, such as a user id or a filter value, grow the table without bound.
+/// </para>
+/// <para>
 /// The lock is per-process: with multiple app instances over a shared distributed cache
 /// (e.g. Redis), stampede protection is best-effort — at most one handler execution per
 /// instance, not one cluster-wide. That duplication is harmless (last write wins with equal
 /// content); a cluster-wide guarantee would need a distributed lock and is deliberately
 /// not attempted here.
+/// </para>
 /// </remarks>
 internal static class QueryCacheKeyLocks
 {
-    /// <summary>Per-key semaphores, one per distinct cache key for the process lifetime.</summary>
-    internal static readonly ConcurrentDictionary<string, SemaphoreSlim> Locks = new(StringComparer.Ordinal);
+    /// <summary>Fixed-width stripes shared by every closed generic decorator.</summary>
+    internal static readonly KeyedSemaphoreStripe Locks = new();
 }

--- a/Source/Core/MMCA.Common.Domain/DomainEvents/BaseDomainEvent.cs
+++ b/Source/Core/MMCA.Common.Domain/DomainEvents/BaseDomainEvent.cs
@@ -3,10 +3,18 @@ using MMCA.Common.Domain.Interfaces;
 namespace MMCA.Common.Domain.DomainEvents;
 
 /// <summary>
-/// Base record for all domain events. Uses <c>record class</c> for structural equality
-/// so duplicate events can be detected. <see cref="DateOccurred"/> defaults to
-/// creation time (UTC), not dispatch time — this captures when the business action happened.
+/// Base record for all domain events. <see cref="DateOccurred"/> defaults to creation time (UTC),
+/// not dispatch time — this captures when the business action happened.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Equality is not a deduplication mechanism.</b> This is a <c>record</c>, so it has structural
+/// equality, but <see cref="MessageId"/> and <see cref="DateOccurred"/> both default to a fresh
+/// value per instance: two logically identical events raised separately are never equal. Anything
+/// relying on that comparison to spot a duplicate would silently never match. Consumer-side
+/// deduplication is the inbox's job (ADR-021), keyed on <see cref="MessageId"/>.
+/// </para>
+/// </remarks>
 /// <remarks>
 /// The creation-time default on <see cref="DateOccurred"/> is a deliberate domain-modelling choice,
 /// not an oversight: a domain event's occurrence instant is, by definition, the moment the aggregate

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/CacheKeyPrefix.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/CacheKeyPrefix.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Options;
+
+namespace MMCA.Common.Infrastructure.Caching;
+
+/// <summary>
+/// Namespace applied to every <see cref="MMCA.Common.Application.Interfaces.ICacheService"/> key.
+/// <para>
+/// Services that share one cache instance also share one keyspace. Nothing stops two of them from
+/// choosing the same key for different data, so a read in one service can be served another
+/// service's value. Giving each service a prefix (for example <c>"conference:"</c>) separates them.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is deliberately applied inside <see cref="DistributedCacheService"/> rather than through
+/// <c>RedisCacheOptions.InstanceName</c>. <c>InstanceName</c> is prepended by
+/// <c>IDistributedCache</c> below our abstraction, where prefix invalidation cannot see it: the
+/// SCAN in <see cref="DistributedCacheService.RemoveByPrefixAsync"/> matches raw Redis keys, so it
+/// would look for <c>product:*</c> while the stored keys were <c>svc:product:*</c> and evict
+/// nothing, silently. Applying the prefix here keeps get, set, remove and prefix eviction working
+/// from the same key shape.
+/// </para>
+/// <para>
+/// Only the distributed cache honors it. <see cref="MemoryCacheService"/> is per-process, so its
+/// keyspace is private by construction and a prefix would add nothing.
+/// </para>
+/// </remarks>
+public sealed class CacheKeyPrefixOptions
+{
+    /// <summary>Configuration section binding to these options.</summary>
+    public const string SectionName = "Cache";
+
+    /// <summary>
+    /// Prefix prepended to every cache key. Empty (the default) keeps keys exactly as callers
+    /// write them, which is correct for a host that does not share its cache.
+    /// </summary>
+    public string KeyPrefix { get; init; } = string.Empty;
+}
+
+/// <summary>Applies <see cref="CacheKeyPrefixOptions.KeyPrefix"/> to cache keys.</summary>
+internal sealed class CacheKeyNamespace(string prefix)
+{
+    /// <summary>A namespace that leaves keys untouched.</summary>
+    public static CacheKeyNamespace None { get; } = new(string.Empty);
+
+    /// <summary>Gets the configured prefix.</summary>
+    public string Prefix { get; } = prefix ?? string.Empty;
+
+    /// <summary>Builds the namespace from bound options, tolerating an unregistered section.</summary>
+    public static CacheKeyNamespace From(IOptions<CacheKeyPrefixOptions>? options)
+    {
+        var prefix = options?.Value.KeyPrefix;
+        return string.IsNullOrEmpty(prefix) ? None : new CacheKeyNamespace(prefix);
+    }
+
+    /// <summary>Qualifies a caller-supplied key.</summary>
+    public string Qualify(string key) =>
+        Prefix.Length == 0 ? key : string.Concat(Prefix, key);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
@@ -17,12 +17,22 @@ namespace MMCA.Common.Infrastructure.Caching;
 internal sealed partial class DistributedCacheService(
     IDistributedCache cache,
     ILogger<DistributedCacheService> logger,
-    IConnectionMultiplexer? connectionMultiplexer = null) : ICacheService
+    IConnectionMultiplexer? connectionMultiplexer = null,
+    CacheKeyNamespace? keyNamespace = null) : ICacheService
 {
+    /// <summary>Keys per delete round trip during prefix invalidation.</summary>
+    private const int DeleteBatchSize = 512;
+
+    /// <summary>
+    /// Namespace applied to every key so services sharing one cache instance cannot collide.
+    /// Defaults to no prefix, which is correct for a host that owns its cache outright.
+    /// </summary>
+    private readonly CacheKeyNamespace _keys = keyNamespace ?? CacheKeyNamespace.None;
+
     /// <inheritdoc />
     public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        byte[]? bytes = await cache.GetAsync(key, cancellationToken).ConfigureAwait(false);
+        byte[]? bytes = await cache.GetAsync(_keys.Qualify(key), cancellationToken).ConfigureAwait(false);
 
         return bytes is null ? default : Deserialize<T>(bytes);
     }
@@ -36,15 +46,12 @@ internal sealed partial class DistributedCacheService(
     {
         byte[] bytes = Serialize(value);
 
-        return cache.SetAsync(key, bytes, CacheOptions.Create(expiration), cancellationToken);
+        return cache.SetAsync(_keys.Qualify(key), bytes, CacheOptions.Create(expiration), cancellationToken);
     }
 
     /// <inheritdoc />
     public Task RemoveAsync(string key, CancellationToken cancellationToken = default) =>
-        cache.RemoveAsync(key, cancellationToken);
-
-    /// <summary>Keys per delete round trip during prefix invalidation.</summary>
-    private const int DeleteBatchSize = 512;
+        cache.RemoveAsync(_keys.Qualify(key), cancellationToken);
 
     /// <summary>Set once (via <see cref="Interlocked"/>) after the missing-multiplexer no-op is logged, so the steady state warns once rather than on every command.</summary>
     private int _noMultiplexerWarned;
@@ -74,7 +81,7 @@ internal sealed partial class DistributedCacheService(
             return;
         }
 
-        var keys = server.KeysAsync(pattern: $"{prefix}*");
+        var keys = server.KeysAsync(pattern: $"{_keys.Qualify(prefix)}*");
         var db = connectionMultiplexer.GetDatabase();
         var batch = new List<RedisKey>(DeleteBatchSize);
 
@@ -112,10 +119,10 @@ internal sealed partial class DistributedCacheService(
         }
 
         var db = connectionMultiplexer.GetDatabase();
-        var value = await db.StringIncrementAsync(key).ConfigureAwait(false);
+        var value = await db.StringIncrementAsync(_keys.Qualify(key)).ConfigureAwait(false);
 
         if (value == 1)
-            await db.KeyExpireAsync(key, expiration).ConfigureAwait(false);
+            await db.KeyExpireAsync(_keys.Qualify(key), expiration).ConfigureAwait(false);
 
         return value;
     }

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -108,7 +108,7 @@ public static class DependencyInjection
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
 
-            services.AddCaching();
+            services.AddCaching(configuration);
 
             services.AddOptions<OutboxSettings>()
                 .Bind(configuration.GetSection(OutboxSettings.SectionName))
@@ -146,9 +146,16 @@ public static class DependencyInjection
         /// when available; otherwise falls back to in-memory cache.
         /// </summary>
         /// <returns>The service collection for chaining.</returns>
-        public IServiceCollection AddCaching()
+        public IServiceCollection AddCaching(IConfiguration? configuration = null)
         {
             services.AddMemoryCache();
+
+            // Optional key namespace so services sharing one cache instance cannot collide
+            // (Cache:KeyPrefix). Absent configuration leaves keys exactly as callers write them.
+            if (configuration is not null)
+            {
+                services.Configure<CacheKeyPrefixOptions>(configuration.GetSection(CacheKeyPrefixOptions.SectionName));
+            }
 
             services.TryAddSingleton<ICacheService>(sp =>
             {
@@ -158,9 +165,11 @@ public static class DependencyInjection
                     var multiplexer = sp.GetService<IConnectionMultiplexer>();
                     var logger = sp.GetService<ILogger<DistributedCacheService>>()
                         ?? NullLogger<DistributedCacheService>.Instance;
-                    return new DistributedCacheService(distributedCache, logger, multiplexer);
+                    var keyNamespace = CacheKeyNamespace.From(sp.GetService<IOptions<CacheKeyPrefixOptions>>());
+                    return new DistributedCacheService(distributedCache, logger, multiplexer, keyNamespace);
                 }
 
+                // In-process: the keyspace is private to this process, so no prefix is needed.
                 return new MemoryCacheService(sp.GetRequiredService<IMemoryCache>());
             });
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Encryption/EncryptedStringConverter.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Encryption/EncryptedStringConverter.cs
@@ -11,9 +11,23 @@ namespace MMCA.Common.Infrastructure.Persistence.Encryption;
 /// <para>
 /// <b>Usage:</b> Apply to individual properties in EF entity configurations:
 /// <code>
-/// builder.Property(e => e.Email)
+/// builder.Property(e => e.SocialSecurityNumber)
 ///     .HasConversion(new EncryptedStringConverter(encryptionKey));
 /// </code>
+/// </para>
+/// <para>
+/// <b>Constraint: the ciphertext is non-deterministic.</b> Every write uses a fresh random nonce,
+/// so the same plaintext encrypts to a different column value each time. That is the correct
+/// property for confidentiality, and it means the column cannot support:
+/// <list type="bullet">
+///   <item>equality or range predicates (<c>Where(u =&gt; u.Email == value)</c> translates to a
+///   comparison against a ciphertext that will never match, returning no rows silently);</item>
+///   <item>unique indexes or any other constraint over the stored value;</item>
+///   <item>server-side sorting or grouping.</item>
+/// </list>
+/// Only apply it to properties that are read back as part of an entity and never queried by value.
+/// A lookup key that must stay searchable needs a separate deterministic surface, such as a
+/// keyed hash stored alongside the encrypted column.
 /// </para>
 /// <para>
 /// <b>Key management:</b> The encryption key should be stored securely (e.g., Azure Key Vault,

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -238,7 +238,10 @@ public sealed partial class OutboxProcessor(
         var processedAny = await DispatchMessagesAsync(
             toProcess, source, dispatcher, messageBus, cancellationToken).ConfigureAwait(false);
 
-        // Use the base DbContext.SaveChangesAsync to bypass audit stamping and event dispatch.
+        // Plain DbContext.SaveChangesAsync, without a user id: the audit interceptor stamps its
+        // system sentinel rather than a caller's identity. The EF interceptors still run (they are
+        // registered on the context, not selected per call), but there is nothing for them to do
+        // here: OutboxMessage is not an aggregate root, so no events are captured.
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // A full eligible batch with progress means more eligible rows may be waiting; the
@@ -368,6 +371,14 @@ public sealed partial class OutboxProcessor(
                 message.ProcessedOn = _timeProvider.GetUtcNow().UtcDateTime;
                 processedAny = true;
                 LogMessageProcessed(logger, message.Id, message.EventType);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Host shutdown, not a delivery failure. Falling into the generic handler below
+                // would increment RetryCount and stamp LastError on this message and, since every
+                // later await fails the same way, on the whole remainder of the batch: a graceful
+                // restart could dead-letter messages that were never actually attempted.
+                throw;
             }
             catch (Exception ex)
             {

--- a/Source/Presentation/MMCA.Common.API/Authorization/PermissionAuthorizationHandler.cs
+++ b/Source/Presentation/MMCA.Common.API/Authorization/PermissionAuthorizationHandler.cs
@@ -37,6 +37,8 @@ public sealed class PermissionAuthorizationHandler(IPermissionRegistry permissio
 
     // Gather roles regardless of how the JWT middleware mapped the role claim type: the standard
     // ClaimTypes.Role URI, or the raw "role"/"roles" claim when inbound-claim mapping is disabled.
+    // Same rule as ICurrentUserService.Roles; this handler has no ICurrentUserService to read from
+    // (it runs on the raw principal), so the predicate is stated once here and once there.
     private static IEnumerable<string> GetRoles(ClaimsPrincipal user) =>
         user.Claims
             .Where(claim =>

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryPipelineTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryPipelineTests.cs
@@ -237,6 +237,9 @@ public sealed class EntityQueryPipelineTests
         _executorMock
             .Setup(e => e.ToListAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
             .Returns<IQueryable<TestEntity>, CancellationToken>((q, _) => Task.FromResult(q.ToList()));
+        _executorMock
+            .Setup(e => e.CountAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .Returns<IQueryable<TestEntity>, CancellationToken>((q, _) => Task.FromResult(q.Count()));
 
         var (items, totalCount) = await _sut.ExecuteAsync<TestEntity, int>(
             query,
@@ -246,7 +249,70 @@ public sealed class EntityQueryPipelineTests
             CancellationToken.None);
 
         items.Should().HaveCount(EntityQueryPipeline.MaxUnboundedResultLimit);
-        totalCount.Should().Be(EntityQueryPipeline.MaxUnboundedResultLimit);
+        totalCount.Should().Be(
+            entities.Count,
+            "the cap bounds what is materialized, not what the total is; reporting the cap told callers the set was exactly that size");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoPagination_BelowTheCap_DoesNotIssueACountQuery()
+    {
+        // The extra round trip is only warranted when the materialized count could be truncated.
+        var entities = Enumerable.Range(1, 5)
+            .Select(i => new TestEntity { Id = i, Name = string.Create(CultureInfo.InvariantCulture, $"E{i}") })
+            .ToList();
+
+        _executorMock
+            .Setup(e => e.ToListAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .Returns<IQueryable<TestEntity>, CancellationToken>((q, _) => Task.FromResult(q.ToList()));
+
+        var (items, totalCount) = await _sut.ExecuteAsync<TestEntity, int>(
+            entities.AsQueryable(),
+            EmptyNavigation(),
+            DefaultParams(),
+            (_, _, _, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        items.Should().HaveCount(5);
+        totalCount.Should().Be(5);
+        _executorMock.Verify(
+            e => e.CountAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PageNumberNearIntMaxValue_ReturnsAnEmptyPageInsteadOfOverflowing()
+    {
+        // pageSize * (pageNumber - 1) overflowed a 32-bit offset and surfaced as a 500.
+        var entities = Enumerable.Range(1, 5)
+            .Select(i => new TestEntity { Id = i, Name = string.Create(CultureInfo.InvariantCulture, $"E{i}") })
+            .ToList();
+
+        _executorMock
+            .Setup(e => e.CountAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entities.Count);
+        _executorMock
+            .Setup(e => e.ToListAsync(It.IsAny<IQueryable<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .Returns<IQueryable<TestEntity>, CancellationToken>((q, _) => Task.FromResult(q.ToList()));
+
+        var parameters = new EntityQueryParameters<TestEntity>
+        {
+            DTOToEntityPropertyMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            PageNumber = int.MaxValue,
+            PageSize = 10,
+        };
+
+        var act = async () => await _sut.ExecuteAsync<TestEntity, int>(
+            entities.AsQueryable(),
+            EmptyNavigation(),
+            parameters,
+            (_, _, _, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        var assertion = await act.Should().NotThrowAsync();
+        var (items, totalCount) = assertion.Subject;
+        items.Should().BeEmpty();
+        totalCount.Should().Be(entities.Count, "the total is unaffected by an out-of-range page");
     }
 
     [Fact]

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceTests.cs
@@ -222,6 +222,33 @@ public class QueryFilterServiceTests
         FluentActions.Invoking(() => QueryFilterService.RegisterStrategy(typeof(string), null!))
             .Should().Throw<ArgumentNullException>();
 
+    // ── A mapped property must actually be applied, not silently dropped ──
+    // ApplyFilters fell back to the DTO name while ValidateFilters fell back to the mapped entity
+    // name, so a plain rename entry validated and was then skipped: the caller got an unfiltered
+    // result set with a 200.
+    [Fact]
+    public void ApplyFilters_MappedToADifferentEntityProperty_AppliesTheFilter()
+    {
+        // "Title" is the DTO-facing name; the entity calls it "Name".
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Title"] = "Name" };
+        var filters = new Dictionary<string, (string, string)> { ["Title"] = ("EQUALS", "Widget") };
+
+        var result = QueryFilterService.ApplyFilters(Products(), filters, map).ToList();
+
+        result.Should().ContainSingle().Which.Name.Should().Be("Widget");
+    }
+
+    [Fact]
+    public void ApplyFilters_MappedRename_AgreesWithValidation()
+    {
+        // The two sides must resolve the same property; anything validation accepts must apply.
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Title"] = "Name" };
+        var filters = new Dictionary<string, (string, string)> { ["Title"] = ("CONTAINS", "adget") };
+
+        QueryFilterService.ValidateFilters<Product>(filters, map).IsSuccess.Should().BeTrue();
+        QueryFilterService.ApplyFilters(Products(), filters, map).Should().ContainSingle();
+    }
+
     private sealed class TestStrategy : IFilterStrategy
     {
         public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value) => query;

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceValidateTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceValidateTests.cs
@@ -194,4 +194,68 @@ public sealed class QueryFilterServiceValidateTests
         result.IsFailure.Should().BeTrue();
         result.Errors.Should().ContainSingle(e => e.Code == "Filter.Operator.NotSupported");
     }
+
+    // ── Unparseable values are rejected rather than silently widening the result set ──
+    // A strategy that cannot parse a value returns the query unfiltered, so
+    // "?filter=price:equals:abc" used to return every row instead of no rows, with a 200.
+    [Theory]
+    [InlineData("Price", "EQUALS", "abc")]
+    [InlineData("Price", "GREATER THAN", "not-a-number")]
+    [InlineData("Price", "IN", "a,b,c")]
+    [InlineData("Price", "BETWEEN", "1")]
+    [InlineData("Price", "BETWEEN", "1,2,3")]
+    [InlineData("Amount", "EQUALS", "twelve")]
+    [InlineData("IsActive", "IS", "maybe")]
+    [InlineData("CreatedOn", "IS", "not-a-date")]
+    public void ValidateFilters_UnparseableValue_ReturnsFailure(string property, string op, string value)
+    {
+        var filters = new Dictionary<string, (string, string)> { [property] = (op, value) };
+
+        var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "Filter.Value.Invalid");
+    }
+
+    [Theory]
+    [InlineData("Price", "EQUALS", "42")]
+    [InlineData("Price", "IN", "1,2,3")]
+    [InlineData("Price", "BETWEEN", "1,10")]
+    [InlineData("Amount", "EQUALS", "12.50")]
+    [InlineData("IsActive", "IS", "true")]
+    [InlineData("CreatedOn", "IS", "2026-07-24")]
+    [InlineData("Name", "CONTAINS", "anything at all")]
+    public void ValidateFilters_ParseableValue_ReturnsSuccess(string property, string op, string value)
+    {
+        var filters = new Dictionary<string, (string, string)> { [property] = (op, value) };
+
+        var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("IS EMPTY")]
+    [InlineData("IS NOT EMPTY")]
+    public void ValidateFilters_PresenceOperator_IgnoresTheValue(string op)
+    {
+        // Presence checks never read the value, so an arbitrary one must not be rejected.
+        var filters = new Dictionary<string, (string, string)> { ["Price"] = (op, "ignored") };
+
+        var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateFilters_UnsupportedOperator_ReportsOnlyTheOperatorError()
+    {
+        // One mistake should not produce two errors describing it.
+        var filters = new Dictionary<string, (string, string)> { ["Price"] = ("CONTAINS", "abc") };
+
+        var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle().Which.Code.Should().Be("Filter.Operator.NotSupported");
+    }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/CurrentUserServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/CurrentUserServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
+using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure.Services;
 using Moq;
 
@@ -96,5 +97,83 @@ public sealed class CurrentUserServiceTests
 
         sut.UserId.Should().Be(10);
         sut.Role.Should().Be("Attendee");
+    }
+
+    // ── IsInRole must consider every role claim, not just the first ──
+    // Comparing against Role alone matched only the first claim, so a principal holding several
+    // roles failed the check for all but whichever happened to be listed first. Latent while tokens
+    // carry one role, and it would have surfaced as a silent authorization denial. These tests hold
+    // the SUT as ICurrentUserService because Roles and IsInRole are default interface members.
+    [Theory]
+    [InlineData("Attendee")]
+    [InlineData("Organizer")]
+    public void IsInRole_WithMultipleRoleClaims_MatchesAnyOfThem(string roleName)
+    {
+        var principal = CreatePrincipal(
+            new Claim(ClaimTypes.Role, "Attendee"),
+            new Claim(ClaimTypes.Role, "Organizer"));
+        ICurrentUserService sut = CreateSut(principal);
+
+        sut.IsInRole(roleName).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInRole_RoleNotHeld_ReturnsFalse()
+    {
+        var principal = CreatePrincipal(
+            new Claim(ClaimTypes.Role, "Attendee"),
+            new Claim(ClaimTypes.Role, "Speaker"));
+        ICurrentUserService sut = CreateSut(principal);
+
+        sut.IsInRole("Organizer").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("organizer")]
+    [InlineData("ORGANIZER")]
+    public void IsInRole_IsCaseInsensitive(string roleName)
+    {
+        var principal = CreatePrincipal(new Claim(ClaimTypes.Role, "Organizer"));
+        ICurrentUserService sut = CreateSut(principal);
+
+        sut.IsInRole(roleName).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("role")]
+    [InlineData("roles")]
+    public void IsInRole_HonorsRawRoleClaimTypes_WhenInboundMappingIsDisabled(string claimType)
+    {
+        var principal = CreatePrincipal(new Claim(claimType, "Organizer"));
+        ICurrentUserService sut = CreateSut(principal);
+
+        sut.IsInRole("Organizer").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInRole_Unauthenticated_ReturnsFalse()
+    {
+        ICurrentUserService sut = CreateSut();
+
+        sut.IsInRole("Organizer").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Roles_ReturnsEveryRoleClaim()
+    {
+        var principal = CreatePrincipal(
+            new Claim(ClaimTypes.Role, "Attendee"),
+            new Claim(ClaimTypes.Role, "Organizer"));
+        ICurrentUserService sut = CreateSut(principal);
+
+        sut.Roles.Should().BeEquivalentTo("Attendee", "Organizer");
+    }
+
+    [Fact]
+    public void Roles_Unauthenticated_IsEmpty()
+    {
+        ICurrentUserService sut = CreateSut();
+
+        sut.Roles.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
Third of three PRs from the MMCA.Common / MMCA.ADC review: the query-contract defects plus the smaller findings.

## 1. A mapped filter was validated then silently dropped

`ApplyFilters` fell back to the **DTO** property name when resolving a filter, while `ValidateFilters` fell back to the **mapped entity** name. A plain rename map entry (`["Name"] = "Title"`) therefore passed validation and was then skipped at `continue`, so the caller got an unfiltered result set with a 200. Both paths now share one `ResolvePropertyInfo`.

ADC's `SpeakerEntityQueryService` escaped this only by accident: `Speaker.FullName` happens to exist as a real computed property, so the DTO-name lookup succeeded.

## 2. Unparseable filter values failed open (ADR-034)

`?filter=id:equals:abc` returned every row. Each strategy silently returns the query unfiltered when it cannot parse a value, and validation never looked at values at all. Per the agreed decision this is now a **400**:

- New `IFilterStrategy.CanParseValue(op, value)` as a **default interface member** returning `true`, so custom strategies are unaffected until they opt in.
- Implemented for Int, Long, Decimal, DateTime, Guid and Bool via a shared `FilterValueParser.CanParse` that encodes the shape they all share: presence checks ignore the value, `IN` needs at least one parseable item, `BETWEEN` needs exactly two bounds, everything else needs the scalar to parse.
- Emitted as `Filter.Value.Invalid`, and suppressed when the operator itself is already invalid so one mistake yields one error.

## 3. Pagination edges

- The offset was `checked(pageSize * (pageNumber - 1))` in 32-bit, so `?pageNumber=2147483647` threw `OverflowException` into a 500 instead of returning the empty page it describes. Now computed in 64-bit and range-checked.
- An unpaginated read reported the 1000-row safety cap as `TotalItemCount`, telling callers the set was exactly 1000. It now issues a count query only when the materialized rows actually hit the cap (no extra round trip below it).
- `PaginationMetadata.PageSize` reported the *requested* size while the pipeline clamped to the ceiling; it now reports what was applied.

## Smaller findings from the same review

- **Query-cache lock table**: moved to the striped lock from PR #111. The old per-key dictionary was documented as "bounded by the set of distinct cache keys", which only holds for parameterless keys; any `CacheKey` embedding a user id or filter value grew it without bound.
- **`IsInRole` saw only the first role claim** (it compared against `Role`). Added `ICurrentUserService.Roles` (default member) and redefined `IsInRole` over it. Latent today since tokens carry one role, and it would have surfaced as a silent authorization denial the moment a second was added.
- **`OutboxProcessor` burned retries on shutdown**: the generic `catch` swallowed `OperationCanceledException`, so a graceful restart incremented `RetryCount` and stamped `LastError` on the whole remainder of the batch. Cancellation now rethrows.
- **The keyed by-id fast path was unreachable**: `IsPrimaryKeyOnlyLookup` treated `includeFKs` as disqualifying, and `EntityControllerBase.GetByIdAsync` defaults it to `true`, so every REST by-id read fell back to the dynamic-filter pipeline (`TOP 1000` plus a client-side `FirstOrDefault`). It now only disqualifies when the entity actually has navigations to include.
- **Shared-cache key collisions**: added an optional `Cache:KeyPrefix` applied inside `DistributedCacheService` (get, set, remove, SCAN pattern and the Redis counter alike). Deliberately not `RedisCacheOptions.InstanceName`, which is applied below our abstraction where `RemoveByPrefixAsync`'s SCAN cannot see it and would silently match nothing.
- **Two comments corrected**: `BaseDomainEvent` claimed structural equality enables duplicate detection (it cannot: `MessageId` and `DateOccurred` default per instance), and `EncryptedStringConverter` used `Email` as its usage example despite non-deterministic ciphertext making equality lookups and unique indexes impossible.

## Verification

- `dotnet build MMCA.Common.slnx -c Release` clean.
- `dotnet test --solution MMCA.Common.slnx -c Release` -> **2420 passed, 0 failed**.
- The 10 new filter tests were confirmed to **fail against the unfixed source**.
- One existing test changed meaning deliberately: `ExecuteAsync_NoPagination_CapsResultsAtUnboundedLimit` asserted `totalCount == 1000` for a 1050-row set, which is the defect. It now asserts the true total, with a new sibling test proving no count query is issued below the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)