### PR TITLE
fix: keep IncrementAsync inside IDistributedCache's storage format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.125.2] - 2026-07-24
+
+Patch fixing a regression introduced by `ICacheService.IncrementAsync` in 1.125.0.
+**Consumers must take this instead of 1.125.0 or 1.125.1.** Those two versions break registration
+and login on any host backed by Redis.
+
+### Fixed
+- **The Redis `INCR` fast path wrote a value its own reader could not parse.**
+  `DistributedCacheService.IncrementAsync` used `StringIncrementAsync`, which writes a Redis
+  **string**, while `StackExchangeRedisCache` stores every entry as a Redis **hash** (`absexp` /
+  `sldexp` / `data`, read back with `HMGET`). The first increment created a string at the counter's
+  key; the next read of that key failed with `WRONGTYPE`, which surfaced as a 500 on the endpoint
+  owning the counter. In practice that is **registration** (`CheckRegistrationRateLimitAsync` reads
+  the per-IP counter before every sign-up) and the ADR-029 **login lockout** counters. A host using
+  the in-memory cache was unaffected, which is why the framework's own tests and CI stayed green;
+  MMCA.ADC's end-to-end suite caught it, failing every registration after the first.
+
+  `IncrementAsync` now goes through `IDistributedCache` for both the read and the write, so the
+  counter is stored the same way it is read. It is therefore a read-modify-write again and can
+  undercount under genuinely concurrent increments; for a brute-force counter a rare lost increment
+  is a much smaller problem than the counter being unreadable. Restoring atomicity means either
+  running the whole update as one Lua script against the hash layout, or moving counters out of
+  `IDistributedCache` so both sides speak Redis strings.
+
 ## [1.125.1] - 2026-07-24
 
 Patch fixing a regression introduced by the `ICurrentUserService.Roles` addition in 1.125.0.

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
@@ -101,30 +101,30 @@ internal sealed partial class DistributedCacheService(
 
     /// <inheritdoc />
     /// <remarks>
-    /// Uses Redis <c>INCR</c> when a multiplexer is available, so concurrent increments cannot
-    /// overwrite each other (the interface default is a read-modify-write and undercounts under
-    /// load, which for a brute-force counter means attempts that never reach the lockout
-    /// threshold). The TTL is applied only when the counter is created, so the window stays
-    /// anchored to the first attempt rather than sliding on every increment. Without a
-    /// multiplexer, falls back to the interface default.
+    /// Deliberately goes through <see cref="IDistributedCache"/> rather than Redis <c>INCR</c>.
+    /// <para>
+    /// <c>INCR</c> would be atomic, which is what this member was added for, but it writes a Redis
+    /// <b>string</b> while <c>StackExchangeRedisCache</c> stores every entry as a Redis <b>hash</b>
+    /// (<c>absexp</c> / <c>sldexp</c> / <c>data</c> fields, read back with <c>HMGET</c>). Mixing the
+    /// two at one key means the next read of that counter fails with <c>WRONGTYPE</c>, which
+    /// surfaces as a 500 on whatever endpoint owns the counter: registration and login in the
+    /// ADR-029 case. The counter has to live in the same storage format as the reads that consult
+    /// it.
+    /// </para>
+    /// <para>
+    /// So this is a read-modify-write and can undercount under genuinely concurrent increments. For
+    /// the brute-force and rate-limit counters this backs, an occasional lost increment is a far
+    /// smaller problem than the counter being unreadable. Making it atomic again means either
+    /// running the whole read-modify-write in one Lua script against the hash layout, or moving
+    /// counters out of <see cref="IDistributedCache"/> entirely so both sides speak Redis strings.
+    /// </para>
     /// </remarks>
     public async Task<long> IncrementAsync(string key, TimeSpan expiration, CancellationToken cancellationToken = default)
     {
-        if (connectionMultiplexer is null)
-        {
-            var current = await GetAsync<long?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
-            var fallback = current + 1;
-            await SetAsync(key, fallback, expiration, cancellationToken).ConfigureAwait(false);
-            return fallback;
-        }
-
-        var db = connectionMultiplexer.GetDatabase();
-        var value = await db.StringIncrementAsync(_keys.Qualify(key)).ConfigureAwait(false);
-
-        if (value == 1)
-            await db.KeyExpireAsync(_keys.Qualify(key), expiration).ConfigureAwait(false);
-
-        return value;
+        var current = await GetAsync<long?>(key, cancellationToken).ConfigureAwait(false) ?? 0;
+        var next = current + 1;
+        await SetAsync(key, next, expiration, cancellationToken).ConfigureAwait(false);
+        return next;
     }
 
     private static T Deserialize<T>(byte[] bytes)

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/DistributedCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/DistributedCacheServiceTests.cs
@@ -206,4 +206,68 @@ public class DistributedCacheServiceTests
 
         dbMock.Verify(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()), Times.Never);
     }
+
+    // ── IncrementAsync must stay inside IDistributedCache's storage format ──
+    // StackExchangeRedisCache stores every entry as a Redis HASH (absexp/sldexp/data, read with
+    // HMGET). A Redis INCR fast path writes a STRING at the same key, so the next read of that
+    // counter fails with WRONGTYPE and surfaces as a 500 on whatever endpoint owns it: registration
+    // and login, for the ADR-029 counters. The counter has to be written the same way it is read.
+    [Fact]
+    public async Task IncrementAsync_PersistsThroughTheDistributedCache_SoItCanBeReadBack()
+    {
+        var cacheMock = new Mock<IDistributedCache>();
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var sut = new DistributedCacheService(cacheMock.Object, NullLog, connectionMock.Object);
+
+        cacheMock.Setup(c => c.GetAsync("counter", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+
+        var value = await sut.IncrementAsync("counter", TimeSpan.FromMinutes(30));
+
+        value.Should().Be(1);
+        cacheMock.Verify(
+            c => c.SetAsync("counter", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the counter must be written through IDistributedCache, not straight to a Redis string");
+        connectionMock.Verify(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object>()), Times.Never,
+            "bypassing IDistributedCache writes a value its own reader cannot parse");
+    }
+
+    [Fact]
+    public async Task IncrementAsync_RoundTripsWithGetAsync()
+    {
+        // The real failure was a write the matching read could not consume, so assert the pair.
+        var cacheMock = new Mock<IDistributedCache>();
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var sut = new DistributedCacheService(cacheMock.Object, NullLog, connectionMock.Object);
+
+        byte[]? stored = null;
+        cacheMock.Setup(c => c.GetAsync("counter", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => stored);
+        cacheMock.Setup(c => c.SetAsync("counter", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>((_, bytes, _, _) => stored = bytes)
+            .Returns(Task.CompletedTask);
+
+        await sut.IncrementAsync("counter", TimeSpan.FromMinutes(30));
+        await sut.IncrementAsync("counter", TimeSpan.FromMinutes(30));
+
+        (await sut.GetAsync<long?>("counter")).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task IncrementAsync_AppliesTheKeyNamespaceConsistentlyWithGetAsync()
+    {
+        var cacheMock = new Mock<IDistributedCache>();
+        var sut = new DistributedCacheService(
+            cacheMock.Object, NullLog, connectionMultiplexer: null, new CacheKeyNamespace("svc:"));
+
+        cacheMock.Setup(c => c.GetAsync("svc:counter", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+
+        await sut.IncrementAsync("counter", TimeSpan.FromMinutes(30));
+
+        cacheMock.Verify(
+            c => c.SetAsync("svc:counter", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
**Hotfix. v1.125.0 and v1.125.1 break registration and login on any Redis-backed host.** Neither ADC nor Store deployed: ADC's deploy failed at the e2e gate and Store's was cancelled before rollout, so production is on the previous release and unaffected.

## What broke

`DistributedCacheService.IncrementAsync` (added in v1.125.0 for the ADR-029 counters) used `StringIncrementAsync`:

```csharp
var value = await db.StringIncrementAsync(_keys.Qualify(key));   // writes a Redis STRING
```

But `StackExchangeRedisCache` stores every entry as a Redis **hash** (`absexp` / `sldexp` / `data`, read back with `HMGET`). So the counter was written in one format and read in another:

1. First sign-up from an IP: `CheckRegistrationRateLimitAsync` reads, key absent, fine. `IncrementRegistrationCountAsync` then creates a **string** at that key.
2. Second sign-up: the read issues `HMGET` against a string key, Redis answers `WRONGTYPE`, and the endpoint 500s.

Same shape for the login-lockout counters. `MemoryCacheService` hosts were unaffected.

## Why CI did not catch it

Common's tests mock `IDistributedCache`, and its integration tiers do not run against a real Redis, so no framework test ever exercised the two storage formats meeting. The consumer suites did: ADC's e2e-gate failed **every registration after the first**, across 12+ tests.

The lesson I took into the tests here: the old test asserted only that `IncrementAsync` returned the right number. The bug was a write that the matching read could not consume, so the new tests assert the **pair** (`IncrementAsync` then `GetAsync` round-trips) and that the write goes through `IDistributedCache` at all. Both were confirmed to fail against the shipped code.

## The fix, and what it costs

`IncrementAsync` reads and writes through `IDistributedCache`, so the counter is stored the way it is read.

That makes it a read-modify-write again, so it **can undercount under genuinely concurrent increments** — the exact thing the Redis path was added to fix. That trade is deliberate: for a brute-force counter, a rare lost increment is a much smaller problem than the counter being unreadable and taking registration down with it. Getting atomicity back properly means either running the whole update as one Lua script against the hash layout, or moving counters out of `IDistributedCache` so both sides speak Redis strings. Neither belongs in a hotfix.

The ADR-029 security fix that motivated all this, keying counters off the **normalized** email so capitalization cannot reset the backoff, is untouched and still in effect.

## Verification

- `dotnet test --solution MMCA.Common.slnx -c Release` -> **2435 passed, 0 failed**.
- The 2 new round-trip tests fail against the shipped code and pass here.
- After tagging v1.125.2 I will re-run both consumer deploys; ADC's e2e-gate is the real proof, since it is what caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)