### PR TITLE
fix(framework): bound the filter cache, share the paging clamp, make transactions re-entrant, schedule outbox retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,3 +587,26 @@ jobs:
       - name: Compile main.bicep
         if: needs.changes.outputs.code == 'true'
         run: az bicep build --file samples/deployment/main.bicep --stdout > /dev/null
+
+  redis-integration:
+    name: Redis integration (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # DistributedCacheService is the one place where the STORAGE FORMAT matters, and a
+    # Mock<IDistributedCache> cannot express it: Redis keys are typed, so a counter written as a
+    # string and read back as a hash round-trips perfectly against a mock and answers WRONGTYPE
+    # against a server. This tier runs the shipped cache against a real Redis. Ubuntu runners ship a
+    # Docker daemon, so Testcontainers works with no extra setup.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # MinVer needs full history
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run Redis integration tests
+        # Deliberately outside MMCA.Common.slnx (it needs Docker, which the fast solution-wide unit
+        # loop must not require), so build/run this project directly by path, like ui-e2e does.
+        run: dotnet test Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/MMCA.Common.Infrastructure.Redis.Tests.csproj -c Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,6 +590,7 @@ jobs:
 
   redis-integration:
     name: Redis integration (Testcontainers)
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # DistributedCacheService is the one place where the STORAGE FORMAT matters, and a
@@ -605,8 +606,19 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Run Redis integration tests
+        # Code-guarded like every other heavy job: a docs-only PR must not pull a Redis image and
+        # start a container. The JOB still runs (and posts its context green) so adding this check to
+        # branch protection stays safe on docs-only PRs, matching the pattern the other jobs use.
+        if: needs.changes.outputs.code == 'true'
         # Deliberately outside MMCA.Common.slnx (it needs Docker, which the fast solution-wide unit
         # loop must not require), so build/run this project directly by path, like ui-e2e does.
         run: dotnet test Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/MMCA.Common.Infrastructure.Redis.Tests.csproj -c Release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -114,6 +114,13 @@
          transitives, so a stale-cache restore could otherwise drift it down to 4.7.2 and dirty the lock. -->
     <PackageVersion Include="Deque.AxeCore.Commons" Version="4.12.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
+    <!-- Redis integration tier only (Tests/Core/MMCA.Common.Infrastructure.Redis.Tests, outside the
+         .slnx, own CI job): a real Redis is the only way to assert the storage FORMAT the cache
+         writes, which a Mock<IDistributedCache> answers for and therefore cannot get wrong.
+         Microsoft.Extensions.Caching.StackExchangeRedis supplies the concrete RedisCache the shipped
+         code only sees as IDistributedCache. -->
+    <PackageVersion Include="Testcontainers.Redis" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
     <PackageVersion Include="NetArchTest.eNhancedEdition" Version="1.4.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />

--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/GetHistory/GetNotificationHistoryHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/GetHistory/GetNotificationHistoryHandler.cs
@@ -1,5 +1,6 @@
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Notifications.PushNotifications.DTOs;
+using MMCA.Common.Application.Services.Query;
 using MMCA.Common.Application.UseCases;
 using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Shared.Abstractions;
@@ -16,12 +17,17 @@ public sealed class GetNotificationHistoryHandler(
     IQueryableExecutor queryableExecutor,
     PushNotificationDTOMapper dtoMapper) : IQueryHandler<GetNotificationHistoryQuery, Result<PagedCollectionResult<PushNotificationDTO>>>
 {
+    /// <summary>Ceiling on the history page size, matching the documented "max 500" on the query.</summary>
+    private const int MaxPageSize = 500;
+
     /// <inheritdoc />
     public async Task<Result<PagedCollectionResult<PushNotificationDTO>>> HandleAsync(
         GetNotificationHistoryQuery query,
         CancellationToken cancellationToken = default)
     {
-        var pageSize = Math.Min(query.PageSize, 500);
+        // Shared 64-bit clamp: see PagingMath. A 32-bit (PageNumber - 1) * PageSize wraps negative
+        // near int.MaxValue, and SQL Server rejects a negative OFFSET outright.
+        var (skip, take) = PagingMath.Clamp(query.PageNumber, query.PageSize, MaxPageSize);
         var repository = unitOfWork.GetRepository<PushNotification, PushNotificationIdentifierType>();
 
         int totalCount = await repository.CountAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -29,12 +35,12 @@ public sealed class GetNotificationHistoryHandler(
         IReadOnlyCollection<PushNotification> paged = await queryableExecutor.ToListAsync(
             repository.TableNoTracking
                 .OrderByDescending(n => n.CreatedOn)
-                .Skip((query.PageNumber - 1) * pageSize)
-                .Take(pageSize),
+                .Skip(skip)
+                .Take(take),
             cancellationToken).ConfigureAwait(false);
 
         IReadOnlyCollection<PushNotificationDTO> dtos = dtoMapper.MapToDTOs(paged);
-        var metadata = new PaginationMetadata(totalCount, pageSize, query.PageNumber);
+        var metadata = new PaginationMetadata(totalCount, take, query.PageNumber);
 
         return Result.Success(new PagedCollectionResult<PushNotificationDTO>(dtos, metadata));
     }

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsHandler.cs
@@ -1,4 +1,5 @@
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Services.Query;
 using MMCA.Common.Application.UseCases;
 using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.UserNotifications;
@@ -16,12 +17,19 @@ public sealed class GetMyNotificationsHandler(
     IUnitOfWork unitOfWork,
     IQueryableExecutor queryableExecutor) : IQueryHandler<GetMyNotificationsQuery, Result<PagedCollectionResult<UserNotificationDTO>>>
 {
+    /// <summary>Ceiling on the inbox page size, matching the documented "max 500" on the query.</summary>
+    private const int MaxPageSize = 500;
+
     /// <inheritdoc />
     public async Task<Result<PagedCollectionResult<UserNotificationDTO>>> HandleAsync(
         GetMyNotificationsQuery query,
         CancellationToken cancellationToken = default)
     {
-        var pageSize = Math.Min(query.PageSize, 500);
+        // Shared 64-bit clamp: Skip/Take must not be derived from a 32-bit
+        // (PageNumber - 1) * PageSize, which wraps negative near int.MaxValue and makes SQL Server
+        // reject the negative OFFSET. It also floors the page size, which the [Range] attribute at
+        // the API boundary enforces but a direct handler caller does not inherit.
+        var (skip, take) = PagingMath.Clamp(query.PageNumber, query.PageSize, MaxPageSize);
         var userNotificationRepo = unitOfWork.GetRepository<UserNotification, UserNotificationIdentifierType>();
         var pushNotificationRepo = unitOfWork.GetRepository<PushNotification, PushNotificationIdentifierType>();
 
@@ -43,10 +51,10 @@ public sealed class GetMyNotificationsHandler(
         int totalCount = await queryableExecutor.CountAsync(joined, cancellationToken).ConfigureAwait(false);
 
         IReadOnlyCollection<UserNotificationDTO> paged = await queryableExecutor.ToListAsync(
-            joined.Skip((query.PageNumber - 1) * pageSize).Take(pageSize),
+            joined.Skip(skip).Take(take),
             cancellationToken).ConfigureAwait(false);
 
-        var metadata = new PaginationMetadata(totalCount, pageSize, query.PageNumber);
+        var metadata = new PaginationMetadata(totalCount, take, query.PageNumber);
         return Result.Success(new PagedCollectionResult<UserNotificationDTO>(paged, metadata));
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/QueryFilterService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/QueryFilterService.cs
@@ -19,9 +19,12 @@ namespace MMCA.Common.Application.Services.Filtering;
 public static class QueryFilterService
 {
     /// <summary>
-    /// Caches PropertyInfo lookups per (entity type, property name) to avoid per-request reflection overhead.
+    /// Caches RESOLVED PropertyInfo lookups per (entity type, property name) to avoid per-request
+    /// reflection overhead. Misses are deliberately not cached: the names probed come from the
+    /// client's query string, so a negative cache is an unbounded, never-evicted static dictionary
+    /// any caller can grow at will. See <see cref="LookupProperty{TEntity}"/>.
     /// </summary>
-    private static readonly ConcurrentDictionary<(Type EntityType, string PropertyName), PropertyInfo?> PropertyCache = new();
+    private static readonly ConcurrentDictionary<(Type EntityType, string PropertyName), PropertyInfo> PropertyCache = new();
 
     private static readonly ConcurrentDictionary<Type, IFilterStrategy> Strategies = new(
         new Dictionary<Type, IFilterStrategy>
@@ -89,16 +92,8 @@ public static class QueryFilterService
 
             var opUpper = op.ToUpperInvariant();
 
-            // Nested properties (e.g. "Category.Name") always use string filtering because
-            // the LINQ Dynamic expression path traverses the property chain as a string
-            if (propertyInfo.PropertyType == typeof(string) ||
-                entityProperty.Contains('.', StringComparison.OrdinalIgnoreCase))
-            {
-                query = StringStrategy.Apply(query, entityProperty, opUpper, value);
-                continue;
-            }
-
-            if (Strategies.TryGetValue(propertyInfo.PropertyType, out var strategy))
+            var strategy = ResolveStrategy(ResolveFilterValueType<TEntity>(entityProperty, propertyInfo));
+            if (strategy is not null)
                 query = strategy.Apply(query, entityProperty, opUpper, value);
         }
 
@@ -155,28 +150,27 @@ public static class QueryFilterService
 
         var opUpper = op.ToUpperInvariant();
 
-        // Nested properties use string filtering
-        if (entityProperty.Contains('.', StringComparison.Ordinal))
-        {
-            ValidateOperatorSupported(StringStrategy, opUpper, op, property, "string", errors);
-            ValidateValueParseable(StringStrategy, opUpper, value, property, "string", errors);
-            return;
-        }
-
-        var strategy = ResolveStrategy(propertyInfo.PropertyType);
+        // Resolve the type the filter VALUE is compared against, walking a nested path to its leaf.
+        // Validation and application must agree on this: routing every dotted path to the string
+        // strategy let a nested non-string leaf pass validation for a string-only operator (say
+        // IS EMPTY on "Category.Id") and then fail inside Dynamic LINQ at query-build time, which is
+        // a 500 for what is really a bad request.
+        var valueType = ResolveFilterValueType<TEntity>(entityProperty, propertyInfo);
+        var strategy = ResolveStrategy(valueType);
 
         if (strategy is null)
         {
             errors.Add(Error.Validation(
                 "Filter.Type.NotSupported",
-                $"No filter strategy registered for type '{propertyInfo.PropertyType.Name}' (property '{property}').",
+                $"No filter strategy registered for type '{(valueType ?? propertyInfo.PropertyType).Name}' (property '{property}').",
                 source: nameof(ValidateFilters),
                 target: property));
             return;
         }
 
-        ValidateOperatorSupported(strategy, opUpper, op, property, propertyInfo.PropertyType.Name, errors);
-        ValidateValueParseable(strategy, opUpper, value, property, propertyInfo.PropertyType.Name, errors);
+        var typeName = (valueType ?? propertyInfo.PropertyType).Name;
+        ValidateOperatorSupported(strategy, opUpper, op, property, typeName, errors);
+        ValidateValueParseable(strategy, opUpper, value, property, typeName, errors);
     }
 
     /// <summary>
@@ -217,6 +211,14 @@ public static class QueryFilterService
     /// <c>["Name"] = "Title"</c>) passed validation and was then silently dropped, returning an
     /// unfiltered result set with a 200.
     /// </para>
+    /// <para>
+    /// Only SUCCESSFUL lookups are cached. Both names probed here are client-influenced (the filter
+    /// key arrives in the query string), so caching misses too let any caller grow a process-lifetime
+    /// static dictionary without bound simply by filtering on names that do not exist: the request
+    /// gets a clean 400 back, which makes the growth invisible in error metrics. A miss now costs a
+    /// reflection lookup instead, which the per-request filter cap in <c>QueryFilterModelBinder</c>
+    /// bounds.
+    /// </para>
     /// </summary>
     private static PropertyInfo? ResolvePropertyInfo<TEntity>(string property, string entityProperty)
     {
@@ -224,16 +226,59 @@ public static class QueryFilterService
             ? entityProperty.Split('.')[0]
             : entityProperty;
 
-        return PropertyCache.GetOrAdd(
-            (typeof(TEntity), property),
-            static key => key.EntityType.GetProperty(key.PropertyName, BindingFlags.Public | BindingFlags.Instance))
-            ?? PropertyCache.GetOrAdd(
-                (typeof(TEntity), propertyName),
-                static key => key.EntityType.GetProperty(key.PropertyName, BindingFlags.Public | BindingFlags.Instance));
+        return LookupProperty<TEntity>(property) ?? LookupProperty<TEntity>(propertyName);
     }
 
-    private static IFilterStrategy? ResolveStrategy(Type propertyType) =>
-        propertyType == typeof(string)
+    /// <summary>
+    /// Resolves one property name against <typeparamref name="TEntity"/>, memoizing hits only.
+    /// </summary>
+    private static PropertyInfo? LookupProperty<TEntity>(string propertyName)
+    {
+        var key = (typeof(TEntity), propertyName);
+        if (PropertyCache.TryGetValue(key, out var cached))
+            return cached;
+
+        var resolved = typeof(TEntity).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+        if (resolved is not null)
+            PropertyCache[key] = resolved;
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Resolves the type a filter value is compared against: for a flat property that is the
+    /// property's own type, and for a dotted path (<c>"Category.Name"</c>) it is the LEAF's type,
+    /// reached by walking each segment.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> when the path cannot be walked (an intermediate segment is not
+    /// a public instance property). Callers fall back to the string strategy in that case, which is
+    /// the behavior every dotted path used to get unconditionally, so an unresolvable path keeps
+    /// working exactly as before rather than newly failing validation.
+    /// </remarks>
+    private static Type? ResolveFilterValueType<TEntity>(string entityProperty, PropertyInfo resolvedRoot)
+    {
+        if (!entityProperty.Contains('.', StringComparison.Ordinal))
+            return resolvedRoot.PropertyType;
+
+        var segments = entityProperty.Split('.');
+
+        // Walk from the path's own root segment rather than from resolvedRoot: the latter may have
+        // matched the DTO-facing name instead, and for a nested path the two need not agree.
+        var current = LookupProperty<TEntity>(segments[0])?.PropertyType;
+
+        for (var i = 1; i < segments.Length && current is not null; i++)
+        {
+            current = current
+                .GetProperty(segments[i], BindingFlags.Public | BindingFlags.Instance)
+                ?.PropertyType;
+        }
+
+        return current;
+    }
+
+    private static IFilterStrategy? ResolveStrategy(Type? propertyType) =>
+        propertyType is null || propertyType == typeof(string)
             ? StringStrategy
             : Strategies.GetValueOrDefault(propertyType);
 

--- a/Source/Core/MMCA.Common.Application/Services/Query/EntityQueryPipeline.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Query/EntityQueryPipeline.cs
@@ -166,20 +166,19 @@ public sealed class EntityQueryPipeline(IQueryableExecutor queryableExecutor) : 
     /// Application-layer caller that bypasses the API boundary cannot request an unbounded page).
     /// </summary>
     /// <remarks>
-    /// The offset is computed in 64-bit and range-checked rather than left to <see langword="checked"/>
-    /// arithmetic: a page number near <see cref="int.MaxValue"/> overflowed and surfaced as a 500
-    /// instead of the empty page that page genuinely holds.
+    /// The 64-bit, range-checked offset arithmetic lives in <see cref="PagingMath"/> so every
+    /// paginating caller shares it; see that type for why a 32-bit multiply is not safe here.
     /// </remarks>
     private static IQueryable<TEntity> ApplyPaging<TEntity>(
         IQueryable<TEntity> query,
         EntityQueryParameters<TEntity> parameters)
     {
-        int pageSize = Math.Min(parameters.PageSize!.Value, MaxUnboundedResultLimit);
-        long skip = (long)pageSize * (parameters.PageNumber!.Value - 1);
+        var (skip, take) = PagingMath.Clamp(
+            parameters.PageNumber!.Value,
+            parameters.PageSize!.Value,
+            MaxUnboundedResultLimit);
 
-        return skip > int.MaxValue
-            ? query.Take(0)
-            : query.Skip((int)skip).Take(pageSize);
+        return query.Skip(skip).Take(take);
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Application/Services/Query/PagingMath.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Query/PagingMath.cs
@@ -1,0 +1,44 @@
+namespace MMCA.Common.Application.Services.Query;
+
+/// <summary>
+/// The one place page number and page size are turned into a Skip/Take pair.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The offset is computed in 64-bit and range-checked rather than left to 32-bit arithmetic:
+/// <c>(pageNumber - 1) * pageSize</c> overflows an <see cref="int"/> for page numbers near
+/// <see cref="int.MaxValue"/> and wraps NEGATIVE, and a negative <c>Skip</c> is not a benign
+/// no-op — SQL Server rejects a negative <c>OFFSET</c> outright, so the request surfaces as a
+/// 500 instead of the empty page that page genuinely holds.
+/// </para>
+/// <para>
+/// This lived only inside <c>EntityQueryPipeline</c>, so handlers that paginate their own
+/// queryable (the notification inbox and history reads) each re-derived it in 32-bit and kept
+/// the overflow. Callers must route through here rather than open-coding the multiply.
+/// </para>
+/// </remarks>
+public static class PagingMath
+{
+    /// <summary>
+    /// Clamps a requested page into a safe <c>Skip</c>/<c>Take</c> pair.
+    /// </summary>
+    /// <param name="pageNumber">The one-based page number. Values below 1 are treated as page 1.</param>
+    /// <param name="pageSize">The requested page size. Clamped into <c>[1, maxPageSize]</c>.</param>
+    /// <param name="maxPageSize">The ceiling this caller enforces on page size.</param>
+    /// <returns>
+    /// The number of rows to skip and to take. A page beyond the reachable offset range yields
+    /// <c>(0, 0)</c>, which materializes the empty page that page actually holds.
+    /// </returns>
+    public static (int Skip, int Take) Clamp(int pageNumber, int pageSize, int maxPageSize)
+    {
+        // A zero or negative page size would otherwise become Take(0) or a negative Take; a zero or
+        // negative page number would become a negative Skip. Both arrive from callers outside the
+        // API boundary's [Range] attributes, so neither can be assumed away here.
+        var take = Math.Clamp(pageSize, 1, Math.Max(maxPageSize, 1));
+        var page = Math.Max(pageNumber, 1);
+
+        long skip = (long)take * (page - 1);
+
+        return skip > int.MaxValue ? (0, 0) : ((int)skip, take);
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Auth/LoginProtectionService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Auth/LoginProtectionService.cs
@@ -63,8 +63,15 @@ public sealed class LoginProtectionService(
     /// <inheritdoc />
     public async Task IncrementFailedAttemptsAsync(string email, CancellationToken cancellationToken = default)
     {
-        // Atomic: a read-modify-write lets parallel attempts overwrite each other's increments, so
-        // a burst of concurrent guesses could stay below MaxFailedAttempts indefinitely.
+        // NOT atomic on the distributed cache today: DistributedCacheService.IncrementAsync is a
+        // read-modify-write, because the Redis INCR it used to issue wrote a plain string key while
+        // IDistributedCache reads entries back as hashes, and the mismatch made the counter
+        // unreadable (WRONGTYPE). Readability was the right thing to buy first, but the cost is the
+        // known one: parallel attempts can overwrite each other's increments, so a burst of
+        // genuinely concurrent guesses can stay below MaxFailedAttempts. Sequential guessing, which
+        // is what a credential-stuffing run against one account looks like, still trips the lockout.
+        // Closing the gap needs the increment made atomic again WITHIN the hash layout (a Lua
+        // script) or counters moved off IDistributedCache so both sides speak Redis strings.
         var newCount = await cacheService.IncrementAsync(
             AttemptsKey(email),
             TimeSpan.FromMinutes(_settings.FailedAttemptWindowMinutes),
@@ -117,10 +124,9 @@ public sealed class LoginProtectionService(
             return;
         }
 
-        // Atomic. On a store with a native counter (Redis) the TTL is also anchored to the first
-        // registration in the window; the read-modify-write fallback keeps the previous
-        // refresh-on-every-write behavior, which makes the window slide but only ever tightens
-        // the limit.
+        // Read-modify-write (see IncrementFailedAttemptsAsync for why the native-counter path was
+        // removed), so the TTL is refreshed on every write. That makes the window slide rather than
+        // stay anchored to the first registration, which only ever tightens the limit.
         await cacheService.IncrementAsync(
             RegistrationKey(ipAddress),
             TimeSpan.FromMinutes(_settings.RegistrationRateLimitWindowMinutes),

--- a/Source/Core/MMCA.Common.Infrastructure/MMCA.Common.Infrastructure.csproj
+++ b/Source/Core/MMCA.Common.Infrastructure/MMCA.Common.Infrastructure.csproj
@@ -5,6 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="MMCA.Common.Infrastructure.Tests" />
+    <!-- Docker-gated Redis tier (outside the .slnx): asserts the storage format against a real
+         server, which the mocked-IDistributedCache unit tier cannot see. -->
+    <InternalsVisibleTo Include="MMCA.Common.Infrastructure.Redis.Tests" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -271,7 +271,12 @@ public sealed class DbContextFactory(
     public void BeginTransaction()
     {
         _transactionActive = true;
-        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).ToArray())
+
+        // Skip contexts that already carry a transaction, symmetrically with Commit/Rollback below.
+        // EF throws InvalidOperationException on a second BeginTransaction for the same connection,
+        // and GetDbContext already enlists late-created contexts, so a context can legitimately be
+        // mid-transaction by the time this runs.
+        foreach (var context in _dbContexts.Values.Where(SupportsTransactions).Where(c => !HasActiveTransaction(c)).ToArray())
             context.Database.BeginTransaction();
     }
 
@@ -302,6 +307,11 @@ public sealed class DbContextFactory(
     /// best-effort (no two-phase commit). The outbox is the cross-source consistency mechanism.
     /// </para>
     /// <para>
+    /// Re-entrant: a nested call joins the ambient transaction and returns the operation's result
+    /// directly. Begin, commit, rollback and the deferred-event flush belong to the outermost call
+    /// alone, so the whole nest commits or rolls back as one unit.
+    /// </para>
+    /// <para>
     /// A returned failed <see cref="Result"/> rolls the transaction back, exactly like an
     /// exception: in a framework that mandates Result-over-exceptions (ADR-013), a handler that
     /// saves and then fails a later invariant must not leave the partial mutation committed.
@@ -324,6 +334,16 @@ public sealed class DbContextFactory(
         Func<CancellationToken, Task<TResult>> operation,
         CancellationToken cancellationToken = default)
     {
+        // Re-entrant call: join the transaction the outer call already opened instead of starting a
+        // second one. Only the OUTERMOST call may begin, commit, roll back, or flush deferred events;
+        // an inner commit would make the outer scope's earlier work durable ahead of its own
+        // decision, turning a nested call into a silent partial commit. Without this, an
+        // ITransactional command whose handler also opens a transaction (the shape Store's
+        // CheckOutHandler and VerifyPaymentHandler avoid only by convention, with a comment on each
+        // command saying so) hit an InvalidOperationException from EF instead.
+        if (_transactionActive)
+            return await operation(cancellationToken).ConfigureAwait(false);
+
         // Use the execution strategy from the first active transactional context
         // (typically SQL Server). If none exists yet, create the default context so
         // the strategy is available before the handler's first repository call.

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -384,6 +384,16 @@ public sealed partial class OutboxProcessor(
             {
                 message.RetryCount++;
                 message.LastError = ex.Message;
+
+                // Re-lease the row for an explicit backoff instead of leaving this cycle's claim on
+                // it. The claim is not cleared outright: the fetch skips leased rows, so a failure
+                // that kept the original lease was retried only after the full LeaseSeconds (300s by
+                // default) no matter what the polling interval or a signal said. That made the retry
+                // cadence an accident of the lease. Capping at the lease keeps a permanently failing
+                // message from becoming unclaimable for longer than a dead replica's rows would.
+                message.LockedUntil = _timeProvider.GetUtcNow().UtcDateTime
+                    .AddSeconds(ComputeRetryBackoffSeconds(message.RetryCount));
+
                 activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 
                 if (message.RetryCount >= _settings.MaxRetries)
@@ -405,6 +415,21 @@ public sealed partial class OutboxProcessor(
         }
 
         return processedAny;
+    }
+
+    /// <summary>
+    /// Exponential backoff for a failed message: <c>base * 2^(retryCount - 1)</c>, capped at the
+    /// lease so a failing row never holds its claim longer than a dead replica's rows would.
+    /// </summary>
+    internal double ComputeRetryBackoffSeconds(int retryCount)
+    {
+        // Clamp the shift exponent before it reaches Math.Pow: MaxRetries is bounded at 20 today,
+        // but the cap below is what actually decides the wait, so there is no reason to let a
+        // future settings change turn this into an overflow.
+        var exponent = Math.Min(Math.Max(retryCount - 1, 0), 16);
+        var backoff = _settings.RetryBackoffBaseSeconds * Math.Pow(2, exponent);
+
+        return Math.Min(backoff, _settings.LeaseSeconds);
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
@@ -82,6 +82,22 @@ public sealed class OutboxSettings
     public int LeaseSeconds { get; init; } = 300;
 
     /// <summary>
+    /// Gets the base, in seconds, of the exponential backoff applied to a FAILED message before it
+    /// is retried (attempt <c>n</c> waits <c>RetryBackoffBaseSeconds * 2^(n-1)</c>, capped at
+    /// <see cref="LeaseSeconds"/>). Defaults to <c>10</c>.
+    /// </summary>
+    /// <remarks>
+    /// A failed message keeps its claim until this backoff elapses. Before this setting existed the
+    /// claim was simply never cleared, so a failure was retried only after the FULL
+    /// <see cref="LeaseSeconds"/> (300s by default) regardless of <see cref="PollingIntervalSeconds"/>
+    /// or an explicit signal: the real retry cadence was an accident of the lease rather than a
+    /// decision. Making it explicit both shortens the first retries and keeps a permanently failing
+    /// message from spinning.
+    /// </remarks>
+    [Range(1, 3600)]
+    public int RetryBackoffBaseSeconds { get; init; } = 10;
+
+    /// <summary>
     /// Gets the number of days a <b>dead-lettered</b> outbox message (retries exhausted, never
     /// delivered) is retained before <c>OutboxCleanupService</c> purges it. <c>0</c> (the default)
     /// falls back to <see cref="RetentionDays"/>. Set it higher than <see cref="RetentionDays"/>

--- a/Source/Presentation/MMCA.Common.API/ModelBinders/QueryFilterModelBinder.cs
+++ b/Source/Presentation/MMCA.Common.API/ModelBinders/QueryFilterModelBinder.cs
@@ -23,6 +23,16 @@ namespace MMCA.Common.API.ModelBinders;
 /// </remarks>
 public sealed class QueryFilterModelBinder : IModelBinder
 {
+    /// <summary>
+    /// Maximum number of distinct filter properties honored on one request. Well past any real
+    /// grid (the widest DTO in either app is nowhere near this), and it bounds the per-request
+    /// reflection work a caller can demand from <c>QueryFilterService</c>, which resolves each
+    /// unknown name by reflection rather than memoizing misses. Surplus entries are dropped rather
+    /// than rejected: they were never valid filters to begin with, and a 400 here would be a
+    /// breaking change for any client that happens to send junk alongside real filters.
+    /// </summary>
+    public const int MaxFilters = 50;
+
     /// <inheritdoc />
     public Task BindModelAsync(ModelBindingContext bindingContext)
     {
@@ -47,7 +57,12 @@ public sealed class QueryFilterModelBinder : IModelBinder
                 continue;
 
             if (!filters.TryGetValue(property, out var tuple))
+            {
+                if (filters.Count >= MaxFilters)
+                    continue;
+
                 tuple = (string.Empty, string.Empty);
+            }
 
             var value = query[key].ToString();
             filters[property] = suffix == "operator"

--- a/Source/Presentation/MMCA.Common.UI/Components/Capabilities/DeepLinkListener.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/Capabilities/DeepLinkListener.razor
@@ -1,6 +1,8 @@
+@using Microsoft.Extensions.Logging
 @using MMCA.Common.UI.Services.Capabilities
 @inject IDeepLinkDispatcher Dispatcher
 @inject NavigationManager Navigation
+@inject ILogger<DeepLinkListener> Logger
 @implements IDisposable
 
 @* Invisible component (ADR-042) — the Blazor end of the deep-link funnel. Rendered once in
@@ -40,6 +42,14 @@
         catch (InvalidOperationException)
         {
             // Component no longer attached; same disposition.
+        }
+        catch (Exception ex)
+        {
+            // Exhaustive by necessity: this is an async void event handler, so anything escaping
+            // here has no caller to observe it. On MAUI that terminates the process; on Server it
+            // is an unobserved exception outside the circuit's error handling. Losing one deep-link
+            // navigation must not be able to take the host down.
+            Logger.LogError(ex, "Deep-link navigation to {Route} failed.", args.Route);
         }
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Components/Capabilities/OfflineBanner.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/Capabilities/OfflineBanner.razor
@@ -1,6 +1,8 @@
+@using Microsoft.Extensions.Logging
 @using MMCA.Common.UI.Services.Capabilities
 @inject IConnectivityStatusService Connectivity
 @inject IStringLocalizer<SharedResource> Localizer
+@inject ILogger<OfflineBanner> Logger
 @implements IDisposable
 
 @* Offline awareness banner (ADR-042). Renders nothing while online. Hosts whose
@@ -46,6 +48,14 @@
         catch (InvalidOperationException)
         {
             // Renderer detached; same disposition.
+        }
+        catch (Exception ex)
+        {
+            // Exhaustive by necessity: this is an async void event handler, so anything escaping
+            // here has no caller to observe it. On MAUI that terminates the process; on Server it
+            // is an unobserved exception outside the circuit's error handling. A banner that fails
+            // to refresh must not be able to take the host down.
+            Logger.LogError(ex, "Offline banner failed to refresh after a connectivity change.");
         }
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Components/Capabilities/PushRegistrationListener.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/Capabilities/PushRegistrationListener.razor
@@ -1,7 +1,9 @@
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.Extensions.Logging
 @using MMCA.Common.UI.Services.Capabilities
 @inject IPushRegistrationService PushRegistration
 @inject AuthenticationStateProvider AuthStateProvider
+@inject ILogger<PushRegistrationListener> Logger
 @implements IDisposable
 
 @* Invisible component (ADR-044) — keeps this device's push installation in sync with the
@@ -57,6 +59,15 @@
         catch (InvalidOperationException)
         {
             // Component no longer attached; same disposition.
+        }
+        catch (Exception ex)
+        {
+            // Exhaustive by necessity: this is an async void event handler, so anything escaping
+            // here has no caller to observe it. On MAUI that terminates the process; on Server it
+            // is an unobserved exception outside the circuit's error handling. RegisterAsync reaches
+            // the network and a platform token provider, so this is the likeliest of the three
+            // capability listeners to throw something other than a lifetime exception.
+            Logger.LogError(ex, "Push registration failed after an authentication state change.");
         }
     }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServicePropertyCacheTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServicePropertyCacheTests.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using System.Reflection;
+using AwesomeAssertions;
+using MMCA.Common.Application.Services.Filtering;
+
+namespace MMCA.Common.Application.Tests.Services.Filtering;
+
+/// <summary>
+/// The filter property cache is static and lives for the life of the process, and the names
+/// probed against it arrive in the query string. Caching MISSES therefore handed any caller an
+/// unbounded, never-evicted dictionary they could grow at will, one entry per bogus filter name,
+/// while the request itself came back as a tidy 400 that showed nothing in error metrics.
+/// </summary>
+public class QueryFilterServicePropertyCacheTests
+{
+    private static readonly Dictionary<string, string> EmptyMap = [];
+
+    private sealed class Widget
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Counts the cache entries belonging to <see cref="Widget"/> only. Asserting on the real static
+    /// field is the point (any indirect proxy would keep passing if negative caching came back), but
+    /// the whole assembly's filter tests share that field and run in parallel, so a total count would
+    /// race them. <see cref="Widget"/> is private to this class, so its slice is ours alone.
+    /// </summary>
+    private static int CacheEntryCount()
+    {
+        var field = typeof(QueryFilterService).GetField("PropertyCache", BindingFlags.NonPublic | BindingFlags.Static);
+        field.Should().NotBeNull("the test pins the real cache, not a stand-in");
+
+        var cache = (IEnumerable<KeyValuePair<(Type EntityType, string PropertyName), PropertyInfo>>)field!.GetValue(null)!;
+        return cache.Count(entry => entry.Key.EntityType == typeof(Widget));
+    }
+
+    [Fact]
+    public void ValidateFilters_WithManyUnknownProperties_DoesNotGrowTheStaticCache()
+    {
+        // Warm any entry the type legitimately caches, so the delta below measures only the misses.
+        QueryFilterService.ValidateFilters<Widget>(
+            new Dictionary<string, (string, string)> { ["Name"] = ("EQUALS", "x") },
+            EmptyMap);
+
+        var before = CacheEntryCount();
+
+        for (var i = 0; i < 500; i++)
+        {
+            var bogus = string.Create(CultureInfo.InvariantCulture, $"NotAProperty{i}");
+            var result = QueryFilterService.ValidateFilters<Widget>(
+                new Dictionary<string, (string, string)> { [bogus] = ("EQUALS", "x") },
+                EmptyMap);
+
+            result.IsFailure.Should().BeTrue("an unknown filter property must still fail closed");
+        }
+
+        CacheEntryCount().Should().Be(
+            before,
+            "unresolvable names come from the client, so memoizing the miss is an unbounded static leak");
+    }
+
+    [Fact]
+    public void ValidateFilters_WithKnownProperty_StillResolvesAndSucceeds()
+    {
+        // The fix must not cost correctness on the path that matters: hits are still cached and
+        // repeated resolution keeps working.
+        for (var i = 0; i < 3; i++)
+        {
+            var result = QueryFilterService.ValidateFilters<Widget>(
+                new Dictionary<string, (string, string)> { ["Name"] = ("CONTAINS", "abc") },
+                EmptyMap);
+
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        CacheEntryCount().Should().BeGreaterThan(0, "resolved lookups are still memoized");
+    }
+
+    [Fact]
+    public void ApplyFilters_WithUnknownProperty_LeavesTheQueryUnfilteredWithoutCaching()
+    {
+        var widgets = new[] { new Widget { Id = 1, Name = "a" }, new Widget { Id = 2, Name = "b" } }.AsQueryable();
+        var before = CacheEntryCount();
+
+        var filtered = QueryFilterService.ApplyFilters(
+            widgets,
+            new Dictionary<string, (string Operator, string Value)> { ["Nope"] = ("EQUALS", "a") },
+            EmptyMap);
+
+        filtered.Count().Should().Be(2);
+        CacheEntryCount().Should().Be(before);
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Query/PagingMathTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Query/PagingMathTests.cs
@@ -1,0 +1,86 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Services.Query;
+
+namespace MMCA.Common.Application.Tests.Services.Query;
+
+/// <summary>
+/// Covers the shared Skip/Take clamp. The interesting cases are the ones a 32-bit
+/// <c>(pageNumber - 1) * pageSize</c> gets wrong: a page number near <see cref="int.MaxValue"/>
+/// wraps NEGATIVE, and a negative OFFSET is rejected by SQL Server rather than ignored, so the
+/// caller sees a 500 where the honest answer is an empty page.
+/// </summary>
+public class PagingMathTests
+{
+    [Fact]
+    public void Clamp_FirstPage_SkipsNothing()
+    {
+        var (skip, take) = PagingMath.Clamp(pageNumber: 1, pageSize: 20, maxPageSize: 500);
+
+        skip.Should().Be(0);
+        take.Should().Be(20);
+    }
+
+    [Fact]
+    public void Clamp_MiddlePage_SkipsWholePages()
+    {
+        var (skip, take) = PagingMath.Clamp(pageNumber: 4, pageSize: 25, maxPageSize: 500);
+
+        skip.Should().Be(75);
+        take.Should().Be(25);
+    }
+
+    [Fact]
+    public void Clamp_PageSizeAboveCeiling_ClampsToCeiling()
+    {
+        var (_, take) = PagingMath.Clamp(pageNumber: 1, pageSize: 100_000, maxPageSize: 500);
+
+        take.Should().Be(500);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Clamp_NonPositivePageSize_FloorsAtOne(int pageSize)
+    {
+        var (skip, take) = PagingMath.Clamp(pageNumber: 3, pageSize: pageSize, maxPageSize: 500);
+
+        take.Should().Be(1, "a zero or negative Take is not a valid query");
+        skip.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(int.MinValue)]
+    public void Clamp_NonPositivePageNumber_TreatedAsFirstPage(int pageNumber)
+    {
+        var (skip, _) = PagingMath.Clamp(pageNumber, pageSize: 20, maxPageSize: 500);
+
+        skip.Should().Be(0, "a negative Skip is rejected outright by SQL Server, not treated as zero");
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue, 500)]
+    [InlineData(int.MaxValue, 20)]
+    [InlineData(int.MaxValue - 1, 500)]
+    [InlineData(5_000_000, 500)]
+    public void Clamp_PageBeyondReachableOffset_YieldsAnEmptyPageRatherThanOverflowing(int pageNumber, int pageSize)
+    {
+        var (skip, take) = PagingMath.Clamp(pageNumber, pageSize, maxPageSize: 500);
+
+        skip.Should().BeGreaterThanOrEqualTo(0, "32-bit multiplication wrapped this negative");
+        (skip, take).Should().Be((0, 0), "a page past the reachable offset range genuinely holds nothing");
+    }
+
+    [Fact]
+    public void Clamp_LargestNonOverflowingPage_StillPaginates()
+    {
+        // Straddles the boundary: this offset fits in an int, so it must page normally rather than
+        // being lumped in with the out-of-range case above.
+        var (skip, take) = PagingMath.Clamp(pageNumber: 4_000_000, pageSize: 500, maxPageSize: 500);
+
+        skip.Should().Be(1_999_999_500);
+        take.Should().Be(500);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/DistributedCacheServiceRedisTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/DistributedCacheServiceRedisTests.cs
@@ -1,0 +1,150 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Infrastructure.Caching;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+
+namespace MMCA.Common.Infrastructure.Redis.Tests;
+
+/// <summary>
+/// Exercises the shipped cache against a REAL Redis.
+/// <para>
+/// The unit tier mocks <c>IDistributedCache</c>, which means it asserts the calls the cache makes,
+/// never the storage format Redis actually ends up holding. That is a blind spot with teeth: Redis
+/// keys are typed, <c>INCR</c> creates a <b>string</b>, and the <c>IDistributedCache</c> Redis
+/// provider stores every entry as a <b>hash</b> of <c>absexp</c>/<c>sldexp</c>/<c>data</c>. Mixing
+/// the two at one key round-trips flawlessly against a mock and answers <c>WRONGTYPE</c> in
+/// production, on the ADR-029 rate-limit and lockout counters.
+/// </para>
+/// <para>
+/// These tests need a Docker daemon, so this project is outside <c>MMCA.Common.slnx</c> and runs in
+/// its own CI job.
+/// </para>
+/// </summary>
+public sealed class DistributedCacheServiceRedisTests : IAsyncLifetime
+{
+    private readonly RedisContainer _redis = new RedisBuilder().WithImage("redis:7-alpine").Build();
+
+    private ConnectionMultiplexer _multiplexer = null!;
+    private IDistributedCache _distributedCache = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _redis.StartAsync();
+
+        var connectionString = _redis.GetConnectionString();
+        _multiplexer = await ConnectionMultiplexer.ConnectAsync(connectionString);
+
+        // The same concrete cache Aspire's AddRedisDistributedCache registers in the service hosts.
+        _distributedCache = new RedisCache(Options.Create(new RedisCacheOptions
+        {
+            ConnectionMultiplexerFactory = () => Task.FromResult<IConnectionMultiplexer>(_multiplexer),
+        }));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_multiplexer is not null)
+            await _multiplexer.DisposeAsync();
+
+        await _redis.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Builds the cache exactly as <c>AddCaching</c> does when both a distributed cache and a
+    /// multiplexer are registered, which is the production shape in every extracted service host.
+    /// </summary>
+    private DistributedCacheService CreateSut() =>
+        new(
+            _distributedCache,
+            NullLogger<DistributedCacheService>.Instance,
+            _multiplexer);
+
+    // ── The counter round-trip: the exact shape that failed in production ──
+    [Fact]
+    public async Task IncrementThenRead_RoundTripsThroughRealRedis()
+    {
+        var sut = CreateSut();
+        var key = $"registration:ip:{Guid.NewGuid():N}";
+
+        var first = await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        first.Should().Be(1);
+
+        // The read that used to throw: the second registration from one IP hit this and 500'd,
+        // because the key existed in a representation the read side could not address.
+        var afterFirst = await sut.GetAsync<long?>(key, TestContext.Current.CancellationToken);
+        afterFirst.Should().Be(1, "a counter must be readable through the same cache that wrote it");
+
+        var second = await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        second.Should().Be(2);
+
+        (await sut.GetAsync<long?>(key, TestContext.Current.CancellationToken)).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task IncrementAsync_AppliesATtlSoCountersDoNotLeak()
+    {
+        var sut = CreateSut();
+        var key = $"login:attempts:{Guid.NewGuid():N}";
+
+        await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        var ttl = await _multiplexer.GetDatabase().KeyTimeToLiveAsync(key);
+        ttl.Should().NotBeNull("a rate-limit counter without a TTL never resets and locks the subject out forever");
+        ttl!.Value.Should().BeGreaterThan(TimeSpan.Zero).And.BeLessThanOrEqualTo(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public async Task IncrementAsync_FromMultipleWritersNeverLosesTheKeyEvenIfItLosesCounts()
+    {
+        // Documents the CURRENT contract honestly. The read-modify-write can undercount under
+        // genuine concurrency (which is why the lockout comment in LoginProtectionService says so),
+        // but the invariant that must hold is that the key stays readable and monotonic: an
+        // unreadable counter takes the endpoint down, an undercount only weakens the limit.
+        var sut = CreateSut();
+        var key = $"login:attempts:{Guid.NewGuid():N}";
+
+        await Task.WhenAll(Enumerable.Range(0, 20).Select(_ =>
+            sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken)));
+
+        var final = await sut.GetAsync<long?>(key, TestContext.Current.CancellationToken);
+
+        final.Should().NotBeNull("concurrent increments must never leave the counter unreadable");
+        final.Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(20);
+    }
+
+    // ── Prefix invalidation over a real SCAN ──
+    [Fact]
+    public async Task RemoveByPrefixAsync_EvictsMatchingKeysAndLeavesOthers()
+    {
+        var sut = CreateSut();
+        var prefix = $"catalog:{Guid.NewGuid():N}:";
+
+        await sut.SetAsync($"{prefix}a", "one", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        await sut.SetAsync($"{prefix}b", "two", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        var survivor = $"other:{Guid.NewGuid():N}";
+        await sut.SetAsync(survivor, "keep", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        await sut.RemoveByPrefixAsync(prefix, TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync<string>($"{prefix}a", TestContext.Current.CancellationToken)).Should().BeNull();
+        (await sut.GetAsync<string>($"{prefix}b", TestContext.Current.CancellationToken)).Should().BeNull();
+        (await sut.GetAsync<string>(survivor, TestContext.Current.CancellationToken)).Should().Be("keep");
+    }
+
+    [Fact]
+    public async Task SetGetRemove_RoundTripsThroughRealRedis()
+    {
+        var sut = CreateSut();
+        var key = $"smoke:{Guid.NewGuid():N}";
+
+        await sut.SetAsync(key, 42, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        (await sut.GetAsync<int?>(key, TestContext.Current.CancellationToken)).Should().Be(42);
+
+        await sut.RemoveAsync(key, TestContext.Current.CancellationToken);
+        (await sut.GetAsync<int?>(key, TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/GlobalUsings.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/MMCA.Common.Infrastructure.Redis.Tests.csproj
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/MMCA.Common.Infrastructure.Redis.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Exercises DistributedCacheService against a REAL Redis via Testcontainers. NOT shipped and
+         deliberately NOT in MMCA.Common.slnx: it needs a Docker daemon and runs in its own CI job,
+         kept out of the fast solution-wide unit feedback loop (same posture as UI.E2E.Tests).
+
+         This tier exists because the mocked-IDistributedCache unit tests structurally cannot catch
+         the class of bug it covers: the storage FORMAT Redis actually sees. A Mock<IDistributedCache>
+         answers whatever it is told to, so a counter written as a Redis string and read back as a
+         Redis hash round-trips perfectly in a unit test and returns WRONGTYPE in production. -->
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Testcontainers.Redis" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Source\Core\MMCA.Common.Infrastructure\MMCA.Common.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
@@ -1,0 +1,1170 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.5.0, )",
+        "resolved": "9.5.0",
+        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "Meziantou.Analyzer": {
+        "type": "Direct",
+        "requested": "[3.0.124, )",
+        "resolved": "3.0.124",
+        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "E+3pfEY68WQh1ZVFTGDNK0JCoayzL3aIDgVHHM85HIbQO7MiABG14A7+ajHH2P/y3a4W2Rla5p2nzut3+mzoyQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[18.7.23, )",
+        "resolved": "18.7.23",
+        "contentHash": "dyj6z8m+LFjpeH69hdnciCcRCmD0YgMlvuQEywiEshjqj/blgQ+PuWX8Vd5gkWQFoBN4e+TFxx6DvGNSv/gIKg=="
+      },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.15.0, )",
+        "resolved": "4.15.0",
+        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.29.0.143774, )",
+        "resolved": "10.29.0.143774",
+        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "Testcontainers.Redis": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "Hy+qKnIBrbEkoiSSIvWSF6i4ECfo+o3mufqro6thjTGDo+ddviPRD+40hSNRqUQAbY/QdW/br6gLLbRjNNZBcA==",
+        "dependencies": {
+          "Testcontainers": "4.8.0"
+        }
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Azure.Core.Amqp": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "AY1ZM4WwLBb9L2WwQoWs7wS2XKYg83tp3yVVdgySdebGN0FuIszuEqCy3Nhv6qHpbkjx/NGuOTsUbF/oNGBgwA==",
+        "dependencies": {
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "System.Memory.Data": "1.0.2"
+        }
+      },
+      "Azure.Messaging.ServiceBus": {
+        "type": "Transitive",
+        "resolved": "7.20.1",
+        "contentHash": "DxCkedWPQuiXrIyFcriOhsQcZmDZW+j9d55Ev4nnK3yjMUFjlVe4Hj37fuZTJlNhC3P+7EumqBTt33R6DfOxGA==",
+        "dependencies": {
+          "Azure.Core": "1.46.2",
+          "Azure.Core.Amqp": "1.3.1",
+          "Microsoft.Azure.Amqp": "2.7.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.4.0",
+        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.129.0",
+        "contentHash": "+mTwpvdnCs0366AfuofuBhUFGHuGraWX+4am+NX93sL1tmLTCX6idDS8stDA6JG/5SYdx+UFn7BNu8H5Fjhj9g==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.129.0",
+        "contentHash": "UxMlIB7XX9jZKWUGk/hosD1VGlnb9BTcMzBkhba9ZvN3PZn/bLlhLSDLLFa29Wh/WUfsngpSfz+zuyfChr7Dqw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.129.0"
+        }
+      },
+      "FluentValidation": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "MassTransit.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.5.5",
+        "contentHash": "0mn2Ay17dD6z5tgSLjbVRlldSbL9iowzFEfVgVfBXVG5ttz9dSWeR4TrdD6pqH93GWXp4CvSmF8i1HqxLX7DZw=="
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "2.5.302",
+        "contentHash": "PTHQHbMJzx1VtUUCpnvPavD7o5X9s2dAJ4uQHAP2kBCwJKICpPTZq0qxzbB4/6iJJiIxem8zlxyfldGAx1SjSQ=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Azure.Amqp": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "gm/AEakujttMzrDhZ5QpRz3fICVkYDn/oDG9SmxDP+J7R8JDBXYU9WWG7hr6wQy40mY+wjUF0yUGXDPRDRNJwQ=="
+      },
+      "Microsoft.Azure.Cosmos": {
+        "type": "Transitive",
+        "resolved": "3.51.0",
+        "contentHash": "g3dBhncM1rpEJ2ZVnZ/oHYIg0rrH6RlYa8mmuqk9WFR6dfyWoTF+nwT2SoQUy4df6lB7lW61M41xjdVioIqQ5w==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.HashCode": "1.1.0",
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "YgZYAWzyNuPVtPq6WNm0bqOWNjYaWgl5mBWTGZyNoXitYBUYSp6iUB9AwK0V1mo793qRJUXz2t6UZrWITZSvuQ=="
+      },
+      "Microsoft.Bcl.HashCode": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "J2G1k+u5unBV+aYcwxo94ip16Rkp65pgWFb0R6zwJipzWNMgvqlWeuI7/+R+e8bob66LnSG+llLJ+z8wI94cHg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "TPCs0ldm7AWqcKmp6f/Xr+14sat7hx4rHfRlS4RgCURBH2thEWbAKEyX7cCWr63zVJVOJIJZTg2cBiUXa8ys6g==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "YbVWMIouzwTKBiLms8boa7xeRT88wI14R1msv3XExFk9n0/sa8nU7MwDa1CKtfLGMJs7O7QWuS9/xhcQ72AD2A==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "cxsK9/Dx7Ka9sfiA1nY8XlSzIaWff5FNRw0+ls8yR+aGzmnah5JGKsTHgQrehjMwGAVud/pjiUZ9MWizfUSkTQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "H1IbHm/MnUgEV0N07WrkPBIIoX7isP6IPaqUdZ3CwbMcUVDGIu+okamW28kyDRfIiZqbTbyHuNIkr4ZSHPyvDw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.10",
+          "Microsoft.Extensions.Telemetry": "10.8.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "cLrqxkuEfcilZ8SjK+9KAnpLk9lOoMPaOokF+wRUYie+iUEcdX4/p/+gJkt0BYgWLthjpBUCkVTBI6Kxg0nsOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tx0R6PY9MNSh0mDKSxbpHLuuec93IxF1cel+1ithQnMNr/vbfLSSHOQHGHIppAJCGfPcEo/wO1Ylj+QpXtzo3A=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "IIWjDZguUJt6yNld9J4V88xuOUzpC76wBwfnRJLRmacmyTTl9jA8+KP5PuHPi7CKz/Vk/q+lQYmobiopuzapzA==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "3Izi75UCUssvo8LPx3OVnEeZay58qaFicrtSnbtUt7q8qQi0gy46gh4V8VUTkMVMKXV6VMyjBVmeNNgeCUJuIw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "BZNgSq/o8gsKExdYoBKPR65fdsxW0cTF8PsdqB8y011AGUJJW300S/ZIsEUD0+sOmGc003Gwv3FYbjrVjvsLNQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "h+fHHBGokepmCX+QZXJk4Ij8OApCb2n2ktoDkNX5CXteXsOxTHMNgjPGpAwdJMFvAL7TtGarUnk3o97NmBq2QQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "yT2Hdj8LpPbcT9C9KlLVxXl09C8zjFaVSaApdOwuecMuoV4s6Sof/mnTDz/+F/lILPIBvrWugR9CC7iRVZgbfQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "7.7.1",
+          "System.IdentityModel.Tokens.Jwt": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "fQ0VVCba75lknUHGldi3iTKAYUQqbzp1Un8+d9cm9nON0Gs8NAkXddNg8iaUB0qi/ybtAmNWizTR4avdkCJ9pQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.7.1"
+        }
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.6.3",
+        "contentHash": "N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA=="
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "MiniProfiler.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "meedJsjpYOeHPhE8H6t+dGQ9zLxcCQVpi4DXzmxmYAXywmTzlo6jv2IASUv5QijTU0CxsROln3FHd8RsTO8Z8A==",
+        "dependencies": {
+          "MiniProfiler.Shared": "4.5.4"
+        }
+      },
+      "MiniProfiler.Shared": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "f8ckFm/xTS8C2Bn4BdVc94dNvg+tRfk0e4XFaETOqRi6r0PUOyn3Z9jTQCVpB3R1pP5WiRsEIrqqxux95BVpTA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.16",
+        "contentHash": "nonu9l0YrZH6krVYbskBjE7uG0VMAnvOQ9PU+RmzUsy+++vHkqzzCkHRoP877OiA3iRTxJyNDLfpcU8hrJ3/YQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "RabbitMQ.Client": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "y3c6ulgULScWthHw5PLM1ShHRLhxg0vCtzX/hh61gRgNecL3ZC3WoBW2HYHoXOVRqTl99Br9E7CZEytGZEsCyQ==",
+        "dependencies": {
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SourceGear.sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.53.3",
+        "contentHash": "PaDT7JwQ00HmXZT1xSGSC0c24A5lVpJYHMrXBuJATdpB2t0nf4Kq9HyPaZhxVW0elPq4XI1s5BLh7qLuObmzFA=="
+      },
+      "SQLitePCLRaw.config.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.4",
+        "contentHash": "W2HMmjAZ1v27fbyzZtONCdC8Ma/tTr5wLAIr4Iq7T4oKrYaI4occJ5TBhSdK4pltwBJLQBG5DcQMz+/w9X4bbg==",
+        "dependencies": {
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.4"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "3.0.4",
+        "contentHash": "cOjxfdjE4zQDvDVDUBfucKGXEaYos4l4l+TVwePJEHp/nl9fkgBz/lIVgfMH5dOyKRmNi6RsptUGtZsvsD7iYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.4",
+        "contentHash": "L4uiEKeRSXxppkGE4iSpgBgC5lNvw2zEN/hAaxTecUS1+DhC6UEFhHaakSYYvnFq7x16B7DQcaXgXy0SkhSwnw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "3.0.4"
+        }
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2024.2.0",
+        "contentHash": "9r+4UF2P51lTztpd+H7SJywk7WgmlWB//Cm2o96c6uGVZU5r58ys2/cD9pCgTk0zCdSkfflWL1WtqQ9I4IVO9Q==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.4.0"
+        }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "dvjqKp+2LpGid6phzrdrS/2mmEPxFl3jE1+L7614q4ZChKbLJCpHXg6sBILlCCED1t//EE+un/UdAetzIMpqnw==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "9.0.4",
+          "System.Security.Cryptography.ProtectedData": "9.0.4"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "getRQEXD8idlpb1KW56XuxImMy0FKp2WJPDf3Qr0kI/QKxxJSftqfDFVo0DZ3HCJRLU73qHSruv5q2l5O47jQQ=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "cUFTcMlz/Qw9s90b2wnWSCvHdjv51Bau9FQqhsr4TlwSe1OX+7SoXUqphis5G74MLOvMOCghxPPlEqOdCrVVGA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "o94k2RKuAce3GeDMlUvIXlhVa1kWpJw95E6C9LwW0KlG0nj5+SgCiIxJ2Eroqb9sLtG1mEMbFttZIBZ13EJPvQ=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.8.0",
+        "contentHash": "P84aPfFCIxyc+yxwj8J1AjDyv+tnhDYosD3kouXdgxHTV2UPeRvck09l1WLqeVa170wyp6t319x9shzAx5wwvQ==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.129.0",
+          "Docker.DotNet.Enhanced.X509": "3.129.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2024.2.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "mmca.common.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "MMCA.Common.Domain": "[1.0.0, )",
+          "Microsoft.FeatureManagement": "[4.6.0, )",
+          "MiniProfiler.AspNetCore.Mvc": "[4.5.4, )",
+          "Scrutor": "[7.0.0, )",
+          "System.Linq.Dynamic.Core": "[1.7.3, )"
+        }
+      },
+      "mmca.common.domain": {
+        "type": "Project",
+        "dependencies": {
+          "MMCA.Common.Shared": "[1.0.0, )"
+        }
+      },
+      "mmca.common.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
+          "Azure.Storage.Blobs": "[12.29.1, )",
+          "MMCA.Common.Application": "[1.0.0, )",
+          "MassTransit": "[8.5.5, )",
+          "MassTransit.Azure.ServiceBus.Core": "[8.5.5, )",
+          "MassTransit.RabbitMQ": "[8.5.5, )",
+          "MessagePack": "[2.5.302, )",
+          "Microsoft.AspNetCore.SignalR.StackExchangeRedis": "[10.0.10, )",
+          "Microsoft.Azure.NotificationHubs": "[4.2.0, )",
+          "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
+          "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.4, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StackExchange.Redis": "[2.13.17, )"
+        }
+      },
+      "mmca.common.shared": {
+        "type": "Project"
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.29.1, )",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "MassTransit": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.5, )",
+        "resolved": "8.5.5",
+        "contentHash": "bSg8k5q+rP1s+dIGXLLbctqDGdIkfDjdxwNWtCUH7xNCN9ZuM7mqSPQPIFgaYIi34e81m4FqAqo4CAHuWPkhRA==",
+        "dependencies": {
+          "MassTransit.Abstractions": "8.5.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "9.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0"
+        }
+      },
+      "MassTransit.Azure.ServiceBus.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.5, )",
+        "resolved": "8.5.5",
+        "contentHash": "/9wmsURLh0CtRpDnI9WLE0NNYHqst7O1t5B7OyF0iUiy5zNy+mq1x9UrsWTz8j63yU4aD23HmMWHLdC+08kaow==",
+        "dependencies": {
+          "Azure.Identity": "1.16.0",
+          "Azure.Messaging.ServiceBus": "7.20.1",
+          "MassTransit": "8.5.5"
+        }
+      },
+      "MassTransit.RabbitMQ": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.5, )",
+        "resolved": "8.5.5",
+        "contentHash": "UxWn4o90YVMF9PBkJeoskOFPneh6YtnI1fLJHtvZiSAG0eoiRrWPGa+6FQCvjkQ/ljCKfjzok2eGZc/vmNZ01A==",
+        "dependencies": {
+          "MassTransit": "8.5.5",
+          "RabbitMQ.Client": "7.1.2"
+        }
+      },
+      "MessagePack": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.302, )",
+        "resolved": "2.5.302",
+        "contentHash": "5DZsKli4dMEpm/glcMAheuO8/IesfaTskbfsuvgnQwWFKS5FN7Z6yNx+5F+UW94E+9N2qt8Zs63/XVzpLsElgA==",
+        "dependencies": {
+          "MessagePack.Annotations": "2.5.302",
+          "Microsoft.NET.StringTools": "17.6.3"
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "mC/dQrt0Etdc9B1hdNy7KDO/E43FfhzHgMajw6Lupryp8XL7B7/3aEN3Zqfagz7LKTbDZadfMvT+XG8flLkKJA==",
+        "dependencies": {
+          "MessagePack": "2.5.302",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
+      "Microsoft.Azure.NotificationHubs": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "LOCxFB/sB1frfuXjecdDRDKEHkH+I1qKRatS5NyWIgYhpKhIcAlPNIJajcwLgQBShckdc3hMG9E+75CnL3qDhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "6.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.1, )",
+        "resolved": "6.1.1",
+        "contentHash": "syGQmIUPAYYHAHyTD8FCkTNThpQWvoA7crnIQRMfp8dyB5A2cWU3fQexlRTFkVmV7S0TjVmthi0LJEFVjHo8AQ==",
+        "dependencies": {
+          "Azure.Core": "1.47.1",
+          "Azure.Identity": "1.14.2",
+          "Microsoft.Bcl.Cryptography": "9.0.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "9.0.4",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.4",
+          "System.Security.Cryptography.Pkcs": "9.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Cosmos": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "Phk1cEJb+laEkrttqj+bO0h0O5/IGUB/CZ5gvox+GpJ01F1dW56Z/h0s0MWem/WBvyXAO0uADEaRQknQRyMY2w==",
+        "dependencies": {
+          "Microsoft.Azure.Cosmos": "3.51.0",
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "kzg9MuQNJvZQxAU+piSkEzc7/1tpW6n1nVSGGMObu2GgxLK8Nf+6fvZundaznTZ+O2KhfPZ8HFNCzMH3PWDUmA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "xwAOvQ1WCfWyA4sRkoYVHyTm8UJ7NDYpRo++2oWuXGQ9g60Z1yepaQBmoPDT2nX24q4ISWnktAW9zARFTiSVvg==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.1",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "DuEBLw2y7ZBfilnaJtlge8f2M49932v43t7j1InceXVjcZzxNrSEkobYXdgZkXuPFnFbKcbWpAS+fZgYEW1BhA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Resilience": "10.8.0"
+        }
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "CentralTransitive",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "kLjGgEhlzuKs6t7g8so1dqsmE5NaSURNPOWkKD056nF43G/6w/VK5Gd02WKgpuBRQ9mjl7odAe462bn3XKBXmg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Configuration": "8.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "8.0.2",
+          "Microsoft.Extensions.Logging": "8.0.1"
+        }
+      },
+      "MiniProfiler.AspNetCore.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.4, )",
+        "resolved": "4.5.4",
+        "contentHash": "+NqXyCy9aNdroPm6leW5+cpngtCnkCdoyOlJzvVN62uucSx+MYkx8jmKbgAt+aCP6aghADfHBExwrTIldHxapg==",
+        "dependencies": {
+          "MiniProfiler.AspNetCore": "4.5.4"
+        }
+      },
+      "MiniProfiler.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.4, )",
+        "resolved": "4.5.4",
+        "contentHash": "SSOuBYtNbM8AMmsYMP6Edr7iBfVYzswVt/yoIDboBRLLUgkA4SyROCJuTTtZ8eJSzlNuq5DIR+BLCCcigaV/vw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.11",
+          "MiniProfiler.Shared": "4.5.4"
+        }
+      },
+      "Scrutor": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "wHWaroody48jnlLoq/REwUltIFLxplXyHTP+sttrc8P7+jkiVqf38afDidJNv4qgD/6zz2NKOYg06xLZ1bG7wQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "gg8vENKV/o0pWLI0eJxnTA4X9e63rOvzkCDMAOePDGLieNSHPCGUiJ4CQDqDyNqIf6IPVzD4TOjqY5ACygZkkA==",
+        "dependencies": {
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.4",
+          "SourceGear.sqlite3": "3.53.3"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.13.17, )",
+        "resolved": "2.13.17",
+        "contentHash": "P7o7ZDBAmBrOLQEw8Pt44iIA08ioj48smRxn4Jp6yzCu6P3DOSU6lj7f+IOtN3pPvSgC9YufvM92ycukEEBCYQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.16",
+          "System.IO.Hashing": "10.0.2"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "CentralTransitive",
+        "requested": "[8.19.2, )",
+        "resolved": "7.7.1",
+        "contentHash": "rQkO1YbAjLwnDJSMpRhRtrc6XwIcEOcUvoEcge+evurpzSZM3UNK+MZfD3sKyTlYsvknZ6eJjSBfnmXqwOsT9Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "System.Linq.Dynamic.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.7.3, )",
+        "resolved": "1.7.3",
+        "contentHash": "0m52+B4Jce/9AXLXPZnnFW7NeLotHBuYvbsVF3D/DTvvbCGJZdskPn5xjr5sjnnFI3XekNdPqG2djyJE3UU7SA=="
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "CentralTransitive",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      }
+    }
+  }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryTransactionTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryTransactionTests.cs
@@ -117,6 +117,69 @@ public sealed class DbContextFactoryTransactionTests : IDisposable
         (await _dbContext.Set<TestAggregate>().AsNoTracking().CountAsync()).Should().Be(1);
     }
 
+    // ── Re-entrancy: a nested call joins the ambient transaction ──
+    [Fact]
+    public async Task ExecuteInTransactionAsync_Nested_DoesNotThrowAndCommitsOnce()
+    {
+        // The shape an ITransactional command whose handler ALSO opens a transaction produces.
+        // Before this was re-entrant, the inner BeginTransaction threw InvalidOperationException
+        // from EF ("already in a transaction"), which is why Store's CheckOutCommand and
+        // VerifyPaymentCommand carry comments explaining they are deliberately not ITransactional.
+        var result = await _sut.ExecuteInTransactionAsync<Result>(
+            async outerCt =>
+            {
+                var context = _sut.GetDbContext(DataSource.SQLServer);
+                context.Set<TestAggregate>().Add(CreateAggregateWithEvent());
+
+                return await _sut.ExecuteInTransactionAsync<Result>(
+                    async innerCt =>
+                    {
+                        await _sut.SaveChangesAsync(innerCt);
+                        return Result.Success();
+                    },
+                    outerCt);
+            });
+
+        result.IsSuccess.Should().BeTrue();
+        (await _dbContext.Set<TestAggregate>().AsNoTracking().CountAsync()).Should().Be(1);
+        _dispatcherMock.Verify(
+            d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the deferred flush belongs to the outermost call alone, so it must not run per nesting level");
+    }
+
+    [Fact]
+    public async Task ExecuteInTransactionAsync_NestedInnerSucceedsButOuterFails_RollsBackEverything()
+    {
+        // The reason an inner call must not commit: it would make the nest's earlier work durable
+        // ahead of the outer scope's own decision, turning nesting into a silent partial commit.
+        var result = await _sut.ExecuteInTransactionAsync<Result>(
+            async outerCt =>
+            {
+                var context = _sut.GetDbContext(DataSource.SQLServer);
+                context.Set<TestAggregate>().Add(CreateAggregateWithEvent());
+
+                var inner = await _sut.ExecuteInTransactionAsync<Result>(
+                    async innerCt =>
+                    {
+                        await _sut.SaveChangesAsync(innerCt);
+                        return Result.Success();
+                    },
+                    outerCt);
+
+                inner.IsSuccess.Should().BeTrue();
+                return Result.Failure(Error.Validation("Invariant.Failed", "outer scope rejected it"));
+            });
+
+        result.IsFailure.Should().BeTrue();
+        (await _dbContext.Set<TestAggregate>().AsNoTracking().CountAsync()).Should().Be(
+            0,
+            "the inner call must not have committed the outer scope's work");
+        _dispatcherMock.Verify(
+            d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // ── Failure/rollback drops the deferred dispatch: nothing is ever delivered in-process ──
     [Fact]
     public async Task ExecuteInTransactionAsync_OperationReturnsFailure_NeverDispatchesDeferredEvents()


### PR DESCRIPTION
Six defects found by a read of the framework's request and background paths, plus the test tier that would have caught a seventh.

Sequenced after #119, which fixed the counter-storage mismatch from the same review. Nothing here overlaps it.

## 1. Unbounded static cache reachable from the query string

`QueryFilterService.PropertyCache` is `static`, never evicted, and keyed by names that arrive in `?filters[X].operator=...`. It memoized **misses** as well as hits, so any caller could grow it without bound one bogus filter name at a time. The request itself came back as a clean 400, so the growth showed nothing in error metrics. Every `GET .../paged` endpoint in both apps reaches it.

Only resolved lookups are cached now. A miss costs a reflection lookup instead, and `QueryFilterModelBinder` gained a per-request filter cap (50, far past the widest real grid) to bound that cost. Surplus entries are dropped rather than rejected: they were never valid filters, and a 400 would be a breaking change for any client sending junk alongside real ones.

## 2. Paging overflow in the two notification handlers

Both re-derived `(PageNumber - 1) * PageSize` in 32-bit, which wraps **negative** near `int.MaxValue`. A negative `Skip` is not a benign no-op: SQL Server rejects a negative `OFFSET` outright, so the request became a 500 instead of the empty page that page genuinely holds.

`EntityQueryPipeline.ApplyPaging` had already solved this in 64-bit and said so in its remarks, but the arithmetic lived only there. It moves to a shared `PagingMath.Clamp`, used by all three call sites. It also floors the page size, which the `[Range]` attributes at the API boundary enforce but a direct handler caller does not inherit.

## 3. `BeginTransaction` had no re-entrancy guard

`Commit` and `Rollback` both filtered on `HasActiveTransaction`; `BeginTransaction` did not, and EF throws `InvalidOperationException` on a second begin for the same connection. An `ITransactional` command whose handler also opened a transaction hit that. It is avoided today only by convention: `CheckOutCommand` and `VerifyPaymentCommand` in Store carry comments explaining they are deliberately not `ITransactional` for exactly this reason.

`ExecuteInTransactionAsync` is now re-entrant: an inner call joins the ambient transaction and returns directly, and begin/commit/rollback plus the deferred-event flush belong to the outermost call alone.

Worth being explicit about the alternative: simply adding a `HasActiveTransaction` filter to `BeginTransaction` would have compiled and looked like a fix, but then the inner `CommitTransaction` would commit the **outer** scope's work early. That trades a loud exception for a silent partial commit, which is strictly worse. Two tests pin this: one asserts the nest commits once, the other asserts an inner success followed by an outer failure rolls back everything.

## 4. Outbox retry cadence was an accident of the lease

`DispatchMessagesAsync` incremented `RetryCount` on failure but never cleared the row's claim, and `FetchCandidatesAsync` skips leased rows. So a failed message was retried only after the full `LeaseSeconds` (300s by default), regardless of `PollingIntervalSeconds` or an explicit signal.

Failures now re-lease for an explicit exponential backoff (`RetryBackoffBaseSeconds`, default 10s, capped at the lease). The claim is deliberately not cleared outright: capping at the lease keeps a permanently failing row from becoming unclaimable for longer than a dead replica's rows would.

## 5. Nested filter paths ignored their leaf type

Every dotted path went to the string strategy regardless of what it pointed at, so a nested non-string leaf (say `IS EMPTY` on `Category.Id`) passed validation and then failed inside Dynamic LINQ at query-build time: a 500 for what is really a bad request. The leaf type is now resolved by walking the path, identically in `ApplyFilters` and `ValidateFilters`.

**Compatibility checked before merging:** an unwalkable path keeps the old string behaviour, so nothing that works today starts failing. Both live nested map entries in the two apps (`ProductEntityQueryService`: `CategoryName` to `Category.Name`, `CategoryEntityQueryService`: `ParentCategoryName` to `ParentCategory.Name`) point at a string leaf, so this is a behavioural no-op for every filter in production.

## 6. `async void` handlers with narrow catches

`DeepLinkListener`, `PushRegistrationListener` and `OfflineBanner` caught only `ObjectDisposedException` and `InvalidOperationException`. Anything else escaped onto the thread pool with no caller to observe it: process termination on MAUI, an unobserved exception outside the circuit's error handling on Server. `PushRegistration.RegisterAsync` reaches the network and a platform token provider, so it is the likeliest to throw something else. All three now log exhaustively.

## Plus: a Redis test tier

`Tests/Core/MMCA.Common.Infrastructure.Redis.Tests` runs the shipped cache against a real Redis via Testcontainers, wired as its own CI job and kept outside the `.slnx` because it needs Docker (same posture as `UI.E2E.Tests`).

This exists because the unit tier **structurally cannot** catch the class of bug #119 fixed. `Mock<IDistributedCache>` answers whatever it is told, so a counter written as a Redis string and read back as a Redis hash round-trips flawlessly in a unit test and returns `WRONGTYPE` against a server. The new tier asserts the counter round-trip, that the TTL is actually applied, that concurrent increments never leave the counter unreadable, and that `RemoveByPrefixAsync` really evicts over a live SCAN.

I could not run it here (no Docker daemon in this environment), so its first real execution will be this PR's CI job. That is the one thing in this PR not yet verified by an actual run.

## Also: two now-false comments

#119 removed the Redis `INCR` path, but `LoginProtectionService` still carried comments asserting the increment is atomic. It is not any more. They now name the residual weakness plainly (concurrent guesses can undercount, so a burst can stay below `MaxFailedAttempts`; sequential guessing still trips the lockout) and record what closing it would take. See the note below.

## Testing

`dotnet build MMCA.Common.slnx -c Release` clean, `dotnet test --solution MMCA.Common.slnx` green at **2454** tests (2435 before, 19 added). Release build of the Redis project clean.

One test-quality note: the property-cache test first shipped as a flake. It asserted a delta on the total cache count, which races the other filter tests mutating the same static field in parallel. It now counts only entries belonging to its own private entity type, and was re-run four times to confirm.

## Follow-up worth a decision, not included here

#119 bought counter readability at the cost of atomicity, and the ADR-029 brute-force counter is the thing that got weaker. Restoring both means either running the read-modify-write in one Lua script against the hash layout, or moving counters off `IDistributedCache` so both sides speak Redis strings. That is a deliberate design call rather than a bug fix, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169X4JC6ub844UcfyVeCvSM
