### PR TITLE
perf(ci): cache NuGet packages, MAUI workloads, and Playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Redirect Playwright's browser install out of ~/.cache/ms-playwright and into the workspace so
+  # actions/cache can carry it between runs (see the ui-e2e "Cache Playwright browsers" step). Both
+  # the install and the test run read this, so it must be workflow-level, not step-level.
+  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.ms-playwright
 
 # Supersede an older still-running check set when a PR is pushed again; a stale run's result is
 # never actionable. Guarded on event_name so a future non-PR trigger cannot cancel itself.
@@ -76,6 +80,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       # Fast, dependency-free drift gate: FACTS.md must match what `build/facts` computes from source
       # (version from the git tag, package count, ADR range, fitness-method/base counts). Fails the
@@ -156,9 +167,47 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
+
+      # This job is the critical path of the whole CI run (measured 7.1-8.2 min, and the only
+      # windows runner), and `dotnet workload install maui` re-downloaded the android/ios/
+      # maccatalyst packs on every single run. Cache the SDK's workload directories, keyed on the
+      # resolved SDK version so an SDK feature-band bump busts it.
+      - name: Resolve SDK version and root (workload cache key)
+        if: needs.changes.outputs.code == 'true'
+        id: sdk
+        shell: bash
+        run: |
+          echo "version=$(dotnet --version)" >> "$GITHUB_OUTPUT"
+          # Resolve the root from dotnet itself rather than trusting $DOTNET_ROOT to be exported:
+          # an empty value here would silently turn the cache paths into garbage and always miss.
+          root=$(dirname "$(command -v dotnet)")
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          echo "sdk=$(dotnet --version)  root=$root"
+
+      - name: Cache MAUI workload packs
+        if: needs.changes.outputs.code == 'true'
+        id: maui-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.sdk.outputs.root }}/sdk-manifests
+            ${{ steps.sdk.outputs.root }}/packs
+            ${{ steps.sdk.outputs.root }}/metadata
+            ${{ steps.sdk.outputs.root }}/library-packs
+            ${{ steps.sdk.outputs.root }}/template-packs
+          key: maui-workload-${{ runner.os }}-${{ steps.sdk.outputs.version }}
 
       - name: Install MAUI workload
         if: needs.changes.outputs.code == 'true'
+        # Still run on a cache hit: it is a no-op that reconciles the manifest, and it is the only
+        # thing that makes a partially-restored cache self-heal rather than fail the build below.
         run: dotnet workload install maui
 
       - name: Build (android + ios + maccatalyst + windows)
@@ -191,6 +240,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Build UI E2E project
         if: needs.changes.outputs.code == 'true'
@@ -198,11 +254,28 @@ jobs:
         # (restore included). They reference MMCA.Common source projects — no GitHub Packages token needed.
         run: dotnet build Tests/Presentation/MMCA.Common.UI.E2E.Tests/MMCA.Common.UI.E2E.Tests.csproj -c Release
 
+      # Browser binaries are ~100-300 MB per engine and were re-downloaded on all three legs of every
+      # run. PLAYWRIGHT_BROWSERS_PATH (workflow env) redirects the install into the workspace so
+      # actions/cache can carry it; the key includes the engine, since each leg installs only its own.
+      - name: Cache Playwright browsers (${{ matrix.browser }})
+        if: needs.changes.outputs.code == 'true'
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ms-playwright
+          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('Tests/Presentation/MMCA.Common.UI.E2E.Tests/packages.lock.json', 'Directory.Packages.props') }}
+
       - name: Install Playwright (${{ matrix.browser }})
         if: needs.changes.outputs.code == 'true'
         run: |
           script=$(find Tests/Presentation/MMCA.Common.UI.E2E.Tests/bin/Release -name playwright.ps1 | head -1)
-          pwsh "$script" install --with-deps ${{ matrix.browser }}
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            # Binaries restored from cache; only the OS-level shared libraries still need installing,
+            # which is the cheap half of --with-deps.
+            pwsh "$script" install-deps ${{ matrix.browser }}
+          else
+            pwsh "$script" install --with-deps ${{ matrix.browser }}
+          fi
 
       - name: Install coverage tool
         if: needs.changes.outputs.code == 'true' && matrix.browser == 'chromium'
@@ -258,6 +331,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Run hot-path benchmarks (Short job, JSON export)
         if: needs.changes.outputs.code == 'true'
@@ -372,6 +452,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Build Helpdesk against Common source (UseLocalMMCA)
         if: needs.changes.outputs.code == 'true'
@@ -412,6 +499,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Pack all packages to a local folder feed
         if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Restore
         run: dotnet restore MMCA.Common.slnx
@@ -76,6 +83,13 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
+          # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
+          # because build/facts and build/perfgate have no lock file and this repo does not pass
+          # --locked-mode, so the props file is what actually pins their versions.
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            Directory.Packages.props
 
       - name: Install MAUI workload
         run: dotnet workload install maui


### PR DESCRIPTION
## Context

Phase 2 of the CI work. Measured 2026-07-21..24: this repo **cached nothing** - a grep for `cache` across `.github/` returned zero hits across 9 `setup-dotnet` uses. Every job re-downloaded the full NuGet graph, the windows job re-downloaded the MAUI workload packs, and all three `ui-e2e` legs re-downloaded their browsers.

## NuGet package cache

`cache: true` on the six `ci.yml` jobs that restore (`build-and-test`, `build-maui`, `ui-e2e`, `performance-smoke`, `consumer-source-build`, `package-consumption`) and both `release.yml` jobs.

The key is the 28 committed lock files **plus `Directory.Packages.props`** - `build/facts` and `build/perfgate` have no lock file and this repo does not pass `--locked-mode`, so the props file is what actually pins their versions. Skipped on `coverage`, which only installs a global tool and never restores.

## MAUI workload cache (the biggest lever here)

`Build MMCA.Common.UI.Maui (windows, 4 TFMs)` is the critical path of the entire run - measured **7.1-8.2 min** while every other job finishes in under 4, and it is the only windows runner. `dotnet workload install maui` re-downloaded the android/ios/maccatalyst packs on every single run.

Now cached on the resolved SDK version, so an SDK feature-band bump busts it. The SDK root is resolved from `dotnet` itself rather than trusting `$DOTNET_ROOT` to be exported - an empty value there would silently turn the cache paths into garbage and miss forever.

The install step still runs on a cache hit: it is a no-op that reconciles the manifest, and it is what lets a partially-restored cache self-heal instead of failing the build below.

## Playwright browser cache

Same shape as the ADC/Store PRs: `PLAYWRIGHT_BROWSERS_PATH` into the workspace, keyed per engine, `install-deps` on a hit instead of the full `install --with-deps`.

## One plan item deliberately dropped

The plan listed "replace implicit restores with explicit `restore` + `--no-restore`". Looked at concretely it buys nothing - the restore runs either way, and it is the NuGet cache above that actually attacks that cost. `dotnet pack` in `package-consumption` cannot take `--no-build` at all, since no build precedes it in that job. Not worth the churn.

## Verification

- Both workflows re-parsed; cached jobs and cache steps enumerated programmatically.
- **All 8 required contexts confirmed still produced.**
- **The first run after merge is a cache miss and should match the current baseline.** The second must show hits in the `setup-dotnet`, `Cache MAUI workload packs`, and `Cache Playwright browsers` step logs. If a restore step gets *slower*, the key is wrong.

No gate, coverage floor, or required check is altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)