### PR TITLE
release: v1.126.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,81 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.126.0] - 2026-07-25
+
+Hardening release from a read of the framework's request and background paths. No breaking changes:
+every item is a behavioural fix or a bound on something previously unbounded. The two settings
+additions have defaults that preserve existing behaviour except where that behaviour was the bug.
+
+### Fixed
+- **The dynamic-filter property cache grew without bound from the query string.**
+  `QueryFilterService` memoized failed lookups as well as successful ones in a `static`,
+  never-evicted dictionary keyed by names taken straight from `?filters[X].operator=...`. Any caller
+  could grow it for the life of the process, one nonexistent filter name at a time, while each
+  request came back as a well-formed 400 that showed nothing in error metrics. Only resolved lookups
+  are cached now; a miss costs a reflection lookup instead. `QueryFilterModelBinder` gained a
+  per-request cap of 50 distinct filters to bound that cost (surplus entries are dropped, not
+  rejected, since they were never valid filters).
+
+- **Paginating the notification inbox and history overflowed to a negative `OFFSET`.**
+  Both handlers derived `(PageNumber - 1) * PageSize` in 32-bit, which wraps negative for page
+  numbers near `int.MaxValue`. SQL Server rejects a negative `OFFSET` outright rather than treating
+  it as zero, so the request became a 500 instead of the empty page that page genuinely holds.
+  `EntityQueryPipeline` had already solved this in 64-bit; the arithmetic now lives once in
+  `PagingMath.Clamp` and all three call sites use it. It also floors the page size, which the
+  `[Range]` attributes at the API boundary enforce but a direct handler caller does not inherit.
+
+- **A nested transaction threw instead of joining the ambient one.**
+  `DbContextFactory.BeginTransaction` began a transaction on every cached context unconditionally,
+  while `CommitTransaction` and `RollbackTransaction` both skipped contexts without one. An
+  `ITransactional` command whose handler also called `ExecuteInTransactionAsync` therefore hit
+  `InvalidOperationException` from EF. `ExecuteInTransactionAsync` is now re-entrant: an inner call
+  joins the ambient transaction and returns directly, and begin, commit, rollback and the
+  deferred-event flush belong to the outermost call alone. Note that simply skipping the second
+  begin would have been worse than the exception: the inner commit would then make the outer scope's
+  earlier work durable ahead of its own decision, turning nesting into a silent partial commit.
+
+- **A failed outbox message was retried on the lease, not on a schedule.**
+  `OutboxProcessor` incremented `RetryCount` on failure but left the row's claim in place, and the
+  poll skips leased rows, so a failure was retried only after the full `Outbox:LeaseSeconds` (300s by
+  default) regardless of `PollingIntervalSeconds` or an explicit signal. The retry cadence was an
+  accident of the lease rather than a decision. Failures now re-lease for an explicit exponential
+  backoff, `Outbox:RetryBackoffBaseSeconds` (default 10) doubling per attempt, capped at the lease.
+
+- **Nested filter paths ignored the type they pointed at.**
+  Every dotted path (`Category.Name`) was routed to the string strategy regardless of its leaf type,
+  so a nested non-string leaf passed validation for a string-only operator such as `IS EMPTY` and
+  then failed inside Dynamic LINQ at query-build time: a 500 for what is really a bad request. The
+  leaf type is now resolved by walking the path, identically in `ApplyFilters` and `ValidateFilters`.
+  A path that cannot be walked keeps the previous string behaviour, so nothing that works today
+  starts failing.
+
+- **The `async void` capability listeners could take the host down.**
+  `DeepLinkListener`, `PushRegistrationListener` and `OfflineBanner` caught only
+  `ObjectDisposedException` and `InvalidOperationException`. Anything else escaped onto the thread
+  pool with no caller to observe it: process termination under MAUI, an unobserved exception outside
+  the circuit's error handling under Blazor Server. `PushRegistrationService.RegisterAsync` reaches
+  the network and a platform token provider, so it was the likeliest to throw something else. All
+  three now log exhaustively.
+
+### Added
+- `Outbox:RetryBackoffBaseSeconds` (default 10, capped at `LeaseSeconds`): the base of the
+  exponential backoff applied to a failed outbox message before it is retried.
+- A Docker-gated Redis integration tier (`Tests/Core/MMCA.Common.Infrastructure.Redis.Tests`, outside
+  the `.slnx`, its own CI job) exercising `DistributedCacheService` against a real Redis. This is the
+  tier that would have caught the 1.125.0 counter regression fixed in 1.125.2: the unit tests mock
+  `IDistributedCache`, so they assert the calls made and never the storage format Redis ends up
+  holding, and a counter written as a string and read back as a hash round-trips perfectly against a
+  mock. It covers the counter round-trip, TTL application, concurrent increments, and prefix
+  eviction over a live `SCAN`.
+
+### Changed
+- The `LoginProtectionService` comments no longer claim the attempt counters are incremented
+  atomically. They have not been since 1.125.2 traded atomicity for readability, and they now name
+  the residual weakness plainly: concurrent guesses can undercount, so a burst can stay under
+  `MaxFailedAttempts`, while sequential guessing still trips the lockout. Closing that gap needs
+  either a Lua script against the hash layout or moving counters off `IDistributedCache`.
+
 ## [1.125.2] - 2026-07-24
 
 Patch fixing a regression introduced by `ICacheService.IncrementAsync` in 1.125.0.


### PR DESCRIPTION
Release notes for v1.126.0, a hardening release from a read of the framework's request and background paths. All six source fixes already landed in #121; this PR only adds the CHANGELOG entry.

No breaking changes. Every item is a behavioural fix or a bound on something previously unbounded, and both settings additions default to preserving existing behaviour except where that behaviour was the bug.

What ships:

- Filter property cache no longer memoizes misses (it was an unbounded static dictionary any caller could grow from the query string), plus a per-request filter cap.
- Notification inbox/history paging uses the shared 64-bit clamp, so a page number near int.MaxValue no longer wraps to a negative OFFSET and 500s.
- ExecuteInTransactionAsync is re-entrant, so a nested transaction joins the ambient one instead of throwing.
- Failed outbox messages retry on an explicit backoff (new Outbox:RetryBackoffBaseSeconds) rather than on the 300s lease.
- Nested filter paths resolve their leaf type instead of assuming string.
- The three async void capability listeners log exhaustively instead of letting an exception escape onto the thread pool.
- Adds a Docker-gated Redis integration tier: the one that would have caught the 1.125.0 counter regression fixed in 1.125.2.

Also records that the LoginProtectionService atomicity comments were corrected: they claimed an atomicity 1.125.2 removed, and now name the residual weakness instead.

Follow-up left open deliberately (design call, not a bug fix): restoring atomic increments without losing readability, via a Lua script against the hash layout or moving counters off IDistributedCache.