### PR TITLE
fix(ci): do not enable the NuGet cache on a docs-only PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props
@@ -170,7 +173,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props
@@ -243,7 +249,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props
@@ -334,7 +343,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props
@@ -455,7 +467,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props
@@ -502,7 +517,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props
@@ -609,7 +627,10 @@ jobs:
           # Cache ~/.nuget/packages. Keyed on the committed lock files PLUS Directory.Packages.props,
           # because build/facts and build/perfgate have no lock file and this repo does not pass
           # --locked-mode, so the props file is what actually pins their versions.
-          cache: true
+          # Gated on the code flag: on a docs-only PR every restore step is skipped, so
+          # ~/.nuget/packages is never created and setup-dotnet's cache-SAVE step fails the whole
+          # job with "Cache folder path ... doesn't exist on disk".
+          cache: ${{ needs.changes.outputs.code == 'true' }}
           cache-dependency-path: |
             **/packages.lock.json
             Directory.Packages.props


### PR DESCRIPTION
Blocks the v1.126.0 release, so this goes first.

## Symptom

Five jobs on the release PR (#124) failed in under 15 seconds each, with no real work attempted: Consumer source build (Helpdesk), Package-mode consumer, Performance gate, UI a11y webkit, and Redis integration. Every one failed in the same place:

\\\
Post Run actions/setup-dotnet@v6
##[error]Cache folder path is retrieved for .NET CLI but doesn't exist on disk: /home/runner/.nuget/packages/
\\\

## Cause

Two changes that are each fine alone. #122 added the docs-only guard, so on a PR whose every changed file is markdown the heavy steps are skipped. #123 added \cache: true\ to setup-dotnet. On a docs-only PR the guard skips every restore, \~/.nuget/packages\ is therefore never created, and setup-dotnet's cache-SAVE post step fails the job for a folder that was never going to exist.

## Why it matters now

This is latent for ordinary PRs and fires on exactly the two PRs a release depends on: the CHANGELOG-only release PR and the post-tag FACTS regeneration PR. Both are markdown-only by construction, so the release flow cannot get a green PR until this is fixed.

## Fix

Gate \cache\ on the same \
eeds.changes.outputs.code\ flag the restore steps already use, in all seven jobs that set it. Code PRs keep the caching; docs-only PRs become a genuine no-op instead of a guaranteed red.

All seven jobs already declare \
eeds: changes\, so the expression resolves everywhere it is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169X4JC6ub844UcfyVeCvSM