### PR TITLE
chore: regenerate FACTS for v1.126.0

### DIFF
--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-07-24 (framework v1.125.2) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-07-25 (framework v1.126.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -11,7 +11,7 @@ _As of: 2026-07-24 (framework v1.125.2) — **generated from source by `build/fa
 > facts (test totals, scorecard indices) live in that repo's published scorecard, **not** here.
 
 ## Framework version
-- **Current: `v1.125.2`** (MinVer-derived from the git tag at `main` HEAD).
+- **Current: `v1.126.0`** (MinVer-derived from the git tag at `main` HEAD).
 - All consumers (**MMCA.ADC**, **MMCA.Store**, MMCA.Helpdesk) track this version in **lockstep** — every
   `MMCA.Common.*` entry in each consumer's `Directory.Packages.props` is bumped together (ADR-016; no phased
   rollout).


### PR DESCRIPTION
Post-tag FACTS pin for v1.126.0. Only the version and date line change.

The drift gate derives the version from the latest reachable tag, so this cannot be done before the tag exists. Verified locally: \uild/facts -- . --check\ exits 0 on this commit.

This is the second markdown-only PR in the release flow, so it is also the second one that would have failed on the setup-dotnet cache bug fixed in #125.