### PR TITLE
§12: parameterize dynamic-LINQ filters and sorts

### DIFF
--- a/Source/Core/MMCA.Common.Application/Services/Filtering/BoolFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/BoolFilterStrategy.cs
@@ -24,9 +24,9 @@ internal sealed class BoolFilterStrategy : IFilterStrategy
         => op switch
         {
             // Presence checks are value-independent, so they precede the bool parse.
-            "IS EMPTY" => query.Where($"{property} == null"),
-            "IS NOT EMPTY" => query.Where($"{property} != null"),
-            "IS" when bool.TryParse(value, out var boolValue) => query.Where($"{property} == @0", boolValue),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
+            "IS" when bool.TryParse(value, out var boolValue) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", boolValue),
             _ => query
         };
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/DateTimeFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/DateTimeFilterStrategy.cs
@@ -29,19 +29,19 @@ internal sealed class DateTimeFilterStrategy : IFilterStrategy
         => op switch
         {
             "IS" when DateTime.TryParse(value, FormatProvider, DateTimeStyles.None, out var dt)
-                => query.Where($"{property} == @0", dt),
+                => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", dt),
             "IS NOT" when DateTime.TryParse(value, FormatProvider, DateTimeStyles.None, out var dt)
-                => query.Where($"{property} != @0", dt),
+                => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", dt),
             "IS AFTER" when DateTime.TryParse(value, FormatProvider, DateTimeStyles.None, out var dt)
-                => query.Where($"{property} > @0", dt),
+                => query.Where(DynamicQueryConfig.Parameterized, $"{property} > @0", dt),
             "IS ON OR AFTER" when DateTime.TryParse(value, FormatProvider, DateTimeStyles.None, out var dt)
-                => query.Where($"{property} >= @0", dt),
+                => query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0", dt),
             "IS BEFORE" when DateTime.TryParse(value, FormatProvider, DateTimeStyles.None, out var dt)
-                => query.Where($"{property} < @0", dt),
+                => query.Where(DynamicQueryConfig.Parameterized, $"{property} < @0", dt),
             "IS ON OR BEFORE" when DateTime.TryParse(value, FormatProvider, DateTimeStyles.None, out var dt)
-                => query.Where($"{property} <= @0", dt),
-            "IS EMPTY" => query.Where($"{property} == null"),
-            "IS NOT EMPTY" => query.Where($"{property} != null"),
+                => query.Where(DynamicQueryConfig.Parameterized, $"{property} <= @0", dt),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
             // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
             _ => ApplyInOrRange(query, property, op, value)
         };
@@ -57,7 +57,7 @@ internal sealed class DateTimeFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseList(value, ParseDateTime);
-        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+        return values.Count == 0 ? query : query.Where(DynamicQueryConfig.Parameterized, $"@0.Contains({property})", values);
     }
 
     private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
@@ -65,7 +65,7 @@ internal sealed class DateTimeFilterStrategy : IFilterStrategy
         // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
         var bounds = FilterValueParser.ParseList(value, ParseDateTime);
         return bounds.Count == 2
-            ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
+            ? query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
             : query;
     }
 

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/DecimalFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/DecimalFilterStrategy.cs
@@ -27,14 +27,14 @@ internal sealed class DecimalFilterStrategy : IFilterStrategy
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "EQUALS" when TryParse(value, out var v) => query.Where($"{property} == @0", v),
-            "NOT EQUALS" when TryParse(value, out var v) => query.Where($"{property} != @0", v),
-            "GREATER THAN" when TryParse(value, out var v) => query.Where($"{property} > @0", v),
-            "LESS THAN" when TryParse(value, out var v) => query.Where($"{property} < @0", v),
-            "GREATER THAN OR EQUAL" when TryParse(value, out var v) => query.Where($"{property} >= @0", v),
-            "LESS THAN OR EQUAL" when TryParse(value, out var v) => query.Where($"{property} <= @0", v),
-            "IS EMPTY" => query.Where($"{property} == null"),
-            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            "EQUALS" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", v),
+            "NOT EQUALS" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", v),
+            "GREATER THAN" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} > @0", v),
+            "LESS THAN" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} < @0", v),
+            "GREATER THAN OR EQUAL" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0", v),
+            "LESS THAN OR EQUAL" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} <= @0", v),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
             // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
             _ => ApplyInOrRange(query, property, op, value)
         };
@@ -53,7 +53,7 @@ internal sealed class DecimalFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseList(value, ParseDecimal);
-        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+        return values.Count == 0 ? query : query.Where(DynamicQueryConfig.Parameterized, $"@0.Contains({property})", values);
     }
 
     private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
@@ -61,7 +61,7 @@ internal sealed class DecimalFilterStrategy : IFilterStrategy
         // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
         var bounds = FilterValueParser.ParseList(value, ParseDecimal);
         return bounds.Count == 2
-            ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
+            ? query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
             : query;
     }
 

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/DynamicQueryConfig.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/DynamicQueryConfig.cs
@@ -1,0 +1,25 @@
+using System.Linq.Dynamic.Core;
+
+namespace MMCA.Common.Application.Services.Filtering;
+
+/// <summary>
+/// Shared <see cref="ParsingConfig"/> for every System.Linq.Dynamic.Core call in the query pipeline
+/// (the filter strategies and <c>QueryFieldService.ApplySorting</c>).
+/// <para>
+/// Dynamic LINQ defaults <see cref="ParsingConfig.UseParameterizedNamesInDynamicQuery"/> to
+/// <see langword="false"/>, which turns each <c>@0</c> argument into a <c>ConstantExpression</c>.
+/// EF inlines constants, so <c>filters["Name"] = ("EQUALS", "Widget")</c> emitted
+/// <c>WHERE [Name] = 'Widget'</c>: a distinct SQL string per distinct filter value, which costs a
+/// SQL Server plan-cache entry per value and misses EF's compiled-query cache on every request.
+/// With the flag on, the value is reached through a member access instead, so EF parameterizes it
+/// and one plan serves every value. <c>QueryParameterizationTests</c> is the guard.
+/// </para>
+/// </summary>
+internal static class DynamicQueryConfig
+{
+    /// <summary>The single instance every dynamic-LINQ call site passes; building one per call would reintroduce the parse cost this avoids.</summary>
+    internal static readonly ParsingConfig Parameterized = new()
+    {
+        UseParameterizedNamesInDynamicQuery = true,
+    };
+}

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/GuidFilterStrategy.cs
@@ -24,10 +24,10 @@ internal sealed class GuidFilterStrategy : IFilterStrategy
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "EQUALS" when Guid.TryParse(value, out var g) => query.Where($"{property} == @0", g),
-            "NOT EQUALS" when Guid.TryParse(value, out var g) => query.Where($"{property} != @0", g),
-            "IS EMPTY" => query.Where($"{property} == null"),
-            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            "EQUALS" when Guid.TryParse(value, out var g) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", g),
+            "NOT EQUALS" when Guid.TryParse(value, out var g) => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", g),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
             // IN parses a comma-separated set rather than a single scalar.
             "IN" => ApplyIn(query, property, value),
             _ => query
@@ -36,7 +36,7 @@ internal sealed class GuidFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseList(value, ParseGuid);
-        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+        return values.Count == 0 ? query : query.Where(DynamicQueryConfig.Parameterized, $"@0.Contains({property})", values);
     }
 
     private static Guid? ParseGuid(string s) => Guid.TryParse(s, out var g) ? g : null;

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
@@ -25,14 +25,14 @@ internal sealed class IntFilterStrategy : IFilterStrategy
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "EQUALS" when int.TryParse(value, out var v) => query.Where($"{property} == @0", v),
-            "NOT EQUALS" when int.TryParse(value, out var v) => query.Where($"{property} != @0", v),
-            "GREATER THAN" when int.TryParse(value, out var v) => query.Where($"{property} > @0", v),
-            "LESS THAN" when int.TryParse(value, out var v) => query.Where($"{property} < @0", v),
-            "GREATER THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where($"{property} >= @0", v),
-            "LESS THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where($"{property} <= @0", v),
-            "IS EMPTY" => query.Where($"{property} == null"),
-            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            "EQUALS" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", v),
+            "NOT EQUALS" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", v),
+            "GREATER THAN" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} > @0", v),
+            "LESS THAN" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} < @0", v),
+            "GREATER THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0", v),
+            "LESS THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} <= @0", v),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
             // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
             _ => ApplyInOrRange(query, property, op, value)
         };
@@ -48,7 +48,7 @@ internal sealed class IntFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseList(value, ParseInt);
-        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+        return values.Count == 0 ? query : query.Where(DynamicQueryConfig.Parameterized, $"@0.Contains({property})", values);
     }
 
     private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
@@ -56,7 +56,7 @@ internal sealed class IntFilterStrategy : IFilterStrategy
         // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
         var bounds = FilterValueParser.ParseList(value, ParseInt);
         return bounds.Count == 2
-            ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
+            ? query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
             : query;
     }
 

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/LongFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/LongFilterStrategy.cs
@@ -27,14 +27,14 @@ internal sealed class LongFilterStrategy : IFilterStrategy
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "EQUALS" when TryParse(value, out var v) => query.Where($"{property} == @0", v),
-            "NOT EQUALS" when TryParse(value, out var v) => query.Where($"{property} != @0", v),
-            "GREATER THAN" when TryParse(value, out var v) => query.Where($"{property} > @0", v),
-            "LESS THAN" when TryParse(value, out var v) => query.Where($"{property} < @0", v),
-            "GREATER THAN OR EQUAL" when TryParse(value, out var v) => query.Where($"{property} >= @0", v),
-            "LESS THAN OR EQUAL" when TryParse(value, out var v) => query.Where($"{property} <= @0", v),
-            "IS EMPTY" => query.Where($"{property} == null"),
-            "IS NOT EMPTY" => query.Where($"{property} != null"),
+            "EQUALS" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", v),
+            "NOT EQUALS" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", v),
+            "GREATER THAN" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} > @0", v),
+            "LESS THAN" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} < @0", v),
+            "GREATER THAN OR EQUAL" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0", v),
+            "LESS THAN OR EQUAL" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} <= @0", v),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
             // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
             _ => ApplyInOrRange(query, property, op, value)
         };
@@ -53,7 +53,7 @@ internal sealed class LongFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseList(value, ParseLong);
-        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+        return values.Count == 0 ? query : query.Where(DynamicQueryConfig.Parameterized, $"@0.Contains({property})", values);
     }
 
     private static IQueryable<T> ApplyBetween<T>(IQueryable<T> query, string property, string value)
@@ -61,7 +61,7 @@ internal sealed class LongFilterStrategy : IFilterStrategy
         // BETWEEN takes exactly two comma-separated bounds ("min,max"), inclusive on both ends.
         var bounds = FilterValueParser.ParseList(value, ParseLong);
         return bounds.Count == 2
-            ? query.Where($"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
+            ? query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0 && {property} <= @1", bounds[0], bounds[1])
             : query;
     }
 

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/StringFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/StringFilterStrategy.cs
@@ -20,12 +20,12 @@ internal sealed class StringFilterStrategy : IFilterStrategy
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "CONTAINS" => query.Where($"{property}.Contains(@0)", value),
-            "NOT CONTAINS" => query.Where($"!{property}.Contains(@0)", value),
-            "EQUALS" => query.Where($"{property} == @0", value),
-            "NOT EQUALS" => query.Where($"{property} != @0", value),
-            "STARTS WITH" => query.Where($"{property}.StartsWith(@0)", value),
-            "ENDS WITH" => query.Where($"{property}.EndsWith(@0)", value),
+            "CONTAINS" => query.Where(DynamicQueryConfig.Parameterized, $"{property}.Contains(@0)", value),
+            "NOT CONTAINS" => query.Where(DynamicQueryConfig.Parameterized, $"!{property}.Contains(@0)", value),
+            "EQUALS" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", value),
+            "NOT EQUALS" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", value),
+            "STARTS WITH" => query.Where(DynamicQueryConfig.Parameterized, $"{property}.StartsWith(@0)", value),
+            "ENDS WITH" => query.Where(DynamicQueryConfig.Parameterized, $"{property}.EndsWith(@0)", value),
             _ => ApplyPresenceOrSet(query, property, op, value),
         };
 
@@ -34,8 +34,8 @@ internal sealed class StringFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyPresenceOrSet<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "IS EMPTY" => query.Where($"string.IsNullOrEmpty({property})"),
-            "IS NOT EMPTY" => query.Where($"!string.IsNullOrEmpty({property})"),
+            "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"string.IsNullOrEmpty({property})"),
+            "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"!string.IsNullOrEmpty({property})"),
             "IN" => ApplyIn(query, property, value),
             _ => query
         };
@@ -43,6 +43,6 @@ internal sealed class StringFilterStrategy : IFilterStrategy
     private static IQueryable<T> ApplyIn<T>(IQueryable<T> query, string property, string value)
     {
         var values = FilterValueParser.ParseStringList(value);
-        return values.Count == 0 ? query : query.Where($"@0.Contains({property})", values);
+        return values.Count == 0 ? query : query.Where(DynamicQueryConfig.Parameterized, $"@0.Contains({property})", values);
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/QueryFieldService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/QueryFieldService.cs
@@ -135,7 +135,7 @@ public sealed class QueryFieldService
             if (sortExpr is not null)
             {
                 var descending = string.Equals(sortDirection, "desc", StringComparison.OrdinalIgnoreCase);
-                return query.OrderBy($"{sortExpr} {(descending ? "descending" : "ascending")}");
+                return query.OrderBy(Filtering.DynamicQueryConfig.Parameterized, $"{sortExpr} {(descending ? "descending" : "ascending")}");
             }
         }
 

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/QueryParameterizationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/QueryParameterizationTests.cs
@@ -1,0 +1,153 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Services;
+using MMCA.Common.Application.Services.Filtering;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// SQL-shape coverage for the dynamic-LINQ query pipeline (rubric section 12). The filter and sort
+/// strategies build their predicates as System.Linq.Dynamic.Core string expressions, and whether the
+/// supplied values reach the database as parameters or as inlined literals decides whether SQL Server
+/// can reuse a plan and whether EF's compiled-query cache hits. Nothing else in the suite inspects the
+/// emitted SQL, so this is the guard that keeps the answer from drifting silently.
+/// </summary>
+public sealed class QueryParameterizationTests : IDisposable
+{
+    private readonly QueryShapeTestDbContext _dbContext = QueryShapeTestDbContext.Create();
+
+    public void Dispose() => _dbContext.Dispose();
+
+    private static readonly Dictionary<string, string> EmptyMap = [];
+
+    private string FilteredSql(string property, string op, string value) =>
+        QueryBody(QueryFilterService
+            .ApplyFilters(_dbContext.Products.AsNoTracking(), new Dictionary<string, (string, string)> { [property] = (op, value) }, EmptyMap)
+            .ToQueryString());
+
+    /// <summary>
+    /// Strips the parameter-declaration preamble that <c>ToQueryString</c> prepends (SQLite emits
+    /// <c>.param set @Value 'Widget'</c> so the statement can be replayed in a shell). The declarations
+    /// necessarily contain the raw values; the question these tests ask is whether the STATEMENT does.
+    /// </summary>
+    private static string QueryBody(string sql) =>
+        string.Join(
+            '\n',
+            sql.Split('\n').Where(l => !l.TrimStart().StartsWith(".param", StringComparison.Ordinal)))
+        .Trim();
+
+    [Fact]
+    public void StringEquals_SendsTheValueAsAParameter()
+    {
+        var sql = FilteredSql("Name", "EQUALS", "Widget");
+
+        sql.Should().NotContain("'Widget'", "an inlined literal defeats plan reuse and misses the EF compiled-query cache");
+        sql.Should().Contain("@", "the filter value must reach the database as a parameter");
+    }
+
+    [Fact]
+    public void StringContains_SendsTheValueAsAParameter()
+    {
+        var sql = FilteredSql("Name", "CONTAINS", "Widget");
+
+        sql.Should().NotContain("'Widget'");
+        sql.Should().Contain("@");
+    }
+
+    [Fact]
+    public void IntComparison_SendsTheValueAsAParameter()
+    {
+        var sql = FilteredSql("Price", "GREATER THAN", "25");
+
+        sql.Should().MatchRegex(@"\B@\w+", "the bound must reach the database as a parameter, not as the literal 25");
+    }
+
+    [Fact]
+    public void TwoValuesOfTheSameFilter_ProduceIdenticalSql()
+    {
+        // The plan-reuse invariant stated directly: only the parameter VALUES may differ between two
+        // requests that filter the same property with the same operator.
+        var first = FilteredSql("Name", "EQUALS", "Widget");
+        var second = FilteredSql("Name", "EQUALS", "Gadget");
+
+        second.Should().Be(first, "distinct filter values must not produce distinct SQL text");
+    }
+
+    [Fact]
+    public void Sorting_DoesNotInlineTheSortColumnAsAValue()
+    {
+        var sql = QueryBody(QueryFieldService
+            .ApplySorting(_dbContext.Products.AsNoTracking(), "Name", "desc", EmptyMap)
+            .ToQueryString());
+
+        sql.Should().Contain("ORDER BY", "the sort must be pushed to the database");
+        sql.Should().Contain("DESC");
+    }
+
+    // ── Test doubles ──
+    public sealed class Product : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int Price { get; set; }
+    }
+
+    public sealed class QueryShapeTestDbContext : ApplicationDbContext
+    {
+        public DbSet<Product> Products => Set<Product>();
+
+        internal override bool SupportsOutbox => false;
+
+        private QueryShapeTestDbContext(DbContextOptions<QueryShapeTestDbContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        public static QueryShapeTestDbContext Create()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(new DomainEventSaveChangesInterceptor(
+                Mock.Of<IDomainEventDispatcher>(),
+                NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+                Mock.Of<IOutboxSignal>()));
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            IServiceProvider sp = services.BuildServiceProvider();
+
+            var options = new DbContextOptionsBuilder<QueryShapeTestDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            var context = new QueryShapeTestDbContext(options, sp);
+            context.Database.OpenConnection();
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Product>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+                e.Property(x => x.Price);
+                e.Property(x => x.RowVersion).IsConcurrencyToken();
+            });
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Performance/MMCA.Common.Benchmarks/MMCA.Common.Benchmarks.csproj
+++ b/Tests/Performance/MMCA.Common.Benchmarks/MMCA.Common.Benchmarks.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Source\Core\MMCA.Common.Application\MMCA.Common.Application.csproj" />
     <ProjectReference Include="..\..\..\Source\Core\MMCA.Common.Domain\MMCA.Common.Domain.csproj" />
     <ProjectReference Include="..\..\..\Source\Core\MMCA.Common.Shared\MMCA.Common.Shared.csproj" />
   </ItemGroup>

--- a/Tests/Performance/MMCA.Common.Benchmarks/QueryPipelineBenchmarks.cs
+++ b/Tests/Performance/MMCA.Common.Benchmarks/QueryPipelineBenchmarks.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using System.Linq.Expressions;
+using BenchmarkDotNet.Attributes;
+using MMCA.Common.Application.Services;
+using MMCA.Common.Application.Services.Filtering;
+
+namespace MMCA.Common.Benchmarks;
+
+/// <summary>
+/// Allocation and latency coverage for the per-request query pipeline (rubric section 12). Filtering
+/// and shaping run on every list read in every consumer, and both are dominated by work that is easy
+/// to regress silently: the dynamic-LINQ predicate is re-parsed on each call, and the shaper reflects
+/// over the DTO's properties. The specification suite next door covers the domain side; this covers
+/// the read side.
+/// </summary>
+[MemoryDiagnoser]
+public class QueryPipelineBenchmarks
+{
+    public sealed class ProductRow
+    {
+        public int Id { get; init; }
+
+        public string Name { get; init; } = string.Empty;
+
+        public string Sku { get; init; } = string.Empty;
+
+        public int Price { get; init; }
+
+        public bool IsActive { get; init; }
+
+        public DateTime CreatedOn { get; init; }
+    }
+
+    private static readonly Dictionary<string, string> NoMap = [];
+
+    private readonly IQueryable<ProductRow> _rows = Enumerable.Range(0, 100)
+        .Select(i => new ProductRow
+        {
+            Id = i,
+            Name = $"Product {i.ToString(CultureInfo.InvariantCulture)}",
+            Sku = $"SKU-{i.ToString("D4", CultureInfo.InvariantCulture)}",
+            Price = i * 3,
+            IsActive = i % 2 == 0,
+            CreatedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(i),
+        })
+        .AsQueryable();
+
+    private readonly List<ProductRow> _materialized;
+
+    public QueryPipelineBenchmarks() => _materialized = [.. _rows];
+
+    /// <summary>Single text filter: the shape behind every grid search box.</summary>
+    [Benchmark]
+    public Expression ApplyFilters_SingleStringContains() =>
+        QueryFilterService.ApplyFilters(
+            _rows,
+            new Dictionary<string, (string, string)> { ["Name"] = ("CONTAINS", "Product 4") },
+            NoMap).Expression;
+
+    /// <summary>Three filters across three strategies: a realistic filtered grid request.</summary>
+    [Benchmark]
+    public Expression ApplyFilters_ThreeMixedOperators() =>
+        QueryFilterService.ApplyFilters(
+            _rows,
+            new Dictionary<string, (string, string)>
+            {
+                ["Name"] = ("CONTAINS", "Product"),
+                ["Price"] = ("GREATER THAN", "50"),
+                ["IsActive"] = ("IS", "true"),
+            },
+            NoMap).Expression;
+
+    /// <summary>Dynamic sort application, run once per paged read.</summary>
+    [Benchmark]
+    public Expression ApplySorting_Descending() =>
+        QueryFieldService.ApplySorting(_rows, "Name", "desc", NoMap).Expression;
+
+    /// <summary>Full-field shaping of one page: no field list, so every property is projected.</summary>
+    [Benchmark]
+    public int ShapeCollectionData_AllFields_100Rows() =>
+        QueryFieldService.ShapeCollectionData(_materialized, fields: null).Count;
+
+    /// <summary>Sparse-field shaping of one page: the `fields=` projection callers are told to prefer.</summary>
+    [Benchmark]
+    public int ShapeCollectionData_ThreeFields_100Rows() =>
+        QueryFieldService.ShapeCollectionData(_materialized, "id,name,price").Count;
+}

--- a/Tests/Performance/perf-baseline.json
+++ b/Tests/Performance/perf-baseline.json
@@ -1,9 +1,14 @@
 {
-  "_comment": "Latency/allocation regression baseline for the BenchmarkDotNet hot-path suite (rubric section 12). Verified in CI by build/perfgate after the Short-job run. Allocation ceilings are per-operation managed bytes (deterministic across machines; measured 0 / 5588 / 3040 on 2026-07-16). Ratio floors are machine-independent effectiveness invariants: the compiled-expression cache must keep IsSatisfiedBy at least 1000x faster than the recompile-each-call anti-pattern (measured ~120,000x); if the cache breaks, the ratio collapses toward 1 and the gate fails. Update this file deliberately, in the same PR as the change that moves the numbers.",
+  "_comment": "Latency/allocation regression baseline for the BenchmarkDotNet hot-path suite (rubric section 12). Verified in CI by build/perfgate after the Short-job run. Allocation ceilings are per-operation managed bytes (deterministic across machines) and carry roughly 25% headroom over the measured value. Specification ceilings measured 0 / 5588 / 3040 on 2026-07-16. Query-pipeline ceilings measured 31703 / 69755 / 18688 / 51896 / 35891 on 2026-07-25, after dynamic-LINQ parameterization; ApplyFilters allocates tens of KB per call because System.Linq.Dynamic.Core re-parses the predicate string on every request, which is exactly the cost this gate exists to keep from growing. Ratio floors are machine-independent effectiveness invariants: the compiled-expression cache must keep IsSatisfiedBy at least 1000x faster than the recompile-each-call anti-pattern (measured ~120,000x); if the cache breaks, the ratio collapses toward 1 and the gate fails. Update this file deliberately, in the same PR as the change that moves the numbers.",
   "allocationCeilingsBytes": {
     "IsSatisfiedBy_CachedCompile": 0,
     "IsSatisfiedBy_RecompileEachCall": 8000,
-    "BuildComposedCriteria": 4500
+    "BuildComposedCriteria": 4500,
+    "ApplyFilters_SingleStringContains": 40000,
+    "ApplyFilters_ThreeMixedOperators": 87000,
+    "ApplySorting_Descending": 23500,
+    "ShapeCollectionData_AllFields_100Rows": 65000,
+    "ShapeCollectionData_ThreeFields_100Rows": 45000
   },
   "ratioFloors": [
     {


### PR DESCRIPTION
## Problem

Every filter strategy and the dynamic sort call `System.Linq.Dynamic.Core` with the default `ParsingConfig`, which leaves `UseParameterizedNamesInDynamicQuery` off. Each `@0` argument becomes a `ConstantExpression`, and EF inlines constants.

Measured before this change, via a new `ToQueryString` test:

```
WHERE "p"."Name" = 'Widget'
WHERE instr("p"."Name", 'Widget') > 0
WHERE "p"."Price" > 25
```

A distinct SQL string per distinct filter value means:
- a SQL Server plan-cache entry per value, and no plan reuse across them
- a miss in EF's compiled-query cache on every request, so the query recompiles

This is on the hottest read path in every consumer: every grid search box, every filtered list endpoint.

## Change

`DynamicQueryConfig.Parameterized`, one shared static config, threaded through all 58 dynamic-LINQ call sites across the seven filter strategies and `QueryFieldService.ApplySorting`. The same reads now emit `= @Value`, and two requests filtering the same property with different values produce byte-identical SQL.

## Guards

Nothing in the suite inspected emitted SQL before, which is why this went unnoticed. Both guards are new:

- **`QueryParameterizationTests`** asserts the statement carries parameters rather than literals, including the plan-reuse invariant stated directly (two values, one SQL text). It strips the `.param` preamble `ToQueryString` prepends, since those declarations necessarily hold the raw values.
- **`QueryPipelineBenchmarks`** adds five `[MemoryDiagnoser]` benchmarks over `ApplyFilters`, `ApplySorting` and `ShapeCollectionData`, with ceilings committed to `perf-baseline.json`. Measured 31686 / 69751 / 18684 / 51901 / 35888 B/op. The tens of KB per `ApplyFilters` call is the predicate re-parse that Dynamic.Core does on every request; this gate pins it so it cannot grow unnoticed.

## Verification

- 2459 tests pass
- Release build warning-free under `TreatWarningsAsErrors`
- `build/perfgate` green over all 8 benchmarks
- FACTS.md up to date

Part of the second four-repo performance program. Not a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169X4JC6ub844UcfyVeCvSM