### PR TITLE
§12: cap the outbox signal, index the retention sweeps, cut per-request allocations

### DIFF
--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/LoggingCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/LoggingCommandDecorator.cs
@@ -26,39 +26,35 @@ public sealed partial class LoggingCommandDecorator<TCommand, TResult>(
         {
             LogCommandStarted(logger, commandName, correlationId);
 
-            var stopwatch = Stopwatch.StartNew();
-            var outcome = "completed";
+            // Timestamp rather than a Stopwatch instance: same resolution, one fewer allocation per
+            // command. Elapsed is captured before logging, so the recorded duration stays the
+            // handler's (matching the previous stopwatch.Stop()-then-log ordering).
+            var startTimestamp = Stopwatch.GetTimestamp();
             try
             {
                 var result = await inner.HandleAsync(command, cancellationToken).ConfigureAwait(false);
-                stopwatch.Stop();
+                var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
 
                 if (result is Shared.Abstractions.Result { IsFailure: true } failureResult)
                 {
-                    outcome = "failed";
                     var errorSummary = string.Join("; ", failureResult.Errors.Select(e => $"{e.Code}: {e.Message}"));
-                    LogCommandFailed(logger, commandName, stopwatch.ElapsedMilliseconds, correlationId, errorSummary);
+                    LogCommandFailed(logger, commandName, (long)elapsed.TotalMilliseconds, correlationId, errorSummary);
+                    RecordDuration(commandName, elapsed, "failed");
                 }
                 else
                 {
-                    LogCommandCompleted(logger, commandName, stopwatch.ElapsedMilliseconds, correlationId);
+                    LogCommandCompleted(logger, commandName, (long)elapsed.TotalMilliseconds, correlationId);
+                    RecordDuration(commandName, elapsed, "completed");
                 }
 
                 return result;
             }
             catch (Exception ex)
             {
-                stopwatch.Stop();
-                outcome = "exception";
-                LogCommandException(logger, commandName, stopwatch.ElapsedMilliseconds, correlationId, ex);
+                var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+                LogCommandException(logger, commandName, (long)elapsed.TotalMilliseconds, correlationId, ex);
+                RecordDuration(commandName, elapsed, "exception");
                 throw;
-            }
-            finally
-            {
-                CqrsMetrics.CommandDuration.Record(
-                    stopwatch.Elapsed.TotalMilliseconds,
-                    new KeyValuePair<string, object?>("command", commandName),
-                    new KeyValuePair<string, object?>("outcome", outcome));
             }
         }
     }
@@ -69,6 +65,12 @@ public sealed partial class LoggingCommandDecorator<TCommand, TResult>(
     /// </summary>
     private static readonly Func<ILogger, string, string, IDisposable?> BeginCommandScope =
         LoggerMessage.DefineScope<string, string>("Command {CommandName} [CorrelationId: {CorrelationId}]");
+
+    private static void RecordDuration(string commandName, TimeSpan elapsed, string outcome) =>
+        CqrsMetrics.CommandDuration.Record(
+            elapsed.TotalMilliseconds,
+            new KeyValuePair<string, object?>("command", commandName),
+            new KeyValuePair<string, object?>("outcome", outcome));
 
     // Started is Debug: the completion line already carries the name and duration, and two
     // Information rows per command doubles ingestion cost for no diagnostic gain.

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/LoggingQueryDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/LoggingQueryDecorator.cs
@@ -21,48 +21,54 @@ public sealed partial class LoggingQueryDecorator<TQuery, TResult>(
         var queryName = typeof(TQuery).Name;
         var correlationId = correlationContext.CorrelationId;
 
-        using (logger.BeginScope(new Dictionary<string, object>
+        using (BeginQueryScope(logger, queryName, correlationId))
         {
-            ["CorrelationId"] = correlationId,
-            ["QueryName"] = queryName,
-        }))
-        {
-            var stopwatch = Stopwatch.StartNew();
-            var outcome = "completed";
+            // Timestamp rather than a Stopwatch instance: same resolution, one fewer allocation per
+            // query. Elapsed is captured before logging, so the recorded duration stays the handler's
+            // (matching the previous stopwatch.Stop()-then-log ordering).
+            var startTimestamp = Stopwatch.GetTimestamp();
             try
             {
                 var result = await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
-                stopwatch.Stop();
+                var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
 
                 if (result is Shared.Abstractions.Result { IsFailure: true } failureResult)
                 {
-                    outcome = "failed";
                     var errorSummary = string.Join("; ", failureResult.Errors.Select(e => $"{e.Code}: {e.Message}"));
-                    LogQueryFailed(logger, queryName, stopwatch.ElapsedMilliseconds, correlationId, errorSummary);
+                    LogQueryFailed(logger, queryName, (long)elapsed.TotalMilliseconds, correlationId, errorSummary);
+                    RecordDuration(queryName, elapsed, "failed");
                 }
                 else
                 {
-                    LogQueryCompleted(logger, queryName, stopwatch.ElapsedMilliseconds, correlationId);
+                    LogQueryCompleted(logger, queryName, (long)elapsed.TotalMilliseconds, correlationId);
+                    RecordDuration(queryName, elapsed, "completed");
                 }
 
                 return result;
             }
             catch (Exception ex)
             {
-                stopwatch.Stop();
-                outcome = "exception";
-                LogQueryException(logger, queryName, stopwatch.ElapsedMilliseconds, correlationId, ex);
+                var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+                LogQueryException(logger, queryName, (long)elapsed.TotalMilliseconds, correlationId, ex);
+                RecordDuration(queryName, elapsed, "exception");
                 throw;
-            }
-            finally
-            {
-                CqrsMetrics.QueryDuration.Record(
-                    stopwatch.Elapsed.TotalMilliseconds,
-                    new KeyValuePair<string, object?>("query", queryName),
-                    new KeyValuePair<string, object?>("outcome", outcome));
             }
         }
     }
+
+    /// <summary>
+    /// Source-generated scope, matching <c>LoggingCommandDecorator</c>: the previous
+    /// <c>BeginScope(new Dictionary&lt;string, object&gt;)</c> allocated a dictionary and boxed the
+    /// scope state on every query, at every log level, including when logging was disabled entirely.
+    /// </summary>
+    private static readonly Func<ILogger, string, string, IDisposable?> BeginQueryScope =
+        LoggerMessage.DefineScope<string, string>("Query {QueryName} [CorrelationId: {CorrelationId}]");
+
+    private static void RecordDuration(string queryName, TimeSpan elapsed, string outcome) =>
+        CqrsMetrics.QueryDuration.Record(
+            elapsed.TotalMilliseconds,
+            new KeyValuePair<string, object?>("query", queryName),
+            new KeyValuePair<string, object?>("outcome", outcome));
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Query {QueryName} completed in {ElapsedMs}ms [CorrelationId: {CorrelationId}]")]
     private static partial void LogQueryCompleted(ILogger logger, string queryName, long elapsedMs, string correlationId);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/EntityDataSourceRegistry.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/EntityDataSourceRegistry.cs
@@ -24,7 +24,8 @@ public sealed class EntityDataSourceRegistry(
 {
     private sealed record Snapshot(
         FrozenDictionary<string, (DataSourceKey Key, Type ConfigurationType)> Entities,
-        FrozenSet<Assembly> ScannedAssemblies);
+        FrozenSet<Assembly> ScannedAssemblies,
+        IReadOnlyCollection<DataSourceKey> PhysicalSources);
 
     private readonly Lock _rebuildLock = new();
     private volatile Snapshot? _snapshot;
@@ -71,8 +72,14 @@ public sealed class EntityDataSourceRegistry(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Precomputed on the snapshot rather than projected per call: the outbox processor and the
+    /// outbox cleanup service both call this on every poll cycle, and re-running
+    /// <c>Select().Distinct()</c> over every registered entity allocated a fresh list each time,
+    /// forever, on a loop that usually finds nothing to do.
+    /// </remarks>
     public IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse() =>
-        [.. GetOrBuildSnapshot().Entities.Values.Select(r => r.Key).Distinct()];
+        GetOrBuildSnapshot().PhysicalSources;
 
     private Snapshot GetOrBuildSnapshot()
     {
@@ -149,7 +156,8 @@ public sealed class EntityDataSourceRegistry(
 
         return new Snapshot(
             entities.ToFrozenDictionary(StringComparer.Ordinal),
-            assemblies.ToFrozenSet());
+            assemblies.ToFrozenSet(),
+            [.. entities.Values.Select(r => r.Key).Distinct()]);
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -245,9 +245,20 @@ public abstract class ApplicationDbContext(
             entity.Property(e => e.LastError).HasMaxLength(4000);
             entity.Property(e => e.TraceId).HasMaxLength(64).IsUnicode(false);
             entity.Property(e => e.SpanId).HasMaxLength(64).IsUnicode(false);
+            // Poll path (OutboxProcessor): pending rows, oldest first. The processor also filters on
+            // RetryCount and LockedUntil, so both ride along as included columns; without them every
+            // candidate row the index returns costs a key lookup back into the table.
             entity.HasIndex(e => new { e.ProcessedOn, e.OccurredOn })
+                  .IncludeProperties(e => new { e.RetryCount, e.LockedUntil })
                   .HasFilter("[ProcessedOn] IS NULL")
                   .HasDatabaseName("IX_OutboxMessages_Pending");
+
+            // Retention path (OutboxCleanupService): processed rows older than the cutoff. The pending
+            // index above deliberately excludes exactly these rows, so without this one the six-hourly
+            // sweep scans the largest partition of the table.
+            entity.HasIndex(e => e.ProcessedOn)
+                  .HasFilter("[ProcessedOn] IS NOT NULL")
+                  .HasDatabaseName("IX_OutboxMessages_Processed");
         });
 
     /// <summary>
@@ -264,6 +275,11 @@ public abstract class ApplicationDbContext(
             entity.HasIndex(e => e.MessageId)
                   .IsUnique()
                   .HasDatabaseName("IX_InboxMessages_MessageId");
+
+            // Retention path (OutboxCleanupService.PurgeInbox): the unique index above is on MessageId,
+            // so the age-based purge had nothing to seek and scanned the table.
+            entity.HasIndex(e => e.ProcessedOn)
+                  .HasDatabaseName("IX_InboxMessages_ProcessedOn");
         });
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxSignal.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxSignal.cs
@@ -2,13 +2,19 @@ namespace MMCA.Common.Infrastructure.Persistence.Outbox;
 
 /// <summary>
 /// <see cref="SemaphoreSlim"/>-based implementation of <see cref="IOutboxSignal"/>.
-/// Multiple rapid <see cref="Signal"/> calls are safe — the semaphore count increments,
-/// but the <see cref="OutboxProcessor"/> processes all pending messages in a single batch,
-/// so extra signals are harmless.
+/// <para>
+/// The semaphore is capped at one permit on purpose. <see cref="OutboxProcessor"/> drains every
+/// pending message in a single batch, so one pending wake-up is all the information a burst of
+/// saves carries. An uncapped semaphore (the default <c>new SemaphoreSlim(0)</c> maxCount of
+/// <see cref="int.MaxValue"/>) accumulated one permit per <see cref="Signal"/> call, so N saves in
+/// a burst made <see cref="WaitAsync"/> return immediately N times and each of those cycles issued
+/// a candidate-fetch query per relational data source that returned nothing. Surplus signals were
+/// harmless for correctness but not for cost. With the cap, the surplus is absorbed here.
+/// </para>
 /// </summary>
 public sealed class OutboxSignal : IOutboxSignal, IDisposable
 {
-    private readonly SemaphoreSlim _semaphore = new(0);
+    private readonly SemaphoreSlim _semaphore = new(0, 1);
 
     /// <inheritdoc />
     public void Signal()
@@ -19,7 +25,7 @@ public sealed class OutboxSignal : IOutboxSignal, IDisposable
         }
         catch (SemaphoreFullException)
         {
-            // Already signaled — safe to ignore.
+            // A wake-up is already pending and one batch drains everything: nothing to add.
         }
     }
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
@@ -193,11 +193,6 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
     /// <summary>
     /// Checks whether an entity with the given ID exists.
     /// </summary>
-    /// <remarks>
-    /// Uses <c>CountAsync</c> instead of <c>AnyAsync</c> as a workaround for a Cosmos DB provider bug
-    /// that generates invalid SQL (unresolved 'root' identifier) when translating <c>AnyAsync</c>
-    /// with a predicate into a subquery.
-    /// </remarks>
     public virtual async Task<bool> ExistsAsync(
         TIdentifierType id,
         bool ignoreQueryFilters = false,
@@ -205,15 +200,10 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
     {
         ArgumentNullException.ThrowIfNull(id);
 
-        if (ignoreQueryFilters)
-        {
-            return await Entities
-                .IgnoreQueryFilters()
-                .CountAsync(e => e.Id.Equals(id), cancellationToken)
-                .ConfigureAwait(false) > 0;
-        }
-
-        return await Entities.CountAsync(e => e.Id.Equals(id), cancellationToken).ConfigureAwait(false) > 0;
+        return await AnyAsync(
+            ignoreQueryFilters ? Entities.IgnoreQueryFilters() : Entities,
+            e => e.Id.Equals(id),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -224,16 +214,32 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
     {
         ArgumentNullException.ThrowIfNull(where);
 
-        if (ignoreQueryFilters)
-        {
-            return await Entities
-                .IgnoreQueryFilters()
-                .CountAsync(where, cancellationToken)
-                .ConfigureAwait(false) > 0;
-        }
-
-        return await Entities.CountAsync(where, cancellationToken).ConfigureAwait(false) > 0;
+        return await AnyAsync(
+            ignoreQueryFilters ? Entities.IgnoreQueryFilters() : Entities,
+            where,
+            cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Existence check, provider-aware.
+    /// </summary>
+    /// <remarks>
+    /// Cosmos DB needs <c>CountAsync</c>: its provider generates invalid SQL (unresolved 'root'
+    /// identifier) when translating a predicated <c>AnyAsync</c> into a subquery. Every other
+    /// provider gets <c>AnyAsync</c>, which short-circuits at the first match; <c>CountAsync</c>
+    /// reads every matching row, so on a predicate that matches a wide set the workaround cost
+    /// O(matches) on providers that never needed it.
+    /// </remarks>
+    private async Task<bool> AnyAsync(
+        IQueryable<TEntity> query,
+        Expression<Func<TEntity, bool>> where,
+        CancellationToken cancellationToken)
+        => IsCosmosProvider
+            ? await query.CountAsync(where, cancellationToken).ConfigureAwait(false) > 0
+            : await query.AnyAsync(where, cancellationToken).ConfigureAwait(false);
+
+    private bool IsCosmosProvider =>
+        _context.Database.ProviderName?.Contains("Cosmos", StringComparison.Ordinal) == true;
 
     /// <summary>Gets a tracked queryable over the entity set.</summary>
     public virtual IQueryable<TEntity> Table => Entities;

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/Factory/RepositoryFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/Factory/RepositoryFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -26,14 +27,14 @@ public sealed class RepositoryFactory(IServiceProvider serviceProvider, IApplica
         where TEntity : AuditableAggregateRootEntity<TIdentifierType>
         where TIdentifierType : notnull
     {
-        IRepository<TEntity, TIdentifierType> repositoryInstance;
-        repositoryInstance = ActivatorUtilities.CreateInstance<EFRepository<TEntity, TIdentifierType>>(
-            _serviceProvider, dbContext);
+        var repositoryInstance = (IRepository<TEntity, TIdentifierType>)Factory(
+            typeof(EFRepository<TEntity, TIdentifierType>), DbContextArg)(_serviceProvider, [dbContext]);
 
         if (_applicationSettings.UseMiniProfiler)
         {
-            repositoryInstance = ActivatorUtilities.CreateInstance<EFRepositoryDecorator<TEntity, TIdentifierType>>(
-                _serviceProvider, repositoryInstance);
+            repositoryInstance = (IRepository<TEntity, TIdentifierType>)Factory(
+                typeof(EFRepositoryDecorator<TEntity, TIdentifierType>),
+                [typeof(IRepository<TEntity, TIdentifierType>)])(_serviceProvider, [repositoryInstance]);
         }
 
         return repositoryInstance;
@@ -50,16 +51,35 @@ public sealed class RepositoryFactory(IServiceProvider serviceProvider, IApplica
         where TEntity : AuditableBaseEntity<TIdentifierType>
         where TIdentifierType : notnull
     {
-        IReadRepository<TEntity, TIdentifierType> repositoryInstance;
-        repositoryInstance = ActivatorUtilities.CreateInstance<EFReadRepository<TEntity, TIdentifierType>>(
-            _serviceProvider, dbContext);
+        var repositoryInstance = (IReadRepository<TEntity, TIdentifierType>)Factory(
+            typeof(EFReadRepository<TEntity, TIdentifierType>), DbContextArg)(_serviceProvider, [dbContext]);
 
         if (_applicationSettings.UseMiniProfiler)
         {
-            repositoryInstance = ActivatorUtilities.CreateInstance<EFReadRepositoryDecorator<TEntity, TIdentifierType>>(
-                _serviceProvider, repositoryInstance);
+            repositoryInstance = (IReadRepository<TEntity, TIdentifierType>)Factory(
+                typeof(EFReadRepositoryDecorator<TEntity, TIdentifierType>),
+                [typeof(IReadRepository<TEntity, TIdentifierType>)])(_serviceProvider, [repositoryInstance]);
         }
 
         return repositoryInstance;
     }
+
+    private static readonly Type[] DbContextArg = [typeof(DbContext)];
+
+    private static readonly ConcurrentDictionary<Type, ObjectFactory> FactoryCache = new();
+
+    /// <summary>
+    /// Returns the cached compiled constructor for a closed repository type.
+    /// <para>
+    /// <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> matches the
+    /// constructor by reflection on every call and caches nothing, so a request touching four
+    /// aggregates paid four reflective activations. Each closed type here always takes the same
+    /// argument shape, so the compiled <see cref="ObjectFactory"/> can be keyed by type alone.
+    /// </para>
+    /// </summary>
+    private static ObjectFactory Factory(Type implementationType, Type[] argumentTypes) =>
+        FactoryCache.GetOrAdd(
+            implementationType,
+            static (type, args) => ActivatorUtilities.CreateFactory(type, args),
+            argumentTypes);
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxSignalTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxSignalTests.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// The signal is capped at one pending permit on purpose: <c>OutboxProcessor</c> drains every
+/// pending message in one batch, so a burst of N saves carries exactly one wake-up's worth of
+/// information. An uncapped semaphore let permits accumulate one per save, and each surplus permit
+/// cost the processor a candidate-fetch round trip per data source that returned nothing.
+/// </summary>
+public sealed class OutboxSignalTests
+{
+    private static readonly TimeSpan NoWait = TimeSpan.Zero;
+
+    [Fact]
+    public async Task ManySignals_GrantExactlyOneWakeUp()
+    {
+        using var signal = new OutboxSignal();
+
+        for (var i = 0; i < 50; i++)
+        {
+            signal.Signal();
+        }
+
+        // The first wait consumes the single permit.
+        await signal.WaitAsync(NoWait, TestContext.Current.CancellationToken);
+
+        // A second wait must find nothing pending and fall through on its timeout rather than
+        // returning immediately 49 more times.
+        var start = Stopwatch.GetTimestamp();
+        await signal.WaitAsync(TimeSpan.FromMilliseconds(150), TestContext.Current.CancellationToken);
+
+        Stopwatch.GetElapsedTime(start).Should().BeGreaterThan(TimeSpan.FromMilliseconds(50),
+            "the surplus signals must have been absorbed, leaving the second wait to time out");
+    }
+
+    [Fact]
+    public async Task SignalAfterDrain_GrantsAnotherWakeUp()
+    {
+        using var signal = new OutboxSignal();
+
+        signal.Signal();
+        await signal.WaitAsync(NoWait, TestContext.Current.CancellationToken);
+
+        // Capping must not swallow a genuinely new signal raised after the batch drained.
+        signal.Signal();
+        var start = Stopwatch.GetTimestamp();
+        await signal.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Stopwatch.GetElapsedTime(start).Should().BeLessThan(TimeSpan.FromSeconds(1),
+            "a signal raised after the drain must wake the processor immediately");
+    }
+
+    [Fact]
+    public void ConcurrentSignals_DoNotThrow()
+    {
+        using var signal = new OutboxSignal();
+
+        // Release() past the cap throws SemaphoreFullException; Signal() swallows it by contract.
+        var act = () => Parallel.For(0, 200, _ => signal.Signal());
+
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
Four independent hot-path fixes, none behavior-changing.

## 1. The outbox signal accumulated one permit per save

`OutboxSignal` was `new SemaphoreSlim(0)`, whose maxCount is `int.MaxValue`, so the `catch (SemaphoreFullException)` at the `Release` site was **unreachable** and permits accumulated one per `Signal()` call.

A burst of N event-raising saves made `WaitAsync` return immediately N times, and each of those cycles issued a candidate-fetch query per relational data source that returned nothing. The class comment said extra signals were harmless: true for correctness, false for cost.

Capped at one permit, which the existing catch already anticipated. `OutboxProcessor` drains everything in one batch, so one pending wake-up is all a burst carries.

## 2. Both retention sweeps ran unindexed

`IX_OutboxMessages_Pending` is filtered `WHERE [ProcessedOn] IS NULL`, which excludes exactly the rows `OutboxCleanupService` looks for (`ProcessedOn != null AND ProcessedOn < cutoff`). The six-hourly sweep therefore scanned the largest partition of the table. The inbox purge filtered `ProcessedOn` against a table indexed only on `MessageId`.

- adds `IX_OutboxMessages_Processed`, filtered `IS NOT NULL`
- adds `IX_InboxMessages_ProcessedOn`
- the pending index gains `RetryCount` and `LockedUntil` as included columns, since the poll filters on both and every candidate row was costing a key lookup

## 3. The query logging decorator allocated per request

`LoggingQueryDecorator` allocated a 2-entry `Dictionary` and boxed the scope state on **every query, at every log level**, including when logging was disabled. Ported to `LoggerMessage.DefineScope`, which `LoggingCommandDecorator` already used for exactly this reason.

Both decorators now time with `Stopwatch.GetTimestamp()` rather than allocating a `Stopwatch`. Elapsed is still captured before logging, so the recorded metric keeps its previous meaning.

## 4. Three allocation cleanups

- `RepositoryFactory` called `ActivatorUtilities.CreateInstance` per repository, which matches the constructor by reflection every call and caches nothing; a request touching four aggregates paid four reflective activations. Now a compiled `ObjectFactory` cached per closed type.
- `EntityDataSourceRegistry.GetPhysicalSourcesInUse` re-ran `Select().Distinct()` over every registered entity and allocated a new list per call; the outbox processor and cleanup service both call it every poll. Precomputed on the snapshot.
- `ExistsAsync` used `CountAsync` on all providers to work around a Cosmos bug. Now branches on provider, so everything else gets `AnyAsync` and short-circuits at the first match instead of reading every matching row.

## Verification

- new `OutboxSignalTests`: surplus signals absorbed, a post-drain signal still wakes immediately, concurrent `Signal()` does not throw
- 2457 tests pass
- Release build warning-free under `TreatWarningsAsErrors`
- FACTS.md up to date

**Consumer note:** the two new indexes need one migration per consumer database. Those ride with the version-bump sweep, not this PR.

Part of the second four-repo performance program. Not a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169X4JC6ub844UcfyVeCvSM