### PR TITLE
§12: detect changes once per save, widen the by-id fast path, cache field projection

### DIFF
--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -69,13 +69,13 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
 
     /// <summary>
     /// Attempts the keyed by-id fast path: for a plain primary-key lookup (no field projection, no
-    /// includes, no specification, default id field) it issues a single <c>TOP 1 WHERE Id = @id</c>
-    /// via the repository's include overload, skipping the dynamic-filter pipeline (which parses a
-    /// string predicate and emits <c>TOP 1000</c> + a client-side <c>FirstOrDefault</c>). That
-    /// overload runs on the filtered <c>TableNoTracking</c>, so soft-delete query filters still
-    /// apply (unlike <c>FindAsync</c>, which bypasses them). Returns <see langword="null"/> when the
-    /// request is not a plain key lookup or the id is not convertible, so the caller uses the
-    /// pipeline.
+    /// specification, default id field, no cross-source navigations) it issues a single
+    /// <c>TOP 1 WHERE Id = @id</c> via the repository's include overload, skipping the
+    /// dynamic-filter pipeline (which parses a string predicate and emits <c>TOP 1000</c> + a
+    /// client-side <c>FirstOrDefault</c>). That overload runs on the filtered
+    /// <c>TableNoTracking</c>, so soft-delete query filters still apply (unlike <c>FindAsync</c>,
+    /// which bypasses them). Returns <see langword="null"/> when the request is not a plain key
+    /// lookup or the id is not convertible, so the caller uses the pipeline.
     /// </summary>
     private async Task<Result<TEntity>?> TryGetByIdFastPathAsync(
         string idValue,
@@ -87,36 +87,48 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
         bool asTracking,
         CancellationToken cancellationToken)
     {
-        if (!IsPrimaryKeyOnlyLookup(idField, includeFKs, includeChildren, specification, fields)
+        if (!TryGetFastPathIncludes(idField, includeFKs, includeChildren, specification, fields, out var includes)
             || !TryConvertId(idValue, out var typedId))
         {
             return null;
         }
 
-        var entity = await Repository.GetByIdAsync(typedId, [], asTracking, cancellationToken).ConfigureAwait(false);
+        var entity = await Repository.GetByIdAsync(typedId, includes, asTracking, cancellationToken).ConfigureAwait(false);
         return entity is null
             ? Result.Failure<TEntity>(Error.NotFound.WithSource(nameof(GetByIdAsync)).WithTarget(typeof(TEntity).Name))
             : Result.Success(entity);
     }
 
     /// <summary>
-    /// Whether the request is a plain primary-key lookup the fast path can serve.
+    /// Whether the request is a primary-key lookup the fast path can serve, and if so which
+    /// navigations it must eager-load.
     /// </summary>
     /// <remarks>
-    /// <paramref name="includeFKs"/> and <paramref name="includeChildren"/> only disqualify the
-    /// request when the entity actually has navigations to include. Treating the flags themselves
-    /// as disqualifying made the fast path unreachable from the REST layer, whose by-id action
-    /// defaults <c>includeFKs</c> to true: every by-id read fell back to the dynamic-filter
-    /// pipeline, which parses a string predicate and emits <c>TOP 1000</c> plus a client-side
+    /// <para>
+    /// Requested includes do not disqualify the request. The repository's include overload applies
+    /// the same <c>Include</c> calls the pipeline would, and auto-applies <c>AsSplitQuery</c> when
+    /// any of them is a child collection, so the two produce the same result for a keyed read.
+    /// Disqualifying on includes left the fast path unreachable for every entity that declares a
+    /// navigation, because the REST by-id action defaults <c>includeFKs</c> to true: those reads
+    /// fell back to the dynamic-filter pipeline and emitted <c>TOP 1000</c> plus a client-side
     /// <c>FirstOrDefault</c> where a keyed <c>TOP 1 WHERE Id = @id</c> would do.
+    /// </para>
+    /// <para>
+    /// Unsupported includes still do disqualify: those are cross-source navigations that only the
+    /// pipeline's <c>INavigationPopulator</c> can batch-load, since no single query spans the
+    /// physical sources.
+    /// </para>
     /// </remarks>
-    private bool IsPrimaryKeyOnlyLookup(
+    private bool TryGetFastPathIncludes(
         string? idField,
         bool includeFKs,
         bool includeChildren,
         Specification<TEntity, TIdentifierType>? specification,
-        string? fields)
+        string? fields,
+        out IReadOnlyList<string> includes)
     {
+        includes = [];
+
         if (fields is not null
             || specification is not null
             || idField is not null && !string.Equals(idField, IdField, StringComparison.OrdinalIgnoreCase))
@@ -129,10 +141,14 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
             return true;
         }
 
-        // Asking for includes on an entity that declares none is the same request as asking for
-        // none, so it stays on the fast path.
         var metadata = NavigationMetadataProvider.BuildIncludes<TEntity>(includeFKs, includeChildren);
-        return metadata.SupportedIncludes.Count == 0 && metadata.UnsupportedIncludes.Count == 0;
+        if (metadata.UnsupportedIncludes.Count != 0)
+        {
+            return false;
+        }
+
+        includes = [.. metadata.SupportedIncludes.Select(nav => nav.PropertyName)];
+        return true;
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Application/Services/QueryFieldService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/QueryFieldService.cs
@@ -51,11 +51,7 @@ public sealed class QueryFieldService
     /// <returns>A dynamic object containing the selected properties.</returns>
     public static ExpandoObject ShapeData<TEntity>(TEntity entity, string? fields)
     {
-        var fieldsSet = ParseFields(fields);
-        var accessors = GetAccessors<TEntity>();
-
-        if (fieldsSet.Count != 0)
-            accessors = FilterAccessorsByFields(accessors, fieldsSet);
+        var accessors = GetShapedAccessors<TEntity>(fields);
 
         IDictionary<string, object?> shapedObject = new ExpandoObject();
 
@@ -78,11 +74,7 @@ public sealed class QueryFieldService
         IEnumerable<TEntity> entities,
         string? fields)
     {
-        var fieldsSet = ParseFields(fields);
-        var accessors = GetAccessors<TEntity>();
-
-        if (fieldsSet.Count != 0)
-            accessors = FilterAccessorsByFields(accessors, fieldsSet);
+        var accessors = GetShapedAccessors<TEntity>(fields);
 
         List<ExpandoObject> shapedObjects = [];
 
@@ -159,16 +151,38 @@ public sealed class QueryFieldService
             return query;
 
         var fieldsSet = ParseFields(fields);
-        var propertyInfos = GetProperties<TEntity>();
+        var selectExpression = ProjectionCache.GetOrAdd(
+            (typeof(TEntity), NormalizeFieldsKey(fieldsSet)),
+            static (_, set) => BuildProjection<TEntity>(set),
+            fieldsSet);
 
+        return selectExpression is null
+            ? query
+            : query.Select((Expression<Func<TEntity, TEntity>>)selectExpression);
+    }
+
+    /// <summary>
+    /// Compiled projection lambdas, keyed by entity type and normalized field set.
+    /// </summary>
+    /// <remarks>
+    /// Rebuilding the <c>MemberInit</c> tree per request meant reflecting over the entity's
+    /// properties and allocating a binding array on every field-projected read, unlike the sibling
+    /// lookup-selector cache in <c>EFReadRepository</c>. A <see langword="null"/> value is cached
+    /// deliberately: it records "this field set projects nothing writable", so the miss is not
+    /// recomputed on every subsequent request.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<(Type EntityType, string Fields), LambdaExpression?> ProjectionCache = new();
+
+    private static Expression<Func<TEntity, TEntity>>? BuildProjection<TEntity>(HashSet<string> fieldsSet)
+    {
         PropertyInfo[] selectedProperties =
         [
-            .. propertyInfos
+            .. GetProperties<TEntity>()
                 .Where(p => p.CanWrite && fieldsSet.Contains(p.Name, StringComparer.OrdinalIgnoreCase))
         ];
 
         if (selectedProperties.Length == 0)
-            return query;
+            return null;
 
         ParameterExpression parameter = Expression.Parameter(typeof(TEntity), "e");
 
@@ -180,9 +194,7 @@ public sealed class QueryFieldService
 
         NewExpression newExpression = Expression.New(typeof(TEntity));
         MemberInitExpression body = Expression.MemberInit(newExpression, bindings);
-        var selectExpression = Expression.Lambda<Func<TEntity, TEntity>>(body, parameter);
-
-        return query.Select(selectExpression);
+        return Expression.Lambda<Func<TEntity, TEntity>>(body, parameter);
     }
 
     /// <summary>
@@ -279,4 +291,34 @@ public sealed class QueryFieldService
             .. accessors
                 .Where(a => fieldsSet.Contains(a.PropertyName, StringComparer.OrdinalIgnoreCase))
         ];
+
+    /// <summary>
+    /// Shaping accessors filtered to a field set, keyed by entity type and normalized field set,
+    /// so a repeated <c>fields=</c> request reuses the array instead of re-filtering per call.
+    /// </summary>
+    private static readonly ConcurrentDictionary<(Type EntityType, string Fields), PropertyAccessor[]> ShapedAccessorCache = new();
+
+    /// <summary>
+    /// Resolves the accessors to shape with: all of them when no field list was given, otherwise
+    /// the cached subset for that field set.
+    /// </summary>
+    private static PropertyAccessor[] GetShapedAccessors<TEntity>(string? fields)
+    {
+        var accessors = GetAccessors<TEntity>();
+        var fieldsSet = ParseFields(fields);
+
+        return fieldsSet.Count == 0
+            ? accessors
+            : ShapedAccessorCache.GetOrAdd(
+                (typeof(TEntity), NormalizeFieldsKey(fieldsSet)),
+                static (_, arg) => FilterAccessorsByFields(arg.Accessors, arg.FieldsSet),
+                (Accessors: accessors, FieldsSet: fieldsSet));
+    }
+
+    /// <summary>
+    /// Order- and case-insensitive cache key, so "name,id" and "Id, Name" share one entry rather
+    /// than multiplying the cache by however many spellings callers happen to send.
+    /// </summary>
+    private static string NormalizeFieldsKey(HashSet<string> fieldsSet) =>
+        string.Join(',', fieldsSet.Select(f => f.ToUpperInvariant()).Order(StringComparer.Ordinal));
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -92,6 +93,18 @@ public abstract class ApplicationDbContext(
         }
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Overridden purely to run change detection once per save. See <see cref="DetectChangesOnce"/>.
+    /// </remarks>
+    public override async Task<int> SaveChangesAsync(
+        bool acceptAllChangesOnSuccess,
+        CancellationToken cancellationToken = default)
+    {
+        using var detection = DetectChangesOnce();
+        return await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Synchronous counterpart of <see cref="SaveChangesAsync(UserIdentifierType?, CancellationToken)"/>:
     /// stamps audit fields with <paramref name="userId"/> through the same interceptor pipeline.
@@ -111,6 +124,52 @@ public abstract class ApplicationDbContext(
         {
             CurrentSaveUserId = null;
         }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Overridden purely to run change detection once per save. See <see cref="DetectChangesOnce"/>.
+    /// </remarks>
+    public override int SaveChanges(bool acceptAllChangesOnSuccess)
+    {
+        using var detection = DetectChangesOnce();
+        return base.SaveChanges(acceptAllChangesOnSuccess);
+    }
+
+    /// <summary>
+    /// Runs change detection once, then suppresses automatic detection for the rest of the save.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>ChangeTracker.Entries&lt;T&gt;()</c> triggers a full <c>DetectChanges</c> on every call and
+    /// memoizes nothing. Two interceptors scan the tracker from <c>SavingChanges</c>
+    /// (<see cref="Interceptors.AuditSaveChangesInterceptor"/> over <c>IAuditableEntity</c>, and
+    /// <see cref="Interceptors.DomainEventSaveChangesInterceptor"/> over <c>IAggregateRoot</c>), and
+    /// EF then detects again on its own before building the save. A save therefore paid three
+    /// O(tracked entities x properties) snapshot comparisons where one suffices.
+    /// </para>
+    /// <para>
+    /// Detecting up front and suppressing the rest is safe because everything the interceptors do
+    /// afterwards bypasses detection anyway: the audit interceptor writes through
+    /// <c>entry.Property(...).CurrentValue</c>, and the domain-event interceptor adds outbox rows
+    /// through <c>Add</c>. Both take effect immediately on the entry. The previous setting is
+    /// restored on the way out, so a caller that had already disabled auto-detect keeps its choice
+    /// and never gets an unexpected detection pass.
+    /// </para>
+    /// </remarks>
+    private DetectChangesScope DetectChangesOnce()
+    {
+        var previous = ChangeTracker.AutoDetectChangesEnabled;
+        if (previous)
+            ChangeTracker.DetectChanges();
+
+        ChangeTracker.AutoDetectChangesEnabled = false;
+        return new DetectChangesScope(ChangeTracker, previous);
+    }
+
+    private readonly struct DetectChangesScope(ChangeTracker changeTracker, bool previousSetting) : IDisposable
+    {
+        public void Dispose() => changeTracker.AutoDetectChangesEnabled = previousSetting;
     }
 
     /// <inheritdoc />

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/SaveChangeDetectionTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/SaveChangeDetectionTests.cs
@@ -1,0 +1,151 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// A save must run change detection exactly once. Two interceptors scan the ChangeTracker from
+/// SavingChanges and EF detects again on its own, and because <c>Entries&lt;T&gt;()</c> memoizes
+/// nothing, each of those scans used to pay a full O(tracked entities x properties) snapshot
+/// comparison. These tests pin the count and, just as importantly, pin that suppressing the extra
+/// passes did not cost the tracker any actual changes.
+/// </summary>
+public sealed class SaveChangeDetectionTests : IDisposable
+{
+    private readonly DetectionTestDbContext _dbContext = DetectionTestDbContext.Create();
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task Save_DetectsChangesExactlyOnce()
+    {
+        _dbContext.Entities.Add(new Widget { Id = 1, Name = "First" });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var detections = 0;
+        _dbContext.ChangeTracker.DetectedAllChanges += (_, _) => detections++;
+
+        var tracked = await _dbContext.Entities.FirstAsync(TestContext.Current.CancellationToken);
+        tracked.Name = "Renamed";
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        detections.Should().Be(1, "one detection pass covers the audit scan, the domain-event scan, and EF's own");
+    }
+
+    [Fact]
+    public async Task Save_StillPersistsAnUntrackedPropertyEdit()
+    {
+        // The behavioural half: detection is suppressed only AFTER one explicit pass, so a plain
+        // property assignment made before SaveChanges must still reach the database.
+        _dbContext.Entities.Add(new Widget { Id = 1, Name = "First" });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var tracked = await _dbContext.Entities.FirstAsync(TestContext.Current.CancellationToken);
+        tracked.Name = "Renamed";
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _dbContext.ChangeTracker.Clear();
+        var reloaded = await _dbContext.Entities.AsNoTracking().FirstAsync(TestContext.Current.CancellationToken);
+        reloaded.Name.Should().Be("Renamed");
+    }
+
+    [Fact]
+    public async Task Save_StampsAuditFields()
+    {
+        // The audit interceptor writes through entry.Property(...).CurrentValue, which takes effect
+        // without detection. Guards that suppression did not silently drop the stamps.
+        _dbContext.Entities.Add(new Widget { Id = 7, Name = "Stamped" });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _dbContext.ChangeTracker.Clear();
+        var reloaded = await _dbContext.Entities.AsNoTracking().FirstAsync(TestContext.Current.CancellationToken);
+        reloaded.CreatedOn.Should().NotBe(default);
+        reloaded.LastModifiedOn.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task Save_RestoresTheCallersAutoDetectSetting()
+    {
+        _dbContext.ChangeTracker.AutoDetectChangesEnabled = false;
+
+        _dbContext.Entities.Add(new Widget { Id = 2, Name = "Second" });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _dbContext.ChangeTracker.AutoDetectChangesEnabled.Should().BeFalse(
+            "a caller that deliberately disabled auto-detect must not have it switched back on");
+    }
+
+    [Fact]
+    public async Task Save_LeavesAutoDetectEnabledForTheNextCaller()
+    {
+        _dbContext.Entities.Add(new Widget { Id = 3, Name = "Third" });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _dbContext.ChangeTracker.AutoDetectChangesEnabled.Should().BeTrue(
+            "suppression lasts for the save only, not for the context's remaining lifetime");
+    }
+
+    // ── Test doubles ──
+    public sealed class Widget : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class DetectionTestDbContext : ApplicationDbContext
+    {
+        public DbSet<Widget> Entities => Set<Widget>();
+
+        internal override bool SupportsOutbox => false;
+
+        private DetectionTestDbContext(DbContextOptions<DetectionTestDbContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        public static DetectionTestDbContext Create()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(new DomainEventSaveChangesInterceptor(
+                Mock.Of<IDomainEventDispatcher>(),
+                NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+                Mock.Of<IOutboxSignal>()));
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            IServiceProvider sp = services.BuildServiceProvider();
+
+            var options = new DbContextOptionsBuilder<DetectionTestDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            var context = new DetectionTestDbContext(options, sp);
+            context.Database.OpenConnection();
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Widget>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+                e.Property(x => x.RowVersion).IsConcurrencyToken();
+            });
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}


### PR DESCRIPTION
Three hot-path fixes across the read and write paths.

## 1. A save ran change detection three times

`ChangeTracker.Entries<T>()` triggers a full `DetectChanges` on every call and memoizes nothing. Two interceptors scan the tracker from `SavingChanges` (audit over `IAuditableEntity`, domain-event capture over `IAggregateRoot`), and EF detects again on its own before building the save. A save therefore paid three O(tracked entities x properties) snapshot comparisons where one suffices.

This **corrects the earlier assessment that deferred this item**, which assumed EF memoized after the first `Entries<>()` access. It does not.

`ApplicationDbContext` now overrides the two EF save entry points to detect once up front and suppress automatic detection for the rest of the save, restoring the caller's setting on the way out. That is safe because everything the interceptors do afterwards bypasses detection anyway: the audit interceptor writes through `entry.Property(...).CurrentValue`, the domain-event interceptor adds outbox rows through `Add`, and both take effect immediately on the entry.

## 2. The by-id fast path was unreachable for most entities

The v1.119.0 fast path required zero includes, but the REST by-id action defaults `includeFKs` to true. Any entity declaring a navigation therefore fell back to the dynamic-filter pipeline and emitted `SELECT TOP(1000) ... WHERE Id = @p` with a client-side `FirstOrDefault`, where a keyed `TOP 1` would do.

Supported includes are now passed into `Repository.GetByIdAsync`'s include overload, which applies the same `Include` calls the pipeline would and auto-applies `AsSplitQuery` when any is a child collection, so the two produce the same result for a keyed read. Unsupported (cross-source) includes still disqualify the fast path: only the pipeline's `INavigationPopulator` can batch-load those, since no single query spans physical sources.

## 3. Field projection rebuilt its expression tree per request

`QueryFieldService` reflected over the entity's properties and allocated a fresh binding array on every field-projected read, unlike the sibling lookup-selector cache in `EFReadRepository`.

Projections and shaping-accessor subsets are now cached, keyed by entity type plus a **normalized** field set (order- and case-insensitive), so `name,id` and `Id, Name` share one entry rather than multiplying the cache by however many spellings callers send. A `null` projection is cached deliberately, so "this field set projects nothing writable" is not recomputed per request.

## Verification

New `SaveChangeDetectionTests` pin both halves of the detection change:
- exactly one detection pass per save (counted via `ChangeTracker.DetectedAllChanges`)
- an untracked property edit still persists
- audit fields are still stamped
- the caller's `AutoDetectChangesEnabled` survives in both directions (left off if they turned it off, left on otherwise)

2459 tests pass; Release build warning-free under `TreatWarningsAsErrors`; FACTS.md up to date.

Part of the second four-repo performance program. Not a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169X4JC6ub844UcfyVeCvSM