### PR TITLE
docs: correct CLAUDE.md CI/release drift (redis job, dual registry)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,11 @@ CI (`.github/workflows/ci.yml`) runs on **pull requests only** (no `push: main` 
 - **consumer-source-build**: cross-repo canary; checks out MMCA.Helpdesk as a sibling and builds/tests it against THIS PR's framework source via its committed `local.props`, so a breaking public-API change fails pre-merge instead of after a release. Required merge gate.
 - **performance-smoke**: runs the BenchmarkDotNet suite (`--job Short`), then `build/perfgate` compares the results against the committed `Tests/Performance/perf-baseline.json` (allocation ceilings + machine-independent ratio floors) and fails on any violation. Moving a number deliberately means updating the baseline file in the same PR.
 - **coverage**: merges the tiers (ReportGenerator) and enforces the floor: the unit tier must stay >= 68.3% line coverage (generated `*.g.cs`/`*.generated.cs` excluded).
-- **build-maui** (windows runner): builds/packs `MMCA.Common.UI.Maui` (the out-of-slnx MAUI package, ADR-042).
+- **build-maui** (windows runner): builds `MMCA.Common.UI.Maui` across its four TFMs (the out-of-slnx MAUI package, ADR-042); packing happens in `release.yml`. Critical path of the run (~7-8 min), so it caches the MAUI workload packs keyed on the resolved SDK version.
 - **sample-deployment-validate**: compiles the `samples/deployment` Bicep templates (`az bicep build`).
+- **redis-integration**: runs `MMCA.Common.Infrastructure.Redis.Tests` against a real Redis via Testcontainers (out of the slnx, so the unit loop needs no Docker). `DistributedCacheService` is the one place the storage FORMAT matters: a counter written as a string and read back as a hash round-trips fine against a `Mock<IDistributedCache>` and answers WRONGTYPE against a server.
 
-Versioning is MinVer from git tags (`fetch-depth: 0` required). `release.yml` triggers on `v*` tags: build/test/pack, CycloneDX SBOM as a hard gate, push to GitHub Packages.
+Versioning is MinVer from git tags (`fetch-depth: 0` required). `release.yml` triggers on `v*` tags: build/test/pack, CycloneDX SBOM as a hard gate, then push to **both** GitHub Packages and nuget.org (ADR-053). The nuget.org push is keyless: the job's OIDC token is exchanged (`NuGet/login`) for a one-hour key, under a trusted-publishing policy pinned to this owner/repo/**workflow file**, so renaming `release.yml` breaks publishing by design. `MMCA.Common.UI.Maui` packs and pushes from a separate `publish-maui` windows job off the same tag.
 
 Gotchas:
 - CI runs on Ubuntu: file paths are case-sensitive; match casing exactly.


### PR DESCRIPTION
Found while refreshing the onboarding CI/CD chapter (Website PR #39). Three inaccuracies in this file's CI/release summary:

- **`redis-integration` was missing from the job list.** `ci.yml` has nine jobs; the list had eight.
- **`build-maui` was described as "builds/packs".** `ci.yml:219-221` only builds it across the four TFMs; the pack happens in `release.yml`'s `publish-maui` job. Also noted the workload-pack caching, since that job is the critical path of the run.
- **`release.yml` was still described as "push to GitHub Packages".** It has published to nuget.org as well since ADR-053 (`release.yml:79-88`), via keyless trusted publishing. Recorded the detail that the nuget.org policy is pinned to the workflow **file** by permanent GitHub id, so renaming `release.yml` breaks publishing by design, which is worth having next to the description rather than only in the workflow comment.

Documentation only, no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6QhZE8qUyVZKvkiYhoY6o