### PR TITLE
chore: replace the banned words "seam"/"seams" in prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,7 +651,7 @@ _No entries were recorded at release time; see the git tag for this release's ch
 - **`UIArchitectureConventionTestsBase`** (`MMCA.Common.Testing.Architecture`, rubric §18): file-scan
   fitness base enforcing the container/presentational split mechanically: every `*.razor.cs` under
   `Source/` stays within a 400-line cap, and every `.razor` file keeps its inline `@code` block within
-  120 lines (substantial logic belongs in the code-behind partial). Seams: `MaxCodeBehindLines`,
+  120 lines (substantial logic belongs in the code-behind partial). Extension points: `MaxCodeBehindLines`,
   `MaxInlineCodeLines`, `MinimumCodeBehindFiles` (non-vacuity guard), `ExcludedPathFragments`.
   Subclassed in-repo as `UIArchitectureConventionTests`.
 - **`StateManagementConventionTestsBase`** (`MMCA.Common.Testing.Architecture`, rubric §19): fitness
@@ -660,7 +660,7 @@ _No entries were recorded at release time; see the git tag for this release's ch
   excluded, deliberate exceptions recorded via `AllowedStaticMembers`), plus a source scan forbidding
   singleton registration of stateful UI services (`*StateService`/`*StateContainer`). Subclassed
   in-repo as `StateManagementConventionTests` (one recorded exception: the `ErrorMessages._localizer`
-  write-once wiring seam).
+  write-once wiring extension point).
 - **Dark-mode axe gate** (`DarkModeE2ETests`, rubric §20/§21): the gallery Login + Components pages are
   re-scanned with the dark palette active (seeded via the `mmca_theme` cookie) inside the blocking
   chromium `ui-e2e` job, closing the tracked dark-palette contrast item.
@@ -684,13 +684,13 @@ _No entries were recorded at release time; see the git tag for this release's ch
 
 ### Added (2026-07-11 move-to-Common extraction wave, E1-E12 of `Docs/Planning/DriftAnalysis-plan.md` 2026-07-11)
 - **`RouteAuthorizationTestsBase`** (`MMCA.Common.Testing.Architecture`): reflection fitness base
-  asserting every governed routable Blazor page carries the required role, with seams
+  asserting every governed routable Blazor page carries the required role, with extension points
   `TargetAssembly` / `RequiredRole` / `IsGovernedPage(Type)` / `MinimumGovernedPages` and a
   non-vacuity guard; replaces five hand-rolled per-repo copies. Attribute detection is
   full-name-based, preserving the package's zero-ASP.NET-reference design.
 - **Contract-test bases** (`MMCA.Common.Testing`): `ServiceInfoVersioningContractTestsBase<T>`
   (the whole /ServiceInfo v1/v2 + version-headers body), `OpenApiContractTestsBase<T>`
-  (document served + well-formed 3.x, seams `MinimumPathCount` / `CorePublicResources`), and
+  (document served + well-formed 3.x, extension points `MinimumPathCount` / `CorePublicResources`), and
   `ProblemDetailsContractTestsBase<T>` (RFC 9457 shape probes + the shared
   `AssertProblemDetailsShapeAsync` helper); app-specific 409 facts stay app-side.
 - **UI HTTP-service test harness** (`MMCA.Common.Testing.UI`): `CapturingHttpMessageHandler`
@@ -942,7 +942,7 @@ _No entries were recorded at release time; see the git tag for this release's ch
   other reserved character in the lookup property name is now percent-encoded (the same treatment
   the paged path gives its sort/filter parameters) instead of corrupting the query string.
 
-### Changed (2026-07-05 TimeProvider seams C-6/C-7)
+### Changed (2026-07-05 TimeProvider extension points C-6/C-7)
 - **`OutboxCleanupService` gains an optional trailing `TimeProvider` constructor parameter** (C-6,
   non-breaking, defaults to `TimeProvider.System`): the hour-scale sweep interval and the retention
   cutoff run on the injectable clock, making the purge sweep deterministically unit-testable with
@@ -1205,7 +1205,7 @@ PII log/telemetry redaction (§30). No breaking changes.
 - **`PiiRedactor` (§30).** `Domain/Privacy/PiiRedactor.cs` masks every `[Pii]`-marked member (shallow,
   value-erasing `[REDACTED]` token, per-type reflection cache) before an entity carrying personal data
   reaches a structured log or telemetry attribute — the redaction half of the `[Pii]` contract (ADR-005),
-  complementing the `IAnonymizable` erasure seam. Covered by `PiiRedactorTests` (incl. "never emits the
+  complementing the `IAnonymizable` erasure extension point. Covered by `PiiRedactorTests` (incl. "never emits the
   clear-text PII values").
 
 ## [1.83.0] - 2026-06-26
@@ -1214,7 +1214,7 @@ Governance + front-end security hardening. No breaking changes.
 
 ### Added
 - **ADR-023 — centralized security-response headers (§26).** Documents the hardened security-headers
-  middleware + pluggable `ICspPolicyProvider` CSP seam (`AddCommonSecurityHeaders`), replacing per-host
+  middleware + pluggable `ICspPolicyProvider` CSP extension point (`AddCommonSecurityHeaders`), replacing per-host
   hand-rolled headers.
 - **Source-generated, CI-gated `FACTS.md` (§34).** `build/facts` computes version / package-count /
   ADR-range / fitness counts from source; the `build-and-test` job runs it with `--check` and fails the
@@ -1248,7 +1248,7 @@ Governance + supply-chain + E2E-stability hardening. No breaking changes.
 ## [1.81.0] - 2026-06-26
 
 Post-v1.80.0 polish: an opt-in OpenAPI UI, FinOps documentation, and test-coverage hardening for the
-v1.80.0 rate-limiter and `TimeProvider` seams. Additive — no breaking changes and no consumer behavior
+v1.80.0 rate-limiter and `TimeProvider` extension points. Additive — no breaking changes and no consumer behavior
 change beyond the new opt-in helper.
 
 ### Added
@@ -1406,7 +1406,7 @@ build-guarded change (ADR-006).
 - **Broker retry policy.** `AddBrokerMessaging` now configures `UseMessageRetry` (exponential backoff)
   on both the RabbitMQ and Azure Service Bus transports. Tunable via new `MessageBus:RetryLimit`,
   `MessageBus:RetryMinIntervalSeconds`, and `MessageBus:RetryMaxIntervalSeconds` settings.
-- **`IAnonymizable`** erasure seam (`MMCA.Common.Domain`) for reconciling soft-delete with
+- **`IAnonymizable`** erasure extension point (`MMCA.Common.Domain`) for reconciling soft-delete with
   data-subject erasure requests. See ADR-005.
 - **`OutboxCleanupService`** background service that purges processed outbox rows. New settings
   `Outbox:RetentionDays` (default 7) and `Outbox:CleanupIntervalHours` (default 6).

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/IArchitectureMap.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/IArchitectureMap.cs
@@ -31,7 +31,7 @@ public enum Layer
 public sealed record LayerRef(string Module, Layer Layer, Assembly Assembly, string RootNamespace);
 
 /// <summary>
-/// The single per-repo seam every architecture fitness function keys off. Each repo supplies one
+/// The single per-repo extension point every architecture fitness function keys off. Each repo supplies one
 /// implementation (e.g. <c>StoreArchitectureMap</c>) declaring its layer/module assemblies; the
 /// shared rule library and abstract test bases consume <em>only</em> this interface, so a rule is
 /// written once and runs identically across MMCA.Common, MMCA.Store and MMCA.ADC.

--- a/Source/Presentation/MMCA.Common.API/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.API/DependencyInjection.cs
@@ -80,7 +80,7 @@ public static class DependencyInjection
         }
 
         /// <summary>
-        /// Registers the edge error-localization seam (ADR-027): <see cref="IErrorLocalizer"/> plus the
+        /// Registers the edge error-localization extension point (ADR-027): <see cref="IErrorLocalizer"/> plus the
         /// framework's own <see cref="ErrorResources"/> source. Called automatically by <c>AddAPI</c>.
         /// Modules add their own error translations additively via <see cref="AddErrorResources{TResource}"/>.
         /// </summary>

--- a/Source/Presentation/MMCA.Common.UI.Web/MMCA.Common.UI.Web.csproj
+++ b/Source/Presentation/MMCA.Common.UI.Web/MMCA.Common.UI.Web.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <!-- The server-side bridge between the WASM-safe MMCA.Common.UI (ITokenStorageService, ApiSettings),
-         the session-cookie plumbing in MMCA.Common.API, and the security-headers CSP seam in
+         the session-cookie plumbing in MMCA.Common.API, and the security-headers CSP extension point in
          MMCA.Common.Aspire. Deliberately a separate package: MMCA.Common.UI stays Shared-only for
          Blazor WASM compatibility and must never pull these server dependencies. -->
     <ProjectReference Include="..\MMCA.Common.UI\MMCA.Common.UI.csproj" />

--- a/Source/Presentation/MMCA.Common.UI/Components/Capabilities/PushRegistrationListener.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/Capabilities/PushRegistrationListener.razor
@@ -8,7 +8,7 @@
 
 @* Invisible component (ADR-044) — keeps this device's push installation in sync with the
    signed-in user. Rendered once in the native layout (via the host's LayoutComponentTypes
-   seam), it registers on startup when a user is already signed in and re-registers whenever
+   extension point), it registers on startup when a user is already signed in and re-registers whenever
    the auth state flips to authenticated (fresh login, token refresh with a rotated platform
    token). Unregistration is NOT handled here: it must happen while still authenticated, so
    AuthUIService.LogoutAsync owns it. Inert when unsupported or the token provider yields

--- a/Source/Presentation/MMCA.Common.UI/Globalization/PseudoLocalizer.cs
+++ b/Source/Presentation/MMCA.Common.UI/Globalization/PseudoLocalizer.cs
@@ -14,7 +14,7 @@ namespace MMCA.Common.UI.Globalization;
 /// visible in one pass: <list type="bullet">
 ///   <item><description>hard-coded (non-resource) strings stay plain ASCII, unmissable beside accented text;</description></item>
 ///   <item><description>fixed-width UI truncates the padded text, exposing layouts that cannot grow;</description></item>
-///   <item><description>concatenated fragments each gain their own sentinel, revealing the seams.</description></item>
+///   <item><description>concatenated fragments each gain their own sentinel, revealing where they were joined.</description></item>
 /// </list>
 /// </remarks>
 public static class PseudoLocalizer

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/StateManagementConventionTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/StateManagementConventionTests.cs
@@ -13,7 +13,7 @@ public sealed class StateManagementConventionTests : StateManagementConventionTe
     protected override IArchitectureMap Map { get; } = new CommonArchitectureMap();
 
     /// <summary>
-    /// <c>ErrorMessages._localizer</c> is a write-once wiring seam, not per-user state: the root layout
+    /// <c>ErrorMessages._localizer</c> is a write-once wiring extension point, not per-user state: the root layout
     /// configures the shared <c>IStringLocalizer</c> exactly once (idempotent), and the localizer itself
     /// resolves against the ambient UI culture per call, so no user's state leaks to another. Keeping the
     /// static message API is deliberate (every consumer call site depends on it, ADR-027).

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxCleanupServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxCleanupServiceTests.cs
@@ -25,7 +25,7 @@ namespace MMCA.Common.Infrastructure.Tests.Persistence;
 /// immediate-shutdown behavior, the private relational-source selection helper (via
 /// reflection, mirroring the existing non-public-member test pattern in this project),
 /// and the purge sweep itself, driven deterministically through the service's
-/// <see cref="TimeProvider"/> seam with a <see cref="FakeTimeProvider"/> over an in-memory
+/// <see cref="TimeProvider"/> extension point with a <see cref="FakeTimeProvider"/> over an in-memory
 /// SQLite <see cref="ApplicationDbContext"/> (the BrokerEventBusTests harness pattern).
 /// </summary>
 public sealed class OutboxCleanupServiceTests
@@ -437,7 +437,7 @@ public sealed class OutboxCleanupServiceTests
     /// Builds an <see cref="OutboxCleanupService"/> wired for a real sweep: a real
     /// <see cref="IServiceScopeFactory"/> resolving a mocked <see cref="IDbContextFactory"/>
     /// (routing each <see cref="DataSourceKey"/> through <paramref name="contextForSource"/>),
-    /// the <see cref="FakeTimeProvider"/> seam, and a logger whose <paramref name="observedLogEvent"/>
+    /// the <see cref="FakeTimeProvider"/> extension point, and a logger whose <paramref name="observedLogEvent"/>
     /// completes the returned task so tests can await the sweep deterministically.
     /// </summary>
     private static (OutboxCleanupService Sut,

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorExecuteAsyncTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorExecuteAsyncTests.cs
@@ -14,7 +14,7 @@ namespace MMCA.Common.Infrastructure.Tests.Persistence;
 /// <summary>
 /// Tests for <see cref="OutboxProcessor.ExecuteAsync"/> edge cases that are not covered
 /// by the ProcessPendingMessagesAsync tests in OutboxProcessorTests. The processor's
-/// <see cref="TimeProvider"/> seam is driven with a <see cref="FakeTimeProvider"/> so the
+/// <see cref="TimeProvider"/> extension point is driven with a <see cref="FakeTimeProvider"/> so the
 /// 5-second startup delay elapses instantly — no test sleeps real seconds.
 /// </summary>
 public sealed class OutboxProcessorExecuteAsyncTests

--- a/Tests/Presentation/MMCA.Common.API.Tests/Localization/ErrorLocalizerTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Localization/ErrorLocalizerTests.cs
@@ -6,7 +6,7 @@ using MMCA.Common.API.Localization;
 namespace MMCA.Common.API.Tests.Localization;
 
 /// <summary>
-/// Verifies the edge error-localization seam (ADR-027): codes resolve to the current UI culture from the
+/// Verifies the edge error-localization extension point (ADR-027): codes resolve to the current UI culture from the
 /// framework's <c>ErrorResources</c> resx (including the Spanish satellite), and unknown/empty codes fall
 /// back to the caller's English message.
 /// </summary>

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/NotificationPagesE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/NotificationPagesE2ETests.cs
@@ -8,7 +8,7 @@ namespace MMCA.Common.UI.E2E.Tests;
 
 /// <summary>
 /// Render-smoke + WCAG 2.1 AA accessibility scans for the shared Notification pages, rendered against
-/// the gallery's stubbed notification seams (the pages are discovered from the MMCA.Common.UI assembly).
+/// the gallery's stubbed notification extension points (the pages are discovered from the MMCA.Common.UI assembly).
 /// </summary>
 public sealed class NotificationPagesE2ETests : GalleryAxeTestBase
 {

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/GalleryHost.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/GalleryHost.cs
@@ -15,7 +15,7 @@ namespace MMCA.Common.UI.Gallery;
 /// <summary>
 /// Builds the backend-less Blazor gallery host. It renders the real <c>MMCA.Common.UI</c> auth pages
 /// (<c>/login</c>, <c>/register</c>) and a primitives showcase (<c>/components</c>) with stub
-/// implementations of the consumer seams (no-op auth, anonymous auth state, null token storage), so a
+/// implementations of the consumer extension points (no-op auth, anonymous auth state, null token storage), so a
 /// real-browser axe accessibility scan can run against the shared UI inside <c>MMCA.Common</c>'s own CI.
 /// </summary>
 public static class GalleryHost
@@ -52,7 +52,7 @@ public static class GalleryHost
 
         builder.Services.AddMudServices();
 
-        // Stub the consumer seams BEFORE AddUIShared so its TryAdd* registrations defer to these.
+        // Stub the consumer extension points BEFORE AddUIShared so its TryAdd* registrations defer to these.
         // The gallery never performs real auth or token I/O. The auth pages render in their
         // signed-out state so axe scans the anonymous markup; the [Authorize]-guarded notification
         // pages (rubric §25) are scanned signed-in via the cookie-toggled fake scheme below.
@@ -72,7 +72,7 @@ public static class GalleryHost
                 GalleryFakeAuthenticationHandler.SchemeName, configureOptions: null);
         builder.Services.AddAuthorization();
 
-        // Canned notification seams so NotificationBell and the notification pages
+        // Canned notification extension points so NotificationBell and the notification pages
         // (/notifications, /notifications/inbox, /notifications/send — discovered from the
         // MMCA.Common.UI assembly) render populated markup for the render/axe E2E scan.
         builder.Services.AddScoped<NotificationState>();

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/BunitTestBase.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/BunitTestBase.cs
@@ -10,7 +10,7 @@ namespace MMCA.Common.UI.Tests;
 /// Repo-local base for MMCA.Common UI component tests. Inherits the shared
 /// <see cref="BunitComponentTestBase"/> (MudBlazor services, loose JSInterop, auth test doubles,
 /// and the MudBlazor provider + interaction helpers) from the <c>MMCA.Common.Testing.UI</c> package.
-/// Kept as a thin repo-local seam so Common-only service registrations can be added in one place.
+/// Kept as a thin repo-local extension point so Common-only service registrations can be added in one place.
 /// </summary>
 public abstract class BunitTestBase : BunitComponentTestBase
 {

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Globalization/ResxMudLocalizerTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Globalization/ResxMudLocalizerTests.cs
@@ -7,7 +7,7 @@ using MudBlazor.Services;
 namespace MMCA.Common.UI.Tests.Globalization;
 
 /// <summary>
-/// Proves the MudBlazor built-in-text localization seam (ADR-027): <c>AddMudServices()</c> registers
+/// Proves the MudBlazor built-in-text localization extension point (ADR-027): <c>AddMudServices()</c> registers
 /// no <see cref="MudLocalizer"/> of its own, so <c>AddUIShared</c>'s <c>TryAddTransient</c> is
 /// authoritative and MudBlazor chrome resolves through the <c>MudTranslations</c> resource pair.
 /// </summary>

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationHubServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationHubServiceTests.cs
@@ -14,7 +14,7 @@ namespace MMCA.Common.UI.Tests.Services.Notifications;
 /// the channel API's argument validation, subscription registry, and disconnected no-op paths.
 /// PARTIAL BY DESIGN: <c>StartAsync</c>, the retry/backoff loop, the ReceiveNotification and
 /// ReceiveChannelEvent wiring, and the join/re-join invocations build a real SignalR
-/// <c>HubConnection</c> internally via <c>HubConnectionBuilder</c> with no injectable seam, so
+/// <c>HubConnection</c> internally via <c>HubConnectionBuilder</c> with no injectable extension point, so
 /// exercising them would attempt real network connections with multi-second backoff. Left
 /// uncovered rather than changing Source (covered end to end by the consuming apps' E2E suites).
 /// </summary>


### PR DESCRIPTION
Workspace style bans the words "seam"/"seams" (2026-07-10) in favour of **boundary**, **extension point**, **pipeline** or **layer**. The original sweep covered the article corpus; these occurrences were left behind in code comments, XML docs and repo markdown.

## Safety

Every hit is a comment, an XML doc, or one assertion message. **No identifier, type name, string key, or behaviour changes** (verified: zero matches outside comments across all four repos).

## How the replacement was chosen

Per occurrence, from the surrounding clause, not blanketly:

| Replacement | Used when |
|---|---|
| **boundary** | something crosses between modules, services or stores (gRPC validation, cross-module calls, extraction, repository, storage) |
| **extension point** | the thing exists to be substituted (DI registration, disabled-module stubs, `TimeProvider`/`FakeTimeProvider`, `IWarmupTask`, `ICspPolicyProvider`, the per-repo `IArchitectureMap`) |
| **accessor** | the integration fixtures' `.ConnectionString` / `.Services` members, which are neither |
| "where they were joined" | `PseudoLocalizer`, where the word meant the visible join between concatenated fragments, not an architectural point |

Lines that **state** the ban are untouched: they have to quote the banned words to define the rule. An early version of the guard missed `without "seam"/"seams"` and rewrote an instruction into nonsense, so the guard now matches the quoting itself and is unit-tested against all six phrasings in use.

## Verification

- `dotnet build` clean, **0 warnings** (TreatWarningsAsErrors is on, so the XML docs are validated)
- zero real occurrences left across all four repos and the workspace docs
- rule statements preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6QhZE8qUyVZKvkiYhoY6o