### PR TITLE
docs: community health files and a local source-mode section (#136, #137, #139)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Bug report
+description: Something in the framework behaves differently from what it documents.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A few fields up front save a round trip: the packages ship in
+        lockstep, so the version is one answer, but which package and which host type are not,
+        and both change how this gets triaged.
+
+        Please do not report suspected **security vulnerabilities** here. Use a private
+        [security advisory](https://github.com/ivanball/MMCA.Common/security/advisories/new)
+        instead (see [SECURITY.md](https://github.com/ivanball/MMCA.Common/blob/main/SECURITY.md)).
+
+  - type: input
+    id: version
+    attributes:
+      label: Framework version
+      description: >-
+        The `MMCA.Common.*` version from your `Directory.Packages.props`, or the `Framework version`
+        line in `FACTS.md`. If you are building against framework source with `local.props`
+        (`UseLocalMMCA=true`), say so and give the commit SHA instead.
+      placeholder: "1.128.0 (or: source mode, commit abc1234)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Which package
+      description: The package the problem surfaces in. Pick more than one only if it genuinely spans them.
+      multiple: true
+      options:
+        - MMCA.Common.Shared
+        - MMCA.Common.Domain
+        - MMCA.Common.Application
+        - MMCA.Common.Infrastructure
+        - MMCA.Common.API
+        - MMCA.Common.Grpc
+        - MMCA.Common.UI
+        - MMCA.Common.UI.Web
+        - MMCA.Common.UI.Maui
+        - MMCA.Common.Aspire
+        - MMCA.Common.Aspire.Hosting
+        - MMCA.Common.Testing
+        - MMCA.Common.Testing.Architecture
+        - MMCA.Common.Testing.E2E
+        - MMCA.Common.Testing.UI
+        - Not sure / spans several
+    validations:
+      required: true
+
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host type
+      description: >-
+        How the code runs. Extraction changes the transport (in-process bus vs broker, direct call
+        vs gRPC), so the same symptom often has a different cause in each.
+      options:
+        - Modular monolith (single host)
+        - Extracted service (behind the YARP gateway)
+        - MAUI head
+        - Test host / integration tests
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: sdk
+    attributes:
+      label: .NET SDK version
+      description: Output of `dotnet --version`.
+      placeholder: "10.0.100"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected, and where that expectation came from (an ADR, an XML doc comment, a guide).
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: >-
+        What happened instead. Paste the full exception, analyzer id, or build error rather than
+        summarizing it: the identifier is usually what makes this searchable later.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal repro
+      description: >-
+        The smallest thing that shows the problem: a failing test, a handler plus its registration,
+        or the relevant configuration section. A link to a branch works too.
+      render: csharp
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Workarounds you tried, related ADRs, whether it reproduces on a clean clone.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/ivanball/MMCA.Common/discussions
+    about: >-
+      How do I do X, is this the intended pattern, does this belong in the framework. Ask in
+      Discussions: it stays findable and does not need a triage decision.
+  - name: Security vulnerability (private)
+    url: https://github.com/ivanball/MMCA.Common/security/advisories/new
+    about: >-
+      Report suspected vulnerabilities privately through a security advisory, never a public issue.
+      See SECURITY.md.
+  - name: Documentation library
+    url: https://ivanball.github.io/docs/
+    about: >-
+      ADRs, the getting-started guide, the evaluation rubric, and the onboarding chapters. Worth a
+      look before filing: most "why is it like this" answers have a record.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature request
+description: Propose a capability or an extension point for the framework.
+title: "[feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The framework earns its keep by being the thing every consumer needs, so the useful case
+        is usually made from a real problem in a consuming app rather than from the abstraction
+        you have in mind. Lead with the problem.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >-
+        What are you unable to do today, and what does the workaround cost? Concrete beats general:
+        the app, the use case, and what you write now instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Which layer does this belong in
+      description: >-
+        Dependencies flow one way (`API`/`Grpc` -> `Infrastructure` -> `Application` -> `Domain` ->
+        `Shared`) and both a compile-time guard and fitness tests enforce it. If the answer is
+        "Domain, but it needs a database", the proposal probably splits into an abstraction plus
+        an implementation in different layers.
+      options:
+        - Shared
+        - Domain
+        - Application
+        - Infrastructure
+        - API
+        - Grpc
+        - UI / UI.Web / UI.Maui
+        - Aspire / Aspire.Hosting
+        - Testing packages
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: shape
+    attributes:
+      label: Proposed shape
+      description: >-
+        The API as you would use it: the interface, the registration call, the attribute. A rough
+        sketch is fine. Say whether existing consumers keep compiling.
+      render: csharp
+    validations:
+      required: false
+
+  - type: dropdown
+    id: adr
+    attributes:
+      label: Would this need an ADR?
+      description: >-
+        Every cross-cutting pattern has an Architecture Decision Record. A new pattern, a new
+        extension point, or a change to an existing pattern needs one; a self-contained helper
+        does not. See the [ADR index](https://ivanball.github.io/docs/adr/).
+      options:
+        - "Yes: it introduces or changes a cross-cutting pattern"
+        - "No: it is self-contained inside one layer"
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >-
+        Including "the consuming app keeps owning this". Not everything belongs in the framework,
+        and saying why this one does is the strongest part of the case.
+    validations:
+      required: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ivanball_76@yahoo.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 Thanks for taking an interest in the framework. This is a short guide; the full contributor
 reference (package layout, layer rules, build/test commands) is [CLAUDE.md](CLAUDE.md).
 
+Participation here is governed by the [Code of Conduct](CODE_OF_CONDUCT.md) (Contributor Covenant
+2.1). By taking part you agree to uphold it.
+
 ## Commit messages: Scoped Commits
 
 This repo uses [Scoped Commits](https://scopedcommits.com/), not Conventional Commits. The scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,11 +91,64 @@ let you catch a breaking change before it ships:
 
 - **The Helpdesk source-build canary** (CI) builds MMCA.Helpdesk against this branch's framework
   *source* (`UseLocalMMCA`), so an API break in your PR fails the PR instead of the next release.
-- **Local source mode** lets you iterate a consumer against your Common branch with no token:
-  in a consumer repo, `cp local.props.template local.props` (it sets `UseLocalMMCA=true` and points
-  at `../MMCA.Common/Source/`). Rebuild Common in Debug first (`dotnet build <Common proj> -c Debug`)
-  before rebuilding the consumer, or the IDE binds a stale ref assembly and reports phantom `CS0103`.
-  A green local source-mode build is not proof CI package-mode is green; expect a CI round-trip.
+- **Local source mode** lets you iterate a consumer against your Common branch with no token. It has
+  two traps that look like code bugs; both are covered in the next section.
+
+## Local source-mode development
+
+Normally a consumer (MMCA.ADC, MMCA.Store, MMCA.Helpdesk) resolves `MMCA.Common.*` as released
+NuGet packages, so a framework change only reaches it after a release. **Local source mode** swaps
+those `PackageReference`s for `ProjectReference`s pointing at your working copy of the framework, so
+a consumer builds against the code you are editing right now, with no GitHub Packages token.
+
+### Turning it on
+
+Clone the consumer as a **sibling** of this repo (the relative path is what makes it work):
+
+```
+C:\Projects\MMCA\
+  MMCA.Common\
+  MMCA.Helpdesk\
+```
+
+Then, in the consumer repo:
+
+```bash
+cp local.props.template local.props
+```
+
+That sets `UseLocalMMCA=true` and points at `../MMCA.Common/Source/`. `local.props` is gitignored,
+so the switch stays local to your machine. MMCA.Helpdesk is the exception: it ships `local.props`
+checked in and is in source mode by default, which is what lets the CI canary build it against a PR.
+
+To go back to package mode, delete (or rename) `local.props` and restore.
+
+### Rebuild Common in Debug first
+
+**Symptom:** you add a member to a framework type, rebuild only the consumer, and the compiler
+reports `CS0103: The name 'X' does not exist in the current context` (or `CS0117` / `CS1061`) against
+the member you just added. The code is correct and the file is right there on disk.
+
+**Cause:** the `ProjectReference` points outside the consumer's solution, so the build binds the
+framework's **last-built Debug reference assembly** rather than recompiling your edit.
+
+**Fix:** build the framework project in Debug before rebuilding the consumer.
+
+```bash
+dotnet build <path to the MMCA.Common project you changed> -c Debug
+```
+
+This is not a code bug and no amount of cleaning the consumer fixes it. Note the configuration: a
+`-c Release` build of the framework does not refresh the **Debug** ref assembly the consumer binds.
+
+### A green source-mode build is not proof CI is green
+
+Source mode and package mode do not fail identically. A local source-mode build can pass (even in
+Release) while CI fails in package mode on an analyzer or a restore rule that only applies to a
+packaged reference: analyzers flowing from a package, `NU1605` downgrades, lock-file drift, and pack
+errors (`NU5xxx`) are all invisible to a source-mode build. The `package-consumption` CI job exists
+precisely to catch these, so expect the occasional CI-only round-trip and do not treat a clean local
+build as the final word.
 
 ## Releases are separate
 


### PR DESCRIPTION
## Summary

Closes the three community-health / documentation issues opened against this repo. One PR, one commit per issue, no behavior change.

- **`#136`** `CODE_OF_CONDUCT: adopt Contributor Covenant 2.1` - the community profile reported `code_of_conduct: MISSING` (health 85%). Verbatim Contributor Covenant 2.1 with the enforcement contact filled in, linked from `CONTRIBUTING.md`. The issue anticipated a prose pass for em dashes and accents: the upstream text needs none, so it is byte-faithful apart from the contact placeholder (which also keeps GitHub's covenant detection working).
- **`#139`** `CONTRIBUTING: document local source-mode development and its stale-DLL trap` - promotes the single `local.props` bullet to its own section: turning source mode on and off, the `CS0103` symptom spelled out so it is searchable, the Debug-rebuild-first fix, and the warning that a green source-mode build is not proof package-mode CI is green.
- **`#137`** `.github: add bug report and feature request issue forms` - `bug_report.yml`, `feature_request.yml`, and a `config.yml` that turns off blank issues and routes questions to Discussions, vulnerabilities to a private advisory, and "why is it like this" to the published ADR index.

## Scope of change

- [x] No public API change (internal only)
- [ ] Public API change (new/changed types, members, or signatures) - **breaking for consumers?** describe the impact below
- [ ] New or changed cross-cutting pattern (an ADR is read/updated below)

## Consumer impact (fill in if the public API changed)

None. No source, project reference, or package metadata is touched.

## Checklist

- [x] `dotnet build MMCA.Common.slnx -c Release` is clean (`TreatWarningsAsErrors` on, 5 analyzers at error). No compiled file changed; CI verifies.
- [x] `dotnet test --solution MMCA.Common.slnx -c Release` passes. No test-affecting change; CI verifies.
- [x] If a project reference or a type moved between packages, both layer gates were updated. Not applicable.
- [x] `FACTS.md` regenerated if this changes the version, package list, ADR range, or fitness counts. Not applicable: none of those change.
- [x] The relevant ADR was read, and updated/added there if a pattern it describes changed. Not applicable: no pattern changes.
- [x] The published scorecard/backlog updated if this closes or moves a remediation item. Not applicable.
- [x] Commit messages follow Scoped Commits.
- [x] No secrets staged. The Code of Conduct enforcement contact is the maintainer address already published on the GitHub profile.

## Verification

- The two issue forms and `config.yml` parse as YAML, and both `bug` and `enhancement` labels already exist in this repo.
- After merge, `gh api repos/ivanball/MMCA.Common/community/profile` should report `code_of_conduct` and `issue_template` present.

Note: `.github/ISSUE_TEMPLATE/*.yml` are not markdown, so this PR does **not** take the docs-only fast CI path; the full matrix runs.

Closes #136
Closes #137
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6QhZE8qUyVZKvkiYhoY6o
