### PR TITLE
docs: correct CLAUDE.md publishing target and stale Helpdesk test count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
       - name: Test Helpdesk (domain + architecture, no DB)
         if: needs.changes.outputs.code == 'true'
         working-directory: MMCA.Helpdesk
-        # Helpdesk's suite is ~44 tests; floor at 40 so a discovery/filter regression fails
+        # Helpdesk's suite is ~91 tests; floor at 40 so a discovery/filter regression fails
         # instead of passing green with near-zero tests discovered.
         run: dotnet test --solution MMCA.Helpdesk.slnx -c Release --no-build --minimum-expected-tests 40
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides framework-specific guidance to Claude Code (claude.ai/code). 
 
 ## Project Overview
 
-MMCA.Common is a .NET 10 NuGet package framework for building modular monolith applications using DDD, Clean Architecture, and CQRS. It publishes its packages to GitHub Packages, versioned in lockstep (authoritative package list and count: `FACTS.md`); it is not a runnable app. `MMCA.Common.UI.Maui` is the one MAUI-TFM package: it lives outside `MMCA.Common.slnx` and is built/packed by dedicated windows jobs (ADR-042). The framework also provides the extraction path for lifting modules into standalone microservices (gRPC transport, transport-agnostic message bus, cross-service JWKS auth, Aspire hosting extensions): see "Microservices Extraction Boundaries" below.
+MMCA.Common is a .NET 10 NuGet package framework for building modular monolith applications using DDD, Clean Architecture, and CQRS. It publishes its packages to **both nuget.org and GitHub Packages** (ADR-053; see the `release.yml` notes under Build & Test), versioned in lockstep (authoritative package list and count: `FACTS.md`); it is not a runnable app. `MMCA.Common.UI.Maui` is the one MAUI-TFM package: it lives outside `MMCA.Common.slnx` and is built/packed by dedicated windows jobs (ADR-042). The framework also provides the extraction path for lifting modules into standalone microservices (gRPC transport, transport-agnostic message bus, cross-service JWKS auth, Aspire hosting extensions): see "Microservices Extraction Boundaries" below.
 
 ## Build & Test
 


### PR DESCRIPTION
Audit of the repo CLAUDE.md against the current tree (workspace-wide pass; sibling PRs in Store and ADC).

## What was wrong

- **Project Overview said the framework publishes to GitHub Packages only.** It contradicted the `release.yml` paragraph in the same file: since ADR-053 every package is pushed to **both nuget.org (keyless OIDC trusted publishing) and GitHub Packages**.
- **`ci.yml` consumer-source-build comment said Helpdesk's suite is ~44 tests.** It is 91 today, verified by running `dotnet test --solution MMCA.Helpdesk.slnx` (91 passed, 0 failed). Comment only: the `--minimum-expected-tests 40` floor is unchanged, since it guards against a discovery regression rather than tracking suite size.

No behavior change: one prose correction and one comment correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)