### PR TITLE
Extraction wave: rate-limit, health-check and test-base lifts (E1, E4, E7, E8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+Extraction wave from the 2026-07-27 drift analysis: reusable infrastructure that had been duplicated
+across MMCA.ADC and MMCA.Store moves into the framework. Consumers adopt during the version sweep.
+
+### BREAKING
+
+- **`MMCA.Common.API`: `AddCommonRateLimiting` now registers an `"auth-ip"` policy.** A consumer that
+  already registers a policy of that name must DELETE its own registration when bumping, because
+  `RateLimiterOptions.AddPolicy` throws on a duplicate name and the host will fail at startup.
+  MMCA.ADC is the only consumer in that position today.
+
+  ```csharp
+  // Before (per-consumer, in the Identity service host):
+  var authIpPermitLimit = builder.Configuration.GetValue("RateLimiting:AuthIp:PermitLimit", 30);
+  services.AddRateLimiter(options => options.AddPolicy("auth-ip", httpContext => { /* ... */ }));
+
+  // After: delete the block above. The policy ships with AddCommonRateLimiting; tune it there.
+  services.AddCommonRateLimiting(authIpPermitLimit: 30);
+
+  // Endpoints reference the shared constant instead of the string literal:
+  [EnableRateLimiting(WebApplicationBuilderExtensions.RateLimitPolicyAuthIp)]
+  ```
+
+### Added
+
+- **`MMCA.Common.API`: per-IP anonymous authentication throttle** (`RateLimitPolicyAuthIp`,
+  `authIpPermitLimit` defaulting to 30 req/min). The global limiter deliberately no-ops for anonymous
+  traffic and account lockout is per-email, so a password spray from one source was otherwise
+  unthrottled. Fails OPEN on an unattributable client IP, so the in-process TestServer (where
+  `RemoteIpAddress` is null) is never throttled.
+- **`MMCA.Common.Aspire`: SQL Server readiness check** in `AddInfrastructureHealthChecks`, with an
+  opt-in `requireSqlServer` fail-fast. The asymmetry with the silently-skipping Redis and RabbitMQ
+  branches is deliberate: an optional cache may legitimately be absent, a service database may not.
+  Adds `AspNetCore.HealthChecks.SqlServer` 9.0.0, matching the Redis/RabbitMQ sibling version.
+- **`MMCA.Common.Testing.Architecture`: `ObservabilityConventionTestsBase`**, the SLO alert-to-runbook
+  pairing gate. Reads the embedded `infra.main.bicep` / `infra.OPERATIONS.md` from the DERIVED type's
+  assembly via a virtual `ResourceAssembly`, so a subclass needs no extra wiring.
+- **`MMCA.Common.Testing`: `GracefulShutdownTestsBase<TEntryPoint>` and
+  `ProductionHostApplicationFactory<TEntryPoint>`.** The factory pins the environment to `Production`
+  (exercising the realistic CORS/HSTS branches a default Development boot skips) and captures the
+  started `IHost` so the shutdown test can drive `StopAsync` directly.
+
 ## [1.128.0] - 2026-07-25
 
 Distribution release. **No source changes: the compiled assemblies are identical to 1.127.0.** What

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -143,6 +143,7 @@
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <!-- Aspire / ServiceDefaults -->
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-07-25 (framework v1.128.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-07-28 (framework v1.128.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -41,10 +41,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **93 test methods across 30 abstract `*TestsBase` classes**, shipped once in the
+- **96 test methods across 31 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **56** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **61** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/packages.lock.json
@@ -309,15 +309,6 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
         }
       },
-      "AspNetCore.HealthChecks.SqlServer": {
-        "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
-        "dependencies": {
-          "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
-        }
-      },
       "AspNetCore.HealthChecks.Uris": {
         "type": "Transitive",
         "resolved": "9.0.0",
@@ -1088,6 +1079,16 @@
         "dependencies": {
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "RabbitMQ.Client": "7.0.0"
+        }
+      },
+      "AspNetCore.HealthChecks.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
         }
       },
       "Azure.Identity": {

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -200,15 +200,42 @@ public static class Extensions
         }
 
         /// <summary>
-        /// Conditionally registers health checks for infrastructure dependencies (Redis, RabbitMQ)
-        /// when their connection strings are configured. These are tagged as readiness checks only —
-        /// they appear in <c>/health</c> but not <c>/alive</c>, so a transient infrastructure outage
-        /// does not kill the process.
+        /// Conditionally registers health checks for infrastructure dependencies (SQL Server, Redis,
+        /// RabbitMQ) when their connection strings are configured. These are tagged as readiness
+        /// checks only — they appear in <c>/health</c> but not <c>/alive</c>, so a transient
+        /// infrastructure outage does not kill the process.
         /// </summary>
+        /// <param name="requireSqlServer">
+        /// When <see langword="true"/>, a missing <c>SQLServerConnectionString</c> throws at startup
+        /// instead of silently skipping the check.
+        /// <para>
+        /// This asymmetry with the Redis/RabbitMQ branches is DELIBERATE, not an oversight. Redis and
+        /// RabbitMQ are optional per host, so their absence is a valid configuration. The service
+        /// database is not: a host that cannot resolve its own connection string is misconfigured,
+        /// and silently registering no check would let it report healthy and take traffic it cannot
+        /// serve. Every consumer host that hand-rolled this check used <c>?? throw</c> for exactly
+        /// that reason, so pass <see langword="true"/> when replacing one.
+        /// </para>
+        /// </param>
         /// <returns>The same builder instance for chaining.</returns>
-        public TBuilder AddInfrastructureHealthChecks()
+        /// <exception cref="InvalidOperationException">
+        /// <paramref name="requireSqlServer"/> is <see langword="true"/> and no
+        /// <c>SQLServerConnectionString</c> is configured.
+        /// </exception>
+        public TBuilder AddInfrastructureHealthChecks(bool requireSqlServer = false)
         {
             var healthChecks = builder.Services.AddHealthChecks();
+
+            var sqlConnectionString = builder.Configuration.GetConnectionString("SQLServerConnectionString");
+            if (requireSqlServer && string.IsNullOrWhiteSpace(sqlConnectionString))
+            {
+                throw new InvalidOperationException("SQLServerConnectionString is not configured.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(sqlConnectionString))
+            {
+                healthChecks.AddSqlServer(sqlConnectionString, name: "sqlserver");
+            }
 
             var redisConnectionString = builder.Configuration.GetConnectionString("redis");
             if (!string.IsNullOrWhiteSpace(redisConnectionString))

--- a/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -20,6 +20,15 @@
           "StackExchange.Redis": "2.7.4"
         }
       },
+      "AspNetCore.HealthChecks.SqlServer": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
       "Azure.Monitor.OpenTelemetry.AspNetCore": {
         "type": "Direct",
         "requested": "[1.5.0, )",
@@ -169,6 +178,11 @@
         "resolved": "10.0.3",
         "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
       },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "5.2.0",
+        "contentHash": "po1jhvFd+8pbfvJR/puh+fkHi0GRanAdvayh/0e47yaM6CXWZ6opUjCMFuYlAnD2LcbyvQE7fPJKvogmaUcN+w=="
+      },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
         "resolved": "10.8.0",
@@ -253,6 +267,53 @@
         "resolved": "8.14.0",
         "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "9wxai3hKgZUb4/NjdRKfQd0QJvtXKDlvmGMYACbEC8DFaicMFCFhQFZq9ZET1kJLwZahf2lfY5Gtcpsx8zYzbg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "jePrSfGAmqT81JDCNSY+fxVWoGuJKt9e6eJ+vT7+quVS55nWl//jGjUQn4eFtVKt4rt5dXaleZdHRB9J9AJZ7Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "BPQhlDzdFvv1PzaUxNSk+VEPwezlDEVADIKmyxubw7IiELK18uJ06RQ9QKKkds30XI+gDu9n8j24XQ8w7fjWcg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "6.35.0",
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "LMtVqnECCCdSmyFoCOxIE5tXQqkOLrvGrL7OxHg41DIm1bpWtaCdGyVcTAfOQpJXvzND9zUKIN/lhngPkYR8vg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "6.35.0",
+          "System.IdentityModel.Tokens.Jwt": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "RN7lvp7s3Boucg1NaNAbqDbxtlLj5Qeb+4uSS1TeK5FSBVM40P4DKaTKChT43sHyKfh7V0zkrMph6DdHvyA4bg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "6.35.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
       "OpenTelemetry": {
         "type": "Transitive",
         "resolved": "1.17.0",
@@ -326,18 +387,62 @@
           "System.Memory.Data": "10.0.3"
         }
       },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.3",
         "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
+      "System.Runtime.Caching": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "4TmlmvGp4kzZomm7J2HJn6IIx0UUrQyhBDyb5O1XiunZlQImXW+B8b7W/sTPcXhSf9rp5NR5aDtQllwbB5elOQ==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "8.0.0"
+        }
+      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
       },
       "mmca.common.shared": {
         "type": "Project"
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.11.4",
+        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
+        "dependencies": {
+          "Azure.Core": "1.38.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.7.0"
+        }
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.1, )",
+        "resolved": "5.2.2",
+        "contentHash": "mtoeRMh7F/OA536c/Cnh8L4H0uLSKB5kSmoi54oN7Fp0hNJDy22IqyMhaMH4PkDCqI7xL//Fvg9ldtuPHG0h5g==",
+        "dependencies": {
+          "Azure.Identity": "1.11.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.0",
+          "System.Runtime.Caching": "8.0.0"
+        }
       },
       "StackExchange.Redis": {
         "type": "CentralTransitive",
@@ -346,6 +451,16 @@
         "contentHash": "lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
         "dependencies": {
           "Pipelines.Sockets.Unofficial": "2.2.8"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "CentralTransitive",
+        "requested": "[8.19.2, )",
+        "resolved": "6.35.0",
+        "contentHash": "yxGIQd3BFK7F6S62/7RdZk3C/mfwyVxvh6ngd1VYMBmbJ1YZZA9+Ku6suylVtso0FjI0wbElpJ0d27CdsyLpBQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
         }
       }
     }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ObservabilityConventionTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ObservabilityConventionTestsBase.cs
@@ -1,0 +1,147 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace MMCA.Common.Testing.Architecture;
+
+/// <summary>
+/// SLO alert-to-runbook pairing gate (rubric section 13): every SLO metric alert provisioned by the
+/// consumer's <c>infra/main.bicep</c> (<c>sloAlertSpecs</c>) must keep a matching triage section in
+/// its <c>infra/OPERATIONS.md</c>, and that section's heading must carry the alert's current
+/// severity, so an alert cannot be added, renamed, or re-tiered without its runbook moving in the
+/// same change. The reverse direction is guarded too: an orphan runbook section whose alert no
+/// longer exists fails the build. A minimum-spec floor keeps the gate non-vacuous, so a drifted
+/// parse anchor fails loudly instead of passing with zero discovered alerts.
+/// <para>
+/// <b>Subclassing:</b> both files must be embedded as manifest resources in the SUBCLASS's test
+/// project, with the logical names <c>infra.main.bicep</c> and <c>infra.OPERATIONS.md</c>:
+/// </para>
+/// <code>
+/// &lt;EmbeddedResource Include="..\..\..\infra\main.bicep"&gt;
+///   &lt;LogicalName&gt;infra.main.bicep&lt;/LogicalName&gt;
+/// &lt;/EmbeddedResource&gt;
+/// </code>
+/// <para>
+/// Resources are read from <see cref="ResourceAssembly"/>, which defaults to the DERIVED type's
+/// assembly. That default is load-bearing: this base ships inside the framework package, so
+/// resolving against its own assembly would look for the consumer's bicep inside
+/// MMCA.Common.Testing.Architecture.dll and always throw.
+/// </para>
+/// </summary>
+public abstract partial class ObservabilityConventionTestsBase
+{
+    private const string AlertNameInfix = "-alert-";
+
+    /// <summary>
+    /// Lowest number of SLO alert specs the consumer's bicep is expected to declare. The floor is
+    /// what keeps this gate honest: discovering fewer means the parse anchors drifted, not that the
+    /// alerts silently disappeared. Raise it in the subclass as the consumer provisions more.
+    /// </summary>
+    protected virtual int MinimumAlertSpecs => 3;
+
+    /// <summary>Manifest-resource logical name of the consumer's IaC template.</summary>
+    protected virtual string BicepResource => "infra.main.bicep";
+
+    /// <summary>Manifest-resource logical name of the consumer's operations runbook.</summary>
+    protected virtual string RunbookResource => "infra.OPERATIONS.md";
+
+    /// <summary>
+    /// Assembly the embedded resources are read from. Defaults to the derived type's assembly, so a
+    /// subclass gets its OWN test project's resources with no extra wiring.
+    /// </summary>
+    protected virtual Assembly ResourceAssembly => GetType().Assembly;
+
+    [Fact]
+    public void SloAlertSpecs_AreDiscovered_GateIsNotVacuous()
+    {
+        var specs = DiscoverAlertSpecs();
+
+        specs.Should().HaveCountGreaterThanOrEqualTo(
+            MinimumAlertSpecs,
+            because: $"infra/main.bicep provisions at least {MinimumAlertSpecs.ToString(CultureInfo.InvariantCulture)} SLO alerts; discovering fewer means the sloAlertSpecs parse anchors drifted and the pairing gate would pass vacuously");
+    }
+
+    [Fact]
+    public void EveryProvisionedSloAlert_HasASeverityCorrectRunbookSection()
+    {
+        var specs = DiscoverAlertSpecs();
+        var runbook = ReadEmbedded(RunbookResource);
+        var headings = DiscoverRunbookAlertHeadings(runbook);
+
+        var violations = new List<string>();
+        foreach (var (key, severity) in specs)
+        {
+            var heading = headings.Find(h => h.Contains(AlertNameInfix + key, StringComparison.Ordinal));
+            if (heading is null)
+            {
+                violations.Add($"alert '{key}' has no '### ...{AlertNameInfix}{key}' runbook section in infra/OPERATIONS.md");
+                continue;
+            }
+
+            var severityTag = string.Create(CultureInfo.InvariantCulture, $"(sev {severity})");
+            if (!heading.Contains(severityTag, StringComparison.Ordinal))
+            {
+                violations.Add(string.Create(CultureInfo.InvariantCulture, $"alert '{key}' is severity {severity} in main.bicep, but its runbook heading does not carry '{severityTag}': {heading.Trim()}"));
+            }
+        }
+
+        violations.Should().BeEmpty(
+            because: "every provisioned SLO alert must keep a severity-correct triage section in infra/OPERATIONS.md, so alerts and runbooks change together (rubric section 13)");
+    }
+
+    [Fact]
+    public void EveryRunbookAlertSection_MapsToAProvisionedAlert()
+    {
+        var specKeys = DiscoverAlertSpecs().ConvertAll(s => s.Key);
+        var runbook = ReadEmbedded(RunbookResource);
+
+        var orphans = DiscoverRunbookAlertHeadings(runbook)
+            .Where(heading => !specKeys.Exists(key => heading.Contains(AlertNameInfix + key, StringComparison.Ordinal)))
+            .ToList();
+
+        orphans.Should().BeEmpty(
+            because: "a runbook section for an alert that main.bicep no longer provisions is stale guidance; remove or rename it in the same change as the alert (rubric section 13)");
+    }
+
+    private List<(string Key, int Severity)> DiscoverAlertSpecs()
+    {
+        var bicep = ReadEmbedded(BicepResource);
+
+        var start = bicep.IndexOf("var sloAlertSpecs", StringComparison.Ordinal);
+        var end = bicep.IndexOf("resource sloAlerts", StringComparison.Ordinal);
+        start.Should().BeGreaterThanOrEqualTo(0, because: "infra/main.bicep must declare the sloAlertSpecs variable this gate parses");
+        end.Should().BeGreaterThan(start, because: "infra/main.bicep must materialize sloAlertSpecs into the sloAlerts resource after declaring it");
+
+        var block = bicep[start..end];
+        var keys = AlertKeyRegex.Matches(block);
+        var severities = AlertSeverityRegex.Matches(block);
+        keys.Count.Should().Be(severities.Count, because: "every sloAlertSpecs entry declares exactly one key and one severity, so a count mismatch means the spec shape changed and this parser must follow");
+
+        var specs = new List<(string Key, int Severity)>(keys.Count);
+        for (var i = 0; i < keys.Count; i++)
+        {
+            specs.Add((keys[i].Groups["key"].Value, int.Parse(severities[i].Groups["sev"].Value, CultureInfo.InvariantCulture)));
+        }
+
+        return specs;
+    }
+
+    private static List<string> DiscoverRunbookAlertHeadings(string runbook) =>
+        [.. RunbookHeadingRegex.Matches(runbook).Select(m => m.Value).Where(h => h.Contains(AlertNameInfix, StringComparison.Ordinal))];
+
+    private string ReadEmbedded(string logicalName)
+    {
+        using var stream = ResourceAssembly.GetManifestResourceStream(logicalName)
+            ?? throw new InvalidOperationException($"{logicalName} must be embedded as a resource in {ResourceAssembly.GetName().Name} for the alert-to-runbook pairing gate to run");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    [GeneratedRegex(@"key:\s*'(?<key>[a-z0-9-]+)'", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 2000)]
+    private static partial Regex AlertKeyRegex { get; }
+
+    [GeneratedRegex(@"severity:\s*(?<sev>\d)", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 2000)]
+    private static partial Regex AlertSeverityRegex { get; }
+
+    [GeneratedRegex(@"^###\s+.*$", RegexOptions.Multiline, matchTimeoutMilliseconds: 2000)]
+    private static partial Regex RunbookHeadingRegex { get; }
+}

--- a/Source/Hosting/MMCA.Common.Testing/GracefulShutdownTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing/GracefulShutdownTestsBase.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Graceful-shutdown gate for a host (rubric section 29): a requested stop must drain and complete
+/// cleanly, firing <see cref="IHostApplicationLifetime.ApplicationStopping"/> then
+/// <see cref="IHostApplicationLifetime.ApplicationStopped"/>, well within a bounded timeout.
+/// <para>
+/// The failure this catches is a hosted service (warm-up runner, service discovery, proxy
+/// infrastructure) that refuses to drain. In production that does not announce itself: it silently
+/// wedges a rolling deploy while the platform waits out its termination grace period. Here the
+/// bounded stop token cancels, <see cref="IHost.StopAsync"/> throws, and the test fails instead.
+/// </para>
+/// <para>
+/// Subclass with the host's entry point and no body; override <see cref="CreateFactory"/> only if
+/// the host needs a fixture beyond a Production-pinned boot.
+/// </para>
+/// </summary>
+/// <typeparam name="TEntryPoint">The host's entry-point class, typically its <c>Program</c>.</typeparam>
+public abstract class GracefulShutdownTestsBase<TEntryPoint>
+    where TEntryPoint : class
+{
+    /// <summary>Seconds allowed for the graceful stop before the test fails it.</summary>
+    protected virtual int ShutdownTimeoutSeconds => 20;
+
+    /// <summary>Creates the factory used to boot the host under test.</summary>
+    protected virtual ProductionHostApplicationFactory<TEntryPoint> CreateFactory() => new();
+
+    [Fact]
+    public async Task Host_StopsGracefully_FiringLifetimeEventsWithinTimeout()
+    {
+        var factory = CreateFactory();
+
+        // Held as a separate ConfiguredAsyncDisposable rather than "await using var factory = ...
+        // .ConfigureAwait(false)": that form would retype factory and lose CreateClient/StartedHost.
+        await using var factoryDisposal = factory.ConfigureAwait(false);
+
+        using (factory.CreateClient())
+        {
+            // Creating a client boots and starts the host; StartedHost is now set.
+        }
+
+        factory.StartedHost.Should().NotBeNull();
+        var host = factory.StartedHost!;
+        var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+        lifetime.ApplicationStarted.IsCancellationRequested.Should().BeTrue("the host should have started");
+
+        // A real graceful stop honoring a bounded timeout: if a hosted service refuses to drain, the
+        // token cancels and StopAsync throws, surfacing the non-graceful shutdown as a test failure.
+        // Reaching the assertions below means StopAsync returned cleanly within the timeout.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(ShutdownTimeoutSeconds));
+        await host.StopAsync(timeout.Token).ConfigureAwait(false);
+
+        lifetime.ApplicationStopping.IsCancellationRequested.Should().BeTrue(
+            "ApplicationStopping must fire during a graceful shutdown");
+        lifetime.ApplicationStopped.IsCancellationRequested.Should().BeTrue(
+            "ApplicationStopped must signal once the host has fully stopped");
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/ProductionHostApplicationFactory.cs
+++ b/Source/Hosting/MMCA.Common.Testing/ProductionHostApplicationFactory.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Boots a real host in-process with the environment pinned to <c>Production</c>, and captures the
+/// started <see cref="IHost"/> so a test can drive its lifetime directly.
+/// <para>
+/// Both parts matter. Pinning <c>Production</c> exercises the realistic branches that a default
+/// <c>Development</c> boot skips (the restrictive CORS policy, HSTS emission, production-only
+/// middleware), which is where host misconfiguration actually hides. Capturing the host is what
+/// makes <see cref="GracefulShutdownTestsBase{TEntryPoint}"/> possible: <see cref="IHost.StopAsync"/>
+/// cannot be reached through the <see cref="WebApplicationFactory{TEntryPoint}"/> surface alone.
+/// </para>
+/// <para>
+/// Suited to hosts that need no database or broker to boot (a reverse-proxy gateway is the usual
+/// case). A host that migrates or seeds on startup needs its own fixture.
+/// </para>
+/// </summary>
+/// <typeparam name="TEntryPoint">The host's entry-point class, typically its <c>Program</c>.</typeparam>
+public class ProductionHostApplicationFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint>
+    where TEntryPoint : class
+{
+    /// <summary>
+    /// The started host. Null until the first client is created, because
+    /// <see cref="WebApplicationFactory{TEntryPoint}"/> builds the host lazily.
+    /// </summary>
+    public IHost? StartedHost { get; private set; }
+
+    /// <inheritdoc />
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.UseEnvironment("Production");
+        StartedHost = base.CreateHost(builder);
+        return StartedHost;
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/WebApplicationBuilderExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/WebApplicationBuilderExtensions.cs
@@ -28,6 +28,15 @@ public static class WebApplicationBuilderExtensions
     /// <summary>Default CORS policy name for development (any origin).</summary>
     public const string CorsPolicyAllowAll = "_allowAll";
 
+    /// <summary>
+    /// Named rate-limit policy throttling ANONYMOUS authentication attempts per client IP. Apply it
+    /// with <c>[EnableRateLimiting(WebApplicationBuilderExtensions.RateLimitPolicyAuthIp)]</c> on
+    /// login/register actions. It exists because the global limiter deliberately no-ops for
+    /// anonymous traffic and per-account lockout is per-email, which leaves a password spray (one
+    /// password, many emails) from a single source otherwise unthrottled.
+    /// </summary>
+    public const string RateLimitPolicyAuthIp = "auth-ip";
+
     /// <summary>True for traffic that must bypass rate limiting: health/liveness probes, JWKS
     /// discovery, and gRPC inter-service calls — all legitimately high-frequency.</summary>
     /// <remarks>Internal (not private) so the partition/exemption logic is unit-testable via
@@ -68,6 +77,31 @@ public static class WebApplicationBuilderExtensions
         });
     }
 
+    /// <summary>
+    /// Partition selector for <see cref="RateLimitPolicyAuthIp"/>: a fixed window keyed on the
+    /// client IP, or no limiter at all when the IP is unattributable.
+    /// </summary>
+    /// <remarks>
+    /// Internal (not private) for the same reason as <see cref="GlobalRateLimitPartition"/>: the
+    /// load-bearing decision (fail open on a null IP rather than collapsing every such request into
+    /// one shared bucket, which would throttle the in-process TestServer and the integration tier to
+    /// a standstill) is worth asserting directly rather than only through a request flood.
+    /// </remarks>
+    internal static RateLimitPartition<string> AuthIpRateLimitPartition(HttpContext httpContext, int authIpPermitLimit)
+    {
+        var clientIp = httpContext.Connection.RemoteIpAddress?.ToString();
+
+        return clientIp is null
+            ? RateLimitPartition.GetNoLimiter("__unknown-ip")
+            : RateLimitPartition.GetFixedWindowLimiter(clientIp, _ => new FixedWindowRateLimiterOptions
+            {
+                Window = TimeSpan.FromMinutes(1),
+                PermitLimit = authIpPermitLimit,
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            });
+    }
+
     extension(IServiceCollection services)
     {
         /// <summary>
@@ -103,9 +137,22 @@ public static class WebApplicationBuilderExtensions
         /// Health/liveness (<c>/health</c>, <c>/alive</c>), JWKS discovery (<c>/.well-known/*</c>) and
         /// gRPC inter-service traffic (<c>application/grpc</c>) are bypassed — they legitimately run
         /// at high frequency. The named "FixedPolicy"/"UserPolicy" limiters remain for opt-in
-        /// <c>[EnableRateLimiting]</c> use.
+        /// <c>[EnableRateLimiting]</c> use, as does <see cref="RateLimitPolicyAuthIp"/>, the per-IP
+        /// anonymous-authentication throttle described on <paramref name="authIpPermitLimit"/>.
         /// </summary>
-        public IServiceCollection AddCommonRateLimiting(int permitLimit = 100, int queueLimit = 2, int perUserPermitLimit = 30, int globalPermitLimit = 300) =>
+        /// <param name="permitLimit">Requests per minute for the opt-in "FixedPolicy" limiter.</param>
+        /// <param name="queueLimit">Queued requests allowed once "FixedPolicy"/"UserPolicy" are saturated.</param>
+        /// <param name="perUserPermitLimit">Requests per minute per user for the opt-in "UserPolicy" limiter.</param>
+        /// <param name="globalPermitLimit">Requests per minute per authenticated user for the always-on global limiter.</param>
+        /// <param name="authIpPermitLimit">
+        /// Requests per minute per client IP for the <see cref="RateLimitPolicyAuthIp"/> policy.
+        /// Default 30 rather than a tighter 10 on purpose: Blazor Server interactive circuits issue
+        /// the login HTTP call SERVER-side, so every Server-circuit user shares the UI host's IP. A
+        /// login burst (and a sequential E2E gate) must fit inside the window, while a spray still
+        /// drops from unlimited to roughly 43K attempts/day/IP with per-account lockout intact on
+        /// top. Tighten toward 10 only once real client IPs are forwarded end to end.
+        /// </param>
+        public IServiceCollection AddCommonRateLimiting(int permitLimit = 100, int queueLimit = 2, int perUserPermitLimit = 30, int globalPermitLimit = 300, int authIpPermitLimit = 30) =>
             services.AddRateLimiter(options =>
             {
                 options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -133,6 +180,18 @@ public static class WebApplicationBuilderExtensions
                             QueueLimit = queueLimit,
                             QueueProcessingOrder = QueueProcessingOrder.OldestFirst
                         }));
+
+                // Per-IP anonymous authentication throttle. Client IP is taken from
+                // Connection.RemoteIpAddress, which the shared pipeline has already resolved from
+                // X-Forwarded-For (UseForwardedHeaders runs before UseRateLimiter), the same
+                // canonical source the global partition uses. A null RemoteIpAddress (in-process
+                // TestServer, integration tests) is NOT limited, mirroring the global limiter's
+                // fail-open posture for unattributable traffic. Endpoints opt in with
+                // [EnableRateLimiting(RateLimitPolicyAuthIp)], so health, JWKS and gRPC are
+                // untouched.
+                options.AddPolicy(
+                    RateLimitPolicyAuthIp,
+                    httpContext => AuthIpRateLimitPartition(httpContext, authIpPermitLimit));
             });
 
         /// <summary>

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -534,6 +534,7 @@
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
+          "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.5.0, )",
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
@@ -629,6 +630,15 @@
         "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
         "dependencies": {
           "StackExchange.Redis": "2.7.4"
+        }
+      },
+      "AspNetCore.HealthChecks.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.2.2"
         }
       },
       "Azure.Identity": {

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/Fixtures/observability-OPERATIONS.md
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/Fixtures/observability-OPERATIONS.md
@@ -1,0 +1,19 @@
+# Fixture operations runbook
+
+Companion to `observability-main.bicep`. Every `### ...-alert-<key> (sev N)` heading below pairs with
+a spec in that template, and the severity in each heading matches the spec, so the base class's
+pairing gate passes against this fixture pair.
+
+## Alert triage
+
+### fixture-alert-failed-requests (sev 2)
+
+Triage steps for the failed-requests alert.
+
+### fixture-alert-response-time (sev 3)
+
+Triage steps for the response-time alert.
+
+### fixture-alert-dependency-failures (sev 2)
+
+Triage steps for the dependency-failures alert.

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/Fixtures/observability-main.bicep
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/Fixtures/observability-main.bicep
@@ -1,0 +1,25 @@
+// Fixture for ObservabilityConventionTestsBase. Deliberately minimal: it carries only the two parse
+// anchors the base looks for (the sloAlertSpecs declaration and the sloAlerts resource that
+// materializes it) plus three well-formed specs, so the base's discovery and pairing logic can be
+// exercised without embedding a real consumer's several-thousand-line template.
+
+var sloAlertSpecs = [
+  {
+    key: 'failed-requests'
+    severity: 2
+  }
+  {
+    key: 'response-time'
+    severity: 3
+  }
+  {
+    key: 'dependency-failures'
+    severity: 2
+  }
+]
+
+resource sloAlerts 'Microsoft.Insights/metricAlerts@2018-03-01' = [
+  for spec in sloAlertSpecs: {
+    name: 'fixture-alert-${spec.key}'
+  }
+]

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/MMCA.Common.Architecture.Tests.csproj
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/MMCA.Common.Architecture.Tests.csproj
@@ -11,6 +11,15 @@
     <EmbeddedResource Include="..\..\..\NavigationFlow.md">
       <LogicalName>NavigationFlow.md</LogicalName>
     </EmbeddedResource>
+    <!-- Fixture IaC pair for ObservabilityConventionTestsBaseTests: proves the shared base reads the
+         SUBCLASS's assembly resources across an assembly boundary, which is the one behaviour that
+         would otherwise break only in the first consumer that adopted the base. -->
+    <EmbeddedResource Include="Fixtures\observability-main.bicep">
+      <LogicalName>fixtures.observability-main.bicep</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Fixtures\observability-OPERATIONS.md">
+      <LogicalName>fixtures.observability-OPERATIONS.md</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit.v3" />

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/ObservabilityConventionTestsBaseTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/ObservabilityConventionTestsBaseTests.cs
@@ -1,0 +1,30 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Cross-assembly guard for <see cref="ObservabilityConventionTestsBase"/>. The base ships inside
+/// the MMCA.Common.Testing.Architecture package but must read the embedded IaC resources of the
+/// SUBCLASS's assembly. Resolving against the base's own assembly instead is a silent break: the
+/// framework's own CI would stay green and the failure would only appear in the first consumer that
+/// adopted it. This subclass lives in a different assembly from the base and points at fixture
+/// resources embedded here, so inheriting the three [Fact]s exercises the whole discovery and
+/// pairing path across the assembly boundary.
+/// </summary>
+public sealed class ObservabilityConventionTestsBaseTests : ObservabilityConventionTestsBase
+{
+    protected override string BicepResource => "fixtures.observability-main.bicep";
+
+    protected override string RunbookResource => "fixtures.observability-OPERATIONS.md";
+
+    /// <summary>
+    /// The regression this file exists for: the default must resolve to the DERIVED type's
+    /// assembly, not the assembly the base was compiled into.
+    /// </summary>
+    [Fact]
+    public void ResourceAssembly_DefaultsToTheDerivedTypesAssembly()
+    {
+        ResourceAssembly.Should().BeSameAs(typeof(ObservabilityConventionTestsBaseTests).Assembly);
+        ResourceAssembly.Should().NotBeSameAs(typeof(ObservabilityConventionTestsBase).Assembly);
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/InfrastructureHealthChecksTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/InfrastructureHealthChecksTests.cs
@@ -1,0 +1,80 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace MMCA.Common.Aspire.Tests.Health;
+
+/// <summary>
+/// Guards the one asymmetry in <c>AddInfrastructureHealthChecks</c>: SQL Server can fail fast on a
+/// missing connection string while Redis and RabbitMQ silently skip. That difference is deliberate
+/// (an optional cache is a valid configuration, a host that cannot resolve its own database is not)
+/// and it is exactly the kind of inconsistency a later refactor "tidies away", so it is asserted
+/// directly rather than left to review.
+/// </summary>
+public sealed class InfrastructureHealthChecksTests
+{
+    [Fact]
+    public void AddInfrastructureHealthChecks_WhenSqlRequiredAndMissing_ThrowsAtStartup()
+    {
+        var builder = BuilderWith([]);
+
+        var act = () => builder.AddInfrastructureHealthChecks(requireSqlServer: true);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*SQLServerConnectionString*");
+    }
+
+    [Fact]
+    public void AddInfrastructureHealthChecks_WhenSqlNotRequiredAndMissing_SkipsSilently()
+    {
+        var builder = BuilderWith([]);
+
+        var act = () => builder.AddInfrastructureHealthChecks();
+
+        act.Should().NotThrow();
+        RegisteredCheckNames(builder).Should().NotContain("sqlserver");
+    }
+
+    [Fact]
+    public void AddInfrastructureHealthChecks_WhenSqlConfigured_RegistersTheCheck()
+    {
+        var builder = BuilderWith(new()
+        {
+            ["ConnectionStrings:SQLServerConnectionString"] = "Server=(local);Database=Test;Integrated Security=true;TrustServerCertificate=true",
+        });
+
+        builder.AddInfrastructureHealthChecks(requireSqlServer: true);
+
+        RegisteredCheckNames(builder).Should().Contain("sqlserver");
+    }
+
+    // Absent Redis/RabbitMQ must never throw, whatever the SQL flag is: they are optional per host.
+    [Fact]
+    public void AddInfrastructureHealthChecks_WithOnlySqlConfigured_DoesNotRegisterOptionalDependencies()
+    {
+        var builder = BuilderWith(new()
+        {
+            ["ConnectionStrings:SQLServerConnectionString"] = "Server=(local);Database=Test;Integrated Security=true;TrustServerCertificate=true",
+        });
+
+        builder.AddInfrastructureHealthChecks(requireSqlServer: true);
+
+        var names = RegisteredCheckNames(builder);
+        names.Should().NotContain("redis");
+        names.Should().NotContain("rabbitmq");
+    }
+
+    private static HostApplicationBuilder BuilderWith(Dictionary<string, string?> settings)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(settings);
+        return builder;
+    }
+
+    private static IReadOnlyList<string> RegisteredCheckNames(HostApplicationBuilder builder) =>
+        [.. builder.Services.BuildServiceProvider()
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<HealthCheckServiceOptions>>()
+            .Value.Registrations.Select(r => r.Name)];
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
@@ -90,6 +90,11 @@
         "resolved": "10.0.3",
         "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
       },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "5.2.0",
+        "contentHash": "po1jhvFd+8pbfvJR/puh+fkHi0GRanAdvayh/0e47yaM6CXWZ6opUjCMFuYlAnD2LcbyvQE7fPJKvogmaUcN+w=="
+      },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
         "resolved": "10.8.0",
@@ -370,6 +375,53 @@
         "resolved": "8.14.0",
         "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "9wxai3hKgZUb4/NjdRKfQd0QJvtXKDlvmGMYACbEC8DFaicMFCFhQFZq9ZET1kJLwZahf2lfY5Gtcpsx8zYzbg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "jePrSfGAmqT81JDCNSY+fxVWoGuJKt9e6eJ+vT7+quVS55nWl//jGjUQn4eFtVKt4rt5dXaleZdHRB9J9AJZ7Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "BPQhlDzdFvv1PzaUxNSk+VEPwezlDEVADIKmyxubw7IiELK18uJ06RQ9QKKkds30XI+gDu9n8j24XQ8w7fjWcg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "6.35.0",
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "LMtVqnECCCdSmyFoCOxIE5tXQqkOLrvGrL7OxHg41DIm1bpWtaCdGyVcTAfOQpJXvzND9zUKIN/lhngPkYR8vg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "6.35.0",
+          "System.IdentityModel.Tokens.Jwt": "6.35.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "6.35.0",
+        "contentHash": "RN7lvp7s3Boucg1NaNAbqDbxtlLj5Qeb+4uSS1TeK5FSBVM40P4DKaTKChT43sHyKfh7V0zkrMph6DdHvyA4bg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "6.35.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -491,15 +543,37 @@
           "System.Memory.Data": "10.0.3"
         }
       },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "fdYxcRjQqTTacKId/2IECojlDSFvp7LP5N78+0z/xH7v/Tuw5ZAxu23Y6PTCRinqyu2ePx+Gn1098NC6jM6d+A=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.3",
         "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
+      "System.Runtime.Caching": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "4TmlmvGp4kzZomm7J2HJn6IIx0UUrQyhBDyb5O1XiunZlQImXW+B8b7W/sTPcXhSf9rp5NR5aDtQllwbB5elOQ==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "8.0.0"
+        }
+      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
       },
       "System.Threading.RateLimiting": {
         "type": "Transitive",
@@ -570,6 +644,7 @@
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
+          "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.5.0, )",
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
@@ -605,6 +680,28 @@
           "StackExchange.Redis": "2.7.4"
         }
       },
+      "AspNetCore.HealthChecks.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.11.4",
+        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
+        "dependencies": {
+          "Azure.Core": "1.38.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.7.0"
+        }
+      },
       "Azure.Monitor.OpenTelemetry.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[1.5.0, )",
@@ -616,6 +713,22 @@
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.15.2",
           "OpenTelemetry.Instrumentation.Http": "1.15.1"
+        }
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.1, )",
+        "resolved": "5.2.2",
+        "contentHash": "mtoeRMh7F/OA536c/Cnh8L4H0uLSKB5kSmoi54oN7Fp0hNJDy22IqyMhaMH4PkDCqI7xL//Fvg9ldtuPHG0h5g==",
+        "dependencies": {
+          "Azure.Identity": "1.11.4",
+          "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.0",
+          "System.Runtime.Caching": "8.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -724,6 +837,16 @@
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "CentralTransitive",
+        "requested": "[8.19.2, )",
+        "resolved": "6.35.0",
+        "contentHash": "yxGIQd3BFK7F6S62/7RdZk3C/mfwyVxvh6ngd1VYMBmbJ1YZZA9+Ku6suylVtso0FjI0wbElpJ0d27CdsyLpBQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
+          "Microsoft.IdentityModel.Tokens": "6.35.0"
         }
       },
       "xunit.v3.extensibility.core": {

--- a/Tests/Presentation/MMCA.Common.API.Tests/Startup/RateLimitPartitionTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Startup/RateLimitPartitionTests.cs
@@ -67,6 +67,39 @@ public sealed class RateLimitPartitionTests
                 Ctx(path: "/api/events", authenticated: true), 300)
             .PartitionKey.Should().Be("authenticated");
 
+    // ── Per-IP anonymous auth throttle (RateLimitPolicyAuthIp) ──
+    [Fact]
+    public void AuthIpRateLimitPartition_ForKnownClientIp_PartitionsByIp() =>
+        WebApplicationBuilderExtensions.AuthIpRateLimitPartition(Ctx(path: "/Auth/login", ip: "203.0.113.9"), 30)
+            .PartitionKey.Should().Be("203.0.113.9");
+
+    // Fails OPEN, not closed. Collapsing unattributable requests into one shared bucket would
+    // throttle the in-process TestServer (RemoteIpAddress is null there) and take the whole
+    // integration tier down with it, so a null IP must get no limiter at all.
+    [Fact]
+    public void AuthIpRateLimitPartition_WhenRemoteIpUnknown_UsesNoLimiterPartition() =>
+        WebApplicationBuilderExtensions.AuthIpRateLimitPartition(Ctx(path: "/Auth/login"), 30)
+            .PartitionKey.Should().Be("__unknown-ip");
+
+    // The policy is anonymous-facing by design: it must partition on IP whether or not a principal
+    // is attached, because a password spray carries no identity to partition on.
+    [Fact]
+    public void AuthIpRateLimitPartition_ForAuthenticatedRequest_StillPartitionsByIp() =>
+        WebApplicationBuilderExtensions.AuthIpRateLimitPartition(
+                Ctx(path: "/Auth/login", authenticated: true, name: "alice", ip: "198.51.100.4"), 30)
+            .PartitionKey.Should().Be("198.51.100.4");
+
+    // Two different sources must never share a bucket, or one spraying host would exhaust the
+    // window for everyone else hitting login.
+    [Fact]
+    public void AuthIpRateLimitPartition_ForDistinctIps_UsesDistinctPartitions()
+    {
+        var first = WebApplicationBuilderExtensions.AuthIpRateLimitPartition(Ctx(ip: "192.0.2.1"), 30).PartitionKey;
+        var second = WebApplicationBuilderExtensions.AuthIpRateLimitPartition(Ctx(ip: "192.0.2.2"), 30).PartitionKey;
+
+        first.Should().NotBe(second);
+    }
+
     private static DefaultHttpContext Ctx(
         string path = "/api/events",
         string? contentType = null,

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -662,6 +662,7 @@
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
+          "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.5.0, )",
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
@@ -765,6 +766,15 @@
         "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
         "dependencies": {
           "StackExchange.Redis": "2.7.4"
+        }
+      },
+      "AspNetCore.HealthChecks.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.2.2"
         }
       },
       "Azure.Identity": {


### PR DESCRIPTION
Wave 1 of the drift remediation program from the 2026-07-27 `/drift-analysis` sweep: reusable infrastructure duplicated across MMCA.ADC and MMCA.Store moves into the framework. Consumers adopt during the version sweep. Plan: `Docs/Planning/DriftAnalysis-plan.md`.

**This is a breaking release.** See the CHANGELOG `Unreleased` section for the migration snippet.

## E1 (breaking): per-IP anonymous auth throttle into `AddCommonRateLimiting`

ADC hand-rolled a per-client-IP limiter for its anonymous Login/Register endpoints; Store had nothing. The gap is real: the shared global limiter **deliberately no-ops for anonymous traffic** and account lockout is keyed on email, so a password spray (one password, many emails) from a single source was unthrottled in Store.

- New public const `RateLimitPolicyAuthIp`, so consumers stop stringly-typing `"auth-ip"`.
- New `authIpPermitLimit` parameter, default 30. Deliberately not a tighter 10: Blazor Server circuits issue the login call **server-side**, so every Server-circuit user shares the UI host's IP. A login burst must fit the window while a spray still drops from unlimited to roughly 43K attempts/day/IP with lockout intact on top.
- Partition logic extracted as `internal static AuthIpRateLimitPartition` rather than left inline, matching the file's existing convention for `GlobalRateLimitPartition` so the decisions are unit-testable instead of only reachable through a request flood.

**It fails OPEN on a null `RemoteIpAddress`.** Collapsing unattributable requests into one shared bucket would throttle the in-process TestServer, where `RemoteIpAddress` is always null, and take the whole integration tier down with it.

**Breaking:** `RateLimiterOptions.AddPolicy` throws on a duplicate name, so ADC must delete its local `auth-ip` registration in the same PR as the pin bump.

## E4: SQL Server readiness check into `AddInfrastructureHealthChecks`

The 4-line registration was byte-identical across 8 consumer hosts. The asymmetry is preserved on purpose and pinned by tests, because it is exactly what a later refactor tidies away:

| Dependency | Missing connection string |
|---|---|
| Redis, RabbitMQ | skip silently (optional per host, absence is valid config) |
| SQL Server | `requireSqlServer: true` throws (a host that cannot resolve its own DB is misconfigured, and a silent skip would let it report healthy and take traffic it cannot serve) |

Adds `AspNetCore.HealthChecks.SqlServer` 9.0.0, matching the Redis/RabbitMQ sibling version and the version both consumers already pin.

## E7: `ObservabilityConventionTestsBase` into Testing.Architecture

The two 118-line copies differed only in namespace and two interpolation styles.

The lift required one **mandatory** change: the original used `Assembly.GetExecutingAssembly()`, which inside a shipped package resolves to `MMCA.Common.Testing.Architecture.dll` and would look for the consumer's bicep there, always throwing. Resources now come from a virtual `ResourceAssembly` defaulting to `GetType().Assembly`.

That break would have been **invisible in this repo's CI** and would only have surfaced in the first consumer to adopt. So `ObservabilityConventionTestsBaseTests` subclasses the base from a *different assembly* against a fixture bicep/runbook pair embedded there, and pins `ResourceAssembly` to the derived assembly.

## E8: graceful-shutdown gate + Production host factory into Testing

Functionally identical in both repos. `Microsoft.AspNetCore.Mvc.Testing` was already referenced, so no new packages.

`ProductionHostApplicationFactory` pins `Production` (exercising the realistic CORS/HSTS branches a Development boot skips) and captures the started `IHost`, which is the only way to reach `StopAsync`.

## Also included

- CHANGELOG `Unreleased` with the BREAKING entry and migration snippet.
- `FACTS.md` regenerated (96 fitness methods across 31 `*TestsBase` classes); the drift gate would otherwise fail.
- `push-release.md` lock counts corrected from 61/54 to the actual **65 ADC / 56 Store**, so the release ritual stops citing stale numbers.

## Not included: E5

`AddCommonRedisCaching` is held back pending a decision. It would pull **three** packages (`Aspire.StackExchange.Redis`, `.DistributedCaching`, `Microsoft.AspNetCore.OutputCaching.StackExchangeRedis`) into `MMCA.Common.Aspire`, which every consumer inherits transitively including MMCA.Helpdesk, which uses no Redis at all. That is a larger supply-chain expansion than the other four combined, for a helper that replaces about four lines per host.

## Verification

- Full solution Release build: 0 warnings, 0 errors. **2479/2479 tests green.**
- `facts --check` passes.
- **Helpdesk consumer-source build run locally against this branch: builds clean, 91/91 green.** That is the required cross-repo canary, verified before pushing rather than discovered in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpWirEitGZ2AMEQhd7NCD9