### PR TITLE
release: v1.129.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.129.0] - 2026-07-28
+
 Extraction wave from the 2026-07-27 drift analysis: reusable infrastructure that had been duplicated
 across MMCA.ADC and MMCA.Store moves into the framework. Consumers adopt during the version sweep.
 


### PR DESCRIPTION
Dates the CHANGELOG section for **v1.129.0**. The source changes already landed on `main` via [#145](https://github.com/ivanball/MMCA.Common/pull/145); this PR only promotes `Unreleased` to `1.129.0`.

## What ships

**BREAKING**: `AddCommonRateLimiting` now registers an `"auth-ip"` policy. A consumer that already registers that policy name must delete its own registration when bumping, because `RateLimiterOptions.AddPolicy` throws on a duplicate and the host fails at startup. **MMCA.ADC is the only consumer in that position**, and it lands with its bump PR.

Also added:
- `MMCA.Common.API`: the per-IP anonymous authentication throttle itself (E1).
- `MMCA.Common.Aspire`: SQL Server readiness branch in `AddInfrastructureHealthChecks` with an opt-in `requireSqlServer` fail-fast (E4).
- `MMCA.Common.Testing.Architecture`: `ObservabilityConventionTestsBase` (E7).
- `MMCA.Common.Testing`: `GracefulShutdownTestsBase<T>` + `ProductionHostApplicationFactory<T>` (E8).

`FACTS.md` is deliberately NOT regenerated here: its version line derives from the tag, which does not exist yet. It follows as a post-tag PR.