### PR TITLE
Apply the anti-spray throttle by default in AuthControllerBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Changed
+
+- **`AuthControllerBase` now applies the anti-spray throttle by default.** `LoginAsync` and
+  `RegisterAsync` carry `[EnableRateLimiting(RateLimitPolicyAuthIp)]`, so every consumer inheriting
+  the base gets per-IP protection on its anonymous credential endpoints without opting in.
+
+  This closes the half-measure in 1.129.0: that release lifted the *policy* into the framework but
+  left each app to *attach* it, and an app that simply inherited these actions (MMCA.Store) silently
+  had no spray protection at all. The global limiter deliberately no-ops for anonymous traffic and
+  account lockout is per-email, so a spray (one password, many emails) from one source was
+  unthrottled there.
+
+  `RefreshAsync` is deliberately NOT throttled: refresh is automatic and periodic, and Blazor Server
+  issues it server-side, so every Server-circuit user shares the UI host's IP. A per-IP window would
+  throttle ordinary token renewal for everyone behind that host. A test asserts that absence so a
+  later "consistency" change has to argue with it.
+
+  **Consumer note:** a host inheriting `AuthControllerBase` must call `AddCommonRateLimiting()`, or
+  it fails at startup on an unregistered policy. All current consumers already do. Consumers that
+  already attach the attribute on their own overrides (MMCA.ADC) are unaffected; the explicit
+  attribute is redundant but harmless.
+
 ## [1.129.0] - 2026-07-28
 
 Extraction wave from the 2026-07-27 drift analysis: reusable infrastructure that had been duplicated

--- a/Source/Presentation/MMCA.Common.API/Controllers/AuthControllerBase.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/AuthControllerBase.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using MMCA.Common.API.Startup;
 using MMCA.Common.Application.Auth;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Shared.Auth;
@@ -12,6 +14,28 @@ namespace MMCA.Common.API.Controllers;
 /// Downstream modules inherit and apply route/version attributes. Override <see cref="RegisterAsync"/>
 /// to inject additional context (e.g., client IP for rate limiting). Password change is owned by the
 /// derived controller, which dispatches the ChangePassword command handler directly.
+/// <para>
+/// <b>Anti-spray throttling is on by default.</b> <see cref="LoginAsync"/> and
+/// <see cref="RegisterAsync"/> carry
+/// <see cref="WebApplicationBuilderExtensions.RateLimitPolicyAuthIp"/>, so any consumer inheriting
+/// this base gets per-IP protection without opting in. That default exists because the alternative
+/// failed in practice: the policy shipped in the framework while each app was left to attach it,
+/// and an app that simply inherited these actions silently had no spray protection at all. The
+/// global limiter deliberately no-ops for anonymous traffic and account lockout is per-email, so a
+/// spray (one password, many emails) from one source is otherwise unthrottled.
+/// </para>
+/// <para>
+/// <b><see cref="RefreshAsync"/> is deliberately NOT throttled.</b> Refresh is automatic and
+/// periodic rather than user-initiated, and Blazor Server circuits issue it server-side, so every
+/// Server-circuit user shares the UI host's IP. A per-IP window there would throttle ordinary token
+/// renewal for everyone behind that host. Refresh tokens are also high-entropy, so brute force is
+/// not the threat password spraying is.
+/// </para>
+/// <para>
+/// Consumers must call <c>AddCommonRateLimiting()</c> (which registers the policy). A consumer that
+/// inherits this base without it fails at startup on an unregistered policy, which is the loud
+/// failure rather than the silent one.
+/// </para>
 /// </summary>
 public abstract class AuthControllerBase(
     IAuthenticationService authenticationService,
@@ -28,8 +52,10 @@ public abstract class AuthControllerBase(
     /// </summary>
     [HttpPost("login")]
     [AllowAnonymous]
+    [EnableRateLimiting(WebApplicationBuilderExtensions.RateLimitPolicyAuthIp)]
     [ProducesResponseType(typeof(AuthenticationResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests, Type = typeof(ProblemDetails))]
     public virtual async Task<ActionResult<AuthenticationResponse>> LoginAsync(
         [FromBody] LoginRequest request,
         CancellationToken cancellationToken)
@@ -47,7 +73,9 @@ public abstract class AuthControllerBase(
     /// </summary>
     [HttpPost("register")]
     [AllowAnonymous]
+    [EnableRateLimiting(WebApplicationBuilderExtensions.RateLimitPolicyAuthIp)]
     [ProducesResponseType(typeof(AuthenticationResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ProblemDetails))]
     public virtual async Task<ActionResult<AuthenticationResponse>> RegisterAsync(

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/AuthControllerBaseRateLimitTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/AuthControllerBaseRateLimitTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.RateLimiting;
+using MMCA.Common.API.Controllers;
+using MMCA.Common.API.Startup;
+
+namespace MMCA.Common.API.Tests.Controllers;
+
+/// <summary>
+/// Pins the anti-spray defaults on <see cref="AuthControllerBase"/>. These are attributes, so
+/// nothing else fails if one is dropped: the endpoint simply stops being throttled and the app keeps
+/// serving traffic. That is exactly how MMCA.Store ended up with no spray protection while the
+/// framework "shipped" the policy, so the presence (and deliberate absence) of the attribute is
+/// asserted directly.
+/// </summary>
+public sealed class AuthControllerBaseRateLimitTests
+{
+    [Theory]
+    [InlineData(nameof(AuthControllerBase.LoginAsync))]
+    [InlineData(nameof(AuthControllerBase.RegisterAsync))]
+    public void AnonymousCredentialEndpoint_CarriesTheAuthIpPolicy(string actionName)
+    {
+        var attribute = Action(actionName).GetCustomAttribute<EnableRateLimitingAttribute>();
+
+        attribute.Should().NotBeNull(
+            because: $"{actionName} is anonymous and credential-bearing, so it must be throttled per client IP by default");
+        attribute!.PolicyName.Should().Be(WebApplicationBuilderExtensions.RateLimitPolicyAuthIp);
+    }
+
+    // Not an oversight: refresh is automatic and periodic, and Blazor Server issues it server-side,
+    // so every Server-circuit user shares the UI host's IP. A per-IP window would throttle ordinary
+    // token renewal for everyone behind that host. Asserted so the "consistency" fix of adding it
+    // has to argue with this test first.
+    [Fact]
+    public void RefreshEndpoint_IsDeliberatelyNotThrottledPerIp() =>
+        Action(nameof(AuthControllerBase.RefreshAsync))
+            .GetCustomAttribute<EnableRateLimitingAttribute>()
+            .Should().BeNull(
+                because: "refresh is automatic and shares the UI host's IP under Blazor Server, so a per-IP window would throttle legitimate token renewal");
+
+    private static MethodInfo Action(string name) =>
+        typeof(AuthControllerBase).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)
+        ?? throw new InvalidOperationException($"AuthControllerBase.{name} not found; this guard must follow the base's action names.");
+}


### PR DESCRIPTION
Closes the half-measure in v1.129.0.

## The problem this fixes

v1.129.0 lifted the per-IP auth throttle **policy** into the framework but left each app to **attach** it. That has a silent failure mode, and it had already bitten: **MMCA.Store inherits `LoginAsync` straight from `AuthControllerBase`, never attached the attribute, and therefore had no spray protection at all** even after adopting the release that supposedly shipped the fix.

The global limiter deliberately no-ops for anonymous traffic and account lockout is per-email, so a spray (one password, many emails) from a single source was unthrottled in Store.

## The change

`LoginAsync` and `RegisterAsync` now carry `[EnableRateLimiting(RateLimitPolicyAuthIp)]`, so per-IP protection is the **default** for every consumer of the base rather than something each app must remember to opt into.

## What is deliberately NOT throttled

`RefreshAsync`. Refresh is automatic and periodic, and Blazor Server issues it **server-side**, so every Server-circuit user shares the UI host's IP. A per-IP window there would throttle ordinary token renewal for everyone behind that host. Refresh tokens are also high-entropy, so brute force is not the threat password spraying is.

A test asserts that absence, so a later "let's be consistent" change has to argue with it first.

## Why tests for attributes

These are attributes: nothing else fails if one is dropped. The endpoint simply stops being throttled and the app keeps serving traffic. That is precisely how Store ended up unprotected, so `AuthControllerBaseRateLimitTests` asserts presence (and refresh's absence) directly by reflection.

## Consumer impact

- A host inheriting this base must call `AddCommonRateLimiting()`, or it fails at **startup** on an unregistered policy. That is the loud failure rather than the silent one. All three consumers already call it.
- MMCA.ADC attaches the attribute on its own overrides; that becomes redundant but stays harmless.
- MMCA.Store gains real protection with no Store-side code change.

## Verification

- Full solution Release: **2482/2482 green**, 0 warnings.
- `facts --check` clean.
- **Helpdesk consumer-source canary run locally: 91/91 green.**