### PR TITLE
release: v1.130.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.130.0] - 2026-07-28
+
 ### Changed
 
 - **`AuthControllerBase` now applies the anti-spray throttle by default.** `LoginAsync` and


### PR DESCRIPTION
Dates the CHANGELOG section for **v1.130.0**. The source change landed on `main` via [#155](https://github.com/ivanball/MMCA.Common/pull/155).

Ships one behavioural change: `AuthControllerBase.LoginAsync` and `RegisterAsync` now carry the per-IP anti-spray throttle by default, closing the gap where v1.129.0 shipped the policy but left each app to attach it (which left MMCA.Store unprotected). `RefreshAsync` is deliberately excluded.

Not breaking: consumers already calling `AddCommonRateLimiting()` need no change.