### PR TITLE
Keep optional infrastructure checks out of the readiness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Fixed
+
+- **Optional infrastructure health checks no longer gate readiness.** The Redis and RabbitMQ checks
+  registered by `AddInfrastructureHealthChecks` are now tagged `optional` and excluded from
+  `/health/ready`; they still report on `/health`.
+
+  This made the method unsafe to adopt. `/health/ready` includes every check not tagged `live`, so a
+  host calling `AddInfrastructureHealthChecks` had its readiness gated on Redis. Both consumer apps
+  degrade gracefully without Redis (`DistributedCacheService` falls back to `MemoryCacheService`), so
+  a cache blip would have taken EVERY replica out of rotation simultaneously and converted a partial
+  degradation into a total outage. The database check stays untagged and still gates readiness, which
+  is correct: a host that cannot reach its own database cannot serve correct responses.
+
+  New public `HealthCheckTags` (`Live` / `Ready` / `Optional`) replaces the magic strings and
+  documents the distinction. Tag a check `Optional` when the app has a working fallback; leave it
+  untagged only when the app genuinely cannot serve without it.
+
 ## [1.130.0] - 2026-07-28
 
 ### Changed

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -106,7 +106,7 @@ public static class Extensions
             builder.Services.AddSingleton<IWarmupTask, OpenIdConnectMetadataWarmupTask>();
 
             builder.Services.AddHealthChecks()
-                .AddCheck<WarmupReadinessHealthCheck>("warmup", tags: ["ready"]);
+                .AddCheck<WarmupReadinessHealthCheck>("warmup", tags: [HealthCheckTags.Ready]);
 
             return builder;
         }
@@ -194,7 +194,7 @@ public static class Extensions
         public TBuilder AddDefaultHealthChecks()
         {
             builder.Services.AddHealthChecks()
-                .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+                .AddCheck("self", () => HealthCheckResult.Healthy(), [HealthCheckTags.Live]);
 
             return builder;
         }
@@ -240,7 +240,7 @@ public static class Extensions
             var redisConnectionString = builder.Configuration.GetConnectionString("redis");
             if (!string.IsNullOrWhiteSpace(redisConnectionString))
             {
-                healthChecks.AddRedis(redisConnectionString, name: "redis");
+                healthChecks.AddRedis(redisConnectionString, name: "redis", tags: [HealthCheckTags.Optional]);
             }
 
             var rabbitConnectionString = builder.Configuration.GetConnectionString("rabbitmq")
@@ -252,7 +252,7 @@ public static class Extensions
                 {
                     var factory = new RabbitMQ.Client.ConnectionFactory { Uri = rabbitUri };
                     return await factory.CreateConnectionAsync().ConfigureAwait(false);
-                }, name: "rabbitmq");
+                }, name: "rabbitmq", tags: [HealthCheckTags.Optional]);
             }
 
             return builder;
@@ -329,16 +329,23 @@ public static class Extensions
             // process as dead when an external dependency (e.g., SQL Server) is down.
             app.MapHealthChecks("/alive", new HealthCheckOptions
             {
-                Predicate = r => r.Tags.Contains("live")
+                Predicate = r => r.Tags.Contains(HealthCheckTags.Live)
             });
 
-            // Readiness: everything except "live"-only checks. Warm-up gate is tagged "ready"
-            // and reports unhealthy until WarmupHostedService finishes; untagged dependency
-            // checks (e.g., AddSqlServer) also show up here so a failing dependency removes
-            // the replica from traffic without restarting the container.
+            // Readiness: everything except "live"-only and "optional" checks. Warm-up gate is
+            // tagged "ready" and reports unhealthy until WarmupHostedService finishes; untagged
+            // dependency checks (e.g., AddSqlServer) also show up here so a failing dependency
+            // removes the replica from traffic without restarting the container.
+            //
+            // "optional" is excluded on purpose. A dependency the app degrades gracefully without
+            // (a distributed cache behind an in-memory fallback, a broker behind a retrying outbox)
+            // must NOT gate readiness: making it readiness-fatal converts a partial degradation
+            // into a total outage, because every replica goes unready at once and the app stops
+            // serving traffic it was perfectly capable of serving. Those checks still surface on
+            // /health, so the degradation is visible without being self-inflicted.
             app.MapHealthChecks("/health/ready", new HealthCheckOptions
             {
-                Predicate = r => !r.Tags.Contains("live")
+                Predicate = r => !r.Tags.Contains(HealthCheckTags.Live) && !r.Tags.Contains(HealthCheckTags.Optional)
             });
 
             return app;

--- a/Source/Hosting/MMCA.Common.Aspire/HealthCheckTags.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/HealthCheckTags.cs
@@ -1,0 +1,33 @@
+namespace MMCA.Common.Aspire;
+
+/// <summary>
+/// Tag names the standard health endpoints from <c>MapDefaultEndpoints()</c> filter on.
+/// </summary>
+public static class HealthCheckTags
+{
+    /// <summary>
+    /// Liveness-only: the check runs on <c>/alive</c> and is EXCLUDED from readiness. Reserved for
+    /// self checks, so an external dependency outage never restarts the container.
+    /// </summary>
+    public const string Live = "live";
+
+    /// <summary>
+    /// Readiness gate: the check runs on <c>/health/ready</c> and holds traffic back until it
+    /// passes. Used by the warm-up gate.
+    /// </summary>
+    public const string Ready = "ready";
+
+    /// <summary>
+    /// A dependency the application degrades gracefully without: it is reported on <c>/health</c>
+    /// but EXCLUDED from <c>/health/ready</c>.
+    /// <para>
+    /// The distinction is load-bearing. A distributed cache sitting behind an in-memory fallback, or
+    /// a broker behind a retrying outbox, can fail without the app losing the ability to serve.
+    /// Gating readiness on it converts a partial degradation into a TOTAL outage: every replica goes
+    /// unready simultaneously and the platform stops routing traffic the app could still handle.
+    /// Tag such checks <see cref="Optional"/>; leave a check untagged only when the app genuinely
+    /// cannot serve correct responses without it (its own database being the standard example).
+    /// </para>
+    /// </summary>
+    public const string Optional = "optional";
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/InfrastructureHealthChecksTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/InfrastructureHealthChecksTests.cs
@@ -66,6 +66,39 @@ public sealed class InfrastructureHealthChecksTests
         names.Should().NotContain("rabbitmq");
     }
 
+    // The readiness contract, and the reason it is asserted rather than assumed: /health/ready
+    // includes every check NOT tagged live or optional. If the Redis check were untagged it would
+    // gate readiness, and a Redis blip would take EVERY replica out of rotation at once, converting
+    // a graceful degradation (DistributedCacheService falls back to MemoryCacheService) into a
+    // total outage. The database is the opposite case: untagged on purpose, because a host that
+    // cannot reach its own database cannot serve correct responses.
+    [Fact]
+    public void OptionalDependencies_AreTaggedOptional_SoTheyDoNotGateReadiness()
+    {
+        var builder = BuilderWith(new()
+        {
+            ["ConnectionStrings:SQLServerConnectionString"] = "Server=(local);Database=Test;Integrated Security=true;TrustServerCertificate=true",
+            ["ConnectionStrings:redis"] = "localhost:6379",
+        });
+
+        builder.AddInfrastructureHealthChecks(requireSqlServer: true);
+
+        var registrations = Registrations(builder);
+
+        registrations.Single(r => r.Name == "redis").Tags
+            .Should().Contain(HealthCheckTags.Optional,
+                because: "the app falls back to an in-memory cache, so a Redis outage must not pull every replica from traffic");
+
+        registrations.Single(r => r.Name == "sqlserver").Tags
+            .Should().NotContain(HealthCheckTags.Optional,
+                because: "a host that cannot reach its own database cannot serve correct responses, so SQL must gate readiness");
+    }
+
+    private static IReadOnlyList<HealthCheckRegistration> Registrations(HostApplicationBuilder builder) =>
+        [.. builder.Services.BuildServiceProvider()
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<HealthCheckServiceOptions>>()
+            .Value.Registrations];
+
     private static HostApplicationBuilder BuilderWith(Dictionary<string, string?> settings)
     {
         var builder = Host.CreateApplicationBuilder();


### PR DESCRIPTION
Found while preparing MMCA.ADC and MMCA.Store to adopt `AddInfrastructureHealthChecks` (drift item E4). **The method was not safely adoptable**, and adopting it would have made things worse.

## The problem

`/health/ready` includes every check **not** tagged `live` (`Extensions.cs`), and the Redis and RabbitMQ checks carried **no tags at all**.

So a host calling `AddInfrastructureHealthChecks` had its **readiness gated on Redis**. Both consumer apps degrade gracefully without Redis (`DistributedCacheService` falls back to `MemoryCacheService`), so a cache blip would have taken **every replica out of rotation simultaneously** and converted a partial degradation into a **total outage** in an app that could still have served every request.

That is a worse failure mode than the missing database check E4 set out to add. It is also very likely *why* no consumer ever adopted this method despite it shipping: the drift analysis logged it as a "missed adoption", but it reads more like deliberate avoidance.

## The fix

Make the safe thing the default rather than adding an opt-out that everyone must remember:

| Check | Tag | Gates readiness? |
|---|---|---|
| `self` | `live` | no (liveness only) |
| `warmup` | `ready` | yes |
| **`sqlserver`** | *(untagged)* | **yes** |
| **`redis`** | **`optional`** | **no** |
| **`rabbitmq`** | **`optional`** | **no** |

Both still report on `/health`, so degradation stays visible without being self-inflicted.

The asymmetry is the point: **an app with no database cannot serve correct responses; an app with no cache can.**

Adds public `HealthCheckTags` (`Live` / `Ready` / `Optional`) to replace the magic strings and document the rule: tag a check `Optional` when the app has a working fallback; leave it untagged only when the app genuinely cannot serve without it.

## Tests

The wrong default is an outage, and nothing else fails if a tag is dropped, so the tags are asserted directly rather than left to review.

## Verification

Full solution Release: **2483/2483 green**, 0 warnings. `facts --check` clean.