### PR TITLE
release: v1.131.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.131.0] - 2026-07-28
+
 ### Fixed
 
 - **Optional infrastructure health checks no longer gate readiness.** The Redis and RabbitMQ checks


### PR DESCRIPTION
Dates the CHANGELOG section for **v1.131.0**. Source landed via [#158](https://github.com/ivanball/MMCA.Common/pull/158).

Ships the readiness-gate fix that makes `AddInfrastructureHealthChecks` safe to adopt: Redis and RabbitMQ checks are tagged `optional` and excluded from `/health/ready`, so a cache or broker blip no longer pulls every replica from traffic. The SQL check stays untagged and still gates readiness.

Unblocks the E4 adoption sweep across ADC, Store and Helpdesk.