### PR TITLE
deps: bump the analyzers group and remediate the new Sonar rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -830,3 +830,23 @@ dotnet_diagnostic.CA2007.severity = warning
 
 [Source/Presentation/MMCA.Common.UI*/**.cs]
 dotnet_diagnostic.CA2007.severity = none
+
+# S8969 / S8970 (new in SonarAnalyzer 10.30): "remove this null-forgiving operator".
+# Downgraded from the baseline error severity because both produce FALSE POSITIVES here, and
+# under TreatWarningsAsErrors a false positive is a broken build rather than a nudge. Measured
+# on the 10.29 -> 10.30 bump: 41 sites flagged, 7 of them wrong.
+#
+#   S8970 was wrong at ALL 3 of its sites (suppressed via NoWarn in Directory.Build.props, since
+#   an .editorconfig severity does not reach Razor-generated code). It claims nullable warnings are disabled and the
+#   operator is therefore pointless, but the flagged code is the deliberate `null!` / `default!`
+#   initializer pattern in .razor components, where removing the operator immediately fails with
+#   CS8625/CS8604. Disabled outright.
+#
+#   S8969 was wrong at 4 of 38. It claims the compiler already knows the expression is non-null,
+#   and at those four the compiler disagreed with CS8602/CS8629. The other 34 were genuine and
+#   have been fixed. Kept as a suggestion so real redundancies still surface without gating CI.
+#
+# Revisit when Sonar tightens these rules; the compiler is the authority on nullability, not the
+# analyzer.
+[*.{cs,razor}]
+dotnet_diagnostic.S8969.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,13 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591;RMG020</NoWarn>
+    <!-- S8970 ("remove this null-forgiving operator; nullable warnings are disabled here") is new in
+         SonarAnalyzer 10.30 and is wrong on every site it flags in this repo: all three are the
+         deliberate `null!` / `default!` initializer pattern in .razor components, where removing the
+         operator immediately fails the build with CS8625/CS8604. Suppressed HERE rather than in
+         .editorconfig because a `dotnet_diagnostic` severity does not reach Razor-generated code.
+         The compiler is the authority on nullability, not the analyzer. -->
+    <NoWarn>$(NoWarn);CS1591;RMG020;S8970</NoWarn>
   </PropertyGroup>
 
   <!-- Suppress xUnit1051 (CancellationToken propagation) in test projects -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,10 +97,10 @@
          upper bounds and fail restore with NU1608. Bump together with Microsoft.Maui.Controls. -->
     <PackageVersion Include="Xamarin.AndroidX.Biometric" Version="1.1.0.30" />
     <!-- Analyzers -->
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.124" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.133" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.29.0.143774" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.30.0.144632" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Testing -->
     <!-- bUnit v2 (BunitContext / Render API) is the line compatible with xUnit v3 / Microsoft Testing Platform. -->

--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -389,7 +389,7 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
 
         // Same rule as the list path: only shape when a field subset was requested.
         return string.IsNullOrWhiteSpace(fields)
-            ? Result.Success<object>(dto!)
+            ? Result.Success<object>(dto)
             : Result.Success<object>(QueryFieldService.ShapeData(dto, fields));
     }
 

--- a/Source/Core/MMCA.Common.Application/packages.lock.json
+++ b/Source/Core/MMCA.Common.Application/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.FeatureManagement": {
         "type": "Direct",
@@ -76,9 +76,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Core/MMCA.Common.Domain/packages.lock.json
+++ b/Source/Core/MMCA.Common.Domain/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -28,9 +28,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Core/MMCA.Common.Infrastructure/packages.lock.json
+++ b/Source/Core/MMCA.Common.Infrastructure/packages.lock.json
@@ -63,9 +63,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
         "type": "Direct",
@@ -191,9 +191,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Direct",

--- a/Source/Core/MMCA.Common.Shared/Extensions/DomainHelper.cs
+++ b/Source/Core/MMCA.Common.Shared/Extensions/DomainHelper.cs
@@ -58,7 +58,7 @@ public static class DomainHelper
             return bool.TryParse(id, out var b) ? (TIdentifier)(object)b : (TIdentifier)(object)false;
 
         if (type.IsEnum)
-            return Enum.TryParse(type, id, ignoreCase: true, out var enumValue) ? (TIdentifier)enumValue! : default!;
+            return Enum.TryParse(type, id, ignoreCase: true, out var enumValue) ? (TIdentifier)enumValue : default!;
 
         throw new FormatException($"Unsupported identifier type: {type.FullName}");
     }

--- a/Source/Core/MMCA.Common.Shared/packages.lock.json
+++ b/Source/Core/MMCA.Common.Shared/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -28,9 +28,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/packages.lock.json
@@ -177,9 +177,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -201,9 +201,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -44,9 +44,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Direct",
@@ -138,9 +138,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -43,9 +43,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Hosting/MMCA.Common.Testing.E2E/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.Playwright": {
         "type": "Direct",
@@ -64,9 +64,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Hosting/MMCA.Common.Testing.UI/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing.UI/packages.lock.json
@@ -23,9 +23,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -53,9 +53,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Hosting/MMCA.Common.Testing/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
@@ -85,9 +85,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Presentation/MMCA.Common.API/Middleware/SoftDeletedUserMiddleware.cs
+++ b/Source/Presentation/MMCA.Common.API/Middleware/SoftDeletedUserMiddleware.cs
@@ -63,7 +63,7 @@ public sealed class SoftDeletedUserMiddleware(RequestDelegate next)
         var cacheKey = string.Create(CultureInfo.InvariantCulture, $"user:deleted:{userId.Value}");
 
         // Check cache first
-        var cachedResult = await cacheService.GetAsync<bool?>(cacheKey).ConfigureAwait(false);
+        var cachedResult = await cacheService.GetAsync<bool?>(cacheKey, context.RequestAborted).ConfigureAwait(false);
         if (cachedResult is true)
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -73,8 +73,8 @@ public sealed class SoftDeletedUserMiddleware(RequestDelegate next)
         if (cachedResult is null)
         {
             // Cache miss — check database
-            var isDeleted = await softDeletedUserValidator.IsUserSoftDeletedAsync(userId.Value).ConfigureAwait(false);
-            await cacheService.SetAsync(cacheKey, isDeleted, CacheDuration).ConfigureAwait(false);
+            var isDeleted = await softDeletedUserValidator.IsUserSoftDeletedAsync(userId.Value, context.RequestAborted).ConfigureAwait(false);
+            await cacheService.SetAsync(cacheKey, isDeleted, CacheDuration, context.RequestAborted).ConfigureAwait(false);
 
             if (isDeleted)
             {

--- a/Source/Presentation/MMCA.Common.API/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.API/packages.lock.json
@@ -28,9 +28,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.AspNetCore.Authentication.Google": {
         "type": "Direct",
@@ -97,9 +97,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Presentation/MMCA.Common.Grpc/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.Grpc/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Direct",
@@ -78,9 +78,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -28,9 +28,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Source/Presentation/MMCA.Common.UI/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.AspNetCore.Components.Authorization": {
         "type": "Direct",
@@ -169,9 +169,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -43,9 +43,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Core/MMCA.Common.Application.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Application.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -43,9 +43,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Core/MMCA.Common.Domain.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Domain.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -34,9 +34,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
@@ -85,9 +85,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Core/MMCA.Common.Shared.Tests/Concurrency/KeyedSemaphoreStripeTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Concurrency/KeyedSemaphoreStripeTests.cs
@@ -83,7 +83,7 @@ public sealed class KeyedSemaphoreStripeTests
         {
             var other = keys.Select(k => sut.AcquireAsync(k)).FirstOrDefault(t => t.IsCompleted);
             other.Should().NotBeNull("with more than one stripe some key must map to a free stripe");
-            (await other!).Dispose();
+            (await other).Dispose();
         }
         finally
         {

--- a/Tests/Core/MMCA.Common.Shared.Tests/Serialization/ResultJsonConverterFactoryTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Serialization/ResultJsonConverterFactoryTests.cs
@@ -23,7 +23,7 @@ public class ResultJsonConverterFactoryTests
         var roundTripped = JsonSerializer.Deserialize<Result>(json);
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.IsSuccess.Should().BeTrue();
+        roundTripped.IsSuccess.Should().BeTrue();
         roundTripped.Errors.Should().BeEmpty();
     }
 
@@ -36,7 +36,7 @@ public class ResultJsonConverterFactoryTests
         var roundTripped = JsonSerializer.Deserialize<Result>(json);
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.IsFailure.Should().BeTrue();
+        roundTripped.IsFailure.Should().BeTrue();
         roundTripped.Errors.Should().ContainSingle()
             .Which.Should().Be(original.Errors[0]);
     }
@@ -51,7 +51,7 @@ public class ResultJsonConverterFactoryTests
         var roundTripped = JsonSerializer.Deserialize<Result<TestDTO>>(json);
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.IsSuccess.Should().BeTrue();
+        roundTripped.IsSuccess.Should().BeTrue();
         roundTripped.Value.Should().Be(original.Value);
     }
 
@@ -64,7 +64,7 @@ public class ResultJsonConverterFactoryTests
         var roundTripped = JsonSerializer.Deserialize<Result<TestDTO>>(json);
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.IsFailure.Should().BeTrue();
+        roundTripped.IsFailure.Should().BeTrue();
         roundTripped.Value.Should().BeNull();
         roundTripped.Errors.Should().ContainSingle()
             .Which.Type.Should().Be(ErrorType.NotFound);
@@ -83,9 +83,9 @@ public class ResultJsonConverterFactoryTests
         var roundTripped = JsonSerializer.Deserialize<Result<PagedCollectionResult<TestDTO>>>(json, WebOptions);
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.IsSuccess.Should().BeTrue();
+        roundTripped.IsSuccess.Should().BeTrue();
         roundTripped.Value.Should().NotBeNull();
-        roundTripped.Value!.Items.Should().BeEquivalentTo(payload.Items);
+        roundTripped.Value.Items.Should().BeEquivalentTo(payload.Items);
         roundTripped.Value.PaginationMetadata.TotalItemCount.Should().Be(2);
         roundTripped.Value.PaginationMetadata.PageSize.Should().Be(10);
         roundTripped.Value.PaginationMetadata.CurrentPage.Should().Be(1);
@@ -112,7 +112,7 @@ public class ResultJsonConverterFactoryTests
         var roundTripped = JsonSerializer.Deserialize<Result<TestDTO>>(json, WebOptions);
 
         roundTripped.Should().NotBeNull();
-        roundTripped!.IsSuccess.Should().BeTrue();
+        roundTripped.IsSuccess.Should().BeTrue();
         roundTripped.Value.Should().Be(new TestDTO(7, "X"));
     }
 }

--- a/Tests/Core/MMCA.Common.Shared.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Shared.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -34,9 +34,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/OutboxPollFilterProcessorTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/OutboxPollFilterProcessorTests.cs
@@ -45,9 +45,9 @@ public sealed class OutboxPollFilterProcessorTests : IDisposable
         using var poll = _outboxSource.StartActivity("OutboxPoll");
         poll.Should().NotBeNull();
 
-        _sut.OnEnd(poll!);
+        _sut.OnEnd(poll);
 
-        IsRecorded(poll!).Should().BeFalse("poll spans must be suppressed from export");
+        IsRecorded(poll).Should().BeFalse("poll spans must be suppressed from export");
     }
 
     [Fact]
@@ -59,9 +59,9 @@ public sealed class OutboxPollFilterProcessorTests : IDisposable
         using var sqlChild = _otherSource.StartActivity("SELECT OutboxMessages");
         sqlChild.Should().NotBeNull();
 
-        _sut.OnEnd(sqlChild!);
+        _sut.OnEnd(sqlChild);
 
-        IsRecorded(sqlChild!).Should().BeFalse("children of poll spans must be suppressed");
+        IsRecorded(sqlChild).Should().BeFalse("children of poll spans must be suppressed");
     }
 
     [Fact]
@@ -72,9 +72,9 @@ public sealed class OutboxPollFilterProcessorTests : IDisposable
         using var grandchild = _otherSource.StartActivity("Leaf");
         grandchild.Should().NotBeNull();
 
-        _sut.OnEnd(grandchild!);
+        _sut.OnEnd(grandchild);
 
-        IsRecorded(grandchild!).Should().BeFalse("the full parent chain is walked");
+        IsRecorded(grandchild).Should().BeFalse("the full parent chain is walked");
     }
 
     [Fact]
@@ -83,9 +83,9 @@ public sealed class OutboxPollFilterProcessorTests : IDisposable
         using var unrelated = _otherSource.StartActivity("SomeRequest");
         unrelated.Should().NotBeNull();
 
-        _sut.OnEnd(unrelated!);
+        _sut.OnEnd(unrelated);
 
-        IsRecorded(unrelated!).Should().BeTrue();
+        IsRecorded(unrelated).Should().BeTrue();
     }
 
     [Fact]
@@ -95,9 +95,9 @@ public sealed class OutboxPollFilterProcessorTests : IDisposable
         using var lookalike = _otherSource.StartActivity("OutboxPoll");
         lookalike.Should().NotBeNull();
 
-        _sut.OnEnd(lookalike!);
+        _sut.OnEnd(lookalike);
 
-        IsRecorded(lookalike!).Should().BeTrue("only the MMCA.Common.Outbox source is filtered");
+        IsRecorded(lookalike).Should().BeTrue("only the MMCA.Common.Outbox source is filtered");
     }
 
     [Fact]
@@ -107,9 +107,9 @@ public sealed class OutboxPollFilterProcessorTests : IDisposable
         using var process = _outboxSource.StartActivity("OutboxProcess");
         process.Should().NotBeNull();
 
-        _sut.OnEnd(process!);
+        _sut.OnEnd(process);
 
-        IsRecorded(process!).Should().BeTrue("real outbox work spans are not poll noise");
+        IsRecorded(process).Should().BeTrue("real outbox work spans are not poll noise");
     }
 
     [Fact]

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -34,9 +34,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -43,9 +43,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
@@ -60,9 +60,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Presentation/MMCA.Common.Grpc.Tests/JwtForwardingClientInterceptorTests.cs
+++ b/Tests/Presentation/MMCA.Common.Grpc.Tests/JwtForwardingClientInterceptorTests.cs
@@ -74,9 +74,9 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        var headers = captured!.Value.Options.Headers;
+        var headers = captured.Value.Options.Headers;
         headers.Should().NotBeNull("the interceptor must attach metadata carrying the forwarded token");
-        headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
+        headers.GetValue(AuthorizationHeader).Should().Be(BearerToken);
     }
 
     // ── AsyncUnaryCall: no ambient HttpContext ──
@@ -96,7 +96,7 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        captured!.Value.Options.Headers.Should().BeNull(
+        captured.Value.Options.Headers.Should().BeNull(
             "background processors without an HTTP request must not gain an Authorization header");
     }
 
@@ -117,7 +117,7 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        captured!.Value.Options.Headers.Should().BeNull();
+        captured.Value.Options.Headers.Should().BeNull();
     }
 
     // ── AsyncUnaryCall: caller already set an Authorization header ──
@@ -138,10 +138,10 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        var headers = captured!.Value.Options.Headers;
+        var headers = captured.Value.Options.Headers;
         headers.Should().BeSameAs(existingHeaders, "an already-authorized call passes through untouched");
-        CountAuthorizationEntries(headers!).Should().Be(1);
-        headers!.GetValue(AuthorizationHeader).Should().Be("Bearer existing-value");
+        CountAuthorizationEntries(headers).Should().Be(1);
+        headers.GetValue(AuthorizationHeader).Should().Be("Bearer existing-value");
     }
 
     // ── AsyncUnaryCall: unrelated headers survive the forwarding ──
@@ -162,9 +162,9 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        var headers = captured!.Value.Options.Headers;
+        var headers = captured.Value.Options.Headers;
         headers.Should().NotBeNull();
-        headers!.GetValue("x-custom").Should().Be("custom-value");
+        headers.GetValue("x-custom").Should().Be("custom-value");
         headers.GetValue(AuthorizationHeader).Should().Be(BearerToken);
         CountAuthorizationEntries(headers).Should().Be(1);
     }
@@ -197,7 +197,7 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        captured!.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
+        captured.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
     }
 
     // ── AsyncServerStreamingCall ──
@@ -222,7 +222,7 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        captured!.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
+        captured.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
     }
 
     // ── AsyncClientStreamingCall ──
@@ -247,7 +247,7 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        captured!.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
+        captured.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
     }
 
     // ── AsyncDuplexStreamingCall ──
@@ -272,7 +272,7 @@ public sealed class JwtForwardingClientInterceptorTests
             });
 
         captured.Should().NotBeNull();
-        captured!.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
+        captured.Value.Options.Headers!.GetValue(AuthorizationHeader).Should().Be(BearerToken);
     }
 }
 

--- a/Tests/Presentation/MMCA.Common.Grpc.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.Grpc.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -43,9 +43,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
@@ -42,9 +42,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -69,9 +69,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.124, )",
-        "resolved": "3.0.124",
-        "contentHash": "nJJak27Tqn5tQGuorOQBiSEUkiKO7NYDH80yomOVGpJ4c49dsXhvTHtif8/vrGUJeld8vuERK/F+kZRfmB8ZRA=="
+        "requested": "[3.0.133, )",
+        "resolved": "3.0.133",
+        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
@@ -43,9 +43,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.29.0.143774, )",
-        "resolved": "10.29.0.143774",
-        "contentHash": "YOBCHTjqb4ak7yjLQhQJ6S0+aTkgnuMcekjCrhWruyIIoWlB1C8W+Fgr18bWit+xx7Gd9sNl5sziOwh6D804Hg=="
+        "requested": "[10.30.0.144632, )",
+        "resolved": "10.30.0.144632",
+        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
Completes the Dependabot sweep. Bumps `Meziantou.Analyzer` 3.0.124 → 3.0.133 and `SonarAnalyzer.CSharp` 10.29 → 10.30 (was **#147**), held out of [#161](https://github.com/ivanball/MMCA.Common/pull/161) because 10.30 ships **three new rules** that fail this build under `TreatWarningsAsErrors`.

Each was triaged on its merits rather than bulk-suppressed or bulk-applied.

## S8949 (3 sites) — a real defect, fixed properly

`SoftDeletedUserMiddleware` called the cache and the soft-delete validator **without a `CancellationToken`**, even though all three APIs accept one. A client disconnect never cancelled the lookups. They now pass `context.RequestAborted`.

This one earned its keep: the bump found a genuine bug.

## S8969 (38 sites) — mostly right, 4 wrong

**34 were genuine** redundant null-forgiving operators and are removed.

**Four were wrong.** The analyzer claimed the compiler already knew the expression was non-null; removing the operator immediately failed with `CS8602` / `CS8629`. Those four are restored, and the rule is downgraded to `suggestion` in `.editorconfig`.

Under `TreatWarningsAsErrors` a false positive is a **broken build**, not a nudge, so a rule at this accuracy cannot gate CI. As a suggestion, real redundancies still surface.

## S8970 (3 sites) — wrong at every site

It claims nullable warnings are disabled and the operator is pointless. Every flagged site is the deliberate `null!` / `default!` initializer pattern in a `.razor` component, where removing it fails with `CS8625` / `CS8604`.

Suppressed via `NoWarn` in `Directory.Build.props` rather than `.editorconfig`, because **a `dotnet_diagnostic` severity does not reach Razor-generated code** — worth knowing for the next Razor-affecting rule.

## Why not just suppress all three, or apply all three

The measured false-positive rate was **7 of 41**. Applying blindly breaks the build; suppressing blindly would have discarded 34 real cleanups and missed a genuine cancellation bug. Both suppressions carry that reasoning inline for whoever revisits them.

## Verification

- Full solution Release: **2483/2483 green**, 0 warnings, 0 errors.
- `facts --check` clean.
- 25 lock files regenerated.

Stacked on #161 conceptually but branched off `main`, so it will need `gh pr update-branch` after that merges.