### PR TITLE
docs: correct the stale performance-gate comment in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,12 +321,14 @@ jobs:
           path: Tests/Presentation/MMCA.Common.UI.E2E.Tests/bin/Release/net10.0/playwright-traces/**
           if-no-files-found: ignore
 
-  # Performance smoke (§12): build + run the BenchmarkDotNet harness with the Dry job (one invocation per
-  # benchmark — seconds, not the full multi-iteration timing run) on every push, so the benchmarked hot
-  # paths (Specification compiled-expression cache + criteria composition) are exercised by CI. This is a
-  # *runs-clean* gate — it fails the build if a benchmarked code path throws or no longer compiles, NOT a
-  # latency-regression gate (full timing runs stay on-demand; see CLAUDE.md and the published COST guide). Kept OUT of
-  # MMCA.Common.slnx (like ui-e2e) so the unit `dotnet test --solution` run stays fast.
+  # Performance gate (§12): build + run the BenchmarkDotNet harness with the Short job (3 warmup + 3
+  # iterations, so real measurements in under a minute) on every PR, then check those results against the
+  # committed baseline. This is a REGRESSION gate, not just a runs-clean one: build/perfgate fails the job
+  # when a benchmarked hot path (Specification compiled-expression cache + criteria composition) breaches
+  # an allocation ceiling or drops below a ratio floor, and a rule naming a benchmark that produced no
+  # measurement fails too, so the gate cannot pass vacuously. Moving a number deliberately means updating
+  # Tests/Performance/perf-baseline.json in the same PR (see CLAUDE.md and the published COST guide). Kept
+  # OUT of MMCA.Common.slnx (like ui-e2e) so the unit `dotnet test --solution` run stays fast.
   performance-smoke:
     name: Performance gate (BenchmarkDotNet Short + baseline verify)
     needs: changes


### PR DESCRIPTION
Found while writing ADR-060 (the performance-regression gate record) during the 2026-07-28 ADR audit. The header comment above `performance-smoke` still describes the job as it was before the baseline verifier landed, and all three of its factual claims are now false:

| Comment says | Reality |
|---|---|
| "the Dry job (one invocation per benchmark)" | the step runs `--job Short` (3 warmup + 3 iterations), `ci.yml:360` |
| "on every push" | CI is `pull_request`-only, as this file's own top comment explains at `ci.yml:3-16` |
| "a *runs-clean* gate ... NOT a latency-regression gate" | `build/perfgate` compares against `Tests/Performance/perf-baseline.json` and fails on an allocation-ceiling breach or a ratio-floor violation |

The last one is the reason this is worth fixing rather than leaving: the step comment 22 lines below already says "Latency-regression gate, not just runs-clean", so the file contradicted itself, and the header is the half a reader hits first. The job's own `name:` has said "BenchmarkDotNet Short + baseline verify" for a while.

Comment-only. `git diff` reports zero non-comment changed lines, so no workflow structure is touched. Also removes the two em dashes the comment carried, per the workspace prose rule.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)