### PR TITLE
docs(aspire): correct the stale no-project-references comment

### DIFF
--- a/Source/Hosting/MMCA.Common.Aspire/Telemetry/OutboxPollFilterProcessor.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Telemetry/OutboxPollFilterProcessor.cs
@@ -15,8 +15,11 @@ namespace MMCA.Common.Aspire.Telemetry;
 public sealed class OutboxPollFilterProcessor : BaseProcessor<Activity>
 {
     // Both names must stay in sync with OutboxProcessor in MMCA.Common.Infrastructure
-    // (OutboxActivitySource / PollActivityName). Duplicated deliberately: the Aspire package
-    // has no project references by design.
+    // (OutboxActivitySource / PollActivityName). Duplicated deliberately: this package does not
+    // reference MMCA.Common.Infrastructure, so AddServiceDefaults stays usable from a host that
+    // does not take the persistence stack (EF Core, MassTransit, SignalR/Redis). Its one
+    // ProjectReference is MMCA.Common.Shared, for HttpResilienceDefaults. The same two literals
+    // also appear in the AddMeter / AddSource calls in Extensions.cs.
     private const string OutboxActivitySourceName = "MMCA.Common.Outbox";
     private const string PollActivityName = "OutboxPoll";
 


### PR DESCRIPTION
## What

`OutboxPollFilterProcessor` duplicates the outbox activity-source name (`MMCA.Common.Outbox`) and poll activity name (`OutboxPoll`) from `OutboxProcessor`, and justified that duplication with:

> Duplicated deliberately: the Aspire package has no project references by design.

That stopped being true when `MMCA.Common.Aspire` took a `ProjectReference` on `MMCA.Common.Shared` for `HttpResilienceDefaults` (`Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj`).

## Why it matters

The comment's conclusion (duplicate the strings) is still correct, but its stated reason is now false, so the next reader either believes a constraint that does not exist or assumes the comment is stale and ignores it. Both are worse than a comment that says the real thing.

## What changed

Comment only, no behavior change. The reason is restated accurately:

- this package does not reference `MMCA.Common.Infrastructure`, where `OutboxProcessor` lives, so `AddServiceDefaults` stays usable from a host that does not take the persistence stack (EF Core, MassTransit, SignalR/Redis);
- its one `ProjectReference` is `MMCA.Common.Shared`, for `HttpResilienceDefaults`;
- the same two literals also appear in the `AddMeter` / `AddSource` calls in `Extensions.cs`, which is the other place they must stay in sync. The original comment named only `OutboxProcessor`.

No line numbers are cited in the replacement, deliberately: line-number references in comments are the same drift risk being fixed here.

## Verification

`dotnet build Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj -c Release` succeeds with 0 warnings under `TreatWarningsAsErrors` and the five error-severity analyzers.

## Provenance

Surfaced by the `/update-onboarding` v1.131.0 drift sweep while authoring the group-16 Aspire chapter: the chapter prose was written to state the narrower true fact, and this is the code-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvitL8F4c7BR4WF3nx9A8J