### PR TITLE
fix: apply culture in process on MAUI Blazor Hybrid heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Fixed
+
+- **Switching language now works on MAUI Blazor Hybrid heads.** The culture switcher navigated to
+  `/culture/set`, a server endpoint mapped by `MapCultureEndpoint()`. A hybrid head hosts no ASP.NET
+  pipeline, so the Blazor `Router` resolved that path instead, matched no page, and rendered the
+  not-found page: on Android, picking Spanish answered "Page Not Found" and dropped the user off the
+  page they were on. The same call sits on the login path, so signing in with a stored `es` preference
+  on a device running in English landed on the not-found page instead of the destination.
+
+  Culture application is now behind `ICultureApplier`. `AddUIShared` keeps the web behaviour as the
+  default (`EndpointCultureApplier`, the same endpoint round trip, unchanged for web heads);
+  `MMCA.Common.UI.Maui` supplies `MauiCultureApplier`, which switches the process culture, persists the
+  choice to device preferences, and reloads the WebView so the tree re-renders under the new culture.
+  `MauiCultureInitializer` restores the persisted culture during `MauiAppBuilder.Build()`, so the
+  choice survives an app restart and the first render is already correct. Both are wired by
+  `UseMauiDeviceCapabilities()`, so hybrid heads need no code change; `UseMauiCulture()` is separately
+  callable for a head that composes its own registrations.
+
+  `SupportedCultures.ResolveClosest` is new: it resolves an arbitrary culture name to the closest
+  allowlisted one (exact match, then language, then the default), so a hybrid head starting from a
+  device locale of `es-MX` gets `es` rather than falling back to English. Web heads already got this
+  from request localization's `Accept-Language` matching; this keeps the two paths from drifting.
+
 > **Consumer versions skipped deliberately.** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
 > 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
 > is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
   `UseMauiDeviceCapabilities()`, so hybrid heads need no code change; `UseMauiCulture()` is separately
   callable for a head that composes its own registrations.
 
+  `<html lang>` now follows the active culture on every head. A Blazor Web head emits it server-side
+  from `CurrentCulture`, but a hybrid head serves a static `index.html` that cannot be templated, so it
+  kept declaring the hardcoded language after a switch and misreported the page language to assistive
+  technology (WCAG 3.1.1). The new non-visual `DocumentLanguage` component, rendered once by
+  `MainLayout`, sets it on first interactive render; it is a no-op on web heads, where the server
+  already emitted the same value. Note that no automated gate catches this class of defect: axe checks
+  that `lang` is present and well-formed, never that it is correct.
+
   `SupportedCultures.ResolveClosest` is new: it resolves an arbitrary culture name to the closest
   allowlisted one (exact match, then language, then the default), so a hybrid head starting from a
   device locale of `es-MX` gets `es` rather than falling back to English. Web heads already got this

--- a/Source/Core/MMCA.Common.Shared/Globalization/SupportedCultures.cs
+++ b/Source/Core/MMCA.Common.Shared/Globalization/SupportedCultures.cs
@@ -37,10 +37,52 @@ public static class SupportedCultures
         && All.Any(c => string.Equals(c, culture, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
+    /// Resolves an arbitrary culture name to the closest supported culture: an exact
+    /// <see cref="All"/> match wins, then a language match (so <c>"es-MX"</c> resolves to <c>"es"</c>),
+    /// otherwise <see cref="Default"/>. Never returns <see cref="PseudoLocale"/>.
+    /// <para>
+    /// Web heads get this fallback for free from request localization's <c>Accept-Language</c>
+    /// matching. It exists here for heads that resolve their own culture and have no request pipeline
+    /// to lean on (MAUI Blazor Hybrid, which resolves against the device locale), so the two paths
+    /// cannot drift.
+    /// </para>
+    /// </summary>
+    /// <param name="culture">Any culture name, including a specific one not on the allowlist.</param>
+    public static string ResolveClosest(string? culture)
+    {
+        if (string.IsNullOrWhiteSpace(culture))
+        {
+            return Default;
+        }
+
+        var exact = All.FirstOrDefault(c => string.Equals(c, culture, StringComparison.OrdinalIgnoreCase));
+        if (exact is not null)
+        {
+            return exact;
+        }
+
+        var language = LanguageOf(culture);
+        var byLanguage = All.FirstOrDefault(
+            c => string.Equals(LanguageOf(c), language, StringComparison.OrdinalIgnoreCase));
+
+        return byLanguage ?? Default;
+    }
+
+    /// <summary>
     /// Returns <see langword="true"/> when <paramref name="culture"/> is the pseudo-localization locale
     /// (<see cref="PseudoLocale"/>), matched case-insensitively.
     /// </summary>
     /// <param name="culture">The culture name to test (e.g. <c>CultureInfo.CurrentUICulture.Name</c>).</param>
     public static bool IsPseudoLocale(string? culture) =>
         string.Equals(culture, PseudoLocale, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The language subtag of a culture name (<c>"es-MX"</c> to <c>"es"</c>), without allocating for a
+    /// neutral culture that is already just its language.
+    /// </summary>
+    private static string LanguageOf(string culture)
+    {
+        var separator = culture.IndexOf('-', StringComparison.Ordinal);
+        return separator < 0 ? culture : culture[..separator];
+    }
 }

--- a/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureApplier.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureApplier.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Components;
+using MMCA.Common.Shared.Globalization;
+using MMCA.Common.UI.Services;
+
+namespace MMCA.Common.UI.Maui.Globalization;
+
+/// <summary>
+/// <see cref="ICultureApplier"/> for MAUI Blazor Hybrid heads (ADR-027). The web default
+/// (<c>EndpointCultureApplier</c>) navigates to the server <c>/culture/set</c> endpoint; a hybrid head
+/// has no ASP.NET pipeline, so that URL is resolved by the Blazor <c>Router</c> instead, matches no
+/// page, and renders the not-found page. This applier switches the culture in process and reloads the
+/// WebView instead.
+/// <para>
+/// The reload is what makes the change visible: resource strings are resolved from
+/// <c>CultureInfo.CurrentUICulture</c> at render time, and Blazor has no API to re-render an entire
+/// component tree in place. A force-load in a <c>BlazorWebView</c> re-boots the Blazor app inside the
+/// WebView while the .NET process (and therefore the culture set just above) stays alive, so every
+/// component re-renders under the new culture and the user lands back on the return path.
+/// </para>
+/// </summary>
+/// <param name="navigation">The hybrid head's navigation manager.</param>
+public sealed class MauiCultureApplier(NavigationManager navigation) : ICultureApplier
+{
+    /// <inheritdoc />
+    public Task ApplyAsync(string culture, string returnPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(culture);
+
+        // Parity with the web endpoint, which honors only allowlisted cultures and otherwise returns the
+        // user to the same page unchanged. The pseudo locale is never reachable here: the switcher only
+        // offers it when IHostEnvironment reports Development, and a MAUI head registers no such service.
+        if (!SupportedCultures.IsSupported(culture))
+        {
+            return Task.CompletedTask;
+        }
+
+        // Order and synchrony are load-bearing: persist and activate BEFORE the reload, with no await in
+        // between, so the culture is already current on the renderer's thread when the tree re-renders.
+        MauiCultureStore.Save(culture);
+        MauiCultureStore.ApplyToProcess(culture);
+
+        var target = string.IsNullOrWhiteSpace(returnPath) ? "/" : returnPath;
+        navigation.NavigateTo(target, forceLoad: true);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureInitializer.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureInitializer.cs
@@ -1,0 +1,23 @@
+namespace MMCA.Common.UI.Maui.Globalization;
+
+/// <summary>
+/// Restores the persisted culture when the MAUI app is built (ADR-027), the hybrid counterpart to the
+/// WASM head's <c>MmcaCultureBootstrap</c>. <c>IMauiInitializeService.Initialize</c> runs inside
+/// <c>MauiAppBuilder.Build()</c>, before any window or page exists, so the very first Blazor render
+/// already happens under the right culture: no flash of the wrong language, and no switch needed on
+/// every launch just to get back to the language the user picked last time.
+/// <para>
+/// Without this, a hybrid head has no culture state of its own and always starts at the device locale,
+/// which is why persisting the choice in <see cref="MauiCultureApplier"/> alone is not enough.
+/// </para>
+/// </summary>
+public sealed class MauiCultureInitializer : IMauiInitializeService
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// <paramref name="services"/> is unused: the culture lives in device preferences and process state,
+    /// both reachable without DI. The parameter belongs to the interface, not to this restore.
+    /// </remarks>
+    public void Initialize(IServiceProvider services) =>
+        MauiCultureStore.ApplyToProcess(MauiCultureStore.Resolve());
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureStore.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureStore.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+using MMCA.Common.Shared.Globalization;
+
+namespace MMCA.Common.UI.Maui.Globalization;
+
+/// <summary>
+/// The single storage + activation path for the culture on a MAUI Blazor Hybrid head (ADR-027).
+/// A hybrid head has no ASP.NET request pipeline, so none of the web machinery applies: there is no
+/// culture cookie to write and nothing reads <c>CookieRequestCultureProvider</c>. The active culture is
+/// process state (<see cref="CultureInfo.DefaultThreadCurrentUICulture"/>) and the choice is persisted
+/// in device preferences so it survives an app restart.
+/// <para>
+/// Deliberately reads and writes <c>Preferences.Default</c> directly rather than going through
+/// <c>IDevicePreferences</c>: that contract is async-only, and the startup restore runs from
+/// <c>IMauiInitializeService.Initialize</c>, a synchronous hook. One value must have exactly one
+/// storage path, so both sides use this class rather than splitting across the two.
+/// </para>
+/// </summary>
+internal static class MauiCultureStore
+{
+    /// <summary>
+    /// The device-preference key. Outside the <c>IDevicePreferences</c> prefix on purpose (see the
+    /// type remarks); changing it silently resets every installed app to the device locale.
+    /// </summary>
+    private const string PreferenceKey = "mmca.culture";
+
+    /// <summary>Persists the user's explicit choice. Best-effort, mirroring the rest of the layer.</summary>
+    /// <param name="culture">A culture from <c>SupportedCultures.All</c>.</param>
+    public static void Save(string culture) => Preferences.Default.Set(PreferenceKey, culture);
+
+    /// <summary>
+    /// Resolves the culture to start under, in the same precedence order the web heads get from request
+    /// localization: the stored explicit choice (the cookie's analogue), then the device locale matched
+    /// by language (<c>Accept-Language</c>'s analogue, so an <c>es-MX</c> phone gets <c>es</c>), then
+    /// the framework default.
+    /// </summary>
+    public static string Resolve()
+    {
+        var stored = Preferences.Default.Get<string?>(PreferenceKey, null);
+
+        return SupportedCultures.IsSupported(stored)
+            ? stored!
+            : SupportedCultures.ResolveClosest(CultureInfo.CurrentUICulture.Name);
+    }
+
+    /// <summary>
+    /// Makes <paramref name="culture"/> the active culture for the process. Both the thread defaults and
+    /// the calling thread are set: the defaults only apply to threads that have not materialized a
+    /// culture yet, and by the time a user switches, the MAUI UI thread (which is also the Blazor
+    /// renderer's dispatcher thread) already has one. Call this synchronously, before any await, so it
+    /// lands on the renderer's thread rather than on whatever thread a continuation resumes on.
+    /// </summary>
+    /// <param name="culture">A culture from <c>SupportedCultures.All</c>.</param>
+    public static void ApplyToProcess(string culture)
+    {
+        var cultureInfo = new CultureInfo(culture);
+
+        CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+        CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
+        CultureInfo.CurrentCulture = cultureInfo;
+        CultureInfo.CurrentUICulture = cultureInfo;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/HostingDependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/HostingDependencyInjection.cs
@@ -1,10 +1,12 @@
+using MMCA.Common.UI.Maui.Globalization;
+using MMCA.Common.UI.Services;
 using Plugin.LocalNotification;
 
 namespace MMCA.Common.UI.Maui;
 
 /// <summary>
-/// <see cref="MauiAppBuilder"/>-level entry point for the device-capability layer (ADR-042).
-/// Call AFTER <c>AddUIShared</c> in <c>MauiProgram.CreateMauiApp</c>.
+/// <see cref="MauiAppBuilder"/>-level entry point for the device-capability layer (ADR-042) and the
+/// hybrid culture wiring (ADR-027). Call AFTER <c>AddUIShared</c> in <c>MauiProgram.CreateMauiApp</c>.
 /// </summary>
 public static class HostingDependencyInjection
 {
@@ -26,6 +28,31 @@ public static class HostingDependencyInjection
             builder.UseLocalNotification();
             builder.Services.AddMauiDeviceCapabilities();
             builder.Services.AddSingleton<IMauiInitializeService, DeviceCapabilitiesInitializer>();
+
+            // Folded in deliberately, despite belonging to ADR-027 rather than ADR-042: a hybrid head
+            // that skips it gets a culture switcher that navigates to a server endpoint it does not
+            // host, which renders the not-found page. Every head already makes this call, so wiring it
+            // here means no head can be left half-configured. UseMauiCulture() stays separately
+            // callable for a head that composes its registrations by hand.
+            builder.UseMauiCulture();
+            return builder;
+        }
+
+        /// <summary>
+        /// Wires culture switching for a hybrid head (ADR-027): replaces the web
+        /// <c>ICultureApplier</c> (which round-trips the server <c>/culture/set</c> endpoint that no
+        /// hybrid head hosts) with the in-process <see cref="MauiCultureApplier"/>, and restores the
+        /// persisted culture at startup via <see cref="MauiCultureInitializer"/>.
+        /// <para>
+        /// Already called by <see cref="UseMauiDeviceCapabilities"/>; calling it twice is harmless.
+        /// Must run AFTER <c>AddUIShared</c> so the plain Add overrides that TryAdd default
+        /// (last registration wins).
+        /// </para>
+        /// </summary>
+        public MauiAppBuilder UseMauiCulture()
+        {
+            builder.Services.AddScoped<ICultureApplier, MauiCultureApplier>();
+            builder.Services.AddSingleton<IMauiInitializeService, MauiCultureInitializer>();
             return builder;
         }
     }

--- a/Source/Presentation/MMCA.Common.UI/Components/CultureSwitcher.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/CultureSwitcher.razor
@@ -3,6 +3,7 @@
 @using Microsoft.Extensions.Hosting
 @inject NavigationManager Navigation
 @inject IServiceProvider Services
+@inject ICultureApplier CultureApplier
 @inject IStringLocalizer<SharedResource> L
 
 <MudMenu Icon="@Icons.Material.Filled.Translate"
@@ -40,11 +41,10 @@
             await writer.SaveAsync(culture, theme: null);
         }
 
+        // Host-specific from here: the web applier round-trips the /culture/set endpoint and reloads,
+        // the MAUI applier switches the process culture in place. Both land back on the current page,
+        // so this call is terminal (ADR-027).
         var current = new Uri(Navigation.Uri).PathAndQuery;
-        var url = $"/culture/set?culture={Uri.EscapeDataString(culture)}&redirectUri={Uri.EscapeDataString(current)}";
-
-        // Full reload: the server re-renders SSR under the new cookie and the WASM runtime re-reads it,
-        // keeping prerender and hydration on the same culture (ADR-027).
-        Navigation.NavigateTo(url, forceLoad: true);
+        await CultureApplier.ApplyAsync(culture, current);
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Components/DocumentLanguage.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/DocumentLanguage.razor
@@ -1,0 +1,26 @@
+@using System.Globalization
+@inject IJSRuntime JS
+
+@* Renders nothing: it exists to keep <html lang> in step with the active UI culture (ADR-027
+   Decision 10). A Blazor Web head already emits the correct value server-side (its App.razor reads
+   CurrentCulture per request), so the call is a harmless no-op there. A MAUI Blazor Hybrid head serves
+   a STATIC index.html with a hardcoded lang and no way to template it, so this is the only place the
+   document language can follow a switch. First render is enough on every head: a culture switch always
+   costs a full reload (the endpoint redirect on web, the WebView re-boot on hybrid), so the document is
+   re-created under the new culture rather than mutated in place. *@
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // JS interop is unavailable during SSR prerender, so this waits for the first interactive render.
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await using var module = await JS.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/MMCA.Common.UI/culture.js");
+        await module.InvokeVoidAsync(
+            "setDocumentLanguage", CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -82,6 +82,12 @@ public static class DependencyInjection
             // Day/Dark theme preference (ADR-028): cookie + localStorage persistence, system-pref default.
             services.TryAddScoped<ThemeService>();
 
+            // Culture switching (ADR-027). The default round-trips the server /culture/set endpoint, which
+            // only exists on a Blazor Web head; MAUI Blazor Hybrid heads override this AFTER AddUIShared
+            // with an in-process applier (UseMauiDeviceCapabilities does it), since a hybrid head has no
+            // ASP.NET pipeline and the endpoint URL would resolve to the Blazor not-found page.
+            services.TryAddScoped<ICultureApplier, EndpointCultureApplier>();
+
             // Per-user culture/theme persistence to the backend (ADR-027/028) — best-effort, anon no-op.
             services.TryAddScoped<IUserPreferenceWriter, ApiUserPreferenceWriter>();
             services.TryAddScoped<IUserPreferenceReader, ApiUserPreferenceReader>();

--- a/Source/Presentation/MMCA.Common.UI/Layout/MainLayout.razor
+++ b/Source/Presentation/MMCA.Common.UI/Layout/MainLayout.razor
@@ -12,6 +12,7 @@
 @inject IStringLocalizer<SharedResource> L
 
 <MmcaThemeProviders />
+<DocumentLanguage />
 
 <a href="#main-content" class="skip-nav">@L["Layout.SkipToMainContent"]</a>
 

--- a/Source/Presentation/MMCA.Common.UI/Pages/Auth/Login.razor
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Auth/Login.razor
@@ -11,6 +11,7 @@
 @inject IOptions<ApiSettings> ApiSettingsOptions
 @inject NavigationManager Navigation
 @inject IUserPreferenceReader PreferenceReader
+@inject ICultureApplier CultureApplier
 @inject ThemeService ThemeService
 @inject IExternalAuthBroker ExternalAuthBroker
 @inject IStringLocalizer<SharedResource> L
@@ -204,10 +205,10 @@
         if (preferences.Culture is not null
             && !string.Equals(preferences.Culture, System.Globalization.CultureInfo.CurrentUICulture.Name, StringComparison.OrdinalIgnoreCase))
         {
-            // Route through /culture/set to write the culture cookie, then reload to the destination.
-            Navigation.NavigateTo(
-                $"/culture/set?culture={Uri.EscapeDataString(preferences.Culture)}&redirectUri={Uri.EscapeDataString(destination)}",
-                forceLoad: true);
+            // The applier owns both the switch and landing on the destination, so this is terminal:
+            // the web head round-trips /culture/set to write the cookie, a MAUI head switches the
+            // process culture in place and reloads the WebView (ADR-027).
+            await CultureApplier.ApplyAsync(preferences.Culture, destination);
             return;
         }
 

--- a/Source/Presentation/MMCA.Common.UI/Services/EndpointCultureApplier.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/EndpointCultureApplier.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Components;
+
+namespace MMCA.Common.UI.Services;
+
+/// <summary>
+/// Default <see cref="ICultureApplier"/> for Blazor Web heads (ADR-027): navigates to the server
+/// <c>GET /culture/set</c> endpoint mapped by <c>MapCultureEndpoint()</c>, which writes the ASP.NET
+/// culture cookie and local-redirects to <c>redirectUri</c>. The force-load is load-bearing: the server
+/// re-renders SSR under the new cookie and the WASM runtime re-reads it on startup
+/// (<see cref="MmcaCultureBootstrap"/>), keeping prerender and hydration on the same culture.
+/// <para>
+/// Only valid where that endpoint exists. A head with no ASP.NET pipeline (MAUI Blazor Hybrid) would
+/// route the URL through the Blazor <c>Router</c> instead, which matches no page and renders the
+/// not-found page, so those heads register their own applier after <c>AddUIShared</c>.
+/// </para>
+/// </summary>
+/// <param name="navigation">The head's navigation manager.</param>
+public sealed class EndpointCultureApplier(NavigationManager navigation) : ICultureApplier
+{
+    /// <inheritdoc />
+    public Task ApplyAsync(string culture, string returnPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(culture);
+
+        var target = string.IsNullOrWhiteSpace(returnPath) ? "/" : returnPath;
+        var url = $"/culture/set?culture={Uri.EscapeDataString(culture)}&redirectUri={Uri.EscapeDataString(target)}";
+
+        // The endpoint validates the culture against the allowlist and ignores anything else, so an
+        // unsupported value lands the user back on the same page unchanged rather than failing.
+        navigation.NavigateTo(url, forceLoad: true);
+        return Task.CompletedTask;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/ICultureApplier.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/ICultureApplier.cs
@@ -1,0 +1,28 @@
+namespace MMCA.Common.UI.Services;
+
+/// <summary>
+/// Applies a culture switch for the current head (ADR-027). The mechanism is host-specific and must
+/// not be hard-coded by the UI: a Blazor Web head round-trips through the server
+/// <c>/culture/set</c> endpoint so the cookie, SSR prerender, and the WASM runtime all agree, while a
+/// MAUI Blazor Hybrid head has no ASP.NET pipeline at all and switches the process culture in place.
+/// <para>
+/// Implementations own landing the user back on the return path: on the web that is the endpoint's
+/// redirect, on a hybrid head it is a WebView reload. Callers must therefore treat
+/// <c>ApplyAsync</c> as terminal and do no further navigation of their own.
+/// </para>
+/// </summary>
+public interface ICultureApplier
+{
+    /// <summary>
+    /// Switches the active culture and returns the user to <paramref name="returnPath"/>.
+    /// </summary>
+    /// <param name="culture">
+    /// The culture to activate (e.g. <c>"es"</c>). Values outside
+    /// <c>SupportedCultures.All</c> are ignored by the underlying mechanism rather than throwing.
+    /// </param>
+    /// <param name="returnPath">
+    /// The app-relative path (with query) to land on afterwards. Empty falls back to <c>"/"</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ApplyAsync(string culture, string returnPath, CancellationToken cancellationToken = default);
+}

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/culture.js
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/culture.js
@@ -21,3 +21,14 @@ export function getCulture() {
     }
     return null;
 }
+
+// Sets <html lang> to the active UI language (ADR-027 Decision 10). A Blazor Web head emits the right
+// value server-side from CurrentCulture, so this is a no-op there. A MAUI Blazor Hybrid head serves a
+// STATIC index.html that cannot be templated, so without this the document keeps declaring whatever
+// language was hardcoded, misreporting the page language to assistive technology (WCAG 3.1.1) after a
+// switch. Automated checks do not catch it: axe flags a missing or malformed lang, never a wrong one.
+export function setDocumentLanguage(language) {
+    if (language) {
+        document.documentElement.lang = language;
+    }
+}

--- a/Tests/Core/MMCA.Common.Shared.Tests/Globalization/SupportedCulturesTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Globalization/SupportedCulturesTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using MMCA.Common.Shared.Globalization;
+
+namespace MMCA.Common.Shared.Tests.Globalization;
+
+/// <summary>
+/// Tests for the culture allowlist (ADR-027), focused on <see cref="SupportedCultures.ResolveClosest"/>:
+/// the fallback chain a head must apply when it resolves its own culture instead of getting request
+/// localization's <c>Accept-Language</c> matching for free (MAUI Blazor Hybrid).
+/// </summary>
+public sealed class SupportedCulturesTests
+{
+    [Theory]
+    [InlineData("en-US", "en-US")]
+    [InlineData("es", "es")]
+    [InlineData("ES", "es")]
+    [InlineData("en-us", "en-US")]
+    public void ResolveClosest_ReturnsTheAllowlistEntry_ForAnExactMatch(string input, string expected) =>
+        SupportedCultures.ResolveClosest(input).Should().Be(expected);
+
+    // The case a device locale actually hits: Android reports a specific culture, the allowlist holds a
+    // neutral one. Without the language match a Spanish phone would silently start in English.
+    [Theory]
+    [InlineData("es-MX", "es")]
+    [InlineData("es-419", "es")]
+    [InlineData("en-GB", "en-US")]
+    public void ResolveClosest_FallsBackToTheLanguage_ForAnUnlistedSpecificCulture(string input, string expected) =>
+        SupportedCultures.ResolveClosest(input).Should().Be(expected);
+
+    [Theory]
+    [InlineData("fr-FR")]
+    [InlineData("de")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void ResolveClosest_FallsBackToTheDefault_ForAnUnsupportedLanguage(string? input) =>
+        SupportedCultures.ResolveClosest(input).Should().Be(SupportedCultures.Default);
+
+    // The pseudo locale is a Development-only diagnostic reached through the switcher and the culture
+    // endpoint, never through allowlist resolution: a persisted or device value must not activate it.
+    [Fact]
+    public void ResolveClosest_NeverReturnsThePseudoLocale() =>
+        SupportedCultures.ResolveClosest(SupportedCultures.PseudoLocale)
+            .Should().Be(SupportedCultures.Default);
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/BunitTestBase.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/BunitTestBase.cs
@@ -22,6 +22,11 @@ public abstract class BunitTestBase : BunitComponentTestBase
         // Common's own tests render the layout chrome; consumer bUnit tests render pages directly.
         Services.AddScoped<ThemeService>();
 
+        // CultureSwitcher (same top-row) injects ICultureApplier, and Login injects it to apply the
+        // signed-in user's stored culture. The production web default, so layout tests exercise the
+        // real navigation; a test that cares about the call itself substitutes its own.
+        Services.AddScoped<ICultureApplier, EndpointCultureApplier>();
+
         // Capability defaults the shared pages/layout inject (ADR-042): Login consults the
         // external-auth broker, MainLayout renders the OfflineBanner. The Testing.UI harness
         // cannot register these (it deliberately does not reference MMCA.Common.UI).

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/CultureSwitcherTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/CultureSwitcherTests.cs
@@ -1,0 +1,93 @@
+using AngleSharp.Dom;
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.Shared.Globalization;
+using MMCA.Common.UI.Components;
+using MMCA.Common.UI.Services;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers <see cref="CultureSwitcher"/> (ADR-027). The regression guard here is that the switcher
+/// delegates to <see cref="ICultureApplier"/> instead of navigating to <c>/culture/set</c> itself: that
+/// URL is a server endpoint, so a hard-coded navigation left MAUI Blazor Hybrid heads (which host no
+/// ASP.NET pipeline) routing it through the Blazor router onto the not-found page.
+/// </summary>
+public sealed class CultureSwitcherTests : BunitTestBase
+{
+    private readonly RecordingCultureApplier _applier = new();
+
+    public CultureSwitcherTests() => Services.AddScoped<ICultureApplier>(_ => _applier);
+
+    // The pseudo locale is offered only when IHostEnvironment reports Development, and no such service
+    // is registered here (nor on a MAUI head), so the allowlist is the whole menu.
+    [Fact]
+    public void OffersEverySupportedCulture()
+    {
+        var items = OpenMenu();
+
+        items.Should().HaveCount(SupportedCultures.All.Count);
+        items.Select(i => i.TextContent).Should().Contain("Español");
+    }
+
+    [Fact]
+    public void SelectingACulture_DelegatesToTheApplier_WithTheCurrentPathAsReturnPath()
+    {
+        var navigation = Services.GetRequiredService<Bunit.TestDoubles.BunitNavigationManager>();
+        navigation.NavigateTo("/sessions?page=2");
+
+        SpanishItem().Click();
+
+        _applier.Culture.Should().Be("es");
+        _applier.ReturnPath.Should().Be("/sessions?page=2");
+    }
+
+    // The switcher must not reintroduce a navigation of its own: the applier owns landing the user back
+    // on the page, and on a hybrid head that is a WebView reload, not a server redirect.
+    [Fact]
+    public void SelectingACulture_DoesNotNavigateOnItsOwn()
+    {
+        var navigation = Services.GetRequiredService<Bunit.TestDoubles.BunitNavigationManager>();
+
+        SpanishItem().Click();
+
+        _applier.Culture.Should().Be("es", "the applier ran, so an empty history is not a no-op test");
+        navigation.History.Should().BeEmpty();
+    }
+
+    private IElement SpanishItem()
+    {
+        var items = OpenMenu();
+
+        // Menu items follow SupportedCultures.All order (the switcher iterates it directly).
+        var spanish = items[SupportedCultures.All.ToList().IndexOf("es")];
+        spanish.TextContent.Should().Be("Español", "the index-to-culture mapping must stay honest");
+        return spanish;
+    }
+
+    // MudMenu renders its items into the popover provider's tree only once opened, so the activator
+    // click is required and the items are queried from the provider, not from the component under test.
+    private IReadOnlyList<IElement> OpenMenu()
+    {
+        var providers = RenderMudProviders();
+        var cut = RenderUnderTest<CultureSwitcher>(_ => { });
+        cut.Find("button").Click();
+
+        return [.. providers.Popover.FindAll("div.mud-menu-item")];
+    }
+
+    private sealed class RecordingCultureApplier : ICultureApplier
+    {
+        public string? Culture { get; private set; }
+
+        public string? ReturnPath { get; private set; }
+
+        public Task ApplyAsync(string culture, string returnPath, CancellationToken cancellationToken = default)
+        {
+            Culture = culture;
+            ReturnPath = returnPath;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/DocumentLanguageTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/DocumentLanguageTests.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using AwesomeAssertions;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers <see cref="DocumentLanguage"/> (ADR-027 Decision 10). A MAUI Blazor Hybrid head serves a static
+/// <c>index.html</c> whose <c>lang</c> cannot be templated, so this component is the only thing that makes
+/// the document language follow a culture switch there. No automated accessibility gate can catch a
+/// <em>wrong</em> <c>lang</c> (axe checks presence and syntax only), which is why it is asserted here.
+/// </summary>
+public sealed class DocumentLanguageTests : BunitTestBase
+{
+    [Theory]
+    [InlineData("es", "es")]
+    [InlineData("en-US", "en")]
+    [InlineData("es-MX", "es")]
+    public void SetsTheDocumentLanguage_ToTheActiveUiCultureLanguage(string culture, string expected)
+    {
+        var original = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+
+            RenderUnderTest<DocumentLanguage>(_ => { });
+
+            var invocation = JSInterop.Invocations["setDocumentLanguage"].Should().ContainSingle().Subject;
+            invocation.Arguments.Should().ContainSingle().Which.Should().Be(expected);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = original;
+        }
+    }
+
+    [Fact]
+    public void RendersNoMarkup()
+    {
+        var cut = RenderUnderTest<DocumentLanguage>(_ => { });
+
+        cut.Markup.Should().BeEmpty();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Globalization/EndpointCultureApplierTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Globalization/EndpointCultureApplierTests.cs
@@ -1,0 +1,77 @@
+using AwesomeAssertions;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.UI.Services;
+using MudBlazor.Services;
+
+namespace MMCA.Common.UI.Tests.Globalization;
+
+/// <summary>
+/// Covers the default web <see cref="ICultureApplier"/> (ADR-027): it must route through the server
+/// <c>/culture/set</c> endpoint with a force-load, because only that round trip writes the culture cookie
+/// that SSR prerender and the WASM runtime both read.
+/// </summary>
+public sealed class EndpointCultureApplierTests : BunitTestBase
+{
+    private BunitNavigationManager Navigation => Services.GetRequiredService<BunitNavigationManager>();
+
+    [Fact]
+    public async Task ApplyAsync_NavigatesToTheCultureEndpoint_WithTheReturnUrlAsRedirect()
+    {
+        var applier = new EndpointCultureApplier(Navigation);
+
+        await applier.ApplyAsync("es", "/sessions?page=2");
+
+        Navigation.Uri.Should().Be(
+            "http://localhost/culture/set?culture=es&redirectUri=" + Uri.EscapeDataString("/sessions?page=2"));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_ForcesAFullLoad_SoTheServerRerendersUnderTheNewCookie()
+    {
+        var applier = new EndpointCultureApplier(Navigation);
+
+        await applier.ApplyAsync("es", "/");
+
+        Navigation.History.Should().ContainSingle().Which.Options.ForceLoad.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ApplyAsync_DefaultsAnEmptyReturnUrlToRoot()
+    {
+        var applier = new EndpointCultureApplier(Navigation);
+
+        await applier.ApplyAsync("es", "   ");
+
+        Navigation.Uri.Should().Be(
+            "http://localhost/culture/set?culture=es&redirectUri=" + Uri.EscapeDataString("/"));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RejectsAMissingCulture()
+    {
+        var applier = new EndpointCultureApplier(Navigation);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => applier.ApplyAsync("  ", "/"));
+    }
+
+    // AddUIShared must keep supplying this implementation via TryAdd: a MAUI head replaces it with a
+    // plain Add AFTER AddUIShared, and last-registration-wins only holds while this side stays a TryAdd.
+    [Fact]
+    public void AddUIShared_RegistersTheEndpointApplier_AsTheDefault()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Api:ApiEndpoint"] = "https://localhost:6001" })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddMudServices();
+        services.AddUIShared(configuration);
+
+        var descriptor = services.Should().ContainSingle(d => d.ServiceType == typeof(ICultureApplier)).Subject;
+        descriptor.ImplementationType.Should().Be<EndpointCultureApplier>();
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+    }
+}


### PR DESCRIPTION
## Problem

Switching language on the Android app answered **"Page Not Found"** and dropped the user off the page they were on.

The culture switcher navigated to `/culture/set`, a server endpoint mapped by `MapCultureEndpoint()`. A MAUI Blazor Hybrid head hosts no ASP.NET pipeline: its `BlazorWebView` resolves every path through the Blazor `Router`, which matched no page and rendered `Pages/NotFound.razor`. The switcher was inert on Android.

The same call sits on the login path (`Login.razor`, applying a stored `User.PreferredCulture`), so signing in on an English-locale device with an `es` profile landed on the not-found page instead of the destination. Writing a culture cookie could not have helped either: nothing on a hybrid head reads `CookieRequestCultureProvider`.

## Fix

Culture application moves behind `ICultureApplier` (ADR-027 Decision 10, amended in the Website repo):

- `EndpointCultureApplier` (web default, `TryAdd` in `AddUIShared`) does exactly what the switcher did before. **No behaviour change for web heads.**
- `MauiCultureApplier` (`MMCA.Common.UI.Maui`, plain `Add` after `AddUIShared`) sets the process **and** calling-thread cultures, persists to device preferences, then force-loads the return path. The reload is load-bearing: resource strings resolve from `CurrentUICulture` at render time and Blazor cannot re-render a whole tree in place, so re-booting the Blazor app inside the WebView (the .NET process, and the culture, survive) is what makes the switch visible.
- `MauiCultureInitializer` restores the persisted culture inside `MauiAppBuilder.Build()`, before any window exists, so the choice survives a restart and the first render is already correct.

Both are wired by `UseMauiDeviceCapabilities()`, so **hybrid heads need no code change**; `UseMauiCulture()` stays separately callable.

`SupportedCultures.ResolveClosest` is new: exact allowlist match, then language (`es-MX` to `es`), then default, never the pseudo locale. Web heads got that fallback from request localization's `Accept-Language` matching; a hybrid head resolving from the device locale needs the same rule, and one implementation keeps them from drifting.

Second commit fixes a related gap found while verifying the first: a hybrid head serves a static `index.html` with `lang` hardcoded, so the document kept declaring English after a switch (WCAG 3.1.1). The new non-visual `DocumentLanguage` component, rendered once by `MainLayout`, sets it on first interactive render and is a no-op on web heads.

## Verification

- Debug and Release: build clean, **2508/2508 tests pass**.
- `MMCA.Common.UI.Maui` Release build across all four TFMs.
- Helpdesk canary against this source: clean, 91/91.
- ADC's Android head builds against this source with zero ADC-side changes, confirming the wiring is picked up.
- Out-of-slnx gallery + UI.E2E.Tests build clean.

**Not covered by any tier:** the WebView reload actually re-rendering under the new culture. Neither bUnit nor the E2E suite runs a `BlazorWebView`, so the tests assert the delegation, the resolution order, and the `lang` value; the reload itself needs a device run. Recorded in the ADR trade-offs rather than implied as covered.

Also note the `lang` defect is invisible to automated accessibility gates: axe checks that `lang` is present and well-formed, never that it is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJTuRMspt7gScYgg43jEm