### PR TITLE
release: v1.132.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+> **Consumer versions skipped deliberately.** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
+> 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
+> is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so
+> sweeping it alone would have cost two production deploys for no behavioural change; 1.129.0 and
+> 1.130.0 were superseded within the same day by 1.131.0, which the consumers took in one pass per
+> ADR-016. An audit that reports the consumers as "several versions behind" for that window is
+> reading history, not a gap.
+
+## [1.132.0] - 2026-07-29
+
 ### Fixed
 
 - **Switching language now works on MAUI Blazor Hybrid heads.** The culture switcher navigated to
@@ -36,14 +46,6 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
   allowlisted one (exact match, then language, then the default), so a hybrid head starting from a
   device locale of `es-MX` gets `es` rather than falling back to English. Web heads already got this
   from request localization's `Accept-Language` matching; this keeps the two paths from drifting.
-
-> **Consumer versions skipped deliberately.** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
-> 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
-> is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so
-> sweeping it alone would have cost two production deploys for no behavioural change; 1.129.0 and
-> 1.130.0 were superseded within the same day by 1.131.0, which the consumers took in one pass per
-> ADR-016. An audit that reports the consumers as "several versions behind" for that window is
-> reading history, not a gap.
 
 ## [1.131.0] - 2026-07-28
 


### PR DESCRIPTION
Cuts `v1.132.0`. Only the CHANGELOG changes here; `FACTS.md` is pinned post-tag in a follow-up PR, since its version line derives from a tag that does not exist yet.

## Headline

**Language switching works on MAUI Blazor Hybrid heads** (#169). The culture switcher navigated to `/culture/set`, a server endpoint. A hybrid head hosts no ASP.NET pipeline, so the Blazor `Router` resolved that path, matched no page, and rendered the not-found page: on Android, picking Spanish answered "Page Not Found". Culture application now sits behind `ICultureApplier`, with the web endpoint round trip as the unchanged default and an in-process applier plus startup restore on the hybrid side. Also fixes a stale `<html lang>` on hybrid heads (WCAG 3.1.1) via the new `DocumentLanguage` component.

Web heads are behaviourally unchanged: the endpoint applier does exactly what the switcher did before, and `DocumentLanguage` re-asserts the value the server already emitted.

New public surface (additive, minor-version appropriate): `ICultureApplier`, `EndpointCultureApplier`, `DocumentLanguage`, `SupportedCultures.ResolveClosest`, `MauiCultureApplier`, `MauiCultureInitializer`, `MauiAppBuilder.UseMauiCulture()`.

## Also carried

Six commits that were already on `main` but never shipped to a consumer (all three sit at 1.131.0):

| Commit | Kind |
|---|---|
| #168 | out-of-slnx lock-file refresh |
| #165, #166, #167 | comment / doc corrections |
| #161, #162 | Dependabot consolidation + analyzer group bump with Sonar remediation |
| #160 | FACTS regen for v1.131.0 |

## Consumer sweep

All three consumers bump in lockstep per ADR-016 after the publish succeeds. Merging the ADC and Store bumps is a production deploy and will be confirmed separately.

## Known gap, not fixed here

The hybrid WebView reload is not covered by any automated tier (neither bUnit nor the E2E suite runs a `BlazorWebView`), so it needs a device run to confirm end to end. Recorded in ADR-027's trade-offs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJTuRMspt7gScYgg43jEm