### PR TITLE
fix: stop the mobile top-row actions overlapping the hamburger

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor.css
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor.css
@@ -193,7 +193,15 @@
     margin-right: 0.25rem;
     color: white;
     white-space: nowrap;
-    min-width: 0;
+    /* Never shrink below the actions' own width. .top-row reserves its 4.5rem right padding for
+       the absolutely positioned .navbar-toggler, but a shrinkable actions box (the previous
+       min-width: 0 plus the default flex-shrink: 1) gets squeezed by the width:100% brand
+       container and spills its nowrap, overflow-visible contents right into that reserve,
+       painting the theme icon over the hamburger. Signed in, .toprow-user-name absorbed the
+       squeeze by ellipsizing, so only the signed-out row (two fixed-width icon buttons, nothing
+       shrinkable) ever showed it. The brand is the element meant to give way instead:
+       .top-row .container-fluid is min-width: 0 and .navbar-brand already ellipsizes. */
+    flex: 0 0 auto;
     /* Prevent the top-row from clipping the badge above the icon */
     overflow: visible;
 }

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/MobileTopRowE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/MobileTopRowE2ETests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Playwright;
 using MMCA.Common.Testing.E2E.Infrastructure;
 using MMCA.Common.UI.E2E.Tests.Infrastructure;
@@ -33,6 +34,37 @@ public sealed class MobileTopRowE2ETests : GalleryAxeTestBase
         // The gallery host runs anonymously, so this also proves the controls are not auth-gated.
         await Expect(topRow.GetByRole(AriaRole.Button, new() { Name = "Language" })).ToBeVisibleAsync();
         await Expect(topRow.GetByTitle("Toggle light/dark theme")).ToBeVisibleAsync();
+    }
+
+    [Fact]
+    public async Task PhoneViewport_TopRowActions_DoNotOverlapTheHamburger()
+    {
+        await Page.SetViewportSizeAsync(390, 844);
+        await Page.GotoAsync("/");
+        await Page.WaitForLoadStateAsync();
+
+        // The theme toggle is the last item in the signed-out top-row, so it is the one that lands on
+        // the hamburger when .toprow-actions is allowed to shrink below its content width. The gallery
+        // host is anonymous, which is exactly the state that used to overlap: signed in, the user-name
+        // span absorbs the squeeze by ellipsizing and hides the defect.
+        var themeToggle = Page.Locator(".toprow-actions").GetByTitle("Toggle light/dark theme");
+        var hamburger = Page.Locator(".navbar-toggler");
+
+        // Settle both before measuring: BoundingBoxAsync does not auto-wait, so reading it straight
+        // after the navigation returns null whenever the interactive render has not landed yet.
+        await Expect(themeToggle).ToBeVisibleAsync();
+        await Expect(hamburger).ToBeVisibleAsync();
+
+        var themeBox = await themeToggle.BoundingBoxAsync();
+        var hamburgerBox = await hamburger.BoundingBoxAsync();
+
+        Assert.NotNull(themeBox);
+        Assert.NotNull(hamburgerBox);
+        var themeRight = (themeBox.X + themeBox.Width).ToString(CultureInfo.InvariantCulture);
+        var hamburgerLeft = hamburgerBox.X.ToString(CultureInfo.InvariantCulture);
+        Assert.True(
+            themeBox.X + themeBox.Width <= hamburgerBox.X,
+            $"Theme toggle (right edge {themeRight}) overlaps the hamburger (left edge {hamburgerLeft}).");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Reported from the AtlDevCon Android app: at phone width, with **no user signed in**, the dark/light toggle paints on top of the hamburger.

`.toprow-actions` carried `min-width: 0` plus the default `flex-shrink: 1`, so the `width: 100%` brand container squeezed it below its own content width. Its contents are `white-space: nowrap` with `overflow: visible`, so they spilled right into the `4.5rem` that `.top-row` reserves for the absolutely positioned `.navbar-toggler`.

Signed in, `.toprow-user-name` (`max-width: 7rem`, `overflow: hidden`, ellipsis) absorbed the squeeze, which is why only the signed-out row (two fixed-width icon buttons, nothing shrinkable) ever showed it. This was never MAUI-specific: every phone-width web render had it, and the desktop app bar is a different element, which is why it went unnoticed.

## Fix

`flex: 0 0 auto` on `.toprow-actions` pins the group to its content width and lets the brand give way instead, which is what `.top-row .container-fluid` (`min-width: 0`) and `.navbar-brand` (`text-overflow: ellipsis`) were already set up to do.

## Verification

Measured against the gallery at a 390px viewport:

| | `.toprow-actions` box | theme toggle right edge | hamburger left edge | result |
|---|---|---|---|---|
| before | 63px wide, needs 76px | 330.98 | 318 | 13px overlap |
| after | 76px wide, needs 76px | 314 | 318 | 4px gap |

`MobileTopRowE2ETests.PhoneViewport_TopRowActions_DoNotOverlapTheHamburger` is new and encodes exactly that geometry: it fails on the old CSS with `Theme toggle (right edge 330.98438) overlaps the hamburger (left edge 318)` and passes with the fix. Full `MMCA.Common.UI.E2E.Tests` suite: 24/24 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJTuRMspt7gScYgg43jEm