### PR TITLE
fix: stop the startup culture restore pinning a hybrid head's language

### DIFF
--- a/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureApplier.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureApplier.cs
@@ -34,8 +34,10 @@ public sealed class MauiCultureApplier(NavigationManager navigation) : ICultureA
             return Task.CompletedTask;
         }
 
-        // Order and synchrony are load-bearing: persist and activate BEFORE the reload, with no await in
-        // between, so the culture is already current on the renderer's thread when the tree re-renders.
+        // Order is load-bearing: persist and activate BEFORE the reload, so the new culture is already
+        // the process default when the tree re-renders. ApplyToProcess deliberately sets only the thread
+        // defaults; see its remarks for why assigning CurrentUICulture here would pin the app to its
+        // startup language for the rest of the session.
         MauiCultureStore.Save(culture);
         MauiCultureStore.ApplyToProcess(culture);
 

--- a/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureStore.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Globalization/MauiCultureStore.cs
@@ -44,11 +44,25 @@ internal static class MauiCultureStore
     }
 
     /// <summary>
-    /// Makes <paramref name="culture"/> the active culture for the process. Both the thread defaults and
-    /// the calling thread are set: the defaults only apply to threads that have not materialized a
-    /// culture yet, and by the time a user switches, the MAUI UI thread (which is also the Blazor
-    /// renderer's dispatcher thread) already has one. Call this synchronously, before any await, so it
-    /// lands on the renderer's thread rather than on whatever thread a continuation resumes on.
+    /// Makes <paramref name="culture"/> the active culture for the process, by setting the thread
+    /// defaults and <b>only</b> the thread defaults.
+    /// <para>
+    /// Assigning <see cref="CultureInfo.CurrentCulture"/> / <see cref="CultureInfo.CurrentUICulture"/>
+    /// here would break runtime switching, which is why this deliberately does not. Those setters write
+    /// to an <c>AsyncLocal</c>, so the value flows with the <see cref="ExecutionContext"/> and is
+    /// RESTORED every time that context is re-entered, taking precedence over the thread defaults. The
+    /// startup restore (<see cref="MauiCultureInitializer"/>) runs before any window exists, so the
+    /// context it writes to is the one every later dispatch descends from, including the Blazor
+    /// renderer's. A later switch could then set the defaults to "es" and still re-render in the
+    /// startup culture forever: the reload re-enters that context, the AsyncLocal wins, and the app is
+    /// stuck on whatever language it launched in. A web head never hits this because request
+    /// localization sets the culture per request, inside each request's own context.
+    /// </para>
+    /// <para>
+    /// Nothing needs the calling thread set explicitly. As long as no code path ever assigns
+    /// <c>Current*</c>, no thread materializes a culture of its own, so the defaults govern every
+    /// thread and every context, and a switch takes effect everywhere at once.
+    /// </para>
     /// </summary>
     /// <param name="culture">A culture from <c>SupportedCultures.All</c>.</param>
     public static void ApplyToProcess(string culture)
@@ -57,7 +71,5 @@ internal static class MauiCultureStore
 
         CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
         CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
-        CultureInfo.CurrentCulture = cultureInfo;
-        CultureInfo.CurrentUICulture = cultureInfo;
     }
 }


### PR DESCRIPTION
## Symptom

Changing the language in the AtlDevCon MAUI app does nothing: the UI stays in English for the rest of the session. The web app is fine. Reported against 1.7.2, which already carries the `MauiCultureApplier` fix from #169, so the in-process switch was running and still not taking effect.

## Root cause

`CultureInfo.CurrentCulture` / `CurrentUICulture` are backed by an `AsyncLocal`. The value flows with the `ExecutionContext` and is **restored** every time that context is re-entered, which takes precedence over `DefaultThreadCurrentUICulture`.

`MauiCultureInitializer` runs inside `MauiAppBuilder.Build()`, before any window exists, so the context it wrote to is the one every later dispatch descends from, including the Blazor renderer's. The sequence:

1. Startup restore sets `Current*` = launch culture. The root context now carries it.
2. User picks Spanish. `ApplyToProcess` sets the defaults to `es` and `Current*` = `es` **in the handler's context**.
3. `NavigateTo(forceLoad: true)` reboots the WebView. The re-attach runs under a context descending from startup.
4. That context restores `en-US`, overriding the new defaults. Every render is English, forever.

Only a full process restart appeared to work, because the restore then seeds that same root context with the stored choice. The preference was never the problem: it persists correctly.

A web head never hits this. Request localization sets the culture per request, inside each request's own context, so nothing long-lived is pinned.

## Fix

`ApplyToProcess` sets the thread defaults and nothing else. With no code path assigning `Current*` anywhere (verified by grep across Common and ADC), no thread or context materializes a culture of its own, so the defaults govern every thread and every context and a switch takes effect across the whole app at once.

## Evidence

Reproduced the semantics standalone on .NET 10.0.10:

| variant | switch handler sees | re-render after reload |
|---|---|---|
| A: startup sets `Current*` + defaults (before this PR) | `es` | **`en-US`** |
| B: startup sets defaults only | `es` | `es` |
| C: `Current*` never assigned (this PR) | `es` | `es` |
| D: restart with `es` already stored | | `es` |

Variant D is why the bug reads as "always English" rather than "needs a restart": the stored choice does apply, but only from the next cold start.

This matches [dotnet/maui#22551](https://github.com/dotnet/maui/issues/22551), whose reporter found that commenting out their startup culture initialization was exactly what let runtime switching work.

## Verification gap

`MMCA.Common.UI.Maui` builds clean for `net10.0-android`, but no test tier runs a `BlazorWebView` and the package has no test project, so **this needs an on-device check before it ships**. Happy to add a MAUI-TFM test project for `MauiCultureStore` as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJTuRMspt7gScYgg43jEm