### PR TITLE
fix: stop preference writes spending a 401 per toggle on a dead session

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/Services/ApiUserPreferenceReader.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/ApiUserPreferenceReader.cs
@@ -17,11 +17,18 @@ public sealed class ApiUserPreferenceReader(
 {
     private static readonly UserPreferences Empty = new(null, null);
 
+    /// <summary>Matches the token-storage skew, so this agrees with the layer that does the refreshing.</summary>
+    private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(30);
+
     /// <inheritdoc/>
     public async Task<UserPreferences> GetAsync(CancellationToken cancellationToken = default)
     {
         var token = await tokenStorageService.GetAccessTokenAsync();
-        if (string.IsNullOrWhiteSpace(token))
+
+        // Same guard as the writer: an expired or unreadable token buys a guaranteed 401, and this read
+        // is best-effort, so the caller cannot act on the failure either way. IsFresh also covers the
+        // anonymous (null) case.
+        if (!JwtTokenInfo.IsFresh(token, ExpirySkew))
         {
             return Empty;
         }

--- a/Source/Presentation/MMCA.Common.UI/Services/ApiUserPreferenceWriter.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/ApiUserPreferenceWriter.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using MMCA.Common.UI.Services.Auth;
 
@@ -5,25 +6,53 @@ namespace MMCA.Common.UI.Services;
 
 /// <summary>
 /// Default <see cref="IUserPreferenceWriter"/>: PUTs the preference to <c>auth/preferences</c> via the
-/// shared <c>"APIClient"</c> (which already attaches the bearer token + Accept-Language). No-ops for
-/// anonymous users and swallows transport errors, so persistence is strictly best-effort over the
-/// cookie-based runtime channel (ADR-027 / ADR-028). Hosts without that endpoint (e.g. the Helpdesk seed)
-/// simply do not register this writer.
+/// shared <c>"APIClient"</c> (which already attaches the bearer token + Accept-Language). No-ops when
+/// there is no usable token and swallows transport errors, so persistence is strictly best-effort over
+/// the cookie-based runtime channel (ADR-027 / ADR-028). Hosts without that endpoint (e.g. the Helpdesk
+/// seed) simply do not register this writer.
+/// <para>
+/// Best-effort means the caller never learns the write failed, which makes a doomed request pure cost:
+/// it cannot help the user and it still lands in failed-request telemetry. Both guards below exist to
+/// keep a signed-out or stale session from spending one 401 per theme or culture toggle, which at low
+/// traffic is enough on its own to trip a failed-request alert rule.
+/// </para>
 /// </summary>
 /// <param name="httpClientFactory">Factory for the named <c>"APIClient"</c>.</param>
-/// <param name="tokenStorageService">Used to detect whether a user is signed in.</param>
+/// <param name="tokenStorageService">Supplies the token this writer decides against.</param>
 public sealed class ApiUserPreferenceWriter(
     IHttpClientFactory httpClientFactory,
     ITokenStorageService tokenStorageService) : IUserPreferenceWriter
 {
+    /// <summary>Matches the token-storage skew, so this agrees with the layer that does the refreshing.</summary>
+    private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(30);
+
     private sealed record UserPreferencesRequest(string? Culture, string? Theme);
+
+    /// <summary>
+    /// The token the API last rejected. Held for the lifetime of this scoped writer so a session the
+    /// server has stopped accepting costs ONE failed request rather than one per toggle. Comparing the
+    /// token itself rather than setting a latch means a fresh sign-in (a different token) resumes
+    /// writing with no reset step and no staleness of its own.
+    /// </summary>
+    private string? _rejectedToken;
 
     /// <inheritdoc/>
     public async Task SaveAsync(string? culture, string? theme, CancellationToken cancellationToken = default)
     {
-        // Anonymous users have no profile to persist to — the cookie is their only channel.
         var token = await tokenStorageService.GetAccessTokenAsync();
-        if (string.IsNullOrWhiteSpace(token))
+
+        // Anonymous users have no profile to persist to, and an expired token cannot acquire one: the
+        // cookie is the only channel either way. IsFresh covers null and unreadable tokens too, so this
+        // is also the anonymous guard.
+        if (!JwtTokenInfo.IsFresh(token, ExpirySkew))
+        {
+            return;
+        }
+
+        // Still current and already refused once. A token can be unexpired and rejected anyway (revoked
+        // session, rotated signing key, a user the API now treats as gone), so expiry alone is not
+        // enough to predict this.
+        if (string.Equals(token, _rejectedToken, StringComparison.Ordinal))
         {
             return;
         }
@@ -35,6 +64,11 @@ public sealed class ApiUserPreferenceWriter(
                 new Uri("auth/preferences", UriKind.Relative),
                 new UserPreferencesRequest(culture, theme),
                 cancellationToken);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                _rejectedToken = token;
+            }
         }
         catch (HttpRequestException)
         {

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/ApiUserPreferenceWriterTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/ApiUserPreferenceWriterTests.cs
@@ -1,0 +1,125 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using AwesomeAssertions;
+using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Auth;
+using MMCA.Common.UI.Tests.Infrastructure;
+using Moq;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// The preference write is best-effort: the caller never learns it failed, so a request that cannot
+/// succeed is pure cost and still counts as a failed request in telemetry. These pin the two guards that
+/// keep a signed-out or stale session from spending one 401 per theme/culture toggle (ADR-027/028).
+/// </summary>
+public sealed class ApiUserPreferenceWriterTests
+{
+    private static string Jwt(DateTime expires) =>
+        new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
+            notBefore: expires.AddMinutes(-60),
+            expires: expires));
+
+    private static string FreshJwt() => Jwt(DateTime.UtcNow.AddMinutes(30));
+
+    private static string ExpiredJwt() => Jwt(DateTime.UtcNow.AddMinutes(-5));
+
+    private static (ApiUserPreferenceWriter Writer, StubHttpMessageHandler Handler) CreateSut(
+        string? token,
+        HttpStatusCode status = HttpStatusCode.NoContent)
+    {
+        var handler = StubHttpMessageHandler.RespondingWith(status);
+        var storage = new Mock<ITokenStorageService>();
+        storage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync(token);
+        return (new ApiUserPreferenceWriter(new StubHttpClientFactory(handler), storage.Object), handler);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithFreshToken_PutsThePreference()
+    {
+        var (writer, handler) = CreateSut(FreshJwt());
+
+        await writer.SaveAsync(culture: "es", theme: null);
+
+        handler.CallCount.Should().Be(1);
+        handler.LastRequest.Method.Should().Be(HttpMethod.Put);
+        handler.LastRequest.Uri!.AbsolutePath.Should().EndWith("auth/preferences");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenAnonymous_DoesNotCallTheApi()
+    {
+        var (writer, handler) = CreateSut(token: null);
+
+        await writer.SaveAsync(culture: "es", theme: null);
+
+        handler.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithExpiredToken_DoesNotSpendAGuaranteed401()
+    {
+        var (writer, handler) = CreateSut(ExpiredJwt());
+
+        await writer.SaveAsync(culture: "es", theme: null);
+
+        handler.CallCount.Should().Be(0, "an expired token cannot be accepted, so the request is pure cost");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WithUnreadableToken_DoesNotCallTheApi()
+    {
+        var (writer, handler) = CreateSut("not-a-jwt");
+
+        await writer.SaveAsync(culture: "es", theme: null);
+
+        handler.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SaveAsync_AfterA401_StopsRetryingWithTheSameToken()
+    {
+        // Unexpired but refused: a revoked session or rotated signing key. Expiry cannot predict this,
+        // so only the response tells us, and every later toggle would repeat the same failed request.
+        var (writer, handler) = CreateSut(FreshJwt(), HttpStatusCode.Unauthorized);
+
+        await writer.SaveAsync(culture: "es", theme: null);
+        await writer.SaveAsync(culture: null, theme: "dark");
+        await writer.SaveAsync(culture: "en-US", theme: null);
+
+        handler.CallCount.Should().Be(1, "three toggles on a rejected session must cost one 401, not three");
+    }
+
+    [Fact]
+    public async Task SaveAsync_AfterA401_ResumesOnceTheUserSignsInAgain()
+    {
+        var rejected = FreshJwt();
+        var handler = StubHttpMessageHandler.RespondingWith(HttpStatusCode.Unauthorized);
+        var storage = new Mock<ITokenStorageService>();
+        storage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync(rejected);
+        var writer = new ApiUserPreferenceWriter(new StubHttpClientFactory(handler), storage.Object);
+
+        await writer.SaveAsync(culture: "es", theme: null);
+        await writer.SaveAsync(culture: "es", theme: null);
+        handler.CallCount.Should().Be(1);
+
+        // A new sign-in yields a different token, which the writer must not treat as the rejected one.
+        // The expiry has to differ: JWTs carry second-resolution timestamps and no other varying claim
+        // here, so two tokens minted in the same second are byte-identical and ARE the same session.
+        storage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync(Jwt(DateTime.UtcNow.AddMinutes(45)));
+        await writer.SaveAsync(culture: "es", theme: null);
+
+        handler.CallCount.Should().Be(2, "a new token is a new session and deserves its own attempt");
+    }
+
+    [Fact]
+    public async Task SaveAsync_AfterASuccess_KeepsWriting()
+    {
+        var (writer, handler) = CreateSut(FreshJwt());
+
+        await writer.SaveAsync(culture: "es", theme: null);
+        await writer.SaveAsync(culture: null, theme: "dark");
+
+        handler.CallCount.Should().Be(2, "nothing was rejected, so nothing should be suppressed");
+    }
+}


### PR DESCRIPTION
## What tripped the alert

`adc-prod-alert-failed-requests` (Sev2, threshold 10 per 15 min) fired on 2026-07-30 at 03:16 UTC with a metric value of 26. Reconstructing the window, **100% of the failed requests were preference writes**:

| count | code | service | request |
|---|---|---|---|
| 15 | 401 | adc-prod-identity | `PUT Auth/preferences` |
| 15 | 401 | adc-prod-gateway | `PUT /Auth/{**catch-all}` (same calls at the proxy) |
| 3 | 401 | adc-prod-ui | `POST /auth/session/token` |

33 failures, all auth, nothing else in the window. Production traces show the shape plainly: three toggles at 03:59:43, :46 and :47 all 401, a login at 04:00:08, then the same writes returning 204.

## Why it happened

Every theme or culture toggle PUTs `auth/preferences`. The write is best-effort by design: the response was never inspected, and a 401 does not throw, so `using var response` disposed it and moved on. The only guard was "token is non-empty", which an expired token passes. `AuthDelegatingHandler` attaches whatever is stored and never refreshes or retries, so nothing recovered.

Net effect: a session the API has stopped accepting costs **one silent failed request per toggle**, forever, with no user-visible symptom. At ADC's traffic that alone is enough to page.

## The fix

Two guards, both in the write path.

**Skip when the token is not usable.** `JwtTokenInfo.IsFresh` is already what token storage uses to decide when to re-acquire, so the writer now agrees with the layer that does the refreshing instead of second-guessing it with a null check. This subsumes the anonymous case.

**Skip when the current token is one the API already rejected.** A token can be unexpired and refused anyway (revoked session, rotated signing key, a user the API now treats as gone), so expiry cannot predict it and only the response can. Remembering the rejected token rather than latching a bool means a fresh sign-in resumes writing on its own, with no reset step and no staleness of its own.

The reader gets the freshness guard too and nothing more: it runs once per login, so it has no repeat-cost problem to solve.

**No behaviour change for the user.** The choice is applied and persisted locally before the write, and the caller could never observe the failure. What changes is that a doomed request is no longer sent.

Deliberately **not** a refresh-and-retry in `AuthDelegatingHandler`: that would change every API call in every head to fix noise on one best-effort write.

## Tests

7 new tests in `ApiUserPreferenceWriterTests`, including the one that matters: three toggles on a rejected session now cost **one** 401 instead of three. Full `MMCA.Common.UI.Tests` project green at 380/380, solution builds clean in Release.

## Still open, not fixed here

Those 401s were served to a token the client believed was fresh, since no `/auth/session/token` hydration was attempted in that window. Signing keys come from configuration rather than being generated per process, so key rotation on deploy is ruled out. The leading remaining explanation is `ServerTokenStorageService`'s SSR branch returning the cookie token with no freshness check when `IHttpContextAccessor` still resolves a stale `HttpContext` on an interactive circuit. That is a separate investigation; this PR stops the noise either way, since both guards act on what the API answers rather than on why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJTuRMspt7gScYgg43jEm