### PR TITLE
fix: BugHunt remediation PR C-1 - persistence integrity + event delivery (M1, M2, M6, M7, M8, M10, M29, M32)

### DIFF
--- a/Source/Core/MMCA.Common.Application/DomainEvents/SafeDomainEventHandler.cs
+++ b/Source/Core/MMCA.Common.Application/DomainEvents/SafeDomainEventHandler.cs
@@ -5,10 +5,28 @@ using MMCA.Common.Domain.DomainEvents;
 namespace MMCA.Common.Application.DomainEvents;
 
 /// <summary>
-/// Base class for domain event handlers that should not break the main transaction on failure.
-/// Wraps <see cref="HandleSafelyAsync"/> in a try-catch that logs errors but does not propagate them.
-/// Use this for side-effect handlers (e.g., sending emails, creating inventory) where failure
-/// should be retried via the outbox rather than rolling back the primary operation.
+/// Base class for domain event handlers that must log their own failure with handler and event
+/// context before the exception continues to the dispatcher. <see cref="HandleSafelyAsync"/> runs
+/// inside an exception filter that writes one error log line and then lets the exception
+/// propagate unchanged; <see cref="OperationCanceledException"/> passes straight through without
+/// a log line, because host shutdown is not a delivery failure.
+/// <para>
+/// The base class used to swallow the exception, which made the "retried via the outbox" promise
+/// false: a handler that reported success had its outbox row marked processed, so nothing ever
+/// retried and the side effect was lost with only a log line to show for it. Propagating hands
+/// the decision to the delivery mechanism instead, which is built for exactly this. On the
+/// outbox-processor path the failed message keeps its retry count, backs off, and dead-letters
+/// after <c>Outbox:MaxRetries</c> attempts.
+/// </para>
+/// <para>
+/// Batch redelivery on the interceptor path is the consequence to design for. The save-changes
+/// interceptor dispatches every local event of one save in a single call, so one rethrowing
+/// handler aborts that call and skips the <c>MarkProcessedAsync</c> step for the WHOLE local
+/// batch: every local event written by that save stays unprocessed and is redelivered by the
+/// outbox processor, not just the event whose handler failed. Delivery is therefore at-least-once
+/// and subclasses must be idempotent, tolerating both a repeat of their own event and a repeat of
+/// every sibling event raised by the same save.
+/// </para>
 /// </summary>
 /// <typeparam name="TDomainEvent">The domain event type this handler processes.</typeparam>
 public abstract class SafeDomainEventHandler<TDomainEvent>(ILogger logger) : IDomainEventHandler<TDomainEvent>
@@ -21,19 +39,33 @@ public abstract class SafeDomainEventHandler<TDomainEvent>(ILogger logger) : IDo
         {
             await HandleSafelyAsync(domainEvent, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException && LogAndRethrow(ex))
         {
-            logger.LogError(
-                ex,
-                "Domain event handler {HandlerType} failed for event {EventType}. The outbox processor will retry.",
-                GetType().Name,
-                typeof(TDomainEvent).Name);
+            // Unreachable: the filter always returns false so the exception keeps propagating.
+            throw;
         }
     }
 
     /// <summary>
-    /// Implement the domain event handling logic. Exceptions thrown here are caught and logged
-    /// by the base class without propagating to the caller.
+    /// Implement the domain event handling logic. Exceptions thrown here are logged by the base
+    /// class and then propagate to the caller, so the outbox can redeliver the event. Implementations
+    /// must be idempotent (see the class remarks for the batch-redelivery contract).
     /// </summary>
     protected abstract Task HandleSafelyAsync(TDomainEvent domainEvent, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Logs the failure and always returns <see langword="false"/> so the exception propagates.
+    /// Running as an exception filter keeps the log write ahead of any unwinding and leaves the
+    /// original stack trace untouched.
+    /// </summary>
+    private bool LogAndRethrow(Exception exception)
+    {
+        logger.LogError(
+            exception,
+            "Domain event handler {HandlerType} failed for event {EventType}. The outbox processor will redeliver the event.",
+            GetType().Name,
+            typeof(TDomainEvent).Name);
+
+        return false;
+    }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -134,6 +134,25 @@ public sealed class DbContextFactory(
             }
         }
 
+        // Every cached context must be clean by the time the unit of work returns; anything still
+        // tracked here is silently lost. The assertion reads the change tracker rather than the
+        // saved set because both loss shapes must be caught: a context materialized past the pass
+        // bound (never in the set) AND a handler mutating an already-saved context (in the set, yet
+        // dirty). Read-only contexts and the outbox finalizer leave nothing tracked, so a clean
+        // scope never trips this.
+        var unsaved = _dbContexts
+            .Where(entry => entry.Value.ChangeTracker.HasChanges())
+            .Select(entry => entry.Key.ToString())
+            .ToArray();
+
+        if (unsaved.Length > 0)
+        {
+            throw new InvalidOperationException(
+                "The unit of work finished with unsaved changes still tracked on: "
+                + string.Join(", ", unsaved)
+                + ". A domain event handler mutated or materialized a context after the bounded save loop had finished; those changes would have been discarded.");
+        }
+
         return result;
     }
 
@@ -170,6 +189,16 @@ public sealed class DbContextFactory(
             foreach (var (entry, _) in savedStates)
                 entry.State = EntityState.Unchanged;
 
+            // The hidden rows are not written this round, so their domain events must not be
+            // captured this round either: capture serializes an event to the outbox and clears it
+            // from the aggregate, which would publish an event for a row inserted a round later.
+            // The exclusion names exactly the hidden entries. A state-based filter (skip every
+            // Unchanged aggregate) would also drop events legitimately raised on an already-saved
+            // aggregate, which is how the identity module publishes registration events.
+            DomainEventSaveChangesInterceptor.BeginCaptureExclusion(
+                context,
+                [.. savedStates.Select(s => s.Entry.Entity)]);
+
             // try/finally: a failed save must not leave IDENTITY_INSERT ON on the pooled
             // connection, nor leave the hidden entries stuck in the Unchanged state (they
             // would be silently dropped from any retried save).
@@ -194,6 +223,8 @@ public sealed class DbContextFactory(
             }
             finally
             {
+                DomainEventSaveChangesInterceptor.EndCaptureExclusion(context);
+
                 foreach (var (entry, originalState) in savedStates)
                     entry.State = originalState;
             }
@@ -329,6 +360,22 @@ public sealed class DbContextFactory(
     /// (along with a duplicate outbox row per event). Clearing is safe because the delegate
     /// re-executes wholesale and re-reads whatever it needs.
     /// </para>
+    /// <para>
+    /// A failure of the <b>commit</b> itself is never retried. Its outcome is unknowable (the
+    /// database may have applied the transaction and lost only the acknowledgement), and the
+    /// strategy would re-run the operation against a possibly-durable commit, duplicating its
+    /// writes. Such a failure surfaces as <see cref="TransactionCommitAmbiguousException"/>
+    /// instead; the caller owns recovery (an <c>[Idempotent]</c> API request replays safely, and
+    /// the outbox delivers whatever the commit did make durable).
+    /// </para>
+    /// <para>
+    /// <b>Limitation, multiple physical sources:</b> commits are sequential, so a commit failure on
+    /// source #2 leaves source #1 already committed. The ambiguity is then a partial commit rather
+    /// than an unknown one, and the caller's replay is what reconciles it. A witness row (a marker
+    /// written inside each source's transaction that a replay can read to learn what landed) would
+    /// close this; it is deliberately not built here, since a single transactional source, the case
+    /// every host runs today, needs none.
+    /// </para>
     /// </remarks>
     public async Task<TResult> ExecuteInTransactionAsync<TResult>(
         Func<CancellationToken, Task<TResult>> operation,
@@ -351,62 +398,140 @@ public sealed class DbContextFactory(
             ?? GetDbContext(DataSource.SQLServer);
 
         var attempt = 0;
+        Exception? commitFailure = null;
         var strategy = context.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async ct =>
+
+        var outcome = await strategy.ExecuteAsync(async ct =>
         {
             if (attempt++ > 0)
                 ResetForRetry();
 
-            BeginTransaction();
+            var (value, failure) = await RunTransactionalAttemptAsync(operation, ct).ConfigureAwait(false);
+            commitFailure = failure;
+            return value;
+        }, cancellationToken).ConfigureAwait(false);
+
+        // Thrown out here, past the strategy, on purpose. The strategy decides retriability by
+        // walking an exception's WHOLE inner chain, so a wrapper carrying the transient commit
+        // error would still be retried; returning normally is the only way to guarantee the
+        // delegate is not re-entered after a commit whose outcome is unknown.
+        if (commitFailure is not null)
+            throw new TransactionCommitAmbiguousException(commitFailure);
+
+        return outcome;
+    }
+
+    /// <summary>
+    /// Runs one attempt of the transactional unit: begin, operate, then commit or roll back.
+    /// </summary>
+    /// <returns>
+    /// The operation's result, plus the commit failure when the commit phase threw. A commit
+    /// failure is RETURNED rather than thrown so the execution strategy sees a completed attempt
+    /// and cannot re-run the operation against a commit that may already be durable.
+    /// </returns>
+    private async Task<(TResult Value, Exception? CommitFailure)> RunTransactionalAttemptAsync<TResult>(
+        Func<CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken)
+    {
+        BeginTransaction();
+        try
+        {
+            var result = await operation(cancellationToken).ConfigureAwait(false);
+
+            if (result is Result { IsFailure: true })
+            {
+                // Business failure: atomicity over partial persistence. RollbackTransaction
+                // also drops any deferred event dispatch (the events' outbox rows roll back
+                // with the data, so nothing may be delivered).
+                RollbackTransaction();
+                return (result, null);
+            }
+
+            var commitFailure = TryCommit();
+            if (commitFailure is not null)
+                return (result, commitFailure);
+
+            // Deliver events only now that the data is durable: in-process handlers must
+            // never act on state that could still roll back. Snapshot first: a handler that
+            // reaches a not-yet-materialized source adds to _dbContexts while we enumerate.
+            foreach (var committedContext in _dbContexts.Values.ToArray())
+            {
+                await DomainEventSaveChangesInterceptor.FlushDeferredAsync(committedContext, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return (result, null);
+        }
+        catch (OperationCanceledException)
+        {
+            // The connection may already be closed; best-effort rollback.
+            // Disposal will clean up if this fails.
             try
             {
-                var result = await operation(ct).ConfigureAwait(false);
-
-                if (result is Result { IsFailure: true })
-                {
-                    // Business failure: atomicity over partial persistence. RollbackTransaction
-                    // also drops any deferred event dispatch (the events' outbox rows roll back
-                    // with the data, so nothing may be delivered).
-                    RollbackTransaction();
-                    return result;
-                }
-
-                CommitTransaction();
-
-                // Deliver events only now that the data is durable: in-process handlers must
-                // never act on state that could still roll back. Snapshot first: a handler that
-                // reaches a not-yet-materialized source adds to _dbContexts while we enumerate.
-                foreach (var committedContext in _dbContexts.Values.ToArray())
-                {
-                    await DomainEventSaveChangesInterceptor.FlushDeferredAsync(committedContext, ct)
-                        .ConfigureAwait(false);
-                }
-
-                return result;
-            }
-            catch (OperationCanceledException)
-            {
-                // The connection may already be closed; best-effort rollback.
-                // Disposal will clean up if this fails.
-                try
-                {
-                    RollbackTransaction();
-                }
-                catch
-                {
-                    _transactionActive = false;
-                    foreach (var abortedContext in _dbContexts.Values.ToArray())
-                        DomainEventSaveChangesInterceptor.DropDeferred(abortedContext);
-                }
-
-                throw;
+                RollbackTransaction();
             }
             catch
             {
-                RollbackTransaction();
-                throw;
+                _transactionActive = false;
+                foreach (var abortedContext in _dbContexts.Values.ToArray())
+                    DomainEventSaveChangesInterceptor.DropDeferred(abortedContext);
             }
-        }, cancellationToken).ConfigureAwait(false);
+
+            throw;
+        }
+        catch
+        {
+            RollbackTransaction();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Commits every enlisted context, returning the failure instead of throwing it.
+    /// </summary>
+    /// <returns><see langword="null"/> on success, otherwise the exception the commit raised.</returns>
+    private Exception? TryCommit()
+    {
+        try
+        {
+            CommitTransaction();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            AbandonAfterCommitFailure();
+            return ex;
+        }
+    }
+
+    /// <summary>
+    /// Best-effort cleanup after a commit whose outcome is unknown: roll back whatever has not
+    /// committed yet (with multiple sources the commits are sequential, so later ones may still be
+    /// open) and drop every context's deferred dispatch. The outbox rows are the only delivery
+    /// record that survives an ambiguous commit, and the outbox processor delivers them if the
+    /// commit did land.
+    /// </summary>
+    private void AbandonAfterCommitFailure()
+    {
+        _transactionActive = false;
+
+        foreach (var context in _dbContexts.Values.ToArray())
+        {
+            DomainEventSaveChangesInterceptor.DropDeferred(context);
+
+            if (!SupportsTransactions(context) || !HasActiveTransaction(context))
+                continue;
+
+            try
+            {
+                context.Database.RollbackTransaction();
+            }
+            catch
+            {
+                // The transaction is already zombied or the connection is gone. Swallowing keeps
+                // the commit ambiguity as the reported failure; disposal releases what is left.
+            }
+        }
     }
 
     /// <inheritdoc />

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/TransactionCommitAmbiguousException.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/TransactionCommitAmbiguousException.cs
@@ -1,0 +1,47 @@
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+
+/// <summary>
+/// Thrown when the commit phase of <see cref="DbContextFactory.ExecuteInTransactionAsync{TResult}"/>
+/// fails, leaving the outcome <b>ambiguous</b>: the transaction may or may not have become durable,
+/// because a commit can fail after the database applied it but before the acknowledgement reached
+/// the client.
+/// <para>
+/// The wrapper exists to take the failure out of the retry path. SQL Server's
+/// <c>EnableRetryOnFailure</c> strategy classifies most commit-phase errors (timeouts, dropped
+/// connections) as transient, and a retry re-runs the whole operation. Against a commit that may
+/// already be durable, that duplicates every write the operation performed, including its outbox
+/// rows. Reporting the ambiguity is the only safe outcome.
+/// </para>
+/// <para>
+/// Recovery belongs to the caller. An API request marked <c>[Idempotent]</c> replays safely, and
+/// whatever the transaction wrote to the outbox is delivered by the outbox processor if the commit
+/// did land. In-process domain event dispatch deferred by the transaction is dropped, so no handler
+/// acts on state that may not exist.
+/// </para>
+/// </summary>
+public sealed class TransactionCommitAmbiguousException : Exception
+{
+    private const string DefaultMessage =
+        "The transaction commit failed with an unknown outcome: it may or may not have been made durable. "
+        + "The operation was deliberately not retried, because retrying a possibly-durable commit duplicates its writes.";
+
+    /// <summary>Initializes a new instance with the default ambiguity message.</summary>
+    public TransactionCommitAmbiguousException()
+        : base(DefaultMessage) { }
+
+    /// <summary>Initializes a new instance with a custom message.</summary>
+    /// <param name="message">The exception message.</param>
+    public TransactionCommitAmbiguousException(string message)
+        : base(message) { }
+
+    /// <summary>Initializes a new instance with a custom message and the failure that caused the ambiguity.</summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The commit failure reported by the provider.</param>
+    public TransactionCommitAmbiguousException(string message, Exception innerException)
+        : base(message, innerException) { }
+
+    /// <summary>Initializes a new instance carrying <paramref name="innerException"/> under the default message.</summary>
+    /// <param name="innerException">The commit failure reported by the provider.</param>
+    public TransactionCommitAmbiguousException(Exception innerException)
+        : base(DefaultMessage, innerException) { }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/DomainEventSaveChangesInterceptor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/DomainEventSaveChangesInterceptor.cs
@@ -54,6 +54,14 @@ public sealed partial class DomainEventSaveChangesInterceptor(
     /// </summary>
     private static readonly ConditionalWeakTable<DbContext, List<DeferredDispatch>> DeferredTable = [];
 
+    /// <summary>
+    /// Aggregate instances whose events must not be captured on the current save, keyed by context.
+    /// Registered by <see cref="MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.DbContextFactory"/>
+    /// while it splits a save into per-table IDENTITY_INSERT rounds, and cleared again once the
+    /// round completes.
+    /// </summary>
+    private static readonly ConditionalWeakTable<DbContext, HashSet<object>> CaptureExclusionTable = [];
+
     /// <inheritdoc />
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
@@ -137,6 +145,39 @@ public sealed partial class DomainEventSaveChangesInterceptor(
     internal static void DropDeferred(DbContext context) => DeferredTable.Remove(context);
 
     /// <summary>
+    /// Excludes exactly <paramref name="entities"/> from event capture on <paramref name="context"/>
+    /// until <see cref="EndCaptureExclusion"/> runs. Called by
+    /// <see cref="MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.DbContextFactory"/> for the entries it
+    /// hides from an IDENTITY_INSERT round: those rows are not written this round, so capturing
+    /// their events here would persist and clear them ahead of the insert that justifies them.
+    /// The round that really writes them captures them.
+    /// </summary>
+    /// <remarks>
+    /// Instance-scoped on purpose. Excluding by entity STATE instead (skipping every Unchanged
+    /// aggregate) would also drop events raised on an already-saved aggregate, which is how the
+    /// identity module publishes its registration events.
+    /// </remarks>
+    /// <param name="context">The context whose next save must skip these entities.</param>
+    /// <param name="entities">The aggregate instances to skip; an empty set clears any exclusion.</param>
+    internal static void BeginCaptureExclusion(DbContext context, IReadOnlyCollection<object> entities)
+    {
+        if (entities.Count == 0)
+        {
+            CaptureExclusionTable.Remove(context);
+            return;
+        }
+
+        CaptureExclusionTable.AddOrUpdate(context, new HashSet<object>(entities, ReferenceEqualityComparer.Instance));
+    }
+
+    /// <summary>
+    /// Ends the exclusion started by <see cref="BeginCaptureExclusion"/>, so the next save on
+    /// <paramref name="context"/> captures every aggregate's events again.
+    /// </summary>
+    /// <param name="context">The context to restore to normal capture.</param>
+    internal static void EndCaptureExclusion(DbContext context) => CaptureExclusionTable.Remove(context);
+
+    /// <summary>
     /// Captures domain events from aggregate roots and serializes them to the outbox table
     /// so they are persisted in the same transaction as the aggregate changes.
     /// </summary>
@@ -150,8 +191,13 @@ public sealed partial class DomainEventSaveChangesInterceptor(
 
         // Snapshot each aggregate's events now: the flush removes exactly these, so anything a
         // handler raises during dispatch survives instead of being cleared along with them.
+        // Entries the factory hid from this IDENTITY_INSERT round are skipped: their rows are not
+        // written yet, so their events belong to the round that writes them.
+        _ = CaptureExclusionTable.TryGetValue(context, out var excluded);
+
         var captures = context.ChangeTracker.Entries<IAggregateRoot>()
-            .Where(e => e.Entity.DomainEvents is { Count: > 0 })
+            .Where(e => e.Entity.DomainEvents is { Count: > 0 }
+                && (excluded is null || !excluded.Contains(e.Entity)))
             .Select(e => new AggregateCapture(e, [.. e.Entity.DomainEvents]))
             .ToArray();
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -26,6 +26,14 @@ namespace MMCA.Common.Infrastructure.Persistence.Outbox;
 /// processes the outboxes of its own databases — services with separate databases never race
 /// for each other's messages.
 /// </para>
+/// <para>
+/// Delivery is at-least-once. A message dispatched but not yet stamped processed (a crash, or a
+/// cancellation landing mid-batch) is redelivered only once its claim lease expires, after
+/// <c>Outbox:LeaseSeconds</c> (300s by default) rather than immediately on restart, because the
+/// claim is persisted before dispatch and the poll skips leased rows. On a graceful shutdown the
+/// cancelled batch flushes the stamps it already collected on the way out, which closes that
+/// duplicate window for the messages it did deliver.
+/// </para>
 /// </summary>
 /// <param name="scopeFactory">Factory for creating DI scopes per processing cycle.</param>
 /// <param name="logger">Logger for processing diagnostics.</param>
@@ -57,6 +65,13 @@ public sealed partial class OutboxProcessor(
 
     /// <summary>Floor for the computed wait so an overdue pending message cannot hot-loop the processor.</summary>
     private static readonly TimeSpan MinimumWait = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Budget for the best-effort save that flushes ProcessedOn stamps when a batch is cancelled
+    /// mid-flight. Deliberately short: the work is one small UPDATE against an already-open
+    /// connection, and anything slower is a dependency that must not delay host shutdown.
+    /// </summary>
+    private static readonly TimeSpan ShutdownSaveTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly ActivitySource OutboxActivitySource = new("MMCA.Common.Outbox");
     private static readonly Meter OutboxMeter = new("MMCA.Common.Outbox");
@@ -235,8 +250,23 @@ public sealed partial class OutboxProcessor(
 
         LogProcessingBatch(logger, toProcess.Count, sourceName);
 
-        var processedAny = await DispatchMessagesAsync(
-            toProcess, source, dispatcher, messageBus, cancellationToken).ConfigureAwait(false);
+        bool processedAny;
+        try
+        {
+            processedAny = await DispatchMessagesAsync(
+                toProcess, source, dispatcher, messageBus, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown landed mid-batch. Every message dispatched before the cancellation carries
+            // its ProcessedOn stamp in the change tracker only, and the batch save below is now
+            // unreachable, so without this the delivered messages stay unprocessed and are
+            // redelivered once their lease expires (LeaseSeconds, 300s by default). Persisting the
+            // stamps on the way out shrinks that duplicate window to nothing on a graceful
+            // shutdown; delivery stays at-least-once for an ungraceful one.
+            await TryPersistStampsOnCancellationAsync(context, sourceName).ConfigureAwait(false);
+            throw;
+        }
 
         // Plain DbContext.SaveChangesAsync, without a user id: the audit interceptor stamps its
         // system sentinel rather than a caller's identity. The EF interceptors still run (they are
@@ -249,6 +279,33 @@ public sealed partial class OutboxProcessor(
         return new OutboxCycleResult(
             HasMoreEligibleWork: eligibleCount == _settings.BatchSize && processedAny,
             earliestPending);
+    }
+
+    /// <summary>
+    /// Best-effort save of the ProcessedOn stamps collected before a cancellation, run on the way
+    /// out of a cancelled batch. Two deliberate constraints:
+    /// <list type="bullet">
+    ///   <item>Its own try/catch. A failure here must never replace the propagating
+    ///   <see cref="OperationCanceledException"/>: the loop in <c>ExecuteAsync</c> recognizes
+    ///   shutdown by that exception type, and swapping it for a save failure would turn a clean
+    ///   stop into a logged error plus another polling cycle.</item>
+    ///   <item>Its own short-lived token rather than <see cref="CancellationToken.None"/>. The
+    ///   caller's token is already cancelled, so it cannot be reused, but an uncancellable save
+    ///   against a dead connection would hold host shutdown open until the command timeout.</item>
+    /// </list>
+    /// </summary>
+    private async Task TryPersistStampsOnCancellationAsync(ApplicationDbContext context, string sourceName)
+    {
+        using var timeout = new CancellationTokenSource(ShutdownSaveTimeout, _timeProvider);
+
+        try
+        {
+            await context.SaveChangesAsync(timeout.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogShutdownSaveFailed(logger, sourceName, ex);
+        }
     }
 
     /// <summary>
@@ -469,6 +526,9 @@ public sealed partial class OutboxProcessor(
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Outbox processing failed for data source {DataSourceName}")]
     private static partial void LogSourceProcessingError(ILogger logger, string dataSourceName, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Outbox shutdown save failed for data source {DataSourceName}: messages delivered in the cancelled batch will be redelivered when their lease expires")]
+    private static partial void LogShutdownSaveFailed(ILogger logger, string dataSourceName, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Processing {Count} pending outbox messages from {DataSourceName}")]
     private static partial void LogProcessingBatch(ILogger logger, int count, string dataSourceName);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
 
 namespace MMCA.Common.Infrastructure.Persistence.Repositories;
 
@@ -13,9 +14,11 @@ namespace MMCA.Common.Infrastructure.Persistence.Repositories;
 /// <typeparam name="TEntity">The entity type.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
 /// <remarks>
-/// The optional <paramref name="timeProvider"/> and <paramref name="currentUserService"/> are
-/// used only by <see cref="ExecuteUpdateAsync"/> for automatic audit stamping; when absent
-/// (direct construction in tests) the system clock is used and the user stamp is skipped.
+/// The optional <paramref name="timeProvider"/> and <paramref name="currentUserService"/> serve
+/// audit stamping: the clock for <see cref="ExecuteUpdateAsync"/>, which bypasses the save
+/// pipeline, and the user for both that path and the <see cref="Save"/> /
+/// <see cref="SaveChangesAsync"/> overloads. When absent (direct construction in tests) the system
+/// clock is used and the user stamp is skipped.
 /// </remarks>
 internal sealed class EFRepository<TEntity, TIdentifierType>(
     DbContext context,
@@ -139,11 +142,22 @@ internal sealed class EFRepository<TEntity, TIdentifierType>(
     }
 
     /// <inheritdoc />
-    public int Save() => _context.SaveChanges();
+    /// <remarks>
+    /// Routes through the user-id overload when the context is an <see cref="ApplicationDbContext"/>,
+    /// so the audit interceptor stamps the acting user instead of the system sentinel it falls back
+    /// to when no id is supplied. A context constructed outside the factory keeps the plain overload.
+    /// </remarks>
+    public int Save() =>
+        _context is ApplicationDbContext applicationContext
+            ? applicationContext.SaveChanges(currentUserService?.UserId)
+            : _context.SaveChanges();
 
     /// <inheritdoc />
+    /// <remarks>See <see cref="Save"/> for why the user id is threaded through.</remarks>
     public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
-        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _context is ApplicationDbContext applicationContext
+            ? await applicationContext.SaveChangesAsync(currentUserService?.UserId, cancellationToken).ConfigureAwait(false)
+            : await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Rolls back all Added/Modified entries to Unchanged and persists the reset

--- a/Source/Core/MMCA.Common.Infrastructure/Services/BrokerEventBus.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/BrokerEventBus.cs
@@ -38,6 +38,31 @@ public sealed class BrokerEventBus(
     {
         ArgumentNullException.ThrowIfNull(integrationEvent);
 
+        await PublishBatchAsync([integrationEvent], cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task PublishAsync(IEnumerable<IIntegrationEvent> integrationEvents, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(integrationEvents);
+
+        var events = integrationEvents as IIntegrationEvent[] ?? [.. integrationEvents];
+        if (events.Length == 0)
+            return;
+
+        await PublishBatchAsync(events, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Persists every event of the batch to the outbox in ONE save, then wakes the processor once.
+    /// The previous per-event save-and-signal loop cost a round trip per event and, worse, was not
+    /// atomic: a failure partway through a batch left the earlier events committed and the rest
+    /// unwritten, so a caller that saw a failure could not tell what had already been published.
+    /// One save makes the batch all-or-nothing, and one signal is all the processor can consume
+    /// anyway (<see cref="IOutboxSignal"/> caps at a single permit and discards the surplus).
+    /// </summary>
+    private async Task PublishBatchAsync(IIntegrationEvent[] events, CancellationToken cancellationToken)
+    {
         var target = dataSourceResolver.ResolveLogical(outboxOptions.Value.DataSource, outboxOptions.Value.DatabaseName);
         var context = dbContextFactory.GetDbContext(target);
 
@@ -50,25 +75,17 @@ public sealed class BrokerEventBus(
                 $"BrokerEventBus requires an outbox-enabled data source. The configured outbox target '{target}' (Outbox:DataSource='{outboxOptions.Value.DataSource}', Outbox:DatabaseName='{outboxOptions.Value.DatabaseName}') does not support OutboxMessage. Configure SQL Server or SQLite, or fall back to InProcessEventBus.");
         }
 
-        var outboxEntry = OutboxMessage.FromDomainEvent(integrationEvent);
-#pragma warning disable VSTHRD103 // EF DbSet.Add is intentionally synchronous (in-memory); AddAsync is only for special value generators (EF guidance).
-        context.Set<OutboxMessage>().Add(outboxEntry);
+        var outboxEntries = new List<OutboxMessage>(events.Length);
+        foreach (var integrationEvent in events)
+            outboxEntries.Add(OutboxMessage.FromDomainEvent(integrationEvent));
+
+#pragma warning disable VSTHRD103 // EF DbSet.AddRange is intentionally synchronous (in-memory); AddRangeAsync is only for special value generators (EF guidance).
+        context.Set<OutboxMessage>().AddRange(outboxEntries);
 #pragma warning restore VSTHRD103
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // Wake the OutboxProcessor immediately so the broker publish doesn't wait for the
         // next polling cycle. The processor batches and publishes via IMessageBus.
         outboxSignal.Signal();
-    }
-
-    /// <inheritdoc />
-    public async Task PublishAsync(IEnumerable<IIntegrationEvent> integrationEvents, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(integrationEvents);
-
-        foreach (var integrationEvent in integrationEvents)
-        {
-            await PublishAsync(integrationEvent, cancellationToken).ConfigureAwait(false);
-        }
     }
 }

--- a/Source/Hosting/MMCA.Common.Aspire/Warmup/WarmupHostedService.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Warmup/WarmupHostedService.cs
@@ -10,12 +10,40 @@ namespace MMCA.Common.Aspire.Warmup;
 /// even if individual tasks fail — a stuck dependency must not keep the replica out of traffic
 /// rotation forever; transient failures are absorbed by the existing Polly retry pipeline on
 /// the first real request.
+/// <para>
+/// Each task is additionally bounded by <see cref="TaskTimeoutSeconds"/>. Failure was already
+/// harmless, but a task that neither completes nor throws used to leave <c>Task.WhenAll</c>
+/// pending forever and the gate closed with it, so the replica never entered rotation at all:
+/// strictly worse than serving a cold one. The timeout turns that case into the existing
+/// log-and-continue failure path, which is the whole point of the gate.
+/// </para>
 /// </summary>
+/// <param name="tasks">The warm-up tasks to run once at startup.</param>
+/// <param name="gate">The readiness gate opened once every task has finished, failed, or timed out.</param>
+/// <param name="logger">Logger for warm-up diagnostics.</param>
+/// <param name="timeProvider">Clock abstraction backing the per-task timeout; defaults to
+/// <see cref="TimeProvider.System"/>.</param>
+/// <param name="taskTimeout">Overrides <see cref="TaskTimeoutSeconds"/> so tests can exercise the
+/// timeout path without waiting two minutes; production always takes the default.</param>
 internal sealed partial class WarmupHostedService(
     IEnumerable<IWarmupTask> tasks,
     WarmupReadinessGate gate,
-    ILogger<WarmupHostedService> logger) : BackgroundService
+    ILogger<WarmupHostedService> logger,
+    TimeProvider? timeProvider = null,
+    TimeSpan? taskTimeout = null) : BackgroundService
 {
+    /// <summary>
+    /// Ceiling on a single warm-up task, in seconds. This is a backstop, not a latency budget:
+    /// the built-in OpenID Connect metadata task is already capped at 90s by the standard
+    /// resilience pipeline, so a task reaching this limit is one that bypassed those defaults or
+    /// is waiting on something that will never arrive. 120s leaves headroom above the resilience
+    /// total while still opening the gate inside a normal rollout window.
+    /// </summary>
+    private const int TaskTimeoutSeconds = 120;
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly TimeSpan _taskTimeout = taskTimeout ?? TimeSpan.FromSeconds(TaskTimeoutSeconds);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var overall = Stopwatch.StartNew();
@@ -37,12 +65,20 @@ internal sealed partial class WarmupHostedService(
         var sw = Stopwatch.StartNew();
         try
         {
-            await task.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            await task.ExecuteAsync(cancellationToken)
+                .WaitAsync(_taskTimeout, _timeProvider, cancellationToken)
+                .ConfigureAwait(false);
             LogTaskCompleted(logger, task.Name, sw.ElapsedMilliseconds);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
+        }
+        catch (TimeoutException ex)
+        {
+            // Same outcome as a failure: the abandoned task keeps running detached, the gate
+            // opens, and the dependency is retried lazily on first use.
+            LogTaskTimedOut(logger, ex, task.Name, sw.ElapsedMilliseconds, _taskTimeout.TotalSeconds);
         }
 #pragma warning disable CA1031 // warm-up failures must never crash the host
         catch (Exception ex)
@@ -63,4 +99,8 @@ internal sealed partial class WarmupHostedService(
     [LoggerMessage(EventId = 3, Level = LogLevel.Information,
         Message = "Warm-up complete in {ElapsedMs}ms — readiness gate open.")]
     private static partial void LogWarmupComplete(ILogger logger, long elapsedMs);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning,
+        Message = "Warm-up task {TaskName} timed out after {ElapsedMs}ms (limit {TimeoutSeconds}s): abandoned so the readiness gate can open; will retry lazily on first use.")]
+    private static partial void LogTaskTimedOut(ILogger logger, Exception exception, string taskName, long elapsedMs, double timeoutSeconds);
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/DomainEvents/SafeDomainEventHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/DomainEvents/SafeDomainEventHandlerTests.cs
@@ -2,63 +2,124 @@ using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using MMCA.Common.Application.DomainEvents;
 using MMCA.Common.Domain.DomainEvents;
-using Moq;
 
 namespace MMCA.Common.Application.Tests.DomainEvents;
 
+/// <summary>
+/// The base class logs the failure and then lets it propagate. Swallowing made the
+/// "retried via the outbox" promise false: a handler reported success, its outbox row was marked
+/// processed, and the side effect was lost. Propagation hands the decision to the delivery
+/// mechanism (outbox retry/dead-letter, or broker redelivery).
+/// </summary>
 public sealed class SafeDomainEventHandlerTests
 {
     // ── Successful handling ──
     [Fact]
     public async Task HandleAsync_WhenHandlerSucceeds_CompletesWithoutException()
     {
-        var logger = new Mock<ILogger<TestSafeDomainEventHandler>>();
-        var sut = new TestSafeDomainEventHandler(logger.Object, shouldThrow: false);
+        var logger = new RecordingLogger();
+        var sut = new TestSafeDomainEventHandler(logger, shouldThrow: false);
         var domainEvent = new TestSafeDomainEvent("test-data");
 
         await FluentActions.Invoking(() => sut.HandleAsync(domainEvent))
             .Should().NotThrowAsync();
 
         sut.WasHandled.Should().BeTrue();
+        logger.Errors.Should().BeEmpty();
     }
 
-    // ── Exception caught and logged ──
+    // ── Exception logged AND propagated (was: caught and swallowed) ──
     [Fact]
-    public async Task HandleAsync_WhenHandlerThrows_CatchesAndLogsWithoutPropagating()
+    public async Task HandleAsync_WhenHandlerThrows_LogsAndPropagates()
     {
-        var logger = new Mock<ILogger<TestSafeDomainEventHandler>>();
-        var sut = new TestSafeDomainEventHandler(logger.Object, shouldThrow: true);
+        var logger = new RecordingLogger();
+        var sut = new TestSafeDomainEventHandler(logger, shouldThrow: true);
         var domainEvent = new TestSafeDomainEvent("test-data");
 
-        await FluentActions.Invoking(() => sut.HandleAsync(domainEvent))
-            .Should().NotThrowAsync();
+        (await FluentActions.Invoking(() => sut.HandleAsync(domainEvent))
+                .Should().ThrowAsync<InvalidOperationException>(
+                    "the delivery mechanism, not the handler, decides what happens to a failed event"))
+            .WithMessage("Handler failed");
 
         sut.WasHandled.Should().BeTrue();
-        logger.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<InvalidOperationException>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
+        logger.Errors.Should().ContainSingle()
+            .Which.Should().BeOfType<InvalidOperationException>();
     }
 
-    // ── OperationCanceledException is not caught ──
+    // ── The log is written before the exception reaches the caller ──
     [Fact]
-    public async Task HandleAsync_WhenOperationCanceledException_Propagates()
+    public async Task HandleAsync_WhenHandlerThrows_WritesTheLogBeforeTheCallerSeesTheException()
     {
-        var logger = new Mock<ILogger<TestSafeDomainEventHandler>>();
-        var sut = new TestSafeDomainEventHandler(logger.Object, throwCancellation: true);
+        var logger = new RecordingLogger();
+        var sut = new TestSafeDomainEventHandler(logger, shouldThrow: true);
+        var domainEvent = new TestSafeDomainEvent("test-data");
+
+        try
+        {
+            await sut.HandleAsync(domainEvent);
+        }
+        catch (InvalidOperationException)
+        {
+            logger.Sequence.Add("caught");
+        }
+
+        logger.Sequence.Should().Equal(
+            ["logged", "caught"],
+            "an exception filter logs on the first pass, so the handler context is recorded even if an outer frame rethrows or wraps");
+    }
+
+    // ── OperationCanceledException still passes straight through, unlogged ──
+    [Fact]
+    public async Task HandleAsync_WhenOperationCanceledException_PropagatesWithoutLogging()
+    {
+        var logger = new RecordingLogger();
+        var sut = new TestSafeDomainEventHandler(logger, throwCancellation: true);
         var domainEvent = new TestSafeDomainEvent("test-data");
 
         await FluentActions.Invoking(() => sut.HandleAsync(domainEvent))
             .Should().ThrowAsync<OperationCanceledException>();
+
+        logger.Errors.Should().BeEmpty("host shutdown is not a delivery failure and must not be logged as one");
+        logger.Sequence.Should().BeEmpty();
     }
 }
 
 // ── Test helpers ──
 public sealed record TestSafeDomainEvent(string Data) : BaseDomainEvent;
+
+/// <summary>
+/// Captures the logged exceptions and the order in which the log write happened relative to
+/// other observable steps, so the tests can assert the exception-filter ordering.
+/// </summary>
+public sealed class RecordingLogger : ILogger
+{
+    public List<Exception> Errors { get; } = [];
+
+    public List<string> Sequence { get; } = [];
+
+    IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel != LogLevel.Error)
+        {
+            return;
+        }
+
+        Sequence.Add("logged");
+        if (exception is not null)
+        {
+            Errors.Add(exception);
+        }
+    }
+}
 
 public sealed class TestSafeDomainEventHandler : SafeDomainEventHandler<TestSafeDomainEvent>
 {

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryCommitAmbiguityTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryCommitAmbiguityTests.cs
@@ -1,0 +1,255 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using MMCA.Common.Shared.Abstractions;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// A commit-phase failure has an unknowable outcome: the database may have applied the transaction
+/// and lost only the acknowledgement. These tests pin that
+/// <see cref="DbContextFactory.ExecuteInTransactionAsync{TResult}"/> reports it as
+/// <see cref="TransactionCommitAmbiguousException"/> and never lets the execution strategy re-run
+/// the operation on top of it. The context here hands out a strategy that retries on ANY exception,
+/// which is what a raw (or naively wrapped) commit failure would have triggered.
+/// </summary>
+public sealed class DbContextFactoryCommitAmbiguityTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly Mock<IDomainEventDispatcher> _dispatcherMock = new();
+    private readonly CommitFailingDbContext _dbContext;
+    private readonly DbContextFactory _sut;
+
+    public DbContextFactoryCommitAmbiguityTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _dbContext = CommitFailingDbContext.Create(_connection, _dispatcherMock.Object);
+
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory.Setup(f => f.Create(It.IsAny<DataSourceKey>())).Returns(_dbContext);
+
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+
+        _sut = new DbContextFactory(
+            physicalFactory.Object,
+            registry.Object,
+            Mock.Of<IDataSourceResolver>(),
+            Mock.Of<ICurrentUserService>());
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        _dbContext.Dispose();
+        _connection.Dispose();
+    }
+
+    // ── The commit failure is wrapped, and the operation runs exactly once ──
+    [Fact]
+    public async Task ExecuteInTransactionAsync_CommitFails_ThrowsAmbiguityWrapperWithoutRerunningTheOperation()
+    {
+        var lostAcknowledgement = new TimeoutException("commit acknowledgement lost");
+        _dbContext.FailCommitWith = lostAcknowledgement;
+        var attempts = 0;
+
+        var act = async () => await _sut.ExecuteInTransactionAsync<Result>(
+            async ct =>
+            {
+                attempts++;
+                var context = _sut.GetDbContext(DataSource.SQLServer);
+                context.Set<TestAggregate>().Add(CreateAggregateWithEvent());
+                await _sut.SaveChangesAsync(ct);
+                return Result.Success();
+            });
+
+        var thrown = await act.Should().ThrowAsync<TransactionCommitAmbiguousException>();
+        thrown.And.InnerException.Should().BeSameAs(
+            lostAcknowledgement,
+            "the provider's failure is the diagnostic payload, not the reported failure mode");
+        attempts.Should().Be(
+            1,
+            "a retry would re-run every write of an operation whose commit may already be durable");
+    }
+
+    // ── Nothing is delivered in-process for a commit nobody can vouch for ──
+    [Fact]
+    public async Task ExecuteInTransactionAsync_CommitFails_DropsTheDeferredDispatch()
+    {
+        _dbContext.FailCommitWith = new TimeoutException("commit acknowledgement lost");
+
+        var act = async () => await _sut.ExecuteInTransactionAsync<Result>(
+            async ct =>
+            {
+                var context = _sut.GetDbContext(DataSource.SQLServer);
+                context.Set<TestAggregate>().Add(CreateAggregateWithEvent());
+                await _sut.SaveChangesAsync(ct);
+                return Result.Success();
+            });
+
+        await act.Should().ThrowAsync<TransactionCommitAmbiguousException>();
+        _dispatcherMock.Verify(
+            d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the outbox is the only delivery record that survives an ambiguous commit");
+        _dbContext.Database.CurrentTransaction.Should().BeNull(
+            "the uncommitted transaction is abandoned before the ambiguity surfaces");
+    }
+
+    // ── Control: the same retrying strategy commits and flushes normally when nothing fails ──
+    [Fact]
+    public async Task ExecuteInTransactionAsync_CommitSucceeds_CommitsAndFlushesAsUsual()
+    {
+        var result = await _sut.ExecuteInTransactionAsync<Result>(
+            async ct =>
+            {
+                var context = _sut.GetDbContext(DataSource.SQLServer);
+                context.Set<TestAggregate>().Add(CreateAggregateWithEvent());
+                await _sut.SaveChangesAsync(ct);
+                return Result.Success();
+            });
+
+        result.IsSuccess.Should().BeTrue();
+        (await _dbContext.Set<TestAggregate>().AsNoTracking().CountAsync()).Should().Be(1);
+        _dispatcherMock.Verify(
+            d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Control: the strategy under test really does retry, so the exemption above is meaningful ──
+    [Fact]
+    public async Task ExecuteInTransactionAsync_OperationFailsBeforeCommit_IsStillRetried()
+    {
+        var attempts = 0;
+
+        var act = async () => await _sut.ExecuteInTransactionAsync<Result>(
+            _ =>
+            {
+                attempts++;
+                throw new TimeoutException("transient failure inside the operation");
+            });
+
+        await act.Should().ThrowAsync<RetryLimitExceededException>();
+        attempts.Should().Be(
+            4,
+            "one attempt plus the strategy's three retries; only the commit phase opts out of this");
+    }
+
+    private static TestAggregate CreateAggregateWithEvent()
+    {
+        var aggregate = new TestAggregate { Id = 1, Name = "Test" };
+        aggregate.AddDomainEvent(new TestLocalEvent());
+        return aggregate;
+    }
+
+    // ── Test doubles ──
+    public sealed record TestLocalEvent : BaseDomainEvent;
+
+    public sealed class TestAggregate : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// A context whose commit can be armed to fail, and whose execution strategy retries on any
+    /// exception. Together they reproduce the shape SQL Server produces in production: a transient
+    /// commit error under <c>EnableRetryOnFailure</c>.
+    /// </summary>
+    public sealed class CommitFailingDbContext : ApplicationDbContext
+    {
+        private FailingDatabaseFacade? _databaseFacade;
+
+        private CommitFailingDbContext(DbContextOptions<CommitFailingDbContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        /// <summary>The exception the next commit raises, or <see langword="null"/> to commit normally.</summary>
+        public Exception? FailCommitWith { get; set; }
+
+        public override DatabaseFacade Database => _databaseFacade ??= new FailingDatabaseFacade(this);
+
+        internal override bool SupportsOutbox => true;
+
+        public static CommitFailingDbContext Create(SqliteConnection connection, IDomainEventDispatcher dispatcher)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(new DomainEventSaveChangesInterceptor(
+                dispatcher,
+                NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+                Mock.Of<IOutboxSignal>()));
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            IServiceProvider sp = services.BuildServiceProvider();
+
+            var options = new DbContextOptionsBuilder<CommitFailingDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var context = new CommitFailingDbContext(options, sp);
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestAggregate>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+                e.Property(x => x.RowVersion).IsConcurrencyToken();
+            });
+            modelBuilder.Entity<OutboxMessage>(entity =>
+            {
+                entity.ToTable("OutboxMessages");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.EventType).IsRequired().HasMaxLength(500);
+                entity.Property(e => e.Payload).IsRequired();
+                entity.Property(e => e.LastError).HasMaxLength(4000);
+            });
+        }
+
+        private sealed class FailingDatabaseFacade(CommitFailingDbContext owner) : DatabaseFacade(owner)
+        {
+            public override void CommitTransaction()
+            {
+                if (owner.FailCommitWith is { } failure)
+                    throw failure;
+
+                base.CommitTransaction();
+            }
+
+            public override IExecutionStrategy CreateExecutionStrategy() => new AlwaysRetryExecutionStrategy(owner);
+        }
+
+        /// <summary>Stands in for <c>SqlServerRetryingExecutionStrategy</c>, but retries on everything.</summary>
+        private sealed class AlwaysRetryExecutionStrategy(DbContext context)
+            : ExecutionStrategy(context, maxRetryCount: 3, maxRetryDelay: TimeSpan.Zero)
+        {
+            protected override bool ShouldRetryOn(Exception exception) => true;
+        }
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactorySaveIntegrityTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactorySaveIntegrityTests.cs
@@ -1,0 +1,188 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// The save loop in <see cref="DbContextFactory.SaveChangesAsync"/> is bounded, and in-process
+/// domain event dispatch runs inside it, so a handler can leave tracked changes behind that the
+/// loop will never reach. These tests pin the post-loop assertion that turns that silent data loss
+/// into a failure, and pin that a context which merely reads does not trip it.
+/// </summary>
+public sealed class DbContextFactorySaveIntegrityTests : IDisposable
+{
+    private static readonly DataSourceKey PrimaryKey = new(DataSource.Sqlite, "Primary");
+    private static readonly DataSourceKey SecondaryKey = new(DataSource.Sqlite, "Secondary");
+
+    private readonly SqliteConnection _primaryConnection;
+    private readonly SqliteConnection _secondaryConnection;
+    private readonly Mock<IDomainEventDispatcher> _dispatcherMock = new();
+    private readonly IntegrityTestDbContext _primary;
+    private readonly IntegrityTestDbContext _secondary;
+    private readonly DbContextFactory _sut;
+
+    public DbContextFactorySaveIntegrityTests()
+    {
+        _primaryConnection = new SqliteConnection("DataSource=:memory:");
+        _primaryConnection.Open();
+        _secondaryConnection = new SqliteConnection("DataSource=:memory:");
+        _secondaryConnection.Open();
+
+        _primary = IntegrityTestDbContext.Create(_primaryConnection, _dispatcherMock.Object, PrimaryKey);
+        _secondary = IntegrityTestDbContext.Create(_secondaryConnection, _dispatcherMock.Object, SecondaryKey);
+
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory
+            .Setup(f => f.Create(It.IsAny<DataSourceKey>()))
+            .Returns<DataSourceKey>(key => key == SecondaryKey ? _secondary : _primary);
+
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+
+        _sut = new DbContextFactory(
+            physicalFactory.Object,
+            registry.Object,
+            Mock.Of<IDataSourceResolver>(),
+            Mock.Of<ICurrentUserService>());
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        _primary.Dispose();
+        _secondary.Dispose();
+        _primaryConnection.Dispose();
+        _secondaryConnection.Dispose();
+    }
+
+    // ── A handler mutating an ALREADY-saved context: in the saved set, yet dirty ──
+    [Fact]
+    public async Task SaveChangesAsync_HandlerMutatesAnAlreadySavedContext_ThrowsNamingThatContext()
+    {
+        _dispatcherMock
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Callback(() => _primary.Set<IntegrityAggregate>().Add(new IntegrityAggregate { Id = 2, Name = "raised by a handler" }))
+            .Returns(Task.CompletedTask);
+
+        var context = _sut.GetDbContext(PrimaryKey);
+        var aggregate = new IntegrityAggregate { Id = 1, Name = "root" };
+        aggregate.AddDomainEvent(new IntegrityEvent());
+        context.Set<IntegrityAggregate>().Add(aggregate);
+
+        var act = async () => await _sut.SaveChangesAsync();
+
+        var thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+        thrown.WithMessage(
+            "*Sqlite/Primary*",
+            "the failure must name the source whose changes would otherwise have been discarded");
+    }
+
+    // ── A context that only reads must never trip the assertion ──
+    [Fact]
+    public async Task SaveChangesAsync_ExtraReadOnlyContext_DoesNotThrow()
+    {
+        _secondary.Set<IntegrityAggregate>().Add(new IntegrityAggregate { Id = 99, Name = "pre-existing" });
+        await _secondary.SaveChangesAsync(null);
+        _secondary.ChangeTracker.Clear();
+
+        var readOnly = _sut.GetDbContext(SecondaryKey);
+        var tracked = await readOnly.Set<IntegrityAggregate>().ToListAsync();
+        var writable = _sut.GetDbContext(PrimaryKey);
+        writable.Set<IntegrityAggregate>().Add(new IntegrityAggregate { Id = 1, Name = "written" });
+
+        var act = async () => await _sut.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync();
+        tracked.Should().ContainSingle("the read-only context tracks an Unchanged row, which is not a pending change");
+    }
+
+    // ── Baseline: an ordinary save with no handler side effects stays clean ──
+    [Fact]
+    public async Task SaveChangesAsync_NothingLeftTracked_ReturnsTheWrittenCount()
+    {
+        var context = _sut.GetDbContext(PrimaryKey);
+        context.Set<IntegrityAggregate>().Add(new IntegrityAggregate { Id = 1, Name = "root" });
+
+        var written = await _sut.SaveChangesAsync();
+
+        written.Should().Be(1);
+    }
+
+    // ── Test doubles ──
+    public sealed record IntegrityEvent : BaseDomainEvent;
+
+    public sealed class IntegrityAggregate : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class IntegrityTestDbContext : ApplicationDbContext
+    {
+        private IntegrityTestDbContext(
+            DbContextOptions<IntegrityTestDbContext> options,
+            IServiceProvider serviceProvider,
+            PhysicalDataSource physicalDataSource)
+            : base(options, serviceProvider, new NullAssemblyProvider(), physicalDataSource)
+        {
+        }
+
+        // No outbox: this fixture is about the save loop, not about event routing, and the local
+        // events then dispatch in-process on every save (which is what materializes the defect).
+        internal override bool SupportsOutbox => false;
+
+        public static IntegrityTestDbContext Create(
+            SqliteConnection connection,
+            IDomainEventDispatcher dispatcher,
+            DataSourceKey key)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(new DomainEventSaveChangesInterceptor(
+                dispatcher,
+                NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+                Mock.Of<IOutboxSignal>()));
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            IServiceProvider sp = services.BuildServiceProvider();
+
+            var options = new DbContextOptionsBuilder<IntegrityTestDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var context = new IntegrityTestDbContext(
+                options,
+                sp,
+                new PhysicalDataSource(key, connection.ConnectionString, null, "AtlDevCon"));
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<IntegrityAggregate>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+                e.Property(x => x.RowVersion).IsConcurrencyToken();
+            });
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DomainEventCaptureExclusionTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DomainEventCaptureExclusionTests.cs
@@ -1,0 +1,188 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Event capture is scoped-exclusion aware: <c>DbContextFactory</c> hides
+/// entries from an IDENTITY_INSERT round by flipping them to Unchanged, and those rows are not
+/// written that round, so their events must not be captured either. The exclusion names exact
+/// instances on purpose; a state-based filter would also drop events raised on a genuinely
+/// already-saved aggregate, which is how the identity module publishes registration events.
+/// </summary>
+public sealed class DomainEventCaptureExclusionTests : IDisposable
+{
+    private readonly List<IDomainEvent> _dispatched = [];
+    private readonly Mock<IDomainEventDispatcher> _dispatcherMock = new();
+    private readonly ExclusionTestDbContext _dbContext;
+
+    public DomainEventCaptureExclusionTests()
+    {
+        _dispatcherMock
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<IDomainEvent>, CancellationToken>((events, _) => _dispatched.AddRange(events))
+            .Returns(Task.CompletedTask);
+
+        _dbContext = ExclusionTestDbContext.Create(new DomainEventSaveChangesInterceptor(
+            _dispatcherMock.Object,
+            NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+            Mock.Of<IOutboxSignal>()));
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // ── The hidden entry's events wait for the round that writes its row ──
+    [Fact]
+    public async Task SaveChangesAsync_ExcludedAggregate_KeepsItsEventsAndDispatchesOnlyTheRest()
+    {
+        var written = Aggregate(1, "written");
+        var hidden = Aggregate(2, "hidden");
+        _dbContext.AddRange(written, hidden);
+
+        DomainEventSaveChangesInterceptor.BeginCaptureExclusion(_dbContext, [hidden]);
+        try
+        {
+            await _dbContext.SaveChangesAsync();
+        }
+        finally
+        {
+            DomainEventSaveChangesInterceptor.EndCaptureExclusion(_dbContext);
+        }
+
+        _dispatched.Should().ContainSingle().Which.Should().BeOfType<ExclusionEvent>()
+            .Which.Tag.Should().Be("written");
+        hidden.DomainEvents.Should().ContainSingle(
+            "an event captured for a row that is not being inserted would be published ahead of its aggregate");
+        written.DomainEvents.Should().BeEmpty();
+    }
+
+    // ── ...and they are captured once the exclusion ends ──
+    [Fact]
+    public async Task SaveChangesAsync_AfterTheExclusionEnds_CapturesTheHeldBackEvents()
+    {
+        var hidden = Aggregate(2, "hidden");
+        _dbContext.Add(hidden);
+
+        DomainEventSaveChangesInterceptor.BeginCaptureExclusion(_dbContext, [hidden]);
+        try
+        {
+            await _dbContext.SaveChangesAsync();
+        }
+        finally
+        {
+            DomainEventSaveChangesInterceptor.EndCaptureExclusion(_dbContext);
+        }
+
+        hidden.Name = "hidden, now written";
+        await _dbContext.SaveChangesAsync();
+
+        _dispatched.Should().ContainSingle().Which.Should().BeOfType<ExclusionEvent>()
+            .Which.Tag.Should().Be("hidden");
+        hidden.DomainEvents.Should().BeEmpty();
+    }
+
+    // ── The exclusion is per instance, never per state ──
+    [Fact]
+    public async Task SaveChangesAsync_UnchangedAggregateCarryingAnEvent_IsStillCaptured()
+    {
+        // The authentication-service shape: an already-persisted user raises a registration event
+        // on a later save. A blanket "skip Unchanged aggregates" filter would silently drop it.
+        var user = Aggregate(1, "registered");
+        user.ClearDomainEvents();
+        _dbContext.Add(user);
+        await _dbContext.SaveChangesAsync();
+        _dispatched.Clear();
+
+        _dbContext.Entry(user).State.Should().Be(EntityState.Unchanged);
+        user.AddDomainEvent(new ExclusionEvent("UserRegistered"));
+
+        await _dbContext.SaveChangesAsync();
+
+        _dispatched.Should().ContainSingle().Which.Should().BeOfType<ExclusionEvent>()
+            .Which.Tag.Should().Be("UserRegistered");
+    }
+
+    // ── An empty exclusion set clears any previous one ──
+    [Fact]
+    public async Task BeginCaptureExclusion_WithNoEntities_ClearsThePreviousExclusion()
+    {
+        var aggregate = Aggregate(1, "written");
+        _dbContext.Add(aggregate);
+
+        DomainEventSaveChangesInterceptor.BeginCaptureExclusion(_dbContext, [aggregate]);
+        DomainEventSaveChangesInterceptor.BeginCaptureExclusion(_dbContext, []);
+        await _dbContext.SaveChangesAsync();
+
+        _dispatched.Should().ContainSingle();
+    }
+
+    private static ExclusionAggregate Aggregate(int id, string tag)
+    {
+        var aggregate = new ExclusionAggregate { Id = id, Name = tag };
+        aggregate.AddDomainEvent(new ExclusionEvent(tag));
+        return aggregate;
+    }
+
+    // ── Test doubles ──
+    public sealed record ExclusionEvent(string Tag) : BaseDomainEvent;
+
+    public sealed class ExclusionAggregate : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class ExclusionTestDbContext : ApplicationDbContext
+    {
+        private ExclusionTestDbContext(DbContextOptions<ExclusionTestDbContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        internal override bool SupportsOutbox => false;
+
+        public static ExclusionTestDbContext Create(DomainEventSaveChangesInterceptor interceptor)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(interceptor);
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            IServiceProvider sp = services.BuildServiceProvider();
+
+            var options = new DbContextOptionsBuilder<ExclusionTestDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            var context = new ExclusionTestDbContext(options, sp);
+            context.Database.OpenConnection();
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<ExclusionAggregate>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+                e.Property(x => x.RowVersion).IsConcurrencyToken();
+            });
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFRepositoryAuditStampTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFRepositoryAuditStampTests.cs
@@ -1,0 +1,172 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Persistence.Repositories;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// The repository's own save entry points must stamp the acting user, exactly like the unit of
+/// work does. They used to call the plain EF overloads, which leave
+/// <c>ApplicationDbContext.CurrentSaveUserId</c> null and make the audit interceptor fall back to
+/// the system sentinel, so anything written through them was attributed to nobody.
+/// </summary>
+public sealed class EFRepositoryAuditStampTests : IDisposable
+{
+    private const int ActingUserId = 42;
+
+    private readonly SqliteConnection _connection;
+    private readonly StampTestDbContext _context;
+
+    public EFRepositoryAuditStampTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _context = StampTestDbContext.Create(_connection);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_OnApplicationDbContext_StampsTheActingUser()
+    {
+        var sut = new EFRepository<StampedEntity, int>(_context, TimeProvider.System, CurrentUser(ActingUserId));
+        await sut.AddAsync(new StampedEntity { Id = 1 });
+
+        await sut.SaveChangesAsync();
+
+        var stored = await _context.Set<StampedEntity>().AsNoTracking().SingleAsync(e => e.Id == 1);
+        stored.CreatedBy.Should().Be(ActingUserId);
+        stored.LastModifiedBy.Should().Be(ActingUserId);
+    }
+
+    [Fact]
+    public async Task Save_OnApplicationDbContext_StampsTheActingUser()
+    {
+        var sut = new EFRepository<StampedEntity, int>(_context, TimeProvider.System, CurrentUser(ActingUserId));
+        await sut.AddAsync(new StampedEntity { Id = 2 });
+
+        var written = sut.Save();
+
+        written.Should().Be(1);
+        var stored = await _context.Set<StampedEntity>().AsNoTracking().SingleAsync(e => e.Id == 2);
+        stored.CreatedBy.Should().Be(ActingUserId);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WithNoCurrentUserService_FallsBackToTheSystemSentinel()
+    {
+        var sut = new EFRepository<StampedEntity, int>(_context);
+        await sut.AddAsync(new StampedEntity { Id = 3 });
+
+        await sut.SaveChangesAsync();
+
+        var stored = await _context.Set<StampedEntity>().AsNoTracking().SingleAsync(e => e.Id == 3);
+        stored.CreatedBy.Should().Be(default, "a repository built without a user is a system operation");
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_OnAContextThatIsNotAnApplicationDbContext_StillPersists()
+    {
+        await using var plainContext = PlainDbContext.Create();
+        var sut = new EFRepository<StampedEntity, int>(plainContext, TimeProvider.System, CurrentUser(ActingUserId));
+        await sut.AddAsync(new StampedEntity { Id = 4 });
+
+        var written = await sut.SaveChangesAsync();
+
+        written.Should().Be(1, "the user-id overloads only exist on ApplicationDbContext; anything else keeps the plain path");
+    }
+
+    private static ICurrentUserService CurrentUser(UserIdentifierType userId)
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.SetupGet(u => u.UserId).Returns(userId);
+        return currentUser.Object;
+    }
+
+    // ── Test doubles ──
+    public sealed class StampedEntity : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class StampTestDbContext : ApplicationDbContext
+    {
+        private StampTestDbContext(DbContextOptions<StampTestDbContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        internal override bool SupportsOutbox => false;
+
+        public static StampTestDbContext Create(SqliteConnection connection)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(new DomainEventSaveChangesInterceptor(
+                Mock.Of<IDomainEventDispatcher>(),
+                NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+                Mock.Of<IOutboxSignal>()));
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            IServiceProvider sp = services.BuildServiceProvider();
+
+            var options = new DbContextOptionsBuilder<StampTestDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var context = new StampTestDbContext(options, sp);
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<StampedEntity>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+                e.Property(x => x.RowVersion).IsConcurrencyToken();
+            });
+    }
+
+    /// <summary>A bare EF context: the direct-construction path the repository must keep supporting.</summary>
+    public sealed class PlainDbContext(DbContextOptions<PlainDbContext> options) : DbContext(options)
+    {
+        public static PlainDbContext Create()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+            var context = new PlainDbContext(new DbContextOptionsBuilder<PlainDbContext>().UseSqlite(connection).Options);
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<StampedEntity>(e =>
+            {
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Id).ValueGeneratedNever();
+                e.Property(x => x.Name);
+            });
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
@@ -560,6 +560,76 @@ public sealed class OutboxProcessorTests : IDisposable
         }
     }
 
+    // ── Shutdown mid-batch: stamps collected before the cancellation are flushed on the way out ──
+    [Fact]
+    public async Task CancellationMidBatch_PersistsStampsOfAlreadyDispatchedMessages()
+    {
+        // Arrange: two eligible messages, oldest first. The dispatcher delivers the first, then
+        // host shutdown cancels the token during the second.
+        using var cts = new CancellationTokenSource();
+        OutboxMessage delivered = CreateEligibleMessage(occurredOn: DateTime.UtcNow.AddMinutes(-10));
+        OutboxMessage interrupted = CreateEligibleMessage(occurredOn: DateTime.UtcNow.AddMinutes(-5));
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(delivered, interrupted);
+        await _dbContext.SaveChangesAsync();
+
+        var calls = 0;
+        _dispatcherMock
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IDomainEvent>, CancellationToken>(async (_, _) =>
+            {
+                calls++;
+                if (calls == 1)
+                {
+                    return;
+                }
+
+                await cts.CancelAsync();
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        // Act
+        Func<Task> act = () => _sut.ProcessPendingMessagesAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>("shutdown must still reach the polling loop");
+
+        // Assert: the delivered message is stamped IN THE DATABASE, not just in the change tracker,
+        // so it is not redelivered when its lease expires.
+        List<OutboxMessage> persisted = await _dbContext.Set<OutboxMessage>().AsNoTracking().ToListAsync();
+        persisted.Single(m => m.Id == delivered.Id).ProcessedOn.Should().NotBeNull(
+            "a message delivered before the cancellation must not be redelivered after the lease expires");
+        persisted.Single(m => m.Id == interrupted.Id).ProcessedOn.Should().BeNull(
+            "the message the cancellation interrupted was never delivered");
+    }
+
+    // ── Shutdown mid-batch: a failing best-effort save must not mask the cancellation ──
+    [Fact]
+    public async Task CancellationMidBatch_WhenTheShutdownSaveFails_StillPropagatesTheCancellation()
+    {
+        // Arrange: the dispatcher cancels AND the database is gone, so the best-effort save on the
+        // way out fails too. The polling loop recognizes shutdown by the exception type, so
+        // swapping the cancellation for the save failure would turn a clean stop into an error
+        // plus another polling cycle.
+        using var cts = new CancellationTokenSource();
+        OutboxMessage message = CreateEligibleMessage();
+        _dbContext.Set<OutboxMessage>().Add(message);
+        await _dbContext.SaveChangesAsync();
+
+        _dispatcherMock
+            .Setup(d => d.DispatchAsync(It.IsAny<IEnumerable<IDomainEvent>>(), It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<IDomainEvent>, CancellationToken>(async (_, _) =>
+            {
+                _dbContext.FailSaves = true;
+                await cts.CancelAsync();
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        // Act / Assert
+        Func<Task> act = () => _sut.ProcessPendingMessagesAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a best-effort save failure must never replace the propagating cancellation");
+
+        _dbContext.FailSaves = false;
+    }
+
     // ── Test doubles ──
 
     /// <summary>
@@ -596,6 +666,16 @@ public sealed class OutboxProcessorTests : IDisposable
         : ApplicationDbContext(options, serviceProvider, assemblyProvider, TestPhysicalDataSources.Sqlite())
     {
         internal override bool SupportsOutbox => true;
+
+        /// <summary>When set, every save fails, standing in for a connection lost at shutdown.</summary>
+        public bool FailSaves { get; set; }
+
+        public override Task<int> SaveChangesAsync(
+            bool acceptAllChangesOnSuccess,
+            CancellationToken cancellationToken = default) =>
+            FailSaves
+                ? Task.FromException<int>(new InvalidOperationException("connection lost"))
+                : base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
 
         protected override void OnModelCreating(ModelBuilder modelBuilder) =>
             modelBuilder.Entity<OutboxMessage>(entity =>

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/BrokerEventBusTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/BrokerEventBusTests.cs
@@ -142,24 +142,57 @@ public sealed class BrokerEventBusTests
         mocks.OutboxSignal.Verify(s => s.Signal(), Times.Never);
     }
 
-    // ── Batch: each event is persisted and signalled individually ──
+    // ── Batch: every event persisted by ONE save, processor woken ONCE ──
     [Fact]
-    public async Task PublishBatch_PersistsEachEventAndSignalsPerEvent()
+    public async Task PublishBatch_PersistsEveryEventInOneSaveAndSignalsOnce()
     {
         await using var context = TestOutboxContext.Create();
         var (sut, mocks) = CreateSut(context);
         var event1 = new TestIntegrationEvent { DateOccurred = DateTime.UtcNow };
         var event2 = new TestIntegrationEvent { DateOccurred = DateTime.UtcNow };
+        var event3 = new TestIntegrationEvent { DateOccurred = DateTime.UtcNow };
 
-        await sut.PublishAsync([event1, event2], CancellationToken.None);
+        await sut.PublishAsync([event1, event2, event3], CancellationToken.None);
 
         List<OutboxMessage> messages = await context.Set<OutboxMessage>().ToListAsync();
-        messages.Should().HaveCount(2);
+        messages.Should().HaveCount(3);
         messages.Should().AllSatisfy(m => m.ProcessedOn.Should().BeNull());
-        mocks.OutboxSignal.Verify(s => s.Signal(), Times.Exactly(2));
+        var payloads = string.Concat(messages.Select(m => m.Payload));
+        payloads.Should().Contain(event1.MessageId.ToString());
+        payloads.Should().Contain(event2.MessageId.ToString());
+        payloads.Should().Contain(event3.MessageId.ToString());
+
+        context.SaveCount.Should().Be(1, "the whole batch must be one round trip, not one per event");
+        mocks.OutboxSignal.Verify(
+            s => s.Signal(),
+            Times.Once,
+            "the signal caps at a single permit, so one wake-up per batch is all the processor can consume");
     }
 
-    // ── Empty batch: no persistence, no signal ──
+    // ── Batch atomicity: a failing save persists nothing and never signals ──
+    [Fact]
+    public async Task PublishBatch_WhenTheSaveFails_PersistsNothingAndDoesNotSignal()
+    {
+        await using var context = TestOutboxContext.Create();
+        context.FailSaves = true;
+        var (sut, mocks) = CreateSut(context);
+
+        Func<Task> act = () => sut.PublishAsync(
+            [
+                new TestIntegrationEvent { DateOccurred = DateTime.UtcNow },
+                new TestIntegrationEvent { DateOccurred = DateTime.UtcNow },
+            ],
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*save failed*");
+
+        context.FailSaves = false;
+        List<OutboxMessage> messages = await context.Set<OutboxMessage>().AsNoTracking().ToListAsync();
+        messages.Should().BeEmpty("one save makes the batch all-or-nothing, so a failure leaves no partial publish behind");
+        mocks.OutboxSignal.Verify(s => s.Signal(), Times.Never);
+    }
+
+    // ── Empty batch: no persistence, no save, no signal ──
     [Fact]
     public async Task PublishBatch_EmptyCollection_DoesNotTouchOutboxOrSignal()
     {
@@ -170,6 +203,7 @@ public sealed class BrokerEventBusTests
 
         List<OutboxMessage> messages = await context.Set<OutboxMessage>().ToListAsync();
         messages.Should().BeEmpty();
+        context.SaveCount.Should().Be(0, "an empty sequence must not cost a no-op save");
         mocks.OutboxSignal.Verify(s => s.Signal(), Times.Never);
     }
 
@@ -204,9 +238,26 @@ public sealed class BrokerEventBusTests
     {
         internal override bool SupportsOutbox => true;
 
+        /// <summary>Number of saves the bus issued, so a batch can assert it cost exactly one.</summary>
+        public int SaveCount { get; private set; }
+
+        /// <summary>When set, every save fails, standing in for a lost connection mid-publish.</summary>
+        public bool FailSaves { get; set; }
+
         private TestOutboxContext(DbContextOptions<TestOutboxContext> options, IServiceProvider serviceProvider)
             : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
         {
+        }
+
+        public override Task<int> SaveChangesAsync(
+            bool acceptAllChangesOnSuccess,
+            CancellationToken cancellationToken = default)
+        {
+            SaveCount++;
+
+            return FailSaves
+                ? Task.FromException<int>(new InvalidOperationException("save failed"))
+                : base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
         }
 
         public static TestOutboxContext Create()

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Warmup/WarmupHostedServiceTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Warmup/WarmupHostedServiceTests.cs
@@ -7,10 +7,17 @@ namespace MMCA.Common.Aspire.Tests.Warmup;
 /// <summary>
 /// The warm-up hosted service (rubric §29): runs every <see cref="IWarmupTask"/> once at startup and
 /// opens the readiness gate afterwards — and opens it even when a task fails, so a transient
-/// dependency outage cannot wedge the replica permanently out of rotation (ADR-025).
+/// dependency outage cannot wedge the replica permanently out of rotation (ADR-025). A task that
+/// hangs instead of failing is bounded by a per-task timeout and lands on that same path.
 /// </summary>
 public sealed class WarmupHostedServiceTests
 {
+    /// <summary>
+    /// Stand-in for the production 120s ceiling. The tasks under test either complete synchronously
+    /// or never complete at all, so this value only decides how long the timeout case takes to run.
+    /// </summary>
+    private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(150);
+
     private sealed class RecordingTask(string name) : IWarmupTask
     {
         public string Name { get; } = name;
@@ -30,6 +37,22 @@ public sealed class WarmupHostedServiceTests
 
         public Task ExecuteAsync(CancellationToken cancellationToken) =>
             throw new InvalidOperationException("boom");
+    }
+
+    /// <summary>A task that never completes and never faults: the case the timeout exists for.</summary>
+    private sealed class HangingTask : IWarmupTask
+    {
+        private readonly TaskCompletionSource _never = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name => "Hanging";
+
+        public bool Executed { get; private set; }
+
+        public Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            Executed = true;
+            return _never.Task;
+        }
     }
 
     private static async Task RunAsync(WarmupReadinessGate gate, params IWarmupTask[] tasks)
@@ -74,5 +97,50 @@ public sealed class WarmupHostedServiceTests
         await RunAsync(gate);
 
         gate.IsReady.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OpensTheGate_WhenATaskHangsPastItsTimeout()
+    {
+        var gate = new WarmupReadinessGate();
+        var hanging = new HangingTask();
+        var survivor = new RecordingTask("survivor");
+
+        using var service = new WarmupHostedService(
+            [hanging, survivor],
+            gate,
+            NullLogger<WarmupHostedService>.Instance,
+            taskTimeout: ShortTimeout);
+        await service.StartAsync(CancellationToken.None);
+        await service.ExecuteTask!;
+
+        hanging.Executed.Should().BeTrue();
+        gate.IsReady.Should().BeTrue(
+            "a task that hangs must not keep the replica out of rotation any more than one that fails");
+        survivor.Executed.Should().BeTrue("other tasks still run alongside the hung one");
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DoesNotWaitForTheTimeout_WhenEveryTaskIsFast()
+    {
+        var gate = new WarmupReadinessGate();
+        var taskA = new RecordingTask("A");
+        var taskB = new RecordingTask("B");
+
+        using var service = new WarmupHostedService(
+            [taskA, taskB],
+            gate,
+            NullLogger<WarmupHostedService>.Instance,
+            taskTimeout: TimeSpan.FromMinutes(10));
+        await service.StartAsync(CancellationToken.None);
+        await service.ExecuteTask!;
+
+        gate.IsReady.Should().BeTrue("the timeout is a ceiling, not a delay: completed tasks open the gate at once");
+        taskA.Executed.Should().BeTrue();
+        taskB.Executed.Should().BeTrue();
+
+        await service.StopAsync(CancellationToken.None);
     }
 }


### PR DESCRIPTION
## Summary

First of two MMCA.Common BugHunt remediation PRs (waves W1 persistence + W2 events/background). Every item was adversarially re-verified against source before implementation; several fixes were corrected by that pass (see ledger notes below).

| Item | Fix |
|---|---|
| M1 | Commit-phase transient failures surface as the new `TransactionCommitAmbiguousException` instead of re-entering the retry delegate after a possibly durable commit (EF's retriability check walks inner exceptions, so the failure is returned past the strategy). Multi-source witness verification deferred and documented. |
| M6 | The bounded save-pass loop now fails loudly (naming the dirty contexts) instead of silently dropping changes materialized after pass 3. |
| M7 | Domain-event capture skips exactly the entries `SaveWithIdentityInsertAsync` temporarily hides (scoped exclusion table); events raised on genuinely Unchanged aggregates keep dispatching (blanket state filtering was disqualified: it would drop `UserRegistered`). |
| M29 | `EFRepository.Save()/SaveChangesAsync()` route through the `ApplicationDbContext` user-id overloads so direct saves stamp the acting user. |
| M2 | `SafeDomainEventHandler` rethrows via a log-and-rethrow filter; the advertised outbox retry/dead-letter actually engages. Doc states the batch-redelivery consequence (at-least-once). |
| M8 | Graceful shutdown best-effort persists in-memory `ProcessedOn` stamps (bounded 5s token, never replaces the OCE), closing the 300s lease-expiry redelivery window. |
| M32 | `BrokerEventBus` batch publish: one save, one signal, empty batches no-op (mirrors `InProcessEventBus`). |
| M10 | Warmup tasks bounded at 120s so a hanging dependency cannot keep `/health/ready` closed forever (replica-stuck-out-of-rotation fix). |

## Verification

- `dotnet build MMCA.Common.slnx` clean Debug + Release (five analyzers at error severity)
- Full `dotnet test --solution MMCA.Common.slnx -c Release`: 2547 passed, 0 failed
- FACTS drift check: up to date (additive public surface only: `TransactionCommitAmbiguousException`)
- Helpdesk source-canary built clean with 91 tests passing against this source (W1)
- New regression tests per item, including a retry-on-any control fixture proving the commit-ambiguity path is not re-entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aXCqcfqf5Ka4hKWQphh3i