### PR TITLE
fix: BugHunt remediation PR C-2 - API boundary, shared contracts, query/caching/UI (M3-M5, M9, M11-M14, M30, M31, M33-M39)

### DIFF
--- a/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
+++ b/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
@@ -153,8 +153,7 @@ public abstract class AuthenticationServiceBase<TUser>(
         var emailExists = await EmailExistsAsync(registerEmail, cancellationToken).ConfigureAwait(false);
         if (emailExists)
         {
-            return Result.Failure<AuthenticationResponse>(
-                Error.Conflict("Auth.EmailAlreadyExists", "An account with this email already exists.", nameof(RegisterAsync)));
+            return EmailAlreadyExistsFailure();
         }
 
         var (hash, salt) = passwordHasher.HashPassword(request.Password);
@@ -169,7 +168,36 @@ public abstract class AuthenticationServiceBase<TUser>(
         user.UpdateRefreshToken(refreshToken, timeProvider.GetUtcNow().UtcDateTime.Add(RefreshTokenLifetime));
 
         await Repository.AddAsync(user, cancellationToken).ConfigureAwait(false);
-        await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types: the persistence exception is not visible from this layer (see below)
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            // The email lookup above is a check-then-act: two concurrent registrations for the same
+            // address both pass it, and the loser only fails here, on the insert. Every consumer
+            // puts a unique index on Email (ADC unfiltered, Store filtered on IsDeleted), so this
+            // save is where the race actually surfaces, and without this catch it surfaces as a
+            // generic 500 instead of the 409 a serialized pair of requests would have produced.
+            //
+            // The catch is deliberately broad: Application has no EF Core dependency (by layer
+            // rule), so DbUpdateException is not a type this file can name. The re-check is what
+            // narrows it. If the address exists now, the concurrent registration is the cause and
+            // the caller gets the same conflict the serial path returns; anything else rethrows
+            // untouched, so a genuine persistence fault still reaches the exception middleware.
+            //
+            // CancellationToken.None: the re-check has to run even when the caller's token is what
+            // aborted the save, otherwise a cancelled save could never be classified.
+            if (await EmailExistsAsync(registerEmail, CancellationToken.None).ConfigureAwait(false))
+            {
+                return EmailAlreadyExistsFailure();
+            }
+
+            throw;
+        }
 
         // Post-commit hook: publish the app's registration side-effect (integration event) and/or
         // re-fetch so the first token can carry an id written post-commit by a domain-event handler.
@@ -318,4 +346,13 @@ public abstract class AuthenticationServiceBase<TUser>(
     /// </summary>
     protected virtual Error CreateRefreshUserMissingError() =>
         Error.Unauthorized("Auth.InvalidToken", "User not found.", nameof(RefreshTokenAsync));
+
+    /// <summary>
+    /// The registration conflict, returned both by the up-front email check and by the
+    /// unique-index race recovery in <see cref="RegisterAsync"/> so the two paths are
+    /// indistinguishable to the caller.
+    /// </summary>
+    private static Result<AuthenticationResponse> EmailAlreadyExistsFailure() =>
+        Result.Failure<AuthenticationResponse>(
+            Error.Conflict("Auth.EmailAlreadyExists", "An account with this email already exists.", nameof(RegisterAsync)));
 }

--- a/Source/Core/MMCA.Common.Application/Interfaces/IDistributedLock.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/IDistributedLock.cs
@@ -1,0 +1,64 @@
+namespace MMCA.Common.Application.Interfaces;
+
+/// <summary>
+/// Mutual exclusion on a logical key across every replica of a service, for critical sections a
+/// per-process lock cannot protect.
+/// <para>
+/// A <see cref="System.Threading.SemaphoreSlim"/> (or
+/// <see cref="MMCA.Common.Shared.Concurrency.KeyedSemaphoreStripe"/>) only serializes callers inside
+/// one process. A service scaled to more than one replica runs the same critical section once per
+/// replica, so anything that relies on "only one of these runs at a time" (the idempotency filter's
+/// execute-then-store window, a single-writer import, a leader-elected job) needs the lock to live
+/// where all the replicas can see it.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are singletons and must be safe to call concurrently.
+/// </para>
+/// <para>
+/// The lock is NOT reentrant: a caller that already holds <c>key</c> and asks for it again waits
+/// for itself and then fails to acquire.
+/// </para>
+/// <para>
+/// This is a best-effort lock, not a consensus protocol. A holder that is paused past its
+/// time-to-live loses the lock without knowing it, so the guarded section must stay correct (if
+/// slower or duplicated) when exclusion is lost. Use it to collapse duplicate work, never as the
+/// only guard on a correctness invariant that persistence can enforce.
+/// </para>
+/// </remarks>
+public interface IDistributedLock
+{
+    /// <summary>
+    /// Attempts to take the lock on <paramref name="key"/>, waiting up to <paramref name="wait"/>
+    /// for a current holder to release it.
+    /// </summary>
+    /// <param name="key">The logical key to lock. Callers sharing one backing store must agree on it.</param>
+    /// <param name="ttl">
+    /// How long the lock survives without an explicit release. This is the crash guard: a holder
+    /// that dies mid-section cannot wedge the key, because the entry expires on its own. Set it
+    /// comfortably above the guarded section's expected duration, since work that outlives the TTL
+    /// is no longer protected.
+    /// </param>
+    /// <param name="wait">
+    /// How long to wait for the lock before giving up. <see cref="TimeSpan.Zero"/> makes the call a
+    /// single non-blocking attempt.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the wait, not the work that follows it.</param>
+    /// <returns>
+    /// A handle whose asynchronous disposal releases the lock, or <see langword="null"/> when the
+    /// lock was still held elsewhere after <paramref name="wait"/> elapsed. Dispose the handle
+    /// inside an <see langword="await"/> <see langword="using"/> so the release happens even when
+    /// the guarded work throws.
+    /// </returns>
+    /// <remarks>
+    /// Release is owner-scoped: a handle releases only the acquisition it represents. Disposing a
+    /// handle whose TTL already expired (so another caller now holds the key) is a no-op rather
+    /// than a release of the new holder's lock. Disposal is idempotent.
+    /// </remarks>
+    Task<IAsyncDisposable?> TryAcquireAsync(
+        string key,
+        TimeSpan ttl,
+        TimeSpan wait,
+        CancellationToken cancellationToken = default);
+}

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IPushDeviceRegistrar.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IPushDeviceRegistrar.cs
@@ -21,5 +21,36 @@ public interface IPushDeviceRegistrar
     /// <param name="installationId">The installation to delete.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Success, or a failure result.</returns>
+    /// <remarks>
+    /// This overload performs no ownership check, so it must not be reached from a caller-supplied
+    /// installation id. Use <see cref="DeleteAsync(UserIdentifierType, string, CancellationToken)"/>
+    /// at any authenticated boundary; this one stays for server-initiated cleanup where the owner
+    /// is already established.
+    /// </remarks>
     Task<Result> DeleteAsync(string installationId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a device installation the given user owns; unknown installation ids and
+    /// installations owned by another user both succeed without deleting anything.
+    /// </summary>
+    /// <param name="userId">The authenticated owner the installation must belong to.</param>
+    /// <param name="installationId">The installation to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success, or a failure result.</returns>
+    /// <remarks>
+    /// <para>
+    /// Installation ids are client-generated, but nothing stops a caller from sending someone
+    /// else's, so the owning <c>user:{id}</c> tag stamped by <see cref="UpsertAsync"/> is verified
+    /// before the delete. A mismatch is reported as success rather than as a not-found: answering
+    /// differently for "no such installation" and "not yours" would turn the endpoint into an
+    /// existence oracle for other users' installation ids, and the caller has nothing to do with
+    /// either answer.
+    /// </para>
+    /// <para>
+    /// The default implementation delegates to the unscoped overload so implementations outside
+    /// this framework keep compiling; implementations that can verify ownership override it.
+    /// </para>
+    /// </remarks>
+    Task<Result> DeleteAsync(UserIdentifierType userId, string installationId, CancellationToken cancellationToken = default) =>
+        DeleteAsync(installationId, cancellationToken);
 }

--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -222,7 +222,7 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
         // Step 1: Validate all query parameters upfront before touching the database
         var validateResult = Result.Combine(
             QueryFieldService.Validate<TEntity>(fields, allowWriteableFields: false),
-            QueryFieldService.Validate<TEntity>(sortColumn, allowWriteableFields: true),
+            QueryFieldService.Validate<TEntity>(sortColumn, DTOToEntityPropertyMap, allowWriteableFields: true),
             QueryFieldService.ValidateSortDirection(sortDirection),
             QueryFilterService.ValidateFilters<TEntity>(filters, DTOToEntityPropertyMap)
             );
@@ -444,26 +444,50 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
             cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Builds the response's pagination metadata so that every value describes what the pipeline
+    /// ACTUALLY did, never what the caller asked for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both branches go through the validating constructor rather than an object initializer: the
+    /// initializer bypassed the constructor's negative-value guards entirely, so an out-of-range
+    /// input reached the derived properties instead of being corrected here.
+    /// </para>
+    /// <para>
+    /// The clamp is recomputed here instead of being read back from <see cref="Query.PagingMath"/>:
+    /// that helper returns a <c>(0, 0)</c> sentinel for a page whose offset is unreachable, and
+    /// reporting that take as the page size would advertise <c>PageSize = 0</c> for a request whose
+    /// page size was perfectly valid.
+    /// </para>
+    /// </remarks>
     private static PaginationMetadata BuildPaginationMetadata(int totalItemCount, int? pageNumber, int? pageSize)
     {
+        // The pipeline owns the total and should never report a negative one, but the constructor
+        // now throws on negatives: floor it so a bad count degrades the metadata instead of turning
+        // a successful read into a 500.
+        var safeTotalItemCount = Math.Max(totalItemCount, 0);
+
         if (!pageNumber.HasValue || !pageSize.HasValue)
         {
-            return new PaginationMetadata
-            {
-                TotalItemCount = totalItemCount,
-                PageSize = totalItemCount,
-                CurrentPage = 1
-            };
+            // An unpaginated read still materializes at most the framework ceiling while reporting
+            // the true total, so the page size is the row count actually returned, not the total.
+            // An empty result leaves PageSize = 0, which the constructor accepts (it rejects only
+            // negatives) and which keeps the derived values coherent: TotalPageCount, FirstRowOnPage
+            // and LastRowOnPage are all 0.
+            return new PaginationMetadata(
+                totalItemCount: safeTotalItemCount,
+                pageSize: Math.Min(safeTotalItemCount, Query.EntityQueryPipeline.MaxUnboundedResultLimit),
+                currentPage: 1);
         }
 
-        return new PaginationMetadata
-        {
-            TotalItemCount = totalItemCount,
-            // Report the page size the pipeline actually applied, not the one requested: the
-            // pipeline clamps to the framework ceiling, so an over-large request previously
-            // advertised a page size the response never contained.
-            PageSize = Math.Min(pageSize.Value, Query.EntityQueryPipeline.MaxUnboundedResultLimit),
-            CurrentPage = pageNumber.Value
-        };
+        // Floor and ceiling together mirror exactly what PagingMath applied for this request: it
+        // takes at least one row and at most the framework ceiling, and treats any page below 1 as
+        // page 1. Without the floor, pageSize = 0 (or negative) advertised PageSize = 0 and
+        // collapsed every derived value to 0 while the pipeline had really fetched one row.
+        return new PaginationMetadata(
+            totalItemCount: safeTotalItemCount,
+            pageSize: Math.Clamp(pageSize.Value, 1, Query.EntityQueryPipeline.MaxUnboundedResultLimit),
+            currentPage: Math.Max(pageNumber.Value, 1));
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/QueryFieldService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/QueryFieldService.cs
@@ -15,6 +15,29 @@ namespace MMCA.Common.Application.Services;
 /// </summary>
 public sealed class QueryFieldService
 {
+    /// <summary>
+    /// Upper bound on the number of entries admitted to EACH of the two field-set caches
+    /// (<see cref="ProjectionCache"/> and <see cref="ShapedAccessorCache"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both caches are keyed by (entity type, normalized field set), and the field set arrives
+    /// verbatim from the client's <c>fields=</c> query string: an entity with N properties has up to
+    /// 2^N distinct subsets, so a caller can grow either dictionary without bound simply by
+    /// permuting the list. Unlike the type-keyed caches in this class, the key space is not bounded
+    /// by the number of entity types in the application.
+    /// </para>
+    /// <para>
+    /// There is deliberately no LRU or eviction policy. These caches exist to skip repeated work for
+    /// the small, hot set of field lists a real client sends, which is admitted long before the cap
+    /// is reached. Past the cap each cache simply stops admitting entries and the request falls back
+    /// to the uncached path (server-side projection is skipped, shaping accessors are filtered per
+    /// request), which is correct but slightly slower, rather than paying for eviction bookkeeping
+    /// on every lookup.
+    /// </para>
+    /// </remarks>
+    private const int MaxCacheEntries = 512;
+
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertiesCache = new();
     private static readonly ConcurrentDictionary<Type, PropertyAccessor[]> AccessorCache = new();
     private static readonly JsonNamingPolicy CamelCase = JsonNamingPolicy.CamelCase;
@@ -151,10 +174,25 @@ public sealed class QueryFieldService
             return query;
 
         var fieldsSet = ParseFields(fields);
-        var selectExpression = ProjectionCache.GetOrAdd(
-            (typeof(TEntity), NormalizeFieldsKey(fieldsSet)),
-            static (_, set) => BuildProjection<TEntity>(set),
-            fieldsSet);
+        var key = (typeof(TEntity), NormalizeFieldsKey(fieldsSet));
+
+        // The hit path stays a lock-free TryGetValue; the Count check (which takes every bucket lock
+        // on a ConcurrentDictionary) runs only on a miss.
+        if (!ProjectionCache.TryGetValue(key, out var selectExpression))
+        {
+            // Past the cap, skip server-side projection instead of admitting another client-shaped
+            // key. Compiling the MemberInit tree per request on this path would turn cache pressure
+            // into CPU churn, which is the more expensive failure; skipping projection only widens
+            // the column list sent to the database, and the response shape is unchanged because
+            // ShapeCollectionData still trims the payload to the requested fields.
+            if (ProjectionCache.Count >= MaxCacheEntries)
+                return query;
+
+            selectExpression = ProjectionCache.GetOrAdd(
+                key,
+                static (_, set) => BuildProjection<TEntity>(set),
+                fieldsSet);
+        }
 
         return selectExpression is null
             ? query
@@ -165,11 +203,19 @@ public sealed class QueryFieldService
     /// Compiled projection lambdas, keyed by entity type and normalized field set.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Rebuilding the <c>MemberInit</c> tree per request meant reflecting over the entity's
     /// properties and allocating a binding array on every field-projected read, unlike the sibling
     /// lookup-selector cache in <c>EFReadRepository</c>. A <see langword="null"/> value is cached
     /// deliberately: it records "this field set projects nothing writable", so the miss is not
     /// recomputed on every subsequent request.
+    /// </para>
+    /// <para>
+    /// Capped at <see cref="MaxCacheEntries"/> (512) entries, with no LRU by design: the field-set
+    /// half of the key is client-supplied, so an entity with N properties admits up to 2^N distinct
+    /// keys. Past the cap, <see cref="ApplyFieldSelection"/> skips server-side projection rather
+    /// than growing this dictionary further. See <see cref="MaxCacheEntries"/>.
+    /// </para>
     /// </remarks>
     private static readonly ConcurrentDictionary<(Type EntityType, string Fields), LambdaExpression?> ProjectionCache = new();
 
@@ -201,12 +247,62 @@ public sealed class QueryFieldService
     /// Validates that all requested field names exist on the entity type.
     /// When <paramref name="allowWriteableFields"/> is false, read-only properties are rejected
     /// (they cannot be used for data shaping since the projection MemberInit requires setters).
+    /// Consults no DTO-to-entity mapping: use the overload that takes one when the same name is
+    /// later resolved through a map.
     /// </summary>
     /// <typeparam name="TEntity">The entity type to validate fields against.</typeparam>
     /// <param name="fields">Comma-separated field names to validate.</param>
     /// <param name="allowWriteableFields">If false, rejects read-only properties.</param>
     /// <returns>A success result, or a failure with validation errors.</returns>
     public static Result Validate<TEntity>(string? fields, bool allowWriteableFields = false)
+        => ValidateFields<TEntity>(fields, dtoToEntityPropertyMap: null, allowWriteableFields);
+
+    /// <summary>
+    /// Validates requested field names against <typeparamref name="TEntity"/>, resolving DTO-facing
+    /// names through <paramref name="dtoToEntityPropertyMap"/> first. Use this overload wherever the
+    /// name is later resolved through the same map (sorting and filtering both do), so validation
+    /// accepts exactly what resolution accepts.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A map hit is accepted UNCONDITIONALLY: the mapped value is never resolved or reflected over.
+    /// Map entries are server-authored (a subclass of the query service supplies them, never the
+    /// client) and their values are deliberately not plain property names of
+    /// <typeparamref name="TEntity"/>: they may be nested navigation paths such as
+    /// <c>"Category.Name"</c> or Dynamic LINQ expressions. Reflecting over them would reject exactly
+    /// the DTO names the map exists to enable, which is what made a mapped sort column fail
+    /// validation while <see cref="ApplySorting"/> would have sorted by it happily.
+    /// </para>
+    /// <para>
+    /// A name with NO map entry falls back to the entity-property check below unchanged (existence,
+    /// plus the read-only rule when <paramref name="allowWriteableFields"/> is false), so a
+    /// client-supplied name the server never mapped is still rejected.
+    /// </para>
+    /// <para>
+    /// A <see langword="null"/> map is treated as an empty one, matching how the other map-aware
+    /// members of this layer (<see cref="ApplySorting"/>, <c>QueryFilterService.ValidateFilters</c>)
+    /// treat a caller that has no mappings.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TEntity">The entity type to validate fields against.</typeparam>
+    /// <param name="fields">Comma-separated field names to validate.</param>
+    /// <param name="dtoToEntityPropertyMap">DTO-to-entity property name mapping (server-authored; entries may be navigation paths or expressions).</param>
+    /// <param name="allowWriteableFields">If false, rejects read-only properties.</param>
+    /// <returns>A success result, or a failure with validation errors.</returns>
+    public static Result Validate<TEntity>(
+        string? fields,
+        IReadOnlyDictionary<string, string> dtoToEntityPropertyMap,
+        bool allowWriteableFields = false)
+        => ValidateFields<TEntity>(fields, dtoToEntityPropertyMap, allowWriteableFields);
+
+    /// <summary>
+    /// Shared body of both <c>Validate</c> overloads. See the map-aware overload for why a map hit
+    /// short-circuits the entity-property check.
+    /// </summary>
+    private static Result ValidateFields<TEntity>(
+        string? fields,
+        IReadOnlyDictionary<string, string>? dtoToEntityPropertyMap,
+        bool allowWriteableFields)
     {
         if (string.IsNullOrWhiteSpace(fields))
             return Result.Success();
@@ -218,6 +314,10 @@ public sealed class QueryFieldService
 
         foreach (string field in fieldsSet)
         {
+            // Server-authored mapping wins outright: the mapped value is not a name to reflect over.
+            if (dtoToEntityPropertyMap is not null && dtoToEntityPropertyMap.ContainsKey(field))
+                continue;
+
             PropertyInfo? property = propertyInfos
                 .FirstOrDefault(p => p.Name.Equals(field, StringComparison.OrdinalIgnoreCase));
 
@@ -296,23 +396,43 @@ public sealed class QueryFieldService
     /// Shaping accessors filtered to a field set, keyed by entity type and normalized field set,
     /// so a repeated <c>fields=</c> request reuses the array instead of re-filtering per call.
     /// </summary>
+    /// <remarks>
+    /// Capped at <see cref="MaxCacheEntries"/> (512) entries, with no LRU by design: the field-set
+    /// half of the key is client-supplied, so an entity with N properties admits up to 2^N distinct
+    /// keys. Past the cap, <see cref="GetShapedAccessors"/> filters per request instead of growing
+    /// this dictionary further. See <see cref="MaxCacheEntries"/>.
+    /// </remarks>
     private static readonly ConcurrentDictionary<(Type EntityType, string Fields), PropertyAccessor[]> ShapedAccessorCache = new();
 
     /// <summary>
     /// Resolves the accessors to shape with: all of them when no field list was given, otherwise
-    /// the cached subset for that field set.
+    /// the cached subset for that field set (or a per-request subset once the cache is at its cap).
     /// </summary>
     private static PropertyAccessor[] GetShapedAccessors<TEntity>(string? fields)
     {
         var accessors = GetAccessors<TEntity>();
         var fieldsSet = ParseFields(fields);
 
-        return fieldsSet.Count == 0
-            ? accessors
-            : ShapedAccessorCache.GetOrAdd(
-                (typeof(TEntity), NormalizeFieldsKey(fieldsSet)),
-                static (_, arg) => FilterAccessorsByFields(arg.Accessors, arg.FieldsSet),
-                (Accessors: accessors, FieldsSet: fieldsSet));
+        if (fieldsSet.Count == 0)
+            return accessors;
+
+        var key = (typeof(TEntity), NormalizeFieldsKey(fieldsSet));
+
+        // The hit path stays a lock-free TryGetValue; the Count check (which takes every bucket lock
+        // on a ConcurrentDictionary) runs only on a miss.
+        if (ShapedAccessorCache.TryGetValue(key, out var cached))
+            return cached;
+
+        // Past the cap, filter per request rather than admitting another client-shaped key. This
+        // path is a single LINQ pass over an already-compiled accessor array (no expression
+        // compilation), so an uncached shape costs a scan, not a rebuild.
+        if (ShapedAccessorCache.Count >= MaxCacheEntries)
+            return FilterAccessorsByFields(accessors, fieldsSet);
+
+        return ShapedAccessorCache.GetOrAdd(
+            key,
+            static (_, arg) => FilterAccessorsByFields(arg.Accessors, arg.FieldsSet),
+            (Accessors: accessors, FieldsSet: fieldsSet));
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/FeatureGateCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/FeatureGateCommandDecorator.cs
@@ -10,7 +10,7 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// with <see cref="ErrorType.NotFound"/> without invoking the handler.
 /// <para>
 /// Registered as the outermost standard decorator so that disabled features are
-/// rejected immediately — before logging, caching, validation, or transaction work.
+/// rejected immediately, before logging, caching, validation, or transaction work.
 /// </para>
 /// </summary>
 /// <typeparam name="TCommand">The command type.</typeparam>
@@ -24,7 +24,23 @@ public sealed class FeatureGateCommandDecorator<TCommand, TResult>(
     /// <see cref="Error"/> instances. Built once per generic type instantiation via reflection
     /// to avoid per-call reflection overhead.
     /// </summary>
-    private static readonly Func<IEnumerable<Error>, TResult> CreateFailure = ResultFailureFactory.Build<TResult>();
+    /// <remarks>
+    /// Built on the first short-circuit rather than in the static constructor:
+    /// <see cref="ResultFailureFactory"/> supports only <see cref="Result"/> and
+    /// <see cref="Result{T}"/>, and an eager static initializer turned an unsupported
+    /// <typeparamref name="TResult"/> into a <see cref="TypeInitializationException"/> at RESOLVE
+    /// time (Scrutor's TryDecorate is unconditional) for a handler that never short-circuits. One
+    /// assignment per closed generic type; a benign duplicate build under a race produces an
+    /// equivalent delegate. The happy path never touches it.
+    /// </remarks>
+    private static Func<IEnumerable<Error>, TResult>? _createFailure;
+
+    /// <summary>
+    /// Returns the failure factory, building it on first use. Kept static so the lazy assignment is
+    /// never a write to a static field from an instance member.
+    /// </summary>
+    private static Func<IEnumerable<Error>, TResult> CreateFailure()
+        => _createFailure ??= ResultFailureFactory.Build<TResult>();
 
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TCommand command, CancellationToken cancellationToken = default)
@@ -35,7 +51,8 @@ public sealed class FeatureGateCommandDecorator<TCommand, TResult>(
         if (await featureManager.IsEnabledAsync(featureGated.FeatureName).ConfigureAwait(false))
             return await inner.HandleAsync(command, cancellationToken).ConfigureAwait(false);
 
-        return CreateFailure([Error.NotFoundError(
+        var createFailure = CreateFailure();
+        return createFailure([Error.NotFoundError(
             "Feature.Disabled",
             $"Feature '{featureGated.FeatureName}' is not currently available.")]);
     }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/FeatureGateQueryDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/FeatureGateQueryDecorator.cs
@@ -10,7 +10,7 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// with <see cref="ErrorType.NotFound"/> without invoking the handler.
 /// <para>
 /// Registered as the outermost standard decorator so that disabled features are
-/// rejected immediately — before logging or caching work.
+/// rejected immediately, before logging or caching work.
 /// </para>
 /// </summary>
 /// <typeparam name="TQuery">The query type.</typeparam>
@@ -24,7 +24,23 @@ public sealed class FeatureGateQueryDecorator<TQuery, TResult>(
     /// <see cref="Error"/> instances. Built once per generic type instantiation via reflection
     /// to avoid per-call reflection overhead.
     /// </summary>
-    private static readonly Func<IEnumerable<Error>, TResult> CreateFailure = ResultFailureFactory.Build<TResult>();
+    /// <remarks>
+    /// Built on the first short-circuit rather than in the static constructor:
+    /// <see cref="ResultFailureFactory"/> supports only <see cref="Result"/> and
+    /// <see cref="Result{T}"/>, and an eager static initializer turned an unsupported
+    /// <typeparamref name="TResult"/> into a <see cref="TypeInitializationException"/> at RESOLVE
+    /// time (Scrutor's TryDecorate is unconditional) for a handler that never short-circuits. One
+    /// assignment per closed generic type; a benign duplicate build under a race produces an
+    /// equivalent delegate. The happy path never touches it.
+    /// </remarks>
+    private static Func<IEnumerable<Error>, TResult>? _createFailure;
+
+    /// <summary>
+    /// Returns the failure factory, building it on first use. Kept static so the lazy assignment is
+    /// never a write to a static field from an instance member.
+    /// </summary>
+    private static Func<IEnumerable<Error>, TResult> CreateFailure()
+        => _createFailure ??= ResultFailureFactory.Build<TResult>();
 
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TQuery query, CancellationToken cancellationToken = default)
@@ -35,7 +51,8 @@ public sealed class FeatureGateQueryDecorator<TQuery, TResult>(
         if (await featureManager.IsEnabledAsync(featureGated.FeatureName).ConfigureAwait(false))
             return await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
 
-        return CreateFailure([Error.NotFoundError(
+        var createFailure = CreateFailure();
+        return createFailure([Error.NotFoundError(
             "Feature.Disabled",
             $"Feature '{featureGated.FeatureName}' is not currently available.")]);
     }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/ValidatingCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/ValidatingCommandDecorator.cs
@@ -33,7 +33,23 @@ public sealed partial class ValidatingCommandDecorator<TCommand, TResult>(
     /// <see cref="Error"/> instances. Built once per generic type instantiation via reflection
     /// to avoid per-call reflection overhead.
     /// </summary>
-    private static readonly Func<IEnumerable<Error>, TResult> CreateFailure = ResultFailureFactory.Build<TResult>();
+    /// <remarks>
+    /// Built on the first short-circuit rather than in the static constructor:
+    /// <see cref="ResultFailureFactory"/> supports only <see cref="Result"/> and
+    /// <see cref="Result{T}"/>, and an eager static initializer turned an unsupported
+    /// <typeparamref name="TResult"/> into a <see cref="TypeInitializationException"/> at RESOLVE
+    /// time (Scrutor's TryDecorate is unconditional) for a handler that never short-circuits. One
+    /// assignment per closed generic type; a benign duplicate build under a race produces an
+    /// equivalent delegate. The happy path never touches it.
+    /// </remarks>
+    private static Func<IEnumerable<Error>, TResult>? _createFailure;
+
+    /// <summary>
+    /// Returns the failure factory, building it on first use. Kept static so the lazy assignment is
+    /// never a write to a static field from an instance member.
+    /// </summary>
+    private static Func<IEnumerable<Error>, TResult> CreateFailure()
+        => _createFailure ??= ResultFailureFactory.Build<TResult>();
 
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TCommand command, CancellationToken cancellationToken = default)
@@ -52,7 +68,8 @@ public sealed partial class ValidatingCommandDecorator<TCommand, TResult>(
         var errors = validationResult.ToErrors(typeof(TCommand).Name).ToList();
         LogValidationFailure(errors);
 
-        return CreateFailure(errors);
+        var createFailure = CreateFailure();
+        return createFailure(errors);
     }
 
     [LoggerMessage(

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
@@ -10,9 +10,10 @@ namespace MMCA.Common.Infrastructure.Caching;
 /// Cache backed by <see cref="IDistributedCache"/> (e.g., Redis, SQL Server).
 /// Serializes values as UTF-8 JSON via <see cref="System.Text.Json.JsonSerializer"/>.
 /// When an <see cref="IConnectionMultiplexer"/> is available (Redis), <see cref="RemoveByPrefixAsync"/>
-/// uses SCAN to enumerate and delete matching keys. Otherwise prefix invalidation is a no-op and is
-/// logged (once for the missing-multiplexer case, which is a steady state; every time for the
-/// anomalous no-server case) so a silently-dead invalidation is observable instead of invisible.
+/// uses SCAN on every non-replica server to enumerate matching keys and deletes them one key per
+/// command. Otherwise prefix invalidation is a no-op and is logged (once for the missing-multiplexer
+/// case, which is a steady state; every time for the anomalous no-server case) so a silently-dead
+/// invalidation is observable instead of invisible.
 /// </summary>
 internal sealed partial class DistributedCacheService(
     IDistributedCache cache,
@@ -20,7 +21,7 @@ internal sealed partial class DistributedCacheService(
     IConnectionMultiplexer? connectionMultiplexer = null,
     CacheKeyNamespace? keyNamespace = null) : ICacheService
 {
-    /// <summary>Keys per delete round trip during prefix invalidation.</summary>
+    /// <summary>Single-key deletes issued and awaited as one group during prefix invalidation.</summary>
     private const int DeleteBatchSize = 512;
 
     /// <summary>
@@ -58,9 +59,24 @@ internal sealed partial class DistributedCacheService(
 
     /// <inheritdoc />
     /// <remarks>
-    /// SCAN enumerates matching keys incrementally; deletes are issued in batches of
-    /// <see cref="DeleteBatchSize"/> (one round trip per batch instead of one per key),
-    /// keeping mutating commands from stalling on large invalidations.
+    /// <para>
+    /// Every non-replica server is scanned, not just the first one the multiplexer reports. Keys
+    /// are distributed across primaries, so scanning one server leaves the entries held by the
+    /// others alive until their TTL expires. Replicas are skipped: their keyspace mirrors a
+    /// primary already scanned, and a delete against a replica is rejected.
+    /// </para>
+    /// <para>
+    /// SCAN enumerates matching keys incrementally and each key is deleted by its own single-key
+    /// command. A multi-key DEL cannot span hash slots under Redis cluster policy, and
+    /// StackExchange.Redis rejects a cross-slot multi-key command by throwing rather than
+    /// under-deleting, which would fault the whole invalidation. Round trips still stay bounded:
+    /// up to <see cref="DeleteBatchSize"/> single-key deletes are in flight at a time and awaited
+    /// as one group.
+    /// </para>
+    /// <para>
+    /// Each server is scanned inside its own try/catch, so one unreachable or failing server is
+    /// logged and skipped instead of aborting invalidation on the servers that are healthy.
+    /// </para>
     /// </remarks>
     public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
     {
@@ -74,30 +90,67 @@ internal sealed partial class DistributedCacheService(
             return;
         }
 
-        var server = connectionMultiplexer.GetServers().FirstOrDefault();
-        if (server is null)
+        // Replicas mirror a primary's keyspace, so scanning them is redundant, and a DEL against a
+        // replica fails outright. Everything else is scanned: a key that lives on another primary
+        // is invisible to the first server's SCAN and would survive the invalidation.
+        IServer[] servers = [.. connectionMultiplexer.GetServers().Where(s => !s.IsReplica)];
+        if (servers.Length == 0)
         {
             LogPrefixEvictionNoServer(logger, prefix);
             return;
         }
 
-        var keys = server.KeysAsync(pattern: $"{_keys.Qualify(prefix)}*");
+        var pattern = $"{_keys.Qualify(prefix)}*";
         var db = connectionMultiplexer.GetDatabase();
-        var batch = new List<RedisKey>(DeleteBatchSize);
 
-        await foreach (var key in keys.WithCancellation(cancellationToken))
+        foreach (var server in servers)
         {
-            batch.Add(key);
-            if (batch.Count == DeleteBatchSize)
+            try
             {
-                await db.KeyDeleteAsync([.. batch]).ConfigureAwait(false);
-                batch.Clear();
+                await ScanAndDeleteAsync(db, server, pattern, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is RedisException or RedisCommandException or TimeoutException)
+            {
+                // Best-effort per server: a transport or command fault on one node must not leave the
+                // remaining nodes un-invalidated. Cancellation is deliberately not caught here.
+                LogPrefixEvictionServerFailed(logger, Describe(server), prefix, ex);
+            }
+        }
+    }
+
+    /// <summary>Scans one server for the pattern and deletes every match, one key per command.</summary>
+    private static async Task ScanAndDeleteAsync(
+        IDatabase db,
+        IServer server,
+        string pattern,
+        CancellationToken cancellationToken)
+    {
+        // Deletes go out one key at a time. Under Redis cluster policy a multi-key DEL must not span
+        // hash slots, and StackExchange.Redis answers a cross-slot multi-key command by throwing, so
+        // batching the keys of a prefix (which hash to arbitrary slots) would fault the invalidation
+        // instead of speeding it up. Single-key deletes are always slot-safe; the round-trip count
+        // stays bounded by keeping a group of them in flight and awaiting the group.
+        var pending = new List<Task<bool>>(DeleteBatchSize);
+
+        await foreach (var key in server.KeysAsync(pattern: pattern)
+            .WithCancellation(cancellationToken)
+            .ConfigureAwait(false))
+        {
+            pending.Add(db.KeyDeleteAsync(key));
+            if (pending.Count == DeleteBatchSize)
+            {
+                await Task.WhenAll(pending).ConfigureAwait(false);
+                pending.Clear();
             }
         }
 
-        if (batch.Count > 0)
-            await db.KeyDeleteAsync([.. batch]).ConfigureAwait(false);
+        if (pending.Count > 0)
+            await Task.WhenAll(pending).ConfigureAwait(false);
     }
+
+    /// <summary>Stable identifier for a server in log output, tolerating an unknown endpoint.</summary>
+    private static string Describe(IServer server) =>
+        server.EndPoint?.ToString() ?? "unknown";
 
     /// <inheritdoc />
     /// <remarks>
@@ -136,6 +189,9 @@ internal sealed partial class DistributedCacheService(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation is a no-op: no IConnectionMultiplexer is registered, so cached entries are bounded only by their TTL. Register a Redis client (AddRedisClient) to enable prefix eviction.")]
     private static partial void LogPrefixEvictionNoMultiplexer(ILogger logger);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation skipped for prefix '{Prefix}': the connection multiplexer reports no servers.")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation skipped for prefix '{Prefix}': the connection multiplexer reports no non-replica servers.")]
     private static partial void LogPrefixEvictionNoServer(ILogger logger, string prefix);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation failed on server '{Server}' for prefix '{Prefix}'; the remaining servers are still processed, so entries on this one are bounded only by their TTL.")]
+    private static partial void LogPrefixEvictionServerFailed(ILogger logger, string server, string prefix, Exception exception);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/MemoryCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/MemoryCacheService.cs
@@ -1,22 +1,41 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Caching.Memory;
 using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Shared.Concurrency;
 
 namespace MMCA.Common.Infrastructure.Caching;
 
 /// <summary>
 /// In-process cache backed by <see cref="IMemoryCache"/>. Tracks all active cache keys
 /// in a <see cref="ConcurrentDictionary{TKey,TValue}"/> to support
-/// <see cref="RemoveByPrefixAsync"/> — a capability <see cref="IMemoryCache"/> lacks natively.
+/// <see cref="RemoveByPrefixAsync"/>, a capability <see cref="IMemoryCache"/> lacks natively.
+/// <para>
+/// The cache and the tracking table are two structures that have to agree, so every mutation of a
+/// key takes that key's stripe from <see cref="KeyedSemaphoreStripe"/> and touches the cache before
+/// the table. See the invariant note on <see cref="SetAsync{T}"/>.
+/// </para>
 /// </summary>
 internal sealed class MemoryCacheService(IMemoryCache cache) : ICacheService
 {
     /// <summary>
     /// Tracks active cache keys. <see cref="IMemoryCache"/> has no key enumeration API,
-    /// so this dictionary enables prefix-based bulk removal. The byte value is unused (set-like usage).
-    /// Keys are automatically removed via the post-eviction callback when entries expire or are evicted.
+    /// so this dictionary enables prefix-based bulk removal. Keys are removed here again by the
+    /// post-eviction callback when entries expire or are evicted.
+    /// <para>
+    /// The value is the tracking token of the cache entry the record belongs to: a plain object
+    /// compared by reference. It exists so a post-eviction callback, which runs asynchronously and
+    /// therefore after its entry may already have been superseded, can remove only its OWN record
+    /// and never the record of a newer live entry.
+    /// </para>
     /// </summary>
-    private readonly ConcurrentDictionary<string, byte> _keys = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, object> _keys = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Serializes the paired mutation of the cache and <c>_keys</c> for one key. Per instance rather
+    /// than static: the tracking table belongs to this service instance, so two instances have
+    /// nothing to serialize against each other.
+    /// </summary>
+    private readonly KeyedSemaphoreStripe _keyLocks = new();
 
     /// <inheritdoc />
     public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
@@ -33,7 +52,16 @@ internal sealed class MemoryCacheService(IMemoryCache cache) : ICacheService
     }
 
     /// <inheritdoc />
-    public Task SetAsync<T>(
+    /// <remarks>
+    /// Establishes the invariant the whole class rests on: the cache entry and its tracking record
+    /// are written under the key's stripe, cache first and <c>_keys</c> second, and every other
+    /// mutating member uses that same lock and that same order. Ordering alone cannot fix this.
+    /// Track-then-write lets a concurrent removal drop the tracking record between the two steps and
+    /// leave a live entry nothing can find; write-then-track lets a removal run entirely between
+    /// them and leave the same orphan. Only mutual exclusion removes the window, after which no
+    /// observer can see a cached entry that <c>_keys</c> does not track.
+    /// </remarks>
+    public async Task SetAsync<T>(
         string key,
         T value,
         TimeSpan? expiration = null,
@@ -46,44 +74,66 @@ internal sealed class MemoryCacheService(IMemoryCache cache) : ICacheService
             options.AbsoluteExpirationRelativeToNow = expiration;
         }
 
+        // Identity of THIS entry's tracking record, handed to the callback as its state.
+        var token = new object();
+
         // Keep _keys in sync: remove the key when evicted (expiration, capacity pressure, or manual
-        // removal). Replacement is deliberately excluded. IMemoryCache queues post-eviction
-        // callbacks to the thread pool, so overwriting a live key fires the OLD entry's callback
-        // asynchronously; it could land after the TryAdd below and delete the tracking record for
-        // the entry that just replaced it. The entry would then be live in the cache but invisible
-        // to RemoveByPrefixAsync, leaving a stale value that only its TTL could clear.
-        options.RegisterPostEvictionCallback((evictedKey, _, reason, _) =>
+        // removal). This callback stays deliberately LOCK-FREE. IMemoryCache queues it to the thread
+        // pool, and waiting on a stripe from a pool thread would stall the pool behind whichever
+        // caller holds it.
+        //
+        // It therefore runs after the fact, when the key may already carry a NEWER live entry, so it
+        // removes the record only while the record is still its own (token compared by reference).
+        // Untracking a live entry is the state that must never happen: the entry stays in the cache
+        // but is invisible to RemoveByPrefixAsync, a stale value only its TTL could clear.
+        //
+        // Replacement keeps its own exclusion in front of that check. Overwriting a live key fires
+        // the OLD entry's callback, and the token for the replacement is published a moment later,
+        // so the cheap reason test settles the common case without depending on the ordering at all.
+        options.RegisterPostEvictionCallback(
+            (evictedKey, _, reason, state) =>
+            {
+                if (reason != EvictionReason.Replaced)
+                    _keys.TryRemove(new KeyValuePair<string, object>(evictedKey.ToString()!, state!));
+            },
+            token);
+
+        using (await _keyLocks.AcquireAsync(key, cancellationToken).ConfigureAwait(false))
         {
-            if (reason != EvictionReason.Replaced)
-                _keys.TryRemove(evictedKey.ToString()!, out _);
-        });
-
-        // Track before writing so a concurrent RemoveByPrefixAsync cannot observe a cached entry
-        // that is not yet in the table.
-        _keys.TryAdd(key, 0);
-        cache.Set(key, value, options);
-
-        return Task.CompletedTask;
+            cache.Set(key, value, options);
+            _keys[key] = token;
+        }
     }
 
     /// <inheritdoc />
-    public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    /// <remarks>Same stripe and same order as <see cref="SetAsync{T}"/>: cache, then <c>_keys</c>.</remarks>
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
     {
-        cache.Remove(key);
-        _keys.TryRemove(key, out _);
-
-        return Task.CompletedTask;
-    }
-
-    /// <inheritdoc />
-    public Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
-    {
-        foreach (var key in _keys.Keys.Where(k => k.StartsWith(prefix, StringComparison.Ordinal)))
+        using (await _keyLocks.AcquireAsync(key, cancellationToken).ConfigureAwait(false))
         {
             cache.Remove(key);
             _keys.TryRemove(key, out _);
         }
+    }
 
-        return Task.CompletedTask;
+    /// <inheritdoc />
+    /// <remarks>
+    /// The candidate list is a snapshot (<see cref="ConcurrentDictionary{TKey,TValue}.Keys"/> already
+    /// copies), so it is enumerated outside every lock. Each key is then removed under its own stripe,
+    /// one at a time, and the stripe is released before the next one is taken. Handles are never
+    /// accumulated across the loop: distinct keys can map to the same stripe and to different stripes
+    /// in a different relative order, so holding several at once would let two prefix removals block
+    /// on each other's stripes and deadlock.
+    /// </remarks>
+    public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+    {
+        foreach (var key in _keys.Keys.Where(k => k.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            using (await _keyLocks.AcquireAsync(key, cancellationToken).ConfigureAwait(false))
+            {
+                cache.Remove(key);
+                _keys.TryRemove(key, out _);
+            }
+        }
     }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Concurrency/InProcessDistributedLock.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Concurrency/InProcessDistributedLock.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces;
+
+namespace MMCA.Common.Infrastructure.Concurrency;
+
+/// <summary>
+/// In-process fallback <see cref="IDistributedLock"/> for hosts with no Redis connection
+/// registered. Serializes callers inside this process only.
+/// <para>
+/// This is the degraded mode, and it is logged once so it is visible rather than silent: with more
+/// than one replica each gets its own instance of this lock, so the guarded section still runs once
+/// per replica. It is correct for a single-replica deployment, for local development, and for tests.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Keyed on the exact key rather than on hashed stripes
+/// (<see cref="MMCA.Common.Shared.Concurrency.KeyedSemaphoreStripe"/>): stripes let two unrelated
+/// keys share a semaphore, which is harmless for a caller that waits indefinitely but not for this
+/// contract, where a bounded wait turns that false sharing into a spurious "held elsewhere" answer
+/// for a key nobody holds. The held-key table is bounded by the number of locks held right now, not
+/// by how many distinct keys the process has ever seen, because entries are removed on release.
+/// </para>
+/// <para>
+/// <c>ttl</c> is accepted and ignored. It exists to bound a holder that died without releasing;
+/// here the holder is a task in this process, and if the process dies the table dies with it.
+/// </para>
+/// </remarks>
+internal sealed partial class InProcessDistributedLock(ILogger<InProcessDistributedLock> logger) : IDistributedLock
+{
+    /// <summary>Gap between acquisition attempts while waiting for a holder to release.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(25);
+
+    private readonly ConcurrentDictionary<string, byte> _held = new(StringComparer.Ordinal);
+
+    /// <summary>Set once (via <see cref="Interlocked"/>) after the degradation is logged, so a steady state warns once rather than on every request.</summary>
+    private int _degradationWarned;
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable?> TryAcquireAsync(
+        string key,
+        TimeSpan ttl,
+        TimeSpan wait,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(ttl, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(wait, TimeSpan.Zero);
+
+        if (Interlocked.Exchange(ref _degradationWarned, 1) == 0)
+        {
+            LogProcessLocalLocking(logger);
+        }
+
+        var startedAt = Stopwatch.GetTimestamp();
+
+        while (true)
+        {
+            if (_held.TryAdd(key, 0))
+            {
+                return new InProcessLockHandle(_held, key);
+            }
+
+            if (Stopwatch.GetElapsedTime(startedAt) >= wait)
+            {
+                return null;
+            }
+
+            await Task.Delay(PollInterval, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Distributed locking is process-local: no IConnectionMultiplexer is registered, so a critical section guarded by IDistributedLock still runs once per replica. Register a Redis client (AddRedisClient) to make it exclusive across replicas.")]
+    private static partial void LogProcessLocalLocking(ILogger logger);
+
+    /// <summary>Releases exactly the acquisition it was created for, once.</summary>
+    private sealed class InProcessLockHandle(ConcurrentDictionary<string, byte> held, string key) : IAsyncDisposable
+    {
+        private int _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                held.TryRemove(key, out _);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Concurrency/RedisDistributedLock.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Concurrency/RedisDistributedLock.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Caching;
+using StackExchange.Redis;
+
+namespace MMCA.Common.Infrastructure.Concurrency;
+
+/// <summary>
+/// Redis-backed <see cref="IDistributedLock"/>: the standard <c>SET key token NX PX ttl</c> lock.
+/// <para>
+/// Acquisition is a single atomic <c>SET</c> with <see cref="When.NotExists"/> and an expiry, so
+/// exactly one replica can win a key, and a holder that crashes releases it by expiry rather than
+/// wedging it forever. Release runs a compare-and-delete script against the owner token, so a
+/// caller whose TTL already lapsed cannot delete the entry a different replica now owns.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Single-instance semantics deliberately: this is the one-Redis lock, not Redlock. It inherits
+/// Redis's failover behavior, which is why <see cref="IDistributedLock"/> is documented as
+/// best-effort.
+/// </remarks>
+internal sealed partial class RedisDistributedLock(
+    IConnectionMultiplexer connectionMultiplexer,
+    ILogger<RedisDistributedLock> logger,
+    CacheKeyNamespace? keyNamespace = null) : IDistributedLock
+{
+    /// <summary>Keyspace prefix, so locks cannot collide with cache entries in a shared instance.</summary>
+    private const string KeyPrefix = "lock:";
+
+    /// <summary>
+    /// Compare-and-delete. Deleting without the comparison would let a caller whose lock already
+    /// expired free the next holder's lock, which is exactly the double-execution this prevents.
+    /// </summary>
+    private const string ReleaseScript =
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+
+    /// <summary>Gap between acquisition attempts while waiting for a holder to release.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(50);
+
+    private readonly CacheKeyNamespace _keys = keyNamespace ?? CacheKeyNamespace.None;
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable?> TryAcquireAsync(
+        string key,
+        TimeSpan ttl,
+        TimeSpan wait,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(ttl, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(wait, TimeSpan.Zero);
+
+        RedisKey redisKey = _keys.Qualify(string.Concat(KeyPrefix, key));
+
+        // Random per acquisition: the release script matches on it, which is what makes a release
+        // owner-scoped instead of "delete whatever is there now".
+        RedisValue token = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+
+        IDatabase database = connectionMultiplexer.GetDatabase();
+        var startedAt = Stopwatch.GetTimestamp();
+
+        while (true)
+        {
+            var acquired = await database
+                .StringSetAsync(redisKey, token, ttl, keepTtl: false, When.NotExists, CommandFlags.None)
+                .ConfigureAwait(false);
+
+            if (acquired)
+            {
+                return new RedisLockHandle(database, redisKey, token, logger);
+            }
+
+            if (Stopwatch.GetElapsedTime(startedAt) >= wait)
+            {
+                return null;
+            }
+
+            await Task.Delay(PollInterval, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Distributed lock '{Key}' had already expired when its holder released it: the guarded section ran longer than the lock's time-to-live and was not exclusive for all of it.")]
+    private static partial void LogLockAlreadyExpired(ILogger logger, string key);
+
+    /// <summary>Releases exactly the acquisition it was created for, once.</summary>
+    private sealed class RedisLockHandle(
+        IDatabase database,
+        RedisKey key,
+        RedisValue token,
+        ILogger logger) : IAsyncDisposable
+    {
+        private int _released;
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _released, 1) != 0)
+            {
+                return;
+            }
+
+            RedisResult result = await database
+                .ScriptEvaluateAsync(ReleaseScript, [key], [token], CommandFlags.None)
+                .ConfigureAwait(false);
+
+            // 0 means the key was gone or held by someone else, i.e. this holder's TTL lapsed
+            // mid-section. Nothing to release, but worth surfacing: the section was not exclusive.
+            if ((long)result == 0)
+            {
+                LogLockAlreadyExpired(logger, key.ToString());
+            }
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -15,6 +15,7 @@ using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Messaging;
 using MMCA.Common.Infrastructure.Auth;
 using MMCA.Common.Infrastructure.Caching;
+using MMCA.Common.Infrastructure.Concurrency;
 using MMCA.Common.Infrastructure.Http;
 using MMCA.Common.Infrastructure.Persistence;
 using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration;
@@ -171,6 +172,26 @@ public static class DependencyInjection
 
                 // In-process: the keyspace is private to this process, so no prefix is needed.
                 return new MemoryCacheService(sp.GetRequiredService<IMemoryCache>());
+            });
+
+            // Cross-replica mutual exclusion, registered alongside the cache because its one
+            // in-framework caller (the API idempotency filter) pairs the two: the lock guards the
+            // execute-then-store window that the cache entry closes. Redis when a multiplexer is
+            // registered, process-local (and warn-once) otherwise, mirroring the cache above.
+            services.TryAddSingleton<IDistributedLock>(sp =>
+            {
+                var multiplexer = sp.GetService<IConnectionMultiplexer>();
+                if (multiplexer is not null)
+                {
+                    var redisLogger = sp.GetService<ILogger<RedisDistributedLock>>()
+                        ?? NullLogger<RedisDistributedLock>.Instance;
+                    var keyNamespace = CacheKeyNamespace.From(sp.GetService<IOptions<CacheKeyPrefixOptions>>());
+                    return new RedisDistributedLock(multiplexer, redisLogger, keyNamespace);
+                }
+
+                var fallbackLogger = sp.GetService<ILogger<InProcessDistributedLock>>()
+                    ?? NullLogger<InProcessDistributedLock>.Instance;
+                return new InProcessDistributedLock(fallbackLogger);
             });
 
             return services;

--- a/Source/Core/MMCA.Common.Infrastructure/Services/AzureNotificationHubDeviceRegistrar.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/AzureNotificationHubDeviceRegistrar.cs
@@ -72,10 +72,48 @@ public sealed class AzureNotificationHubDeviceRegistrar(
         catch (MessagingException ex)
         {
             logger.LogError(ex, "Device installation delete failed");
-            return Result.Failure(Error.Failure(
-                code: "PushDevice.DeleteFailed",
-                message: "The device could not be unregistered from push notifications.",
-                source: nameof(AzureNotificationHubDeviceRegistrar)));
+            return DeleteFailed();
         }
     }
+
+    /// <inheritdoc />
+    public async Task<Result> DeleteAsync(UserIdentifierType userId, string installationId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // The hub is the only ownership store: the installation's tags carry the
+            // user:{id} stamp written by UpsertAsync, so read-then-delete is the check.
+            // A concurrent re-registration of the same id between the two calls is the
+            // owner's own doing, so no lock is warranted.
+            Installation installation = await hubClient.GetInstallationAsync(installationId, cancellationToken).ConfigureAwait(false);
+            if (!OwnedBy(installation, userId))
+            {
+                // Someone else's installation (or one registered before ownership tagging).
+                // Reported as success: see the interface remarks on the existence oracle.
+                return Result.Success();
+            }
+
+            await hubClient.DeleteInstallationAsync(installationId, cancellationToken).ConfigureAwait(false);
+            return Result.Success();
+        }
+        catch (MessagingEntityNotFoundException)
+        {
+            // Idempotent delete: an unknown installation is already the desired state.
+            return Result.Success();
+        }
+        catch (MessagingException ex)
+        {
+            logger.LogError(ex, "Device installation delete failed");
+            return DeleteFailed();
+        }
+    }
+
+    private static bool OwnedBy(Installation installation, UserIdentifierType userId) =>
+        installation.Tags is { } tags && tags.Contains(NativePushPayloads.UserTag(userId), StringComparer.Ordinal);
+
+    private static Result DeleteFailed() =>
+        Result.Failure(Error.Failure(
+            code: "PushDevice.DeleteFailed",
+            message: "The device could not be unregistered from push notifications.",
+            source: nameof(AzureNotificationHubDeviceRegistrar)));
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Services/NullPushDeviceRegistrar.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/NullPushDeviceRegistrar.cs
@@ -18,4 +18,8 @@ public sealed class NullPushDeviceRegistrar : IPushDeviceRegistrar
     /// <inheritdoc />
     public Task<Result> DeleteAsync(string installationId, CancellationToken cancellationToken = default) =>
         Task.FromResult(Result.Success());
+
+    /// <inheritdoc />
+    public Task<Result> DeleteAsync(UserIdentifierType userId, string installationId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(Result.Success());
 }

--- a/Source/Core/MMCA.Common.Shared/Extensions/DomainHelper.cs
+++ b/Source/Core/MMCA.Common.Shared/Extensions/DomainHelper.cs
@@ -18,6 +18,15 @@ public static class DomainHelper
         /// <typeparam name="TIdentifier">The target identifier type to parse into.</typeparam>
         /// <returns>The parsed identifier value, or the type's default for null/invalid input.</returns>
         /// <exception cref="FormatException">Thrown when <typeparamref name="TIdentifier"/> is not a supported type.</exception>
+        /// <remarks>
+        /// This overload coerces by design: malformed input is indistinguishable from a legitimate
+        /// default value (<c>"maybe"</c> and <c>"false"</c> both yield <see langword="false"/> for
+        /// <see cref="bool"/>, an unrecognized enum name yields the enum default, and <c>"abc"</c>
+        /// yields <c>0</c> for numeric identifiers). That is the intended behavior for route
+        /// identifiers, where an unparsable value degrades to a not-found lookup. When malformed
+        /// input must be distinguished from a legitimate default (<see cref="bool"/> and enum
+        /// callers especially), use <c>TryParse&lt;TIdentifier&gt;(out TIdentifier)</c> instead.
+        /// </remarks>
         public TIdentifier Parse<TIdentifier>()
         {
             var type = typeof(TIdentifier);
@@ -29,6 +38,40 @@ public static class DomainHelper
                 return default!;
 
             return ParseNonEmpty<TIdentifier>(id, type);
+        }
+
+        /// <summary>
+        /// Attempts to parse this string into the target identifier type, reporting success instead
+        /// of coercing malformed input to a default value. Supports the same identifier types as
+        /// <c>Parse&lt;TIdentifier&gt;()</c>.
+        /// </summary>
+        /// <typeparam name="TIdentifier">The target identifier type to parse into.</typeparam>
+        /// <param name="result">
+        /// When this method returns <see langword="true"/>, the parsed value; otherwise the type's
+        /// default (<see cref="string.Empty"/> for <see cref="string"/>).
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> when the value parsed; <see langword="false"/> for null, empty,
+        /// whitespace-only, or malformed input.
+        /// </returns>
+        /// <exception cref="FormatException">Thrown when <typeparamref name="TIdentifier"/> is not a supported type.</exception>
+        public bool TryParse<TIdentifier>(out TIdentifier result)
+        {
+            var type = typeof(TIdentifier);
+
+            if (type == typeof(string))
+            {
+                result = (TIdentifier)(object)(id ?? string.Empty);
+                return id is not null;
+            }
+
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                result = default!;
+                return false;
+            }
+
+            return TryParseNonEmpty(id, type, out result);
         }
     }
 
@@ -59,6 +102,66 @@ public static class DomainHelper
 
         if (type.IsEnum)
             return Enum.TryParse(type, id, ignoreCase: true, out var enumValue) ? (TIdentifier)enumValue : default!;
+
+        throw new FormatException($"Unsupported identifier type: {type.FullName}");
+    }
+
+    // Called from extension(string? id).TryParse<T>(out T): IDE0051 false positive with preview extension types
+#pragma warning disable IDE0051
+    private static bool TryParseNonEmpty<TIdentifier>(string id, Type type, out TIdentifier result)
+#pragma warning restore IDE0051
+    {
+        if (type == typeof(Guid))
+        {
+            var parsed = Guid.TryParse(id, out var g);
+            result = (TIdentifier)(object)g;
+            return parsed;
+        }
+
+        if (type == typeof(int))
+        {
+            var parsed = int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i);
+            result = (TIdentifier)(object)i;
+            return parsed;
+        }
+
+        if (type == typeof(long))
+        {
+            var parsed = long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l);
+            result = (TIdentifier)(object)l;
+            return parsed;
+        }
+
+        return TryParseOtherTypes(id, type, out result);
+    }
+
+    private static bool TryParseOtherTypes<TIdentifier>(string id, Type type, out TIdentifier result)
+    {
+        if (type == typeof(ulong))
+        {
+            var parsed = ulong.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ul);
+            result = (TIdentifier)(object)ul;
+            return parsed;
+        }
+
+        if (type == typeof(bool))
+        {
+            var parsed = bool.TryParse(id, out var b);
+            result = (TIdentifier)(object)b;
+            return parsed;
+        }
+
+        if (type.IsEnum)
+        {
+            if (Enum.TryParse(type, id, ignoreCase: true, out var enumValue))
+            {
+                result = (TIdentifier)enumValue;
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
 
         throw new FormatException($"Unsupported identifier type: {type.FullName}");
     }

--- a/Source/Core/MMCA.Common.Shared/ValueObjects/Currency.cs
+++ b/Source/Core/MMCA.Common.Shared/ValueObjects/Currency.cs
@@ -60,16 +60,25 @@ public sealed record Currency : ValueObject
 
 /// <summary>
 /// Serializes <see cref="Currency"/> as its ISO 4217 code string in JSON.
-/// Deserialization validates the code against <see cref="Currency.All"/>.
+/// Deserialization validates the code against <see cref="Currency.All"/>; a non-string token
+/// (number, object, array, boolean) and an unknown code both throw <see cref="JsonException"/>,
+/// matching the API-layer converter so non-MVC paths (cache, outbox, integration events,
+/// typed HttpClient calls) fail the same way MVC model binding does.
 /// </summary>
+/// <remarks>
+/// <see cref="JsonConverter{T}.HandleNull"/> is left at its default (<see langword="false"/>),
+/// so the serializer short-circuits a JSON null token before this converter runs and nullable
+/// <c>Currency?</c> / <c>Money?</c> members keep deserializing to <see langword="null"/>.
+/// </remarks>
 public sealed class CurrencyJsonConverter : JsonConverter<Currency>
 {
     /// <inheritdoc />
     public override Currency? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var code = reader.GetString();
-        if (code is null)
-            return null;
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException("Currency must be a string.");
+
+        string code = reader.GetString() ?? string.Empty;
 
         var result = Currency.FromCode(code);
         if (result.IsFailure)

--- a/Source/Core/MMCA.Common.Shared/ValueObjects/Money.cs
+++ b/Source/Core/MMCA.Common.Shared/ValueObjects/Money.cs
@@ -34,9 +34,22 @@ public sealed record Money : ValueObject
     /// <summary>Gets a value indicating whether the amount is less than zero.</summary>
     public bool IsNegative => Amount < 0;
 
+    /// <summary>
+    /// Round-trip constructor: used by System.Text.Json and by EF Core when it materializes the
+    /// owned type. Every round-trip must supply a currency, because "no currency" is represented by
+    /// the <see cref="ValueObjects.Currency.None"/> sentinel and never by <see langword="null"/>.
+    /// A materializer that can yield <see langword="null"/> (a JSON payload omitting the currency
+    /// property, or an EF value converter that maps an unknown code to <see langword="null"/>) is a
+    /// broken contract, so it fails fast here instead of surfacing later as a null reference.
+    /// </summary>
+    /// <param name="amount">The monetary amount.</param>
+    /// <param name="currency">The currency; <see cref="ValueObjects.Currency.None"/> for a currency-less zero.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="currency"/> is <see langword="null"/>.</exception>
     [JsonConstructor]
     private Money(decimal amount, Currency currency)
     {
+        ArgumentNullException.ThrowIfNull(currency);
+
         Amount = amount;
         Currency = currency;
     }

--- a/Source/Presentation/MMCA.Common.API/Controllers/Notifications/DevicesController.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/Notifications/DevicesController.cs
@@ -44,14 +44,27 @@ public sealed class DevicesController(
         return result.IsFailure ? HandleFailure(result.Errors) : NoContent();
     }
 
-    /// <summary>Removes a device installation (DELETE /Notifications/Devices/{installationId}). Idempotent.</summary>
+    /// <summary>
+    /// Removes a device installation (DELETE /Notifications/Devices/{installationId}). Idempotent,
+    /// and scoped to the caller: the id comes from the client, so the registrar verifies the
+    /// installation's owner tag before deleting. An id that does not exist and an id belonging to
+    /// another user both answer 204 without deleting anything, so the response cannot be used to
+    /// probe for other users' installation ids.
+    /// </summary>
     [HttpDelete("{installationId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
     public async Task<ActionResult> DeleteAsync(
         string installationId,
         CancellationToken cancellationToken = default)
     {
-        Result result = await registrar.DeleteAsync(installationId, cancellationToken).ConfigureAwait(false);
+        UserIdentifierType? userId = currentUserService.UserId;
+        if (!userId.HasValue)
+        {
+            return HandleFailure([Error.Unauthorized("PushDevice.Unauthorized", "User is not authenticated.")]);
+        }
+
+        Result result = await registrar.DeleteAsync(userId.Value, installationId, cancellationToken).ConfigureAwait(false);
         return result.IsFailure ? HandleFailure(result.Errors) : NoContent();
     }
 }

--- a/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyFilter.cs
+++ b/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyFilter.cs
@@ -18,16 +18,21 @@ namespace MMCA.Common.API.Idempotency;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Uses a double-check locking pattern with per-key <see cref="SemaphoreSlim"/> instances to prevent
-/// concurrent duplicate execution when multiple requests arrive with the same idempotency key
-/// before the first completes. The flow is:
+/// Uses a double-check locking pattern to prevent concurrent duplicate execution when multiple
+/// requests arrive with the same idempotency key before the first completes. The flow is:
 /// </para>
 /// <list type="number">
 ///   <item>Check cache (fast path, no lock)</item>
-///   <item>Acquire per-key semaphore</item>
+///   <item>Acquire the key's lock</item>
 ///   <item>Re-check cache (another request may have completed while waiting)</item>
 ///   <item>Execute the action and cache the result</item>
 /// </list>
+/// <para>
+/// The lock is an <see cref="IDistributedLock"/> when the host registers one, because a per-process
+/// lock only serializes duplicates that land on the same replica, and both deployed apps run more
+/// than one. Hosts without one fall back to the per-process
+/// <see cref="KeyedSemaphoreStripe"/> below, which is correct for a single replica.
+/// </para>
 /// <para>
 /// Replayed responses include the <c>X-Idempotent-Replay: true</c> header so clients can
 /// distinguish cached responses from original executions.
@@ -58,18 +63,33 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
     private static readonly TimeSpan DefaultExpiration = TimeSpan.FromHours(24);
 
     /// <summary>
-    /// Serializes concurrent requests that map to the same cache key. Striped rather than
-    /// one-semaphore-per-key: the key embeds a caller-supplied value, so a per-key table would
-    /// either grow without bound or need an eager removal that races (a removal between another
-    /// request's lookup and its wait lets a third request create a fresh semaphore, and both
-    /// then execute concurrently, which is exactly what this lock exists to prevent).
+    /// Serializes concurrent requests that map to the same cache key when no
+    /// <see cref="IDistributedLock"/> is registered. Striped rather than one-semaphore-per-key: the
+    /// key embeds a caller-supplied value, so a per-key table would either grow without bound or
+    /// need an eager removal that races (a removal between another request's lookup and its wait
+    /// lets a third request create a fresh semaphore, and both then execute concurrently, which is
+    /// exactly what this lock exists to prevent).
     /// </summary>
     private static readonly KeyedSemaphoreStripe KeyLocks = new();
+
+    /// <summary>
+    /// How long the distributed lock survives without release. Generous relative to a normal
+    /// request so a slow action still finishes under its own lock, and short enough that a replica
+    /// killed mid-action does not block the client's retry for long.
+    /// </summary>
+    private static readonly TimeSpan LockTimeToLive = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How long to wait for another replica to finish the same key before giving up. Sized to cover
+    /// a typical action's duration: a duplicate that arrives while the original is still running
+    /// usually waits this out and replays the stored response instead of being told to retry.
+    /// </summary>
+    private static readonly TimeSpan LockWait = TimeSpan.FromSeconds(5);
 
     /// <inheritdoc />
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        // No idempotency key header — execute normally without deduplication
+        // No idempotency key header: execute normally without deduplication
         if (!context.HttpContext.Request.Headers.TryGetValue(IdempotencyKeyHeader, out var keyValues)
             || string.IsNullOrWhiteSpace(keyValues.ToString()))
         {
@@ -84,22 +104,120 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
         if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
             return;
 
-        // Slow path: acquire the key's stripe to serialize concurrent duplicates
+        // Slow path. The lock has to span execute-and-store, so a duplicate cannot slip in between
+        // the action finishing and its response reaching the cache.
+        var distributedLock = context.HttpContext.RequestServices.GetService<IDistributedLock>();
+        if (distributedLock is null)
+        {
+            await ExecuteUnderProcessLockAsync(context, next, cache, cacheKey).ConfigureAwait(false);
+            return;
+        }
+
+        await ExecuteUnderDistributedLockAsync(context, next, cache, cacheKey, distributedLock).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the guarded section under the per-process stripe. Used when the host registers no
+    /// <see cref="IDistributedLock"/>, which is the whole of a single-replica or test host.
+    /// </summary>
+    private static async Task ExecuteUnderProcessLockAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next,
+        ICacheService cache,
+        string cacheKey)
+    {
         using (await KeyLocks.AcquireAsync(cacheKey, context.HttpContext.RequestAborted).ConfigureAwait(false))
         {
             // Double-check: another request may have completed and cached while we waited
             if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
                 return;
 
-            var executedContext = await next().ConfigureAwait(false);
-            await TryStoreAsync(context, cache, cacheKey, executedContext).ConfigureAwait(false);
+            await ExecuteAndStoreAsync(context, next, cache, cacheKey).ConfigureAwait(false);
         }
     }
+
+    /// <summary>
+    /// Runs the guarded section under a lock every replica can see.
+    /// </summary>
+    /// <remarks>
+    /// The per-process stripe this replaces only serializes duplicates that land on the SAME
+    /// replica. Both deployed apps run at least two, so two duplicates that land on different
+    /// replicas both missed the cache, both executed, and the second overwrote the first's stored
+    /// response: the exact double execution the filter exists to prevent.
+    /// <para>
+    /// When the lock is held elsewhere, the holder is executing this same key right now. Waiting it
+    /// out and replaying its stored response is the good outcome and the common one. If the wait
+    /// expires with nothing stored, the action is still running (or its replica died), and the only
+    /// two options left are to execute concurrently, which is the defect, or to tell the client the
+    /// request is in flight. It gets 409 Conflict, which is retryable and honest, rather than a
+    /// duplicate write.
+    /// </para>
+    /// </remarks>
+    private static async Task ExecuteUnderDistributedLockAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next,
+        ICacheService cache,
+        string cacheKey,
+        IDistributedLock distributedLock)
+    {
+        IAsyncDisposable? handle = await distributedLock
+            .TryAcquireAsync(cacheKey, LockTimeToLive, LockWait, context.HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (handle is null)
+        {
+            if (!await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
+                context.Result = InFlightDuplicateResult();
+
+            return;
+        }
+
+        await using (handle.ConfigureAwait(false))
+        {
+            // Double-check: the previous holder may have completed and cached while we waited
+            if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
+                return;
+
+            await ExecuteAndStoreAsync(context, next, cache, cacheKey).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Executes the action and caches its response.</summary>
+    private static async Task ExecuteAndStoreAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next,
+        ICacheService cache,
+        string cacheKey)
+    {
+        var executedContext = await next().ConfigureAwait(false);
+        await TryStoreAsync(context, cache, cacheKey, executedContext).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The response for a duplicate whose original is still executing on another replica. Deliberately
+    /// not a replay: there is nothing stored yet, and executing would duplicate the write.
+    /// </summary>
+    private static ObjectResult InFlightDuplicateResult() =>
+        new(new ProblemDetails
+        {
+            Status = StatusCodes.Status409Conflict,
+            Title = "Request in progress",
+            Detail = "A request with this Idempotency-Key is still being processed. Retry with the same key to receive its response.",
+        })
+        {
+            StatusCode = StatusCodes.Status409Conflict,
+        };
 
     /// <summary>
     /// Serves the cached response for <paramref name="cacheKey"/> when one exists, returning
     /// whether the request was short-circuited.
     /// </summary>
+    /// <remarks>
+    /// A stored record with an empty body came from a body-less result (204, or a bare status code),
+    /// so it replays as a plain status code. Answering it as a <see cref="ContentResult"/> with
+    /// <c>application/json</c> would put a content type on a response with no content, which the
+    /// original did not have.
+    /// </remarks>
     private static async Task<bool> TryReplayAsync(
         ActionExecutingContext context,
         ICacheService cache,
@@ -110,41 +228,42 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
             return false;
 
         context.HttpContext.Response.Headers.Append("X-Idempotent-Replay", "true");
-        context.Result = new ContentResult
-        {
-            StatusCode = cached.StatusCode,
-            Content = cached.ResponseBody,
-            ContentType = "application/json"
-        };
+        context.Result = string.IsNullOrEmpty(cached.ResponseBody)
+            ? new StatusCodeResult(cached.StatusCode)
+            : new ContentResult
+            {
+                StatusCode = cached.StatusCode,
+                Content = cached.ResponseBody,
+                ContentType = "application/json"
+            };
 
         return true;
     }
 
     /// <summary>
-    /// Caches the executed response when it is a successful <see cref="ObjectResult"/>.
+    /// Caches the executed response when it is successful and representable as a status code plus an
+    /// optional JSON body: an <see cref="ObjectResult"/> (which covers 200/201/202 with a payload)
+    /// or a body-less <see cref="StatusCodeResult"/> such as the 204 from <c>NoContent()</c>.
     /// Non-2xx results are deliberately not stored: replaying a failure for the whole retention
     /// window would mean a client retrying the same key after a transient 500 keeps receiving that
     /// 500 for 24 hours instead of the retry actually executing. Redirects and file results are
     /// skipped because the record carries only a status code and a JSON body.
     /// </summary>
+    /// <remarks>
+    /// The 204 case was previously skipped, which left every command that answers <c>NoContent()</c>
+    /// with no stored response at all: a duplicate re-executed the action instead of replaying, so
+    /// the endpoints most likely to be retried (the body-less writes) were the ones idempotency did
+    /// not actually cover.
+    /// </remarks>
     private static async Task TryStoreAsync(
         ActionExecutingContext context,
         ICacheService cache,
         string cacheKey,
         ActionExecutedContext executedContext)
     {
-        if (executedContext.Result is not ObjectResult objectResult)
+        var record = BuildRecord(executedContext.Result);
+        if (record is null)
             return;
-
-        var statusCode = objectResult.StatusCode ?? StatusCodes.Status200OK;
-        if (statusCode is < 200 or >= 300)
-            return;
-
-#pragma warning disable VSTHRD103 // JsonSerializer.Serialize to a string is correctly synchronous; SerializeAsync is only for writing to a stream.
-        var record = new IdempotencyRecord(
-            statusCode,
-            JsonSerializer.Serialize(objectResult.Value, JsonSerializerOptions.Web));
-#pragma warning restore VSTHRD103
 
         var idempotencySettings = context.HttpContext.RequestServices
             .GetService<IOptions<IdempotencySettings>>();
@@ -154,6 +273,39 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
 
         await cache.SetAsync(cacheKey, record, expiration).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Builds the cacheable snapshot of a result, or <see langword="null"/> when the result is not
+    /// one this record shape can represent.
+    /// </summary>
+    private static IdempotencyRecord? BuildRecord(IActionResult? result)
+    {
+        switch (result)
+        {
+            case ObjectResult objectResult:
+                var objectStatus = objectResult.StatusCode ?? StatusCodes.Status200OK;
+#pragma warning disable VSTHRD103 // JsonSerializer.Serialize to a string is correctly synchronous; SerializeAsync is only for writing to a stream.
+                return IsSuccess(objectStatus)
+                    ? new IdempotencyRecord(
+                        objectStatus,
+                        JsonSerializer.Serialize(objectResult.Value, JsonSerializerOptions.Web))
+                    : null;
+#pragma warning restore VSTHRD103
+
+            // NoContentResult and OkResult are StatusCodeResults, and so is anything from
+            // StatusCode(int). The record's body is non-nullable, so a body-less response stores
+            // the empty string and TryReplayAsync replays it without a content type.
+            case StatusCodeResult statusCodeResult:
+                return IsSuccess(statusCodeResult.StatusCode)
+                    ? new IdempotencyRecord(statusCodeResult.StatusCode, string.Empty)
+                    : null;
+
+            default:
+                return null;
+        }
+    }
+
+    private static bool IsSuccess(int statusCode) => statusCode is >= 200 and < 300;
 
     /// <summary>
     /// Derives the cache key from the caller's identity, the HTTP method, the route template and

--- a/Source/Presentation/MMCA.Common.Grpc/Interceptors/GrpcResultExceptionInterceptor.cs
+++ b/Source/Presentation/MMCA.Common.Grpc/Interceptors/GrpcResultExceptionInterceptor.cs
@@ -34,7 +34,7 @@ public sealed partial class GrpcResultExceptionInterceptor(ILogger<GrpcResultExc
         catch (ResultFailureException ex)
         {
             LogResultFailure(logger, context.Method, ex);
-            throw ex.Errors.ToRpcException();
+            throw ToTransportException(ex);
         }
     }
 
@@ -55,7 +55,7 @@ public sealed partial class GrpcResultExceptionInterceptor(ILogger<GrpcResultExc
         catch (ResultFailureException ex)
         {
             LogResultFailure(logger, context.Method, ex);
-            throw ex.Errors.ToRpcException();
+            throw ToTransportException(ex);
         }
     }
 
@@ -75,7 +75,7 @@ public sealed partial class GrpcResultExceptionInterceptor(ILogger<GrpcResultExc
         catch (ResultFailureException ex)
         {
             LogResultFailure(logger, context.Method, ex);
-            throw ex.Errors.ToRpcException();
+            throw ToTransportException(ex);
         }
     }
 
@@ -96,8 +96,45 @@ public sealed partial class GrpcResultExceptionInterceptor(ILogger<GrpcResultExc
         catch (ResultFailureException ex)
         {
             LogResultFailure(logger, context.Method, ex);
-            throw ex.Errors.ToRpcException();
+            throw ToTransportException(ex);
         }
+    }
+
+    /// <summary>
+    /// Builds the transport exception for a caught <see cref="ResultFailureException"/>, shared by
+    /// all four handler shapes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When the exception carries errors, the standard <c>ToRpcException</c> mapping applies and the
+    /// structured trailers come with it.
+    /// </para>
+    /// <para>
+    /// When it carries none, which is what the message-only constructors produce, that mapping
+    /// answers the placeholder detail "Unspecified failure" and the real
+    /// <see cref="Exception.Message"/> is lost: the caller sees a failure with no cause. Synthesizing
+    /// an <c>Error.Failure</c> to carry the message is not the fix, because <c>ErrorType.Failure</c>
+    /// maps to <see cref="StatusCode.InvalidArgument"/>
+    /// (<c>ResultGrpcExtensions</c>), which would blame the caller for a server-side fault. So the
+    /// empty case keeps <see cref="StatusCode.Internal"/>, the status the shared mapping already
+    /// chooses for an empty list, and replaces only the detail. An inner exception's message is
+    /// appended, since it is usually the one that names the actual cause.
+    /// </para>
+    /// </remarks>
+    /// <param name="exception">The caught result-failure exception.</param>
+    /// <returns>The <see cref="RpcException"/> to surface to the caller.</returns>
+    private static RpcException ToTransportException(ResultFailureException exception)
+    {
+        if (exception.Errors.Count > 0)
+        {
+            return exception.Errors.ToRpcException();
+        }
+
+        var detail = exception.InnerException is null
+            ? exception.Message
+            : string.Concat(exception.Message, ": ", exception.InnerException.Message);
+
+        return new RpcException(new Status(StatusCode.Internal, detail));
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "gRPC method {Method} returned a result failure")]

--- a/Source/Presentation/MMCA.Common.UI/Components/MmcaThemeProviders.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/MmcaThemeProviders.razor
@@ -15,6 +15,7 @@
 
 @code {
     private bool _isDarkMode;
+    private bool _disposed;
 
     protected override void OnInitialized() => ThemeService.OnChange += OnThemeChanged;
 
@@ -29,11 +30,44 @@
         }
     }
 
-    private void OnThemeChanged(object? sender, EventArgs e)
+    // ThemeService.OnChange is raised synchronously, and one scoped ThemeService feeds several
+    // subscribers (this component plus every ThemeToggle placement). Disposal can therefore land
+    // between the event firing and this component's render dispatch: the invocation list is captured
+    // when the event is raised, so a handler still runs after its component is gone. Guarding here
+    // also stops a throw from cutting off the subscribers queued behind this one.
+    private void OnThemeChanged(object? sender, EventArgs e) => _ = RerenderSafeAsync();
+
+    private async Task RerenderSafeAsync()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _isDarkMode = ThemeService.IsDarkMode;
-        InvokeAsync(StateHasChanged);
+
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Component was disposed between event firing and render dispatch.
+        }
+        catch (InvalidOperationException)
+        {
+            // Same race, surfaced by the renderer as a disposed/unavailable dispatcher.
+        }
     }
 
-    public void Dispose() => ThemeService.OnChange -= OnThemeChanged;
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        ThemeService.OnChange -= OnThemeChanged;
+    }
 }

--- a/Source/Presentation/MMCA.Common.UI/Components/MobileInfiniteScrollList.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/MobileInfiniteScrollList.razor.cs
@@ -8,8 +8,10 @@ namespace MMCA.Common.UI.Components;
 
 /// <summary>
 /// Code-behind for the mobile infinite-scroll card list: page fetching via an IntersectionObserver
-/// sentinel, a rendered-item cap bounding DOM growth, cancellation of superseded fetches, and
-/// localized load-failure handling with retry.
+/// sentinel, a rendered-item cap bounding DOM growth, generation-guarded supersession of in-flight
+/// fetches (<see cref="ResetAsync"/> bumps a generation counter AND cancels the outstanding token;
+/// a fetch that completes under a superseded generation discards its results and leaves the page
+/// counter alone), and localized load-failure handling with retry.
 /// </summary>
 /// <typeparam name="TItem">The list item type rendered by the card template.</typeparam>
 public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
@@ -43,6 +45,13 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
     private readonly List<TItem> _items = [];
     private int _totalCount;
     private int _currentPage;
+
+    /// <summary>
+    /// Incremented by <see cref="ResetAsync"/> to supersede every fetch already in flight. A load
+    /// snapshots it before awaiting and discards its results when the value moved while it waited.
+    /// </summary>
+    private int _generation;
+
     private bool _isInitialLoad = true;
     private bool _isLoadingMore;
     private bool _hasMore = true;
@@ -127,18 +136,30 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
         _isLoadingMore = true;
         _loadError = false;
 
-        if (_cts is not null)
-        {
-            await _cts.CancelAsync();
-            _cts.Dispose();
-        }
+        // Snapshot the generation this load belongs to. Whoever supersedes it (ResetAsync) owns
+        // cancelling and disposing the token source it publishes here.
+        int generation = _generation;
+        var cts = new CancellationTokenSource();
+        _cts = cts;
 
-        _cts = new CancellationTokenSource();
+        // The page number is computed, not committed: _currentPage only advances on a successful,
+        // non-superseded completion. A cancelled, failed, or superseded fetch therefore leaves the
+        // counter untouched, so nothing has to be compensated back and no page is ever re-requested.
+        int targetPage = _currentPage + 1;
 
         try
         {
-            _currentPage++;
-            var (items, totalCount) = await FetchPage(_currentPage, PageSize, _cts.Token);
+            var (items, totalCount) = await FetchPage(targetPage, PageSize, cts.Token);
+
+            // The generation, not the token, is authoritative: FetchPage is consumer-supplied and may
+            // ignore the CancellationToken entirely, so a superseded fetch can still complete
+            // successfully. This check is what keeps its rows out of the list ResetAsync just cleared.
+            if (_disposed || generation != _generation)
+            {
+                return;
+            }
+
+            _currentPage = targetPage;
             _items.AddRange(items);
             _totalCount = totalCount;
 
@@ -148,11 +169,15 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
         }
         catch (OperationCanceledException)
         {
-            _currentPage--;
+            // Superseded or disposed; the page counter never advanced, so there is nothing to undo.
         }
         catch (Exception)
         {
-            _currentPage--;
+            if (_disposed || generation != _generation)
+            {
+                return;
+            }
+
             _loadError = true;
 
             if (isInitial)
@@ -164,7 +189,20 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
         }
         finally
         {
-            _isLoadingMore = false;
+            if (generation == _generation)
+            {
+                // A superseding reset already cleared the flag (and the reload it started may have set
+                // it again), so only the current generation is allowed to clear it.
+                _isLoadingMore = false;
+            }
+
+            if (ReferenceEquals(_cts, cts))
+            {
+                // Only the still-current source is ours to dispose: a resetter that superseded this
+                // load already cancelled and disposed the one it took over.
+                _cts = null;
+                cts.Dispose();
+            }
         }
     }
 
@@ -180,6 +218,24 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
     /// </summary>
     public async Task ResetAsync()
     {
+        // Supersede first: any fetch already awaiting FetchPage now belongs to an older generation
+        // and must drop its results instead of appending them to the list cleared below.
+        _generation++;
+
+        var stale = _cts;
+        _cts = null;
+
+        if (stale is not null)
+        {
+            await stale.CancelAsync();
+            stale.Dispose();
+        }
+
+        // The superseded load no longer owns the in-flight marker, and it will not clear it (its
+        // generation moved). Without clearing it here the reload below would early-return, leaving
+        // the list empty until the next sentinel hit.
+        _isLoadingMore = false;
+
         _items.Clear();
         _currentPage = 0;
         _totalCount = 0;

--- a/Source/Presentation/MMCA.Common.UI/Components/ThemeToggle.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/ThemeToggle.razor
@@ -11,6 +11,8 @@
                OnClick="ToggleAsync" />
 
 @code {
+    private bool _disposed;
+
     protected override void OnInitialized() => ThemeService.OnChange += OnThemeChanged;
 
     private async Task ToggleAsync()
@@ -25,7 +27,42 @@
         }
     }
 
-    private void OnThemeChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
+    // ThemeService.OnChange is raised synchronously, and one scoped ThemeService feeds several
+    // subscribers (both ThemeToggle placements plus MmcaThemeProviders). Disposal can therefore land
+    // between the event firing and this component's render dispatch: the invocation list is captured
+    // when the event is raised, so a handler still runs after its component is gone. Guarding here
+    // also stops a throw from cutting off the subscribers queued behind this one.
+    private void OnThemeChanged(object? sender, EventArgs e) => _ = RerenderSafeAsync();
 
-    public void Dispose() => ThemeService.OnChange -= OnThemeChanged;
+    private async Task RerenderSafeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Component was disposed between event firing and render dispatch.
+        }
+        catch (InvalidOperationException)
+        {
+            // Same race, surfaced by the renderer as a disposed/unavailable dispatcher.
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        ThemeService.OnChange -= OnThemeChanged;
+    }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Auth/AuthenticationServiceBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Auth/AuthenticationServiceBaseTests.cs
@@ -246,6 +246,45 @@ public sealed class AuthenticationServiceBaseTests
             Times.Never);
     }
 
+    // The email check and the insert are a check-then-act: two concurrent registrations for the
+    // same address both pass the check and the loser fails on the unique Email index. That used to
+    // escape as a 500; it now resolves to the same conflict a serialized pair would have produced.
+    [Fact]
+    public async Task RegisterAsync_WhenAConcurrentRegistrationWinsTheUniqueIndex_ReturnsConflict()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.UnitOfWork
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => sut.EmailExists = true)
+            .ThrowsAsync(new InvalidOperationException("Cannot insert duplicate key row in index 'IX_Users_Email'."));
+
+        Result<AuthenticationResponse> result = await sut.RegisterAsync(
+            new RegisterRequest("racer@example.com", "pw", "A", "B"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Code == "Auth.EmailAlreadyExists" && e.Type == ErrorType.Conflict);
+        sut.EmailExistsCallCount.Should().Be(
+            2,
+            "the failed save is classified by re-checking the address, since this layer cannot name the EF exception type");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenTheSaveFailsForAnyOtherReason_Rethrows()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.UnitOfWork
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("connection reset"));
+
+        Func<Task> act = async () => await sut.RegisterAsync(
+            new RegisterRequest("new@example.com", "pw", "A", "B"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("connection reset", "the broad catch classifies, it does not swallow");
+        sut.EmailExistsCallCount.Should().Be(2);
+    }
+
     [Fact]
     public async Task RegisterAsync_WhenUserFactoryFails_ReturnsFactoryFailure()
     {
@@ -603,6 +642,9 @@ public sealed class TestAuthenticationService(
 
     public bool EmailExists { get; set; }
 
+    /// <summary>Times the base asked. The post-save re-check that classifies a failed insert is the second.</summary>
+    public int EmailExistsCallCount { get; private set; }
+
     public Result<TestAuthUser>? CreateUserResult { get; set; }
 
     public Result LoginCandidateResult { get; set; } = Result.Success();
@@ -617,8 +659,11 @@ public sealed class TestAuthenticationService(
         return Task.FromResult(UntrackedUser);
     }
 
-    protected override Task<bool> EmailExistsAsync(Email? email, CancellationToken cancellationToken) =>
-        Task.FromResult(EmailExists);
+    protected override Task<bool> EmailExistsAsync(Email? email, CancellationToken cancellationToken)
+    {
+        EmailExistsCallCount++;
+        return Task.FromResult(EmailExists);
+    }
 
     protected override Result<TestAuthUser> CreateUser(RegisterRequest request, byte[] passwordHash, byte[] passwordSalt) =>
         CreateUserResult ?? Result.Success(new TestAuthUser

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/FeatureGateCommandDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/FeatureGateCommandDecoratorTests.cs
@@ -85,6 +85,57 @@ public sealed class FeatureGateCommandDecoratorTests
             Times.Never);
     }
 
+    // ── A handler whose TResult is neither Result nor Result<T> ──
+    // Scrutor's TryDecorate is unconditional, so such a handler gets decorated too. Building the
+    // failure delegate eagerly (in the static constructor) turned that into a
+    // TypeInitializationException the moment the decorator was RESOLVED, even for a command that
+    // never short-circuits.
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_NonFeatureGatedCommand_PassesThrough()
+    {
+        var inner = new Mock<ICommandHandler<PlainCommand, string>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<PlainCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("handled");
+
+        var sut = new FeatureGateCommandDecorator<PlainCommand, string>(inner.Object, _featureManager.Object);
+
+        var result = await sut.HandleAsync(new PlainCommand());
+
+        result.Should().Be("handled");
+        inner.Verify(x => x.HandleAsync(It.IsAny<PlainCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_EnabledFeature_PassesThrough()
+    {
+        var inner = new Mock<ICommandHandler<FeatureGatedCommand, string>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<FeatureGatedCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("handled");
+        _featureManager.Setup(x => x.IsEnabledAsync("TestFeature")).ReturnsAsync(true);
+
+        var sut = new FeatureGateCommandDecorator<FeatureGatedCommand, string>(inner.Object, _featureManager.Object);
+
+        var result = await sut.HandleAsync(new FeatureGatedCommand());
+
+        result.Should().Be("handled");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_DisabledFeature_FailsOnlyOnTheShortCircuit()
+    {
+        var inner = new Mock<ICommandHandler<FeatureGatedCommandWithValue, string>>();
+        _featureManager.Setup(x => x.IsEnabledAsync("TestFeature")).ReturnsAsync(false);
+
+        var sut = new FeatureGateCommandDecorator<FeatureGatedCommandWithValue, string>(
+            inner.Object, _featureManager.Object);
+
+        // Fabricating a failure is genuinely impossible for this TResult, so the short-circuit path
+        // still fails: as the factory's own InvalidOperationException, at the point of use.
+        Func<Task> act = () => sut.HandleAsync(new FeatureGatedCommandWithValue());
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
     // ── Enabled feature works with generic Result<T> ──
     [Fact]
     public async Task HandleAsync_EnabledFeature_WithGenericResult_DelegatesToInner()

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/FeatureGateQueryDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/FeatureGateQueryDecoratorTests.cs
@@ -67,6 +67,57 @@ public sealed class FeatureGateQueryDecoratorTests
         inner.Verify(x => x.HandleAsync(It.IsAny<FeatureGatedQuery>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ── A handler whose TResult is neither Result nor Result<T> ──
+    // Scrutor's TryDecorate is unconditional, so such a handler gets decorated too. Building the
+    // failure delegate eagerly (in the static constructor) turned that into a
+    // TypeInitializationException the moment the decorator was RESOLVED, even for a query that
+    // never short-circuits.
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_NonFeatureGatedQuery_PassesThrough()
+    {
+        var inner = new Mock<IQueryHandler<PlainQuery, string>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<PlainQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("data");
+
+        var sut = new FeatureGateQueryDecorator<PlainQuery, string>(inner.Object, _featureManager.Object);
+
+        var result = await sut.HandleAsync(new PlainQuery());
+
+        result.Should().Be("data");
+        inner.Verify(x => x.HandleAsync(It.IsAny<PlainQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_EnabledFeature_PassesThrough()
+    {
+        var inner = new Mock<IQueryHandler<FeatureGatedQuery, string>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<FeatureGatedQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("data");
+        _featureManager.Setup(x => x.IsEnabledAsync("QueryFeature")).ReturnsAsync(true);
+
+        var sut = new FeatureGateQueryDecorator<FeatureGatedQuery, string>(inner.Object, _featureManager.Object);
+
+        var result = await sut.HandleAsync(new FeatureGatedQuery());
+
+        result.Should().Be("data");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_DisabledFeature_FailsOnlyOnTheShortCircuit()
+    {
+        var inner = new Mock<IQueryHandler<FeatureGatedQueryNonGeneric, string>>();
+        _featureManager.Setup(x => x.IsEnabledAsync("QueryFeature")).ReturnsAsync(false);
+
+        var sut = new FeatureGateQueryDecorator<FeatureGatedQueryNonGeneric, string>(
+            inner.Object, _featureManager.Object);
+
+        // Fabricating a failure is genuinely impossible for this TResult, so the short-circuit path
+        // still fails: as the factory's own InvalidOperationException, at the point of use.
+        Func<Task> act = () => sut.HandleAsync(new FeatureGatedQueryNonGeneric());
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
     // ── Disabled feature with non-generic Result ──
     [Fact]
     public async Task HandleAsync_DisabledFeature_WithNonGenericResult_ReturnsFailure()

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/ValidatingCommandDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/ValidatingCommandDecoratorTests.cs
@@ -109,6 +109,79 @@ public sealed class ValidatingCommandDecoratorTests
         inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ── A handler whose TResult is neither Result nor Result<T> ──
+    // Scrutor's TryDecorate is unconditional, so such a handler gets decorated too. Building the
+    // failure delegate eagerly (in the static constructor) turned that into a
+    // TypeInitializationException the moment the decorator was RESOLVED, even for a command that
+    // always validates cleanly.
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_NoValidators_PassesThroughToInnerHandler()
+    {
+        var inner = new Mock<ICommandHandler<TestValidatingCommand, string>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("handled");
+
+        IEnumerable<IValidator<TestValidatingCommand>> validators = [];
+        var sut = new ValidatingCommandDecorator<TestValidatingCommand, string>(
+            inner.Object,
+            validators,
+            NullLogger<ValidatingCommandDecorator<TestValidatingCommand, string>>.Instance);
+
+        var result = await sut.HandleAsync(new TestValidatingCommand("valid"));
+
+        result.Should().Be("handled");
+        inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_ValidationPasses_CallsInnerHandler()
+    {
+        var inner = new Mock<ICommandHandler<TestValidatingCommand, string>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("handled");
+
+        var validator = new Mock<IValidator<TestValidatingCommand>>();
+        validator.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        IEnumerable<IValidator<TestValidatingCommand>> validators = [validator.Object];
+        var sut = new ValidatingCommandDecorator<TestValidatingCommand, string>(
+            inner.Object,
+            validators,
+            NullLogger<ValidatingCommandDecorator<TestValidatingCommand, string>>.Instance);
+
+        var result = await sut.HandleAsync(new TestValidatingCommand("valid"));
+
+        result.Should().Be("handled");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonResultTResult_ValidationFails_FailsOnlyOnTheShortCircuit()
+    {
+        var inner = new Mock<ICommandHandler<TestValidatingCommand, string>>();
+
+        var validator = new Mock<IValidator<TestValidatingCommand>>();
+        var failures = new List<ValidationFailure>
+        {
+            new("Name", "Name is required")
+        };
+        validator.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(failures));
+
+        IEnumerable<IValidator<TestValidatingCommand>> validators = [validator.Object];
+        var sut = new ValidatingCommandDecorator<TestValidatingCommand, string>(
+            inner.Object,
+            validators,
+            NullLogger<ValidatingCommandDecorator<TestValidatingCommand, string>>.Instance);
+
+        // Fabricating a failure is genuinely impossible for this TResult, so the short-circuit path
+        // still fails: as the factory's own InvalidOperationException, at the point of use.
+        Func<Task> act = () => sut.HandleAsync(new TestValidatingCommand(string.Empty));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // ── Result<T> generic variant passes through ──
     [Fact]
     public async Task HandleAsync_GenericResult_ValidationPasses_CallsInnerHandler()

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryServiceTests.cs
@@ -211,4 +211,250 @@ public sealed class EntityQueryServiceTests
     {
         public IReadOnlyDictionary<string, string> GetPropertyMap() => DTOToEntityPropertyMap;
     }
+
+    // ── Harness: the REAL query pipeline over an in-memory queryable ──
+    // Sorting, paging and the pagination metadata are only meaningful together, so these tests
+    // drive the real EntityQueryPipeline and only fake the EF-facing executor.
+    private sealed class InMemoryQueryableExecutor : IQueryableExecutor
+    {
+        public IQueryable<T> Include<T>(IQueryable<T> query, string navigationPropertyPath)
+            where T : class
+            => query;
+
+        public IQueryable<T> AsSplitQuery<T>(IQueryable<T> query)
+            where T : class
+            => query;
+
+        public Task<List<T>> ToListAsync<T>(IQueryable<T> query, CancellationToken cancellationToken = default)
+            => Task.FromResult(query.ToList());
+
+        public Task<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken = default)
+            => Task.FromResult(query.Count());
+    }
+
+    private sealed class FakeEntityDTOMapper : IEntityDTOMapper<FakeEntity, FakeEntityDTO, int>
+    {
+        public FakeEntityDTO MapToDTO(FakeEntity entity) => new() { Id = entity.Id, Name = entity.Name };
+    }
+
+    /// <summary>
+    /// A subclass that maps a DTO-facing name onto an entity property, exactly as a module's own
+    /// query service does (for example "CategoryName" -> "Category.Name").
+    /// </summary>
+    private sealed class MappedEntityQueryService(
+        IUnitOfWork unitOfWork,
+        INavigationMetadataProvider navigationMetadataProvider,
+        IEntityQueryPipeline queryPipeline,
+        IEntityDTOMapper<FakeEntity, FakeEntityDTO, int> dtoMapper,
+        INavigationPopulator<FakeEntity> navigationPopulator)
+        : EntityQueryService<FakeEntity, FakeEntityDTO, int>(unitOfWork, navigationMetadataProvider, queryPipeline, dtoMapper, navigationPopulator)
+    {
+        protected override IReadOnlyDictionary<string, string> DTOToEntityPropertyMap { get; } =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["DisplayName"] = "Name" };
+    }
+
+    private static MappedEntityQueryService CreateSutOver(
+        List<FakeEntity> data,
+        IEntityQueryPipeline? pipeline = null)
+    {
+        var repo = new Mock<IReadRepository<FakeEntity, int>>();
+        repo.Setup(r => r.Table).Returns(data.AsQueryable());
+        repo.Setup(r => r.TableNoTracking).Returns(data.AsQueryable());
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork.Setup(x => x.GetReadRepository<FakeEntity, int>()).Returns(repo.Object);
+
+        var navigationMetadataProvider = new Mock<INavigationMetadataProvider>();
+        navigationMetadataProvider
+            .Setup(p => p.BuildIncludes<FakeEntity>(It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(new NavigationMetadata());
+
+        return new MappedEntityQueryService(
+            unitOfWork.Object,
+            navigationMetadataProvider.Object,
+            pipeline ?? new EntityQueryPipeline(new InMemoryQueryableExecutor()),
+            new FakeEntityDTOMapper(),
+            Mock.Of<INavigationPopulator<FakeEntity>>());
+    }
+
+    private static List<FakeEntity> Rows(int count)
+        => [.. Enumerable.Range(1, count).Select(i => new FakeEntity { Id = i, Name = "Row" })];
+
+    // ── Sort-column validation honors the DTO-to-entity map ──
+    [Fact]
+    public async Task GetAllAsync_MappedSortColumn_PassesValidationAndSorts()
+    {
+        var sut = CreateSutOver(
+        [
+            new FakeEntity { Id = 1, Name = "C" },
+            new FakeEntity { Id = 2, Name = "A" },
+            new FakeEntity { Id = 3, Name = "B" },
+        ]);
+
+        // "DisplayName" is not a property of FakeEntity: only the map makes it sortable, and the
+        // sort would have worked all along. Validating it without the map returned a 400 instead.
+        var result = await sut.GetAllAsync(sortColumn: "DisplayName", sortDirection: "asc");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Cast<FakeEntityDTO>().Select(d => d.Name).Should().Equal("A", "B", "C");
+    }
+
+    [Fact]
+    public async Task GetAllAsync_MappedSortColumn_Descending_Sorts()
+    {
+        var sut = CreateSutOver(
+        [
+            new FakeEntity { Id = 1, Name = "A" },
+            new FakeEntity { Id = 2, Name = "B" },
+        ]);
+
+        var result = await sut.GetAllAsync(sortColumn: "DisplayName", sortDirection: "desc");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Cast<FakeEntityDTO>().Select(d => d.Name).Should().Equal("B", "A");
+    }
+
+    [Fact]
+    public async Task GetAllAsync_UnmappedBogusSortColumn_StillReturnsValidationFailure()
+    {
+        var sut = CreateSutOver([new FakeEntity { Id = 1, Name = "A" }]);
+
+        var result = await sut.GetAllAsync(sortColumn: "TotallyBogus");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Code == "Error.InvalidEntityField");
+    }
+
+    [Fact]
+    public async Task GetAllAsync_UnmappedRealSortColumn_StillPassesValidation()
+    {
+        var sut = CreateSutOver(
+        [
+            new FakeEntity { Id = 2, Name = "B" },
+            new FakeEntity { Id = 1, Name = "A" },
+        ]);
+
+        var result = await sut.GetAllAsync(sortColumn: "Name", sortDirection: "asc");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Cast<FakeEntityDTO>().Select(d => d.Id).Should().Equal(1, 2);
+    }
+
+    // ── Pagination metadata: floors, ceiling, and coherent derived values ──
+    [Theory]
+    [InlineData(0, 0, 1, 1, 1, 25)]
+    [InlineData(-3, -5, 1, 1, 1, 25)]
+    [InlineData(1, 0, 1, 1, 1, 25)]
+    [InlineData(0, 10, 1, 10, 10, 3)]
+    public async Task GetAllAsync_NonPositivePaging_ReportsThePageThePipelineActuallyApplied(
+        int pageNumber,
+        int pageSize,
+        int expectedCurrentPage,
+        int expectedPageSize,
+        int expectedItemCount,
+        int expectedTotalPageCount)
+    {
+        var sut = CreateSutOver(Rows(25));
+
+        var result = await sut.GetAllAsync(pageNumber: pageNumber, pageSize: pageSize);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().HaveCount(expectedItemCount);
+
+        var metadata = result.Value.PaginationMetadata;
+        metadata.TotalItemCount.Should().Be(25);
+        metadata.PageSize.Should().Be(expectedPageSize);
+        metadata.CurrentPage.Should().Be(expectedCurrentPage);
+        metadata.TotalPageCount.Should().Be(expectedTotalPageCount);
+        metadata.FirstRowOnPage.Should().Be(1);
+        metadata.LastRowOnPage.Should().Be(expectedPageSize);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_PageSizeAboveTheCeiling_ReportsTheCeiling()
+    {
+        var sut = CreateSutOver(Rows(25));
+
+        var result = await sut.GetAllAsync(pageNumber: 1, pageSize: 5000);
+
+        result.Value!.PaginationMetadata.PageSize.Should().Be(EntityQueryPipeline.MaxUnboundedResultLimit);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_PageBeyondTheReachableOffset_StillReportsTheClampedPageSize()
+    {
+        var sut = CreateSutOver(Rows(25));
+
+        // PagingMath returns its (0, 0) offset-overflow sentinel here, so the page is genuinely
+        // empty; the metadata must still report the page size the request asked for, not 0.
+        var result = await sut.GetAllAsync(pageNumber: int.MaxValue, pageSize: 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().BeEmpty();
+        result.Value.PaginationMetadata.PageSize.Should().Be(10);
+        result.Value.PaginationMetadata.TotalItemCount.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_Unpaginated_ReportsTheMaterializedRowCountAsPageSize()
+    {
+        var sut = CreateSutOver(Rows(7));
+
+        var result = await sut.GetAllAsync(sortColumn: null);
+
+        var metadata = result.Value!.PaginationMetadata;
+        metadata.TotalItemCount.Should().Be(7);
+        metadata.PageSize.Should().Be(7);
+        metadata.CurrentPage.Should().Be(1);
+        metadata.TotalPageCount.Should().Be(1);
+        metadata.FirstRowOnPage.Should().Be(1);
+        metadata.LastRowOnPage.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_UnpaginatedEmptyResult_ProducesCoherentMetadata()
+    {
+        var sut = CreateSutOver([]);
+
+        var result = await sut.GetAllAsync(sortColumn: null);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().BeEmpty();
+
+        var metadata = result.Value.PaginationMetadata;
+        metadata.TotalItemCount.Should().Be(0);
+        metadata.PageSize.Should().Be(0);
+        metadata.CurrentPage.Should().Be(1);
+        metadata.TotalPageCount.Should().Be(0);
+        metadata.FirstRowOnPage.Should().Be(0);
+        metadata.LastRowOnPage.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NegativeTotalFromThePipeline_IsFlooredInsteadOfThrowing()
+    {
+        var pipeline = new Mock<IEntityQueryPipeline>();
+        pipeline
+            .Setup(p => p.ExecuteAsync<FakeEntity, int>(
+                It.IsAny<IQueryable<FakeEntity>>(),
+                It.IsAny<NavigationMetadata>(),
+                It.IsAny<EntityQueryParameters<FakeEntity>>(),
+                It.IsAny<Func<IReadOnlyCollection<FakeEntity>, NavigationMetadata, bool, bool, CancellationToken, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<(IReadOnlyCollection<FakeEntity> Items, int TotalCount)>(
+                (Array.Empty<FakeEntity>(), -5)));
+
+        var sut = CreateSutOver([], pipeline.Object);
+
+        // The validating constructor rejects negatives, so an impossible count must be floored
+        // rather than allowed to turn a successful read into an exception.
+        var result = await sut.GetAllAsync(sortColumn: null);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var metadata = result.Value!.PaginationMetadata;
+        metadata.TotalItemCount.Should().Be(0);
+        metadata.PageSize.Should().Be(0);
+        metadata.CurrentPage.Should().Be(1);
+    }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/QueryFieldServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/QueryFieldServiceTests.cs
@@ -1,4 +1,4 @@
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using MMCA.Common.Application.Services;
 
 namespace MMCA.Common.Application.Tests.Services;
@@ -234,6 +234,207 @@ public class QueryFieldServiceTests
 
         result.IsFailure.Should().BeTrue();
         result.Errors.Should().HaveCount(2);
+    }
+
+    // ── Validate: DTO-to-entity map overload ──
+    // The map is server-authored, so a mapped name is accepted without resolving its VALUE: mapped
+    // values are navigation paths or Dynamic LINQ expressions, not necessarily property names.
+    public sealed class MappedDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Display => Name.ToUpperInvariant();
+    }
+
+    private static Dictionary<string, string> Map(params (string DtoName, string EntityPath)[] entries)
+        => entries.ToDictionary(e => e.DtoName, e => e.EntityPath, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Validate_WithMap_MappedNestedPath_ReturnsSuccess()
+    {
+        // "CategoryName" is not a property of MappedDto at all; only the map makes it valid.
+        var result = QueryFieldService.Validate<MappedDto>(
+            "CategoryName",
+            Map(("CategoryName", "Category.Name")),
+            allowWriteableFields: true);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithMap_MappedExpressionValue_ReturnsSuccess()
+    {
+        // A mapped value that is an expression rather than a property path is still accepted:
+        // the value is never resolved or reflected over.
+        var result = QueryFieldService.Validate<MappedDto>(
+            "Label",
+            Map(("Label", "Id.ToString() + Name")),
+            allowWriteableFields: true);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithMap_MappedReadOnlyProperty_IsAcceptedForShaping()
+    {
+        // A map hit short-circuits the read-only rule too: the server author decided this name
+        // resolves to something usable, so the CanWrite check never runs.
+        var result = QueryFieldService.Validate<MappedDto>(
+            "Caption",
+            Map(("Caption", "Display")),
+            allowWriteableFields: false);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithMap_UnmappedBogusField_StillReturnsFailure()
+    {
+        var result = QueryFieldService.Validate<MappedDto>(
+            "CategoryName,NotAField",
+            Map(("CategoryName", "Category.Name")),
+            allowWriteableFields: true);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle()
+            .Which.Message.Should().Contain("NotAField");
+    }
+
+    [Fact]
+    public void Validate_WithMap_UnmappedReadOnlyProperty_StillRejectedForShaping()
+    {
+        var result = QueryFieldService.Validate<MappedDto>("Display", Map(), allowWriteableFields: false);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle()
+            .Which.Message.Should().Contain("read-only");
+    }
+
+    [Fact]
+    public void Validate_WithEmptyMap_BehavesLikeTheMaplessOverload()
+    {
+        QueryFieldService.Validate<MappedDto>("Id,Name", Map()).IsSuccess.Should().BeTrue();
+        QueryFieldService.Validate<MappedDto>("NonExistent", Map()).IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithMap_MapLookupIsCaseInsensitiveWhenTheMapIs()
+    {
+        var result = QueryFieldService.Validate<MappedDto>(
+            "categoryname",
+            Map(("CategoryName", "Category.Name")),
+            allowWriteableFields: true);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // ── Field-set cache caps ──
+    // Both caches are keyed by a client-supplied field set, so they are capped. The assertions are
+    // "<= cap", never "== cap": the caches are static and shared with every other test in the run.
+    private const int MaxCacheEntries = 512;
+
+    public sealed class CacheProbeEntity
+    {
+        public int P0 { get; set; }
+        public int P1 { get; set; }
+        public int P2 { get; set; }
+        public int P3 { get; set; }
+        public int P4 { get; set; }
+        public int P5 { get; set; }
+        public int P6 { get; set; }
+        public int P7 { get; set; }
+        public int P8 { get; set; }
+        public int P9 { get; set; }
+    }
+
+    private static readonly string[] ProbeProperties =
+        ["P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9"];
+
+    /// <summary>Distinct, non-empty field sets built from the bits of <paramref name="index"/>.</summary>
+    private static string FieldSet(int index)
+        => string.Join(
+            ',',
+            Enumerable.Range(0, ProbeProperties.Length)
+                .Where(bit => (index & (1 << bit)) != 0)
+                .Select(bit => ProbeProperties[bit]));
+
+    private static int CacheEntryCount(string cacheFieldName)
+    {
+        var cache = typeof(QueryFieldService)
+            .GetField(cacheFieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .GetValue(null)!;
+
+        return (int)cache.GetType().GetProperty("Count")!.GetValue(cache)!;
+    }
+
+    [Fact]
+    public void ApplyFieldSelection_ManyDistinctFieldSets_StopsGrowingTheProjectionCache()
+    {
+        var query = new List<CacheProbeEntity> { new() { P0 = 1, P3 = 3, P9 = 9 } }.AsQueryable();
+
+        for (var i = 1; i <= 700; i++)
+        {
+            _ = QueryFieldService.ApplyFieldSelection(query, FieldSet(i)).ToList();
+        }
+
+        CacheEntryCount("ProjectionCache").Should().BeLessThanOrEqualTo(MaxCacheEntries);
+    }
+
+    [Fact]
+    public void ApplyFieldSelection_PastTheCap_SkipsProjectionButStillReturnsCorrectRows()
+    {
+        var entity = new CacheProbeEntity { P0 = 1, P3 = 3, P9 = 9 };
+        var query = new List<CacheProbeEntity> { entity }.AsQueryable();
+
+        for (var i = 1; i <= 700; i++)
+        {
+            _ = QueryFieldService.ApplyFieldSelection(query, FieldSet(i)).ToList();
+        }
+
+        // "P0,P3,P9" (bits 0, 3 and 9) is set 521 of the enumeration above, so it was already past
+        // the cap when the loop reached it: the cache holds no entry for it and admits none now.
+        var entriesBefore = CacheEntryCount("ProjectionCache");
+        var rows = QueryFieldService.ApplyFieldSelection(query, "P0,P3,P9").ToList();
+
+        CacheEntryCount("ProjectionCache").Should().Be(entriesBefore);
+        rows.Should().ContainSingle();
+        rows[0].P0.Should().Be(1);
+        rows[0].P3.Should().Be(3);
+        rows[0].P9.Should().Be(9);
+    }
+
+    [Fact]
+    public void ShapeData_ManyDistinctFieldSets_StopsGrowingTheShapedAccessorCache()
+    {
+        var entity = new CacheProbeEntity { P0 = 1, P3 = 3, P9 = 9 };
+
+        for (var i = 1; i <= 700; i++)
+        {
+            QueryFieldService.ShapeData(entity, FieldSet(i));
+        }
+
+        CacheEntryCount("ShapedAccessorCache").Should().BeLessThanOrEqualTo(MaxCacheEntries);
+    }
+
+    [Fact]
+    public void ShapeData_PastTheCap_StillShapesToTheRequestedFields()
+    {
+        var entity = new CacheProbeEntity { P0 = 1, P3 = 3, P9 = 9 };
+
+        for (var i = 1; i <= 700; i++)
+        {
+            QueryFieldService.ShapeData(entity, FieldSet(i));
+        }
+
+        // Same reasoning as the projection test: this field set is past the cap, so the accessors
+        // are filtered per request and nothing new is admitted.
+        var entriesBefore = CacheEntryCount("ShapedAccessorCache");
+        var dict = (IDictionary<string, object?>)QueryFieldService.ShapeData(entity, "P0,P3,P9");
+
+        CacheEntryCount("ShapedAccessorCache").Should().Be(entriesBefore);
+        dict.Should().ContainKeys("p0", "p3", "p9");
+        dict.Should().NotContainKeys("p1", "p2");
+        dict["p3"].Should().Be(3);
     }
 
     // ── ValidateSortDirection ──

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/DistributedCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/DistributedCacheServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.Extensions.Caching.Distributed;
@@ -150,20 +151,23 @@ public class DistributedCacheServiceTests
                 It.IsAny<CommandFlags>()))
             .Returns(keys.ToAsyncEnumerable());
 
-        dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey[]>(), It.IsAny<CommandFlags>()))
-            .ReturnsAsync(2);
+        dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
 
         var sut = new DistributedCacheService(cacheMock.Object, NullLog, connectionMock.Object);
 
         await sut.RemoveByPrefixAsync("prefix:");
 
-        // Deletes are batched: both keys go out in one round trip instead of one per key.
+        // One command per key, never a multi-key DEL. The keys behind a prefix hash to arbitrary
+        // slots, and under cluster policy StackExchange.Redis answers a cross-slot multi-key command
+        // by throwing rather than under-deleting, so batching them would fault the invalidation.
         dbMock.Verify(
-            d => d.KeyDeleteAsync(
-                It.Is<RedisKey[]>(k => k.Length == 2 && k[0] == (RedisKey)"prefix:key1" && k[1] == (RedisKey)"prefix:key2"),
-                It.IsAny<CommandFlags>()),
+            d => d.KeyDeleteAsync(It.Is<RedisKey>(k => k == (RedisKey)"prefix:key1"), It.IsAny<CommandFlags>()),
             Times.Once);
-        dbMock.Verify(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()), Times.Never);
+        dbMock.Verify(
+            d => d.KeyDeleteAsync(It.Is<RedisKey>(k => k == (RedisKey)"prefix:key2"), It.IsAny<CommandFlags>()),
+            Times.Once);
+        dbMock.Verify(d => d.KeyDeleteAsync(It.IsAny<RedisKey[]>(), It.IsAny<CommandFlags>()), Times.Never);
     }
 
     [Fact]
@@ -206,6 +210,161 @@ public class DistributedCacheServiceTests
 
         dbMock.Verify(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()), Times.Never);
     }
+
+    // ── Prefix eviction must cover every primary, not one arbitrary server ──
+    // GetServers() reports every endpoint the multiplexer knows. Scanning only the first one leaves
+    // the keys held by the other primaries alive until their TTL expires, so an invalidation that
+    // reports success has silently done part of the job.
+    [Fact]
+    public async Task RemoveByPrefixAsync_WithRedis_ScansEveryNonReplicaServer()
+    {
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var dbMock = new Mock<IDatabase>();
+        var primaryA = ServerStub("primary-a", isReplica: false, "prefix:a1");
+        var primaryB = ServerStub("primary-b", isReplica: false, "prefix:b1");
+
+        connectionMock.Setup(c => c.GetServers()).Returns([primaryA.Object, primaryB.Object]);
+        connectionMock.Setup(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+        dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+
+        var sut = new DistributedCacheService(new Mock<IDistributedCache>().Object, NullLog, connectionMock.Object);
+
+        await sut.RemoveByPrefixAsync("prefix:");
+
+        VerifyScanned(primaryA, Times.Once());
+        VerifyScanned(primaryB, Times.Once());
+        VerifyDeleted(dbMock, "prefix:a1", Times.Once());
+        VerifyDeleted(dbMock, "prefix:b1", Times.Once());
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_WithRedis_DoesNotScanReplicas()
+    {
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var dbMock = new Mock<IDatabase>();
+        var primary = ServerStub("primary", isReplica: false, "prefix:a1");
+        var replica = ServerStub("replica", isReplica: true, "prefix:a1");
+
+        connectionMock.Setup(c => c.GetServers()).Returns([primary.Object, replica.Object]);
+        connectionMock.Setup(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+        dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+
+        var sut = new DistributedCacheService(new Mock<IDistributedCache>().Object, NullLog, connectionMock.Object);
+
+        await sut.RemoveByPrefixAsync("prefix:");
+
+        // A replica mirrors a primary that was already scanned, and a DEL against it is rejected,
+        // so scanning it would only re-issue deletes that cannot succeed.
+        VerifyScanned(primary, Times.Once());
+        VerifyScanned(replica, Times.Never());
+        VerifyDeleted(dbMock, "prefix:a1", Times.Once());
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_WithRedis_AllServersAreReplicas_IsNoOp()
+    {
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var replica = ServerStub("replica", isReplica: true, "prefix:a1");
+
+        connectionMock.Setup(c => c.GetServers()).Returns([replica.Object]);
+
+        var sut = new DistributedCacheService(new Mock<IDistributedCache>().Object, NullLog, connectionMock.Object);
+
+        await sut.RemoveByPrefixAsync("prefix:");
+
+        VerifyScanned(replica, Times.Never());
+        connectionMock.Verify(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_WithRedis_WhenOneServerScanFails_StillEvictsOnTheOthers()
+    {
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var dbMock = new Mock<IDatabase>();
+        var healthy = ServerStub("healthy", isReplica: false, "prefix:ok1");
+        var broken = ServerStub("broken", isReplica: false);
+        broken.Setup(s => s.KeysAsync(
+                It.IsAny<int>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<int>(),
+                It.IsAny<CommandFlags>()))
+            .Throws(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "node unreachable"));
+
+        // Broken first, so a fault that aborted the loop would take the healthy server with it.
+        connectionMock.Setup(c => c.GetServers()).Returns([broken.Object, healthy.Object]);
+        connectionMock.Setup(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+        dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+
+        var logger = new WarningCountingLogger();
+        var sut = new DistributedCacheService(new Mock<IDistributedCache>().Object, logger, connectionMock.Object);
+
+        await FluentActions.Invoking(() => sut.RemoveByPrefixAsync("prefix:"))
+            .Should().NotThrowAsync("one unreachable node must not fail the whole invalidation");
+
+        VerifyScanned(healthy, Times.Once());
+        VerifyDeleted(dbMock, "prefix:ok1", Times.Once());
+        logger.WarningCount.Should().Be(1, "the skipped node must be observable, not silent");
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_WithRedis_WhenOneServerDeleteFails_StillEvictsOnTheOthers()
+    {
+        var connectionMock = new Mock<IConnectionMultiplexer>();
+        var dbMock = new Mock<IDatabase>();
+        var failing = ServerStub("failing", isReplica: false, "prefix:bad1");
+        var healthy = ServerStub("healthy", isReplica: false, "prefix:ok1");
+
+        connectionMock.Setup(c => c.GetServers()).Returns([failing.Object, healthy.Object]);
+        connectionMock.Setup(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+        dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+        dbMock.Setup(d => d.KeyDeleteAsync(It.Is<RedisKey>(k => k == (RedisKey)"prefix:bad1"), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisServerException("CROSSSLOT Keys in request don't hash to the same slot"));
+
+        var logger = new WarningCountingLogger();
+        var sut = new DistributedCacheService(new Mock<IDistributedCache>().Object, logger, connectionMock.Object);
+
+        await FluentActions.Invoking(() => sut.RemoveByPrefixAsync("prefix:"))
+            .Should().NotThrowAsync();
+
+        VerifyScanned(healthy, Times.Once());
+        VerifyDeleted(dbMock, "prefix:ok1", Times.Once());
+        logger.WarningCount.Should().Be(1);
+    }
+
+    private static Mock<IServer> ServerStub(string host, bool isReplica, params string[] keys)
+    {
+        var serverMock = new Mock<IServer>();
+        serverMock.SetupGet(s => s.IsReplica).Returns(isReplica);
+        serverMock.SetupGet(s => s.EndPoint).Returns(new DnsEndPoint(host, 6379));
+        serverMock.Setup(s => s.KeysAsync(
+                It.IsAny<int>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<int>(),
+                It.IsAny<CommandFlags>()))
+            .Returns(keys.Select(k => (RedisKey)k).ToAsyncEnumerable());
+
+        return serverMock;
+    }
+
+    private static void VerifyScanned(Mock<IServer> server, Times times) =>
+        server.Verify(
+            s => s.KeysAsync(
+                It.IsAny<int>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<int>(),
+                It.IsAny<CommandFlags>()),
+            times);
+
+    private static void VerifyDeleted(Mock<IDatabase> db, string key, Times times) =>
+        db.Verify(
+            d => d.KeyDeleteAsync(It.Is<RedisKey>(k => k == (RedisKey)key), It.IsAny<CommandFlags>()),
+            times);
 
     // ── IncrementAsync must stay inside IDistributedCache's storage format ──
     // StackExchangeRedisCache stores every entry as a Redis HASH (absexp/sldexp/data, read with

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/MemoryCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/MemoryCacheServiceTests.cs
@@ -1,7 +1,10 @@
+using System.Collections;
 using System.Globalization;
+using System.Reflection;
 using AwesomeAssertions;
 using Microsoft.Extensions.Caching.Memory;
 using MMCA.Common.Infrastructure.Caching;
+using MMCA.Common.Shared.Concurrency;
 
 namespace MMCA.Common.Infrastructure.Tests.Caching;
 
@@ -166,4 +169,94 @@ public sealed class MemoryCacheServiceTests : IDisposable
         await FluentActions.Invoking(() => _sut.RemoveByPrefixAsync("product:"))
             .Should().NotThrowAsync();
     }
+
+    // ── The cache and the key table must move as one ──
+    // Both SetAsync and RemoveByPrefixAsync mutate two structures: the IMemoryCache entry and the
+    // tracking table that makes prefix eviction possible at all. Without mutual exclusion a Set can
+    // land between a removal's two steps (or the removal between the Set's), leaving a LIVE cache
+    // entry the table no longer tracks: invisible to every later prefix invalidation and clearable
+    // only by its TTL. The post-eviction callback cannot repair that, so the stripe has to prevent it.
+    [Fact]
+    public async Task RemoveByPrefixAsync_InterleavedWithSetAsync_CannotLeaveALiveUntrackedEntry()
+    {
+        const string cacheKey = "product:1";
+        await _sut.SetAsync(cacheKey, "first");
+
+        // Force the interleaving rather than racing for it: the test takes the key's own stripe, so
+        // both operations park at exactly the point where the unsynchronized version could interleave.
+        var gate = await KeyLocksOf(_sut).AcquireAsync(cacheKey);
+
+        var set = Task.Run(() => _sut.SetAsync(cacheKey, "second"));
+        var removeByPrefix = Task.Run(() => _sut.RemoveByPrefixAsync("product:"));
+
+        await Task.Delay(100);
+
+        set.IsCompleted.Should().BeFalse("SetAsync must wait for the key's stripe");
+        removeByPrefix.IsCompleted.Should().BeFalse("RemoveByPrefixAsync must wait for the key's stripe");
+        (await _sut.GetAsync<string>(cacheKey)).Should().Be("first", "no half of either mutation may be visible");
+        TrackedKeysOf(_sut).Should().Contain(cacheKey, "no half of either mutation may be visible");
+
+        gate.Dispose();
+        await Task.WhenAll(set, removeByPrefix);
+
+        // Whichever order the stripe hands out, the two structures still agree afterwards: the entry
+        // is either gone, or present AND tracked. Present-but-untracked is the defect.
+        var live = await _sut.GetAsync<string>(cacheKey);
+        if (live is not null)
+        {
+            TrackedKeysOf(_sut).Should().Contain(
+                cacheKey, "a live entry the table does not track survives every future prefix invalidation");
+        }
+    }
+
+    [Fact]
+    public async Task RemoveAsync_TakesTheSameStripeAsSetAsync()
+    {
+        const string cacheKey = "product:1";
+        await _sut.SetAsync(cacheKey, "first");
+
+        var gate = await KeyLocksOf(_sut).AcquireAsync(cacheKey);
+        var remove = Task.Run(() => _sut.RemoveAsync(cacheKey));
+
+        await Task.Delay(100);
+
+        remove.IsCompleted.Should().BeFalse("RemoveAsync must wait for the key's stripe");
+        (await _sut.GetAsync<string>(cacheKey)).Should().Be("first");
+
+        gate.Dispose();
+        await remove;
+
+        (await _sut.GetAsync<string>(cacheKey)).Should().BeNull();
+        TrackedKeysOf(_sut).Should().NotContain(cacheKey);
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_AfterSet_EvictsTheEntryAndItsTrackingRecord()
+    {
+        await _sut.SetAsync("product:1", "A");
+        await _sut.SetAsync("category:1", "C");
+
+        await _sut.RemoveByPrefixAsync("product:");
+
+        (await _sut.GetAsync<string>("product:1")).Should().BeNull();
+        (await _sut.GetAsync<string>("category:1")).Should().Be("C");
+        TrackedKeysOf(_sut).Should().NotContain("product:1");
+        TrackedKeysOf(_sut).Should().Contain("category:1");
+    }
+
+    /// <summary>Reads the per-instance stripe set so a test can force a specific interleaving.</summary>
+    private static KeyedSemaphoreStripe KeyLocksOf(MemoryCacheService service) =>
+        (KeyedSemaphoreStripe)FieldOf(service, "_keyLocks");
+
+    /// <summary>
+    /// Snapshots the tracking table's keys. Read through the non-generic dictionary interface so the
+    /// test does not pin the value type the implementation happens to track records with.
+    /// </summary>
+    private static IReadOnlyList<string> TrackedKeysOf(MemoryCacheService service) =>
+        [.. ((IDictionary)FieldOf(service, "_keys")).Keys.Cast<string>()];
+
+    private static object FieldOf(MemoryCacheService service, string name) =>
+        typeof(MemoryCacheService)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(service)!;
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Concurrency/InProcessDistributedLockTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Concurrency/InProcessDistributedLockTests.cs
@@ -1,0 +1,98 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Infrastructure.Concurrency;
+
+namespace MMCA.Common.Infrastructure.Tests.Concurrency;
+
+/// <summary>
+/// Tests for the process-local <c>IDistributedLock</c> fallback used when no Redis connection is
+/// registered. It must still honor the contract the Redis implementation does: exclusive per exact
+/// key, bounded wait, owner-scoped and idempotent release.
+/// </summary>
+public sealed class InProcessDistributedLockTests
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
+
+    private readonly InProcessDistributedLock _sut =
+        new(NullLogger<InProcessDistributedLock>.Instance);
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenFree_Acquires()
+    {
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        handle.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenAlreadyHeld_ReturnsNull()
+    {
+        await using IAsyncDisposable? held = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        IAsyncDisposable? second = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        held.Should().NotBeNull();
+        second.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_AfterRelease_AcquiresAgain()
+    {
+        IAsyncDisposable? first = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+        await first!.DisposeAsync();
+
+        IAsyncDisposable? second = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        second.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_DoesNotBlockADifferentKey()
+    {
+        await using IAsyncDisposable? held = await _sut.TryAcquireAsync(
+            "key-a", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        IAsyncDisposable? other = await _sut.TryAcquireAsync(
+            "key-b", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        held.Should().NotBeNull();
+        other.Should().NotBeNull(
+            "keys are exact, not hashed into shared stripes: false sharing would report a key as held that nobody holds");
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenTheHolderReleasesDuringTheWait_Acquires()
+    {
+        IAsyncDisposable? held = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        Task<IAsyncDisposable?> waiter = _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        await held!.DisposeAsync();
+
+        (await waiter).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotentAndDoesNotReleaseTheNextHolder()
+    {
+        IAsyncDisposable? first = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+        await first!.DisposeAsync();
+
+        await using IAsyncDisposable? second = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+        await first.DisposeAsync();
+
+        second.Should().NotBeNull();
+        IAsyncDisposable? third = await _sut.TryAcquireAsync(
+            "key", Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+        third.Should().BeNull("the second holder still owns the key after the first handle is disposed again");
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Concurrency/RedisDistributedLockTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Concurrency/RedisDistributedLockTests.cs
@@ -1,0 +1,181 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Infrastructure.Concurrency;
+using Moq;
+using StackExchange.Redis;
+
+namespace MMCA.Common.Infrastructure.Tests.Concurrency;
+
+/// <summary>
+/// Tests for the Redis <c>SET NX PX</c> lock behind <c>IDistributedLock</c>: acquisition must be a
+/// single atomic conditional set carrying a TTL (so a crashed holder cannot wedge the key), and
+/// release must be a compare-and-delete on the owner token (so a holder whose TTL already lapsed
+/// cannot free the lock a different replica now owns).
+/// </summary>
+public sealed class RedisDistributedLockTests
+{
+    private const string Key = "idempotency:abc";
+    private const string QualifiedKey = "lock:idempotency:abc";
+
+    private static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
+
+    private readonly Mock<IDatabase> _database = new();
+    private readonly Mock<IConnectionMultiplexer> _multiplexer = new();
+    private readonly RedisDistributedLock _sut;
+
+    public RedisDistributedLockTests()
+    {
+        _multiplexer
+            .Setup(x => x.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+            .Returns(_database.Object);
+        _database
+            .Setup(x => x.ScriptEvaluateAsync(
+                It.IsAny<string>(),
+                It.IsAny<RedisKey[]>(),
+                It.IsAny<RedisValue[]>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisResult.Create((RedisValue)1));
+
+        _sut = new RedisDistributedLock(_multiplexer.Object, NullLogger<RedisDistributedLock>.Instance);
+    }
+
+    private void SetupAcquire(params bool[] results)
+    {
+        var attempt = 0;
+        _database
+            .Setup(x => x.StringSetAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(),
+                It.IsAny<When>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                var index = Interlocked.Increment(ref attempt) - 1;
+                return results[Math.Min(index, results.Length - 1)];
+            });
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenKeyIsFree_SetsOwnerTokenConditionallyWithTheTtl()
+    {
+        SetupAcquire(true);
+
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            Key, Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        handle.Should().NotBeNull();
+        _database.Verify(
+            x => x.StringSetAsync(
+                (RedisKey)QualifiedKey,
+                It.Is<RedisValue>(v => !v.IsNullOrEmpty),
+                Ttl,
+                false,
+                When.NotExists,
+                It.IsAny<CommandFlags>()),
+            Times.Once,
+            "acquisition must be one conditional SET carrying the TTL, never a GET-then-SET");
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHeldElsewhere_ReturnsNullWithoutExecuting()
+    {
+        SetupAcquire(false);
+
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            Key, Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        handle.Should().BeNull("a zero wait is a single non-blocking attempt");
+        _database.Verify(
+            x => x.StringSetAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(),
+                It.IsAny<When>(),
+                It.IsAny<CommandFlags>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryAcquireAsync_WhenHolderReleasesDuringTheWait_Acquires()
+    {
+        SetupAcquire(false, false, true);
+
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            Key, Ttl, TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        handle.Should().NotBeNull("the wait retries until the holder releases");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DeletesOnlyWhenTheStoredValueIsStillItsOwnToken()
+    {
+        SetupAcquire(true);
+        RedisValue writtenToken = default;
+        _database
+            .Setup(x => x.StringSetAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(),
+                It.IsAny<When>(),
+                It.IsAny<CommandFlags>()))
+            .Callback<RedisKey, RedisValue, TimeSpan?, bool, When, CommandFlags>(
+                (_, value, _, _, _, _) => writtenToken = value)
+            .ReturnsAsync(true);
+
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            Key, Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+        await handle!.DisposeAsync();
+
+        _database.Verify(
+            x => x.ScriptEvaluateAsync(
+                It.Is<string>(script => script.Contains("del", StringComparison.OrdinalIgnoreCase)),
+                It.Is<RedisKey[]>(keys => keys.Length == 1 && keys[0] == (RedisKey)QualifiedKey),
+                It.Is<RedisValue[]>(values => values.Length == 1 && values[0] == writtenToken),
+                It.IsAny<CommandFlags>()),
+            Times.Once,
+            "release is a compare-and-delete on the owner token, not an unconditional DEL");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        SetupAcquire(true);
+
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            Key, Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+        await handle!.DisposeAsync();
+        await handle.DisposeAsync();
+
+        _database.Verify(
+            x => x.ScriptEvaluateAsync(
+                It.IsAny<string>(),
+                It.IsAny<RedisKey[]>(),
+                It.IsAny<RedisValue[]>(),
+                It.IsAny<CommandFlags>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WhenTheLockAlreadyExpired_DoesNotThrow()
+    {
+        SetupAcquire(true);
+        _database
+            .Setup(x => x.ScriptEvaluateAsync(
+                It.IsAny<string>(),
+                It.IsAny<RedisKey[]>(),
+                It.IsAny<RedisValue[]>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisResult.Create((RedisValue)0));
+
+        IAsyncDisposable? handle = await _sut.TryAcquireAsync(
+            Key, Ttl, TimeSpan.Zero, TestContext.Current.CancellationToken);
+
+        Func<Task> act = async () => await handle!.DisposeAsync();
+
+        await act.Should().NotThrowAsync("a lapsed TTL is logged, not surfaced to the guarded work");
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/DependencyInjectionTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/DependencyInjectionTests.cs
@@ -7,9 +7,11 @@ using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure.Caching;
+using MMCA.Common.Infrastructure.Concurrency;
 using MMCA.Common.Infrastructure.Persistence;
 using MMCA.Common.Infrastructure.Services;
 using Moq;
+using StackExchange.Redis;
 
 namespace MMCA.Common.Infrastructure.Tests;
 
@@ -59,6 +61,31 @@ public sealed class DependencyInjectionTests
         ICacheService cacheService = provider.GetRequiredService<ICacheService>();
 
         cacheService.Should().BeOfType<DistributedCacheService>();
+    }
+
+    [Fact]
+    public void AddCaching_WithoutARedisConnection_FallsBackToProcessLocalLocking()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IDistributedLock distributedLock = provider.GetRequiredService<IDistributedLock>();
+
+        distributedLock.Should().BeOfType<InProcessDistributedLock>();
+    }
+
+    [Fact]
+    public void AddCaching_WithARedisConnection_UsesTheRedisLock()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Mock<IConnectionMultiplexer>().Object);
+        services.AddCaching();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IDistributedLock distributedLock = provider.GetRequiredService<IDistributedLock>();
+
+        distributedLock.Should().BeOfType<RedisDistributedLock>();
     }
 
     [Fact]

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/AzureNotificationHubDeviceRegistrarTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/AzureNotificationHubDeviceRegistrarTests.cs
@@ -1,0 +1,171 @@
+using System.Runtime.CompilerServices;
+using AwesomeAssertions;
+using Microsoft.Azure.NotificationHubs;
+using Microsoft.Azure.NotificationHubs.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Infrastructure.Services;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Tests for the Azure Notification Hubs device registrar (ADR-044), focused on the ownership
+/// check: installation ids are client-supplied, so the user-scoped delete verifies the
+/// <c>user:{id}</c> tag that the upsert stamps before it removes anything.
+/// </summary>
+public sealed class AzureNotificationHubDeviceRegistrarTests
+{
+    private const string InstallationId = "3f0c2f9c1e8b4b6c9d3a5e7f0a1b2c3d";
+    private const UserIdentifierType Owner = 42;
+    private const UserIdentifierType Stranger = 99;
+
+    private readonly Mock<INotificationHubClient> _hubClient = new();
+    private readonly AzureNotificationHubDeviceRegistrar _sut;
+
+    public AzureNotificationHubDeviceRegistrarTests() =>
+        _sut = new AzureNotificationHubDeviceRegistrar(
+            _hubClient.Object,
+            NullLogger<AzureNotificationHubDeviceRegistrar>.Instance);
+
+    /// <summary>
+    /// The SDK's messaging exceptions have no public constructors, so a thrown instance has to be
+    /// materialized without running one.
+    /// </summary>
+    private static T CreateSdkException<T>()
+        where T : Exception =>
+        (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+
+    private void SetupInstallation(params string[] tags) =>
+        _hubClient
+            .Setup(x => x.GetInstallationAsync(InstallationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Installation
+            {
+                InstallationId = InstallationId,
+                Platform = NotificationPlatform.FcmV1,
+                PushChannel = "fcm-registration-token",
+                Tags = [.. tags],
+            });
+
+    [Fact]
+    public async Task DeleteAsync_WhenTheCallerOwnsTheInstallation_Deletes()
+    {
+        SetupInstallation("user:42");
+
+        var result = await _sut.DeleteAsync(Owner, InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        _hubClient.Verify(
+            x => x.DeleteInstallationAsync(InstallationId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenTheInstallationBelongsToAnotherUser_DoesNotDelete()
+    {
+        SetupInstallation("user:42");
+
+        var result = await _sut.DeleteAsync(Stranger, InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue(
+            "not-yours answers exactly like unknown-id, so the endpoint is not an existence oracle");
+        _hubClient.Verify(
+            x => x.DeleteInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "another user's device must survive a delete aimed at its installation id");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenTheOwnerTagIsAPrefixOfAnother_DoesNotDelete()
+    {
+        // "user:420" must not satisfy an ownership check for user 42: the comparison is whole-tag
+        // and ordinal, not a prefix match.
+        SetupInstallation("user:420");
+
+        var result = await _sut.DeleteAsync(Owner, InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        _hubClient.Verify(
+            x => x.DeleteInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenTheInstallationHasNoOwnerTag_DoesNotDelete()
+    {
+        SetupInstallation();
+
+        var result = await _sut.DeleteAsync(Owner, InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        _hubClient.Verify(
+            x => x.DeleteInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenTheInstallationIsUnknown_SucceedsIdempotently()
+    {
+        _hubClient
+            .Setup(x => x.GetInstallationAsync(InstallationId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(CreateSdkException<MessagingEntityNotFoundException>());
+
+        var result = await _sut.DeleteAsync(Owner, InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        _hubClient.Verify(
+            x => x.DeleteInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenTheHubFails_ReturnsFailure()
+    {
+        _hubClient
+            .Setup(x => x.GetInstallationAsync(InstallationId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(CreateSdkException<MessagingException>());
+
+        var result = await _sut.DeleteAsync(Owner, InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "PushDevice.DeleteFailed");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UnscopedOverload_StillDeletesWithoutAnOwnershipLookup()
+    {
+        var result = await _sut.DeleteAsync(InstallationId, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        _hubClient.Verify(
+            x => x.DeleteInstallationAsync(InstallationId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _hubClient.Verify(
+            x => x.GetInstallationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the unscoped overload is for server-initiated cleanup where the owner is already established");
+    }
+
+    [Fact]
+    public async Task UpsertAsync_StampsTheOwnerTagTheDeleteChecksFor()
+    {
+        Installation? captured = null;
+        _hubClient
+            .Setup(x => x.CreateOrUpdateInstallationAsync(It.IsAny<Installation>(), It.IsAny<CancellationToken>()))
+            .Callback<Installation, CancellationToken>((installation, _) => captured = installation)
+            .Returns(Task.CompletedTask);
+
+        var result = await _sut.UpsertAsync(
+            Owner,
+            new()
+            {
+                InstallationId = InstallationId,
+                Platform = "FCMV1",
+                PushChannel = "fcm-registration-token",
+            },
+            TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        captured.Should().NotBeNull();
+        captured!.Tags.Should().Contain("user:42", "the delete's ownership check reads this tag back");
+    }
+}

--- a/Tests/Core/MMCA.Common.Shared.Tests/Extensions/DomainHelperTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Extensions/DomainHelperTests.cs
@@ -85,4 +85,153 @@ public class DomainHelperTests
     public void Parse_UnsupportedType_ThrowsFormatException() =>
         FluentActions.Invoking(() => "1.5".Parse<decimal>())
             .Should().Throw<FormatException>();
+
+    // ── TryParse: String ──
+    [Fact]
+    public void TryParse_String_ReturnsTrueAndValue()
+    {
+        "hello".TryParse<string>(out var value).Should().BeTrue();
+        value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void TryParse_NullString_ReturnsFalseAndEmpty()
+    {
+        ((string?)null).TryParse<string>(out var value).Should().BeFalse();
+        value.Should().Be(string.Empty);
+    }
+
+    // ── TryParse: Int ──
+    [Fact]
+    public void TryParse_ValidInt_ReturnsTrueAndValue()
+    {
+        "42".TryParse<int>(out var value).Should().BeTrue();
+        value.Should().Be(42);
+    }
+
+    [Fact]
+    public void TryParse_InvalidInt_ReturnsFalseAndZero()
+    {
+        "abc".TryParse<int>(out var value).Should().BeFalse();
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryParse_NullInt_ReturnsFalseAndZero()
+    {
+        ((string?)null).TryParse<int>(out var value).Should().BeFalse();
+        value.Should().Be(0);
+    }
+
+    // ── TryParse: Long ──
+    [Fact]
+    public void TryParse_ValidLong_ReturnsTrueAndValue()
+    {
+        "9999999999".TryParse<long>(out var value).Should().BeTrue();
+        value.Should().Be(9_999_999_999L);
+    }
+
+    [Fact]
+    public void TryParse_InvalidLong_ReturnsFalseAndZero()
+    {
+        "xyz".TryParse<long>(out var value).Should().BeFalse();
+        value.Should().Be(0L);
+    }
+
+    // ── TryParse: Ulong ──
+    [Fact]
+    public void TryParse_ValidUlong_ReturnsTrueAndValue()
+    {
+        "18446744073709551615".TryParse<ulong>(out var value).Should().BeTrue();
+        value.Should().Be(ulong.MaxValue);
+    }
+
+    [Fact]
+    public void TryParse_InvalidUlong_ReturnsFalseAndZero()
+    {
+        "-1".TryParse<ulong>(out var value).Should().BeFalse();
+        value.Should().Be(0UL);
+    }
+
+    // ── TryParse: Guid ──
+    [Fact]
+    public void TryParse_ValidGuid_ReturnsTrueAndValue()
+    {
+        var guid = Guid.NewGuid();
+
+        guid.ToString().TryParse<Guid>(out var value).Should().BeTrue();
+        value.Should().Be(guid);
+    }
+
+    [Fact]
+    public void TryParse_InvalidGuid_ReturnsFalseAndEmpty()
+    {
+        "not-a-guid".TryParse<Guid>(out var value).Should().BeFalse();
+        value.Should().Be(Guid.Empty);
+    }
+
+    // ── TryParse: Bool (the case Parse cannot distinguish) ──
+    [Fact]
+    public void TryParse_TrueString_ReturnsTrueAndTrue()
+    {
+        "true".TryParse<bool>(out var value).Should().BeTrue();
+        value.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryParse_FalseString_ReturnsTrueAndFalse()
+    {
+        "false".TryParse<bool>(out var value).Should().BeTrue();
+        value.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_InvalidBool_ReturnsFalse()
+    {
+        "maybe".TryParse<bool>(out var value).Should().BeFalse();
+        value.Should().BeFalse();
+    }
+
+    // ── TryParse: Enum ──
+    [Fact]
+    public void TryParse_ValidEnum_ReturnsTrueAndValue()
+    {
+        "Monday".TryParse<DayOfWeek>(out var value).Should().BeTrue();
+        value.Should().Be(DayOfWeek.Monday);
+    }
+
+    [Fact]
+    public void TryParse_CaseInsensitiveEnum_ReturnsTrueAndValue()
+    {
+        "friday".TryParse<DayOfWeek>(out var value).Should().BeTrue();
+        value.Should().Be(DayOfWeek.Friday);
+    }
+
+    [Fact]
+    public void TryParse_InvalidEnum_ReturnsFalseAndDefault()
+    {
+        "notaday".TryParse<DayOfWeek>(out var value).Should().BeFalse();
+        value.Should().Be(DayOfWeek.Sunday); // the enum default, which Parse cannot distinguish from a real "Sunday"
+    }
+
+    // ── TryParse: Whitespace / empty ──
+    [Fact]
+    public void TryParse_WhitespaceForNonString_ReturnsFalseAndDefault()
+    {
+        "  ".TryParse<int>(out var value).Should().BeFalse();
+        value.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryParse_EmptyForNonString_ReturnsFalseAndDefault()
+    {
+        string.Empty.TryParse<Guid>(out var value).Should().BeFalse();
+        value.Should().Be(Guid.Empty);
+    }
+
+    // ── TryParse: Unsupported type ──
+    [Fact]
+    public void TryParse_UnsupportedType_ThrowsFormatException() =>
+        FluentActions.Invoking(() => "1.5".TryParse<decimal>(out _))
+            .Should().Throw<FormatException>();
 }

--- a/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/CurrencyJsonConverterTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/CurrencyJsonConverterTests.cs
@@ -41,6 +41,20 @@ public class CurrencyJsonConverterTests
         FluentActions.Invoking(() => JsonSerializer.Deserialize<Currency>("\"XYZ\""))
             .Should().Throw<JsonException>();
 
+    [Theory]
+    [InlineData("123")]
+    [InlineData("{\"Code\":\"USD\"}")]
+    [InlineData("[\"USD\"]")]
+    [InlineData("true")]
+    public void Read_NonStringToken_ThrowsJsonException(string json) =>
+        FluentActions.Invoking(() => JsonSerializer.Deserialize<Currency>(json))
+            .Should().Throw<JsonException>();
+
+    [Fact]
+    public void Read_EmptyStringCode_ThrowsJsonException() =>
+        FluentActions.Invoking(() => JsonSerializer.Deserialize<Currency>("\"\""))
+            .Should().Throw<JsonException>();
+
     [Fact]
     public void Read_NullValue_ReturnsNull()
     {

--- a/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/MoneySerializationTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/MoneySerializationTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Shared.Tests.ValueObjects;
+
+/// <summary>
+/// Pins the round-trip contract of the private [JsonConstructor]: it is also the constructor EF Core
+/// uses to materialize the owned type, so a materializer that yields a null currency must fail fast.
+/// </summary>
+public class MoneySerializationTests
+{
+    private static Money Usd(decimal amount) => Money.Create(amount, Currency.Usd).Value!;
+
+    // -- Round-trip --
+    [Fact]
+    public void Roundtrip_FullPayload_PreservesAmountAndCurrency()
+    {
+        var json = JsonSerializer.Serialize(Usd(12.5m));
+
+        var deserialized = JsonSerializer.Deserialize<Money>(json);
+
+        deserialized.Should().Be(Usd(12.5m));
+    }
+
+    [Fact]
+    public void Serialize_WritesCurrencyAsCodeString()
+    {
+        var json = JsonSerializer.Serialize(Usd(3m));
+
+        json.Should().Contain("\"Currency\":\"USD\"");
+    }
+
+    // -- Missing / null currency --
+    [Fact]
+    public void Deserialize_PayloadMissingCurrency_ThrowsArgumentNullException() =>
+        FluentActions.Invoking(() => JsonSerializer.Deserialize<Money>("{\"Amount\":5}"))
+            .Should().Throw<ArgumentNullException>();
+
+    [Fact]
+    public void Deserialize_PayloadWithNullCurrency_ThrowsArgumentNullException() =>
+        FluentActions.Invoking(() => JsonSerializer.Deserialize<Money>("{\"Amount\":5,\"Currency\":null}"))
+            .Should().Throw<ArgumentNullException>();
+
+    // -- Currency.None sentinel --
+    [Fact]
+    public void Serialize_Zero_WritesEmptyCurrencyCode()
+    {
+        var json = JsonSerializer.Serialize(Money.Zero());
+
+        json.Should().Contain("\"Currency\":\"\"");
+    }
+
+    [Fact]
+    public void Deserialize_ZeroPayload_ThrowsJsonException()
+    {
+        // The Currency.None sentinel is an in-memory/EF concept: its empty code is not a valid
+        // ISO 4217 code, so the currency converter rejects it on the way back in. Documented
+        // contract, unchanged by the constructor guard.
+        var json = JsonSerializer.Serialize(Money.Zero());
+
+        FluentActions.Invoking(() => JsonSerializer.Deserialize<Money>(json))
+            .Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Roundtrip_ZeroWithCurrency_PreservesValue()
+    {
+        var json = JsonSerializer.Serialize(Money.Zero(Currency.Usd));
+
+        var deserialized = JsonSerializer.Deserialize<Money>(json);
+
+        deserialized.Should().Be(Money.Zero(Currency.Usd));
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/DevicesControllerTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/DevicesControllerTests.cs
@@ -80,15 +80,69 @@ public sealed class DevicesControllerTests
     }
 
     [Fact]
-    public async Task DeleteAsync_ReturnsNoContent()
+    public async Task DeleteAsync_ScopesTheDeleteToTheCurrentUser()
     {
         _registrar
-            .Setup(x => x.DeleteAsync("abc123", It.IsAny<CancellationToken>()))
+            .Setup(x => x.DeleteAsync(42, "abc123", It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
         var controller = CreateController();
 
         var result = await controller.DeleteAsync("abc123", TestContext.Current.CancellationToken);
 
         result.Should().BeOfType<NoContentResult>();
+        _registrar.Verify(
+            x => x.DeleteAsync(42, "abc123", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the installation id comes from the client, so the owner must be stamped server-side");
+        _registrar.Verify(
+            x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the unscoped overload performs no ownership check and must not be reached from the endpoint");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenInstallationIsUnknownOrNotOwned_StillReturnsNoContent()
+    {
+        // Both cases reach the controller as a successful registrar result on purpose: answering
+        // 404 for one and 204 for the other would let a caller probe for other users' ids.
+        _registrar
+            .Setup(x => x.DeleteAsync(42, "someone-elses-id", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        var controller = CreateController();
+
+        var result = await controller.DeleteAsync("someone-elses-id", TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithoutAuthenticatedUser_IsUnauthorized()
+    {
+        var controller = CreateController(userId: null);
+
+        var result = await controller.DeleteAsync("abc123", TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        _registrar.Verify(
+            x => x.DeleteAsync(It.IsAny<UserIdentifierType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _registrar.Verify(
+            x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenRegistrarFails_ReturnsProblemDetails()
+    {
+        _registrar
+            .Setup(x => x.DeleteAsync(42, "abc123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(Error.Failure("PushDevice.DeleteFailed", "Hub unavailable.")));
+        var controller = CreateController();
+
+        var result = await controller.DeleteAsync("abc123", TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 }

--- a/Tests/Presentation/MMCA.Common.API.Tests/Idempotency/IdempotencyFilterTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Idempotency/IdempotencyFilterTests.cs
@@ -21,11 +21,15 @@ public sealed class IdempotencyFilterTests
         string? userId = null,
         string method = "POST",
         string? routeTemplate = null,
-        Mock<ICacheService>? sharedCache = null)
+        Mock<ICacheService>? sharedCache = null,
+        IDistributedLock? distributedLock = null)
     {
         var cache = sharedCache ?? new Mock<ICacheService>();
         var services = new ServiceCollection();
         services.AddSingleton(cache.Object);
+        if (distributedLock is not null)
+            services.AddSingleton(distributedLock);
+
         var serviceProvider = services.BuildServiceProvider();
 
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
@@ -448,5 +452,243 @@ public sealed class IdempotencyFilterTests
                 It.IsAny<TimeSpan>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // ── Body-less successes ──
+    // Only ObjectResult used to be stored, so every command answering NoContent() cached nothing at
+    // all: a duplicate re-executed the action instead of replaying it, which is the whole point of
+    // the filter. StatusCodeResults are now stored with an empty body.
+    [Fact]
+    public async Task NoContentResponse_IsCachedWithAnEmptyBody()
+    {
+        var sut = new IdempotencyFilter();
+        var (context, cache) = CreateContext($"no-content-{Guid.NewGuid()}");
+
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = new NoContentResult()
+            }));
+
+        cache.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.Is<IdempotencyRecord>(r => r.StatusCode == 204 && r.ResponseBody.Length == 0),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FailureStatusCodeResult_NotCached()
+    {
+        var sut = new IdempotencyFilter();
+        var (context, cache) = CreateContext($"status-failure-{Guid.NewGuid()}");
+
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = new StatusCodeResult(409)
+            }));
+
+        cache.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the 2xx-only rule applies to body-less results too");
+    }
+
+    [Fact]
+    public async Task CachedEmptyBody_ReplaysAsAStatusCodeWithNoContentType()
+    {
+        var sut = new IdempotencyFilter();
+        var (context, cache) = CreateContext($"replay-no-content-{Guid.NewGuid()}");
+
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IdempotencyRecord(204, string.Empty));
+
+        var nextCalled = false;
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse();
+        context.Result.Should().BeOfType<StatusCodeResult>(
+            "a response with no body must not be replayed as application/json content");
+        ((StatusCodeResult)context.Result!).StatusCode.Should().Be(204);
+        context.HttpContext.Response.Headers["X-Idempotent-Replay"].ToString().Should().Be("true");
+    }
+
+    // ── Cross-replica duplicates ──
+    // The per-process stripe only serializes duplicates that land on the same replica, and both
+    // deployed apps run more than one, so an IDistributedLock guards the execute-then-store window.
+    [Fact]
+    public async Task DistributedLock_WhenAcquired_ExecutesOnceAndReleases()
+    {
+        var sut = new IdempotencyFilter();
+        var handle = new TrackingHandle();
+        var distributedLock = new Mock<IDistributedLock>();
+        distributedLock
+            .Setup(x => x.TryAcquireAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(handle);
+
+        var (context, cache) = CreateContext($"lock-free-{Guid.NewGuid()}", distributedLock: distributedLock.Object);
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        var nextCalls = 0;
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextCalls++;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = new ObjectResult(new { id = 1 }) { StatusCode = 201 }
+            });
+        });
+
+        nextCalls.Should().Be(1);
+        handle.Disposals.Should().Be(1, "the lock must be released even though the action succeeded");
+        cache.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the store has to happen inside the lock, before it is released");
+    }
+
+    [Fact]
+    public async Task DistributedLock_WhenHeldElsewhereAndTheHolderStored_ReplaysWithoutExecuting()
+    {
+        var sut = new IdempotencyFilter();
+        var distributedLock = new Mock<IDistributedLock>();
+        distributedLock
+            .Setup(x => x.TryAcquireAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IAsyncDisposable?)null);
+
+        var (context, cache) = CreateContext($"lock-held-{Guid.NewGuid()}", distributedLock: distributedLock.Object);
+
+        // Fast path misses; by the time the acquire gives up, the other replica has stored its response.
+        var getCalls = 0;
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => Interlocked.Increment(ref getCalls) == 1
+                ? null
+                : new IdempotencyRecord(200, "{\"id\":1}"));
+
+        var nextCalled = false;
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse("the other replica already ran this key; running it again is the double execution");
+        context.Result.Should().BeOfType<ContentResult>();
+        ((ContentResult)context.Result!).Content.Should().Be("{\"id\":1}");
+        context.HttpContext.Response.Headers["X-Idempotent-Replay"].ToString().Should().Be("true");
+    }
+
+    [Fact]
+    public async Task DistributedLock_WhenHeldElsewhereAndNothingStored_ReportsTheDuplicateInFlight()
+    {
+        var sut = new IdempotencyFilter();
+        var distributedLock = new Mock<IDistributedLock>();
+        distributedLock
+            .Setup(x => x.TryAcquireAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IAsyncDisposable?)null);
+
+        var (context, cache) = CreateContext($"lock-inflight-{Guid.NewGuid()}", distributedLock: distributedLock.Object);
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        var nextCalled = false;
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse("executing while another replica holds the key is exactly the duplicate write");
+        context.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        cache.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DistributedLock_IsAskedForABoundedWaitAndACrashGuardTtl()
+    {
+        var sut = new IdempotencyFilter();
+        var distributedLock = new Mock<IDistributedLock>();
+        distributedLock
+            .Setup(x => x.TryAcquireAsync(
+                It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TrackingHandle());
+
+        var (context, cache) = CreateContext($"lock-args-{Guid.NewGuid()}", distributedLock: distributedLock.Object);
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+
+        await sut.OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)));
+
+        distributedLock.Verify(
+            x => x.TryAcquireAsync(
+                It.Is<string>(key => key.StartsWith("idempotency:", StringComparison.Ordinal)),
+                It.Is<TimeSpan>(ttl => ttl > TimeSpan.Zero),
+                It.Is<TimeSpan>(wait => wait > TimeSpan.Zero && wait < TimeSpan.FromMinutes(1)),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the lock is taken on the same key the response is cached under, with a finite wait");
+    }
+
+    /// <summary>Lock handle that records how many times it was released.</summary>
+    private sealed class TrackingHandle : IAsyncDisposable
+    {
+        public int Disposals { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposals++;
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/Tests/Presentation/MMCA.Common.Grpc.Tests/GrpcResultExceptionInterceptorTests.cs
+++ b/Tests/Presentation/MMCA.Common.Grpc.Tests/GrpcResultExceptionInterceptorTests.cs
@@ -1,0 +1,152 @@
+using AwesomeAssertions;
+using Grpc.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Grpc.Exceptions;
+using MMCA.Common.Grpc.Interceptors;
+using MMCA.Common.Shared.Abstractions;
+using Moq;
+using Xunit;
+
+namespace MMCA.Common.Grpc.Tests;
+
+/// <summary>
+/// Verifies how <see cref="GrpcResultExceptionInterceptor"/> turns a caught
+/// <see cref="ResultFailureException"/> into transport status.
+/// <para>
+/// The error-carrying case keeps the shared <c>ToRpcException</c> mapping. The empty-errors case
+/// (what the message-only constructors produce) used to discard the exception message entirely and
+/// answer the placeholder "Unspecified failure", leaving the caller with a failure and no cause.
+/// It now keeps <see cref="StatusCode.Internal"/> and carries the real message: synthesizing an
+/// <c>Error.Failure</c> instead would have downgraded a server-side fault to
+/// <see cref="StatusCode.InvalidArgument"/>, blaming the caller.
+/// </para>
+/// </summary>
+public sealed class GrpcResultExceptionInterceptorTests
+{
+    private const string Boom = "the handler could not complete";
+
+    private readonly GrpcResultExceptionInterceptor _sut =
+        new(NullLogger<GrpcResultExceptionInterceptor>.Instance);
+
+    private readonly FakeServerCallContext _context = new();
+
+    [Fact]
+    public async Task UnaryServerHandler_WhenTheFailureCarriesNoErrors_KeepsInternalAndTheMessage()
+    {
+        Func<Task> act = async () => await _sut.UnaryServerHandler<string, string>(
+            "request",
+            _context,
+            (_, _) => throw new ResultFailureException(Boom));
+
+        RpcException thrown = (await act.Should().ThrowAsync<RpcException>()).Which;
+        thrown.StatusCode.Should().Be(StatusCode.Internal, "an empty error list is a server-side fault, not a bad request");
+        thrown.Status.Detail.Should().Be(Boom);
+    }
+
+    [Fact]
+    public async Task UnaryServerHandler_WhenTheFailureHasAnInnerException_AppendsItsMessage()
+    {
+        Func<Task> act = async () => await _sut.UnaryServerHandler<string, string>(
+            "request",
+            _context,
+            (_, _) => throw new ResultFailureException(Boom, new InvalidOperationException("socket closed")));
+
+        RpcException thrown = (await act.Should().ThrowAsync<RpcException>()).Which;
+        thrown.StatusCode.Should().Be(StatusCode.Internal);
+        thrown.Status.Detail.Should().Be($"{Boom}: socket closed");
+    }
+
+    [Fact]
+    public async Task UnaryServerHandler_WhenTheFailureCarriesErrors_UsesTheSharedMappingUnchanged()
+    {
+        Func<Task> act = async () => await _sut.UnaryServerHandler<string, string>(
+            "request",
+            _context,
+            (_, _) => throw new ResultFailureException([Error.NotFound.WithSource("Handler")]));
+
+        RpcException thrown = (await act.Should().ThrowAsync<RpcException>()).Which;
+        thrown.StatusCode.Should().Be(StatusCode.NotFound);
+        thrown.Trailers.Should().Contain(entry => entry.Key == "error-0-code");
+    }
+
+    [Fact]
+    public async Task UnaryServerHandler_WhenTheHandlerSucceeds_PassesTheResponseThrough()
+    {
+        var response = await _sut.UnaryServerHandler<string, string>(
+            "request",
+            _context,
+            (request, _) => Task.FromResult(request + "-ok"));
+
+        response.Should().Be("request-ok");
+    }
+
+    [Fact]
+    public async Task ServerStreamingServerHandler_WhenTheFailureCarriesNoErrors_KeepsInternalAndTheMessage()
+    {
+        Func<Task> act = async () => await _sut.ServerStreamingServerHandler<string, string>(
+            "request",
+            new Mock<IServerStreamWriter<string>>().Object,
+            _context,
+            (_, _, _) => throw new ResultFailureException(Boom));
+
+        RpcException thrown = (await act.Should().ThrowAsync<RpcException>()).Which;
+        thrown.StatusCode.Should().Be(StatusCode.Internal);
+        thrown.Status.Detail.Should().Be(Boom);
+    }
+
+    [Fact]
+    public async Task ClientStreamingServerHandler_WhenTheFailureCarriesNoErrors_KeepsInternalAndTheMessage()
+    {
+        Func<Task> act = async () => await _sut.ClientStreamingServerHandler<string, string>(
+            new Mock<IAsyncStreamReader<string>>().Object,
+            _context,
+            (_, _) => throw new ResultFailureException(Boom));
+
+        RpcException thrown = (await act.Should().ThrowAsync<RpcException>()).Which;
+        thrown.StatusCode.Should().Be(StatusCode.Internal);
+        thrown.Status.Detail.Should().Be(Boom);
+    }
+
+    [Fact]
+    public async Task DuplexStreamingServerHandler_WhenTheFailureCarriesNoErrors_KeepsInternalAndTheMessage()
+    {
+        Func<Task> act = async () => await _sut.DuplexStreamingServerHandler<string, string>(
+            new Mock<IAsyncStreamReader<string>>().Object,
+            new Mock<IServerStreamWriter<string>>().Object,
+            _context,
+            (_, _, _) => throw new ResultFailureException(Boom));
+
+        RpcException thrown = (await act.Should().ThrowAsync<RpcException>()).Which;
+        thrown.StatusCode.Should().Be(StatusCode.Internal);
+        thrown.Status.Detail.Should().Be(Boom);
+    }
+
+    /// <summary>Minimal call context: the interceptor only reads <c>Method</c> for the log line.</summary>
+    private sealed class FakeServerCallContext : ServerCallContext
+    {
+        protected override string MethodCore => "/mmca.Test/Method";
+
+        protected override string HostCore => "localhost";
+
+        protected override string PeerCore => "ipv4:127.0.0.1:5000";
+
+        protected override DateTime DeadlineCore => DateTime.UtcNow.AddMinutes(1);
+
+        protected override Metadata RequestHeadersCore { get; } = [];
+
+        protected override CancellationToken CancellationTokenCore => CancellationToken.None;
+
+        protected override Metadata ResponseTrailersCore { get; } = [];
+
+        protected override Status StatusCore { get; set; }
+
+        protected override WriteOptions? WriteOptionsCore { get; set; }
+
+        protected override AuthContext AuthContextCore { get; } = new(null, []);
+
+        protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options) =>
+            throw new NotSupportedException();
+
+        protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/MmcaThemeProvidersTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/MmcaThemeProvidersTests.cs
@@ -21,6 +21,9 @@ public sealed class MmcaThemeProvidersTests : BunitTestBase
     private static readonly FieldInfo OnChangeField = typeof(ThemeService)
         .GetField("OnChange", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
+    private static readonly FieldInfo IsDarkModeField = typeof(MmcaThemeProviders)
+        .GetField("_isDarkMode", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
     [Fact]
     public void Render_ProducesAllFourMudProviders_WithTheMmcaTheme()
     {
@@ -75,5 +78,33 @@ public sealed class MmcaThemeProvidersTests : BunitTestBase
 
         OnChangeField.GetValue(themeService).Should().BeNull(
             "the scoped ThemeService outlives the component, so Dispose must unsubscribe");
+    }
+
+    [Fact]
+    public async Task ThemeChangeRaisedAfterDisposal_IsIgnored_AndDoesNotThrow()
+    {
+        var themeService = Services.GetRequiredService<ThemeService>();
+        var cut = RenderUnderTest<MmcaThemeProviders>(_ => { });
+        var instance = cut.Instance;
+
+        // Let the first-render initialization settle so it cannot race the flip below.
+        await cut.WaitForAssertionAsync(() => themeService.IsInitialized.Should().BeTrue());
+
+        // OnChange is raised synchronously and its invocation list is captured at the raise, so a
+        // subscriber disposed partway through the chain (one scoped ThemeService feeds this component
+        // and every ThemeToggle placement) still gets called. Capture the delegate to replay that race.
+        var subscribers = (EventHandler?)OnChangeField.GetValue(themeService);
+        subscribers.Should().NotBeNull();
+
+        await DisposeComponentsAsync();
+        await themeService.SetDarkModeAsync(true);
+        IsDarkModeField.GetValue(instance).Should().Be(false, "the disposed component never saw the flip");
+
+        var raise = () => subscribers!.Invoke(themeService, EventArgs.Empty);
+
+        raise.Should().NotThrow(
+            "a rerender dispatched onto a disposed component must not surface to the publisher");
+        IsDarkModeField.GetValue(instance).Should().Be(false,
+            "the disposal guard returns before the handler refreshes state from the service");
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/MobileInfiniteScrollListTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/MobileInfiniteScrollListTests.cs
@@ -105,4 +105,70 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
 
         await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("Bravo"));
     }
+
+    [Fact]
+    public async Task ResetDuringAnInFlightFetch_DiscardsTheStalePage_AndReloadsWithoutRefetching()
+    {
+        var requestedPages = new List<int>();
+        var stalePage = new TaskCompletionSource<(IReadOnlyList<string> Items, int TotalItems)>();
+
+        Task<(IReadOnlyList<string> Items, int TotalItems)> GatedFetch(int page, int pageSize, CancellationToken ct)
+        {
+            requestedPages.Add(page);
+
+            // Call 1 is the initial load. Call 2 (the sentinel's page 2) is held open so the reset
+            // lands while it is still outstanding. Everything after that answers immediately.
+            if (requestedPages.Count == 1)
+            {
+                return Task.FromResult<(IReadOnlyList<string>, int)>((["Original"], 3));
+            }
+
+            if (requestedPages.Count == 2)
+            {
+                return stalePage.Task;
+            }
+
+            return page == 1
+                ? Task.FromResult<(IReadOnlyList<string>, int)>((["FreshPageOne"], 3))
+                : Task.FromResult<(IReadOnlyList<string>, int)>((["FreshPageTwo"], 3));
+        }
+
+        var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
+            .Add(c => c.CardTemplate, item => item)
+            .Add(c => c.PageSize, 1)
+            .Add(c => c.FetchPage, GatedFetch));
+
+        cut.Markup.Should().Contain("Original");
+
+        // Drive the whole race inside a single dispatcher work item so every step is deterministic:
+        // the sentinel's page-2 fetch suspends on the gate, the search/filter criteria change lands
+        // on top of it, and only then does the superseded fetch answer.
+        Task? supersededLoad = null;
+        await cut.InvokeAsync(async () =>
+        {
+            supersededLoad = cut.Instance.OnSentinelVisible();
+
+            await cut.Instance.ResetAsync();
+
+            stalePage.SetResult((["Stale"], 50));
+        });
+
+        await supersededLoad!;
+
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain(
+            "FreshPageOne", "the reset must actually reload, not early-return on the in-flight flag"));
+        cut.Markup.Should().NotContain("Stale", "a superseded fetch must not append into the list the reset cleared");
+        cut.Markup.Should().NotContain("Original");
+        cut.FindComponents<MudCard>().Count.Should().Be(1);
+
+        // Initial load, the superseded page 2, then the reset's reload of page 1.
+        requestedPages.Should().Equal(1, 2, 1);
+
+        // The next sentinel hit must move forward instead of re-requesting the page the superseded
+        // fetch already consumed (which would render a duplicate row).
+        await cut.InvokeAsync(() => cut.Instance.OnSentinelVisible());
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("FreshPageTwo"));
+        requestedPages.Should().Equal(1, 2, 1, 2);
+        cut.FindComponents<MudCard>().Count.Should().Be(2);
+    }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/ThemeToggleTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/ThemeToggleTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.UI.Components;
+using MMCA.Common.UI.Services;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers <see cref="ThemeToggle"/>, the app-bar Day/Dark switch (ADR-028): clicking flips the scoped
+/// <see cref="ThemeService"/>, an external theme change re-renders the button, disposal unsubscribes
+/// so the long-lived service never calls back into a dead component, and a change that was already
+/// being raised when disposal landed is ignored instead of throwing back at the publisher.
+/// </summary>
+public sealed class ThemeToggleTests : BunitTestBase
+{
+    private static readonly FieldInfo OnChangeField = typeof(ThemeService)
+        .GetField("OnChange", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    [Fact]
+    public void ClickingTheToggle_FlipsTheThemeService()
+    {
+        var themeService = Services.GetRequiredService<ThemeService>();
+        var cut = RenderUnderTest<ThemeToggle>(_ => { });
+
+        cut.Find("button").Click();
+
+        cut.WaitForAssertion(() => themeService.IsDarkMode.Should().BeTrue(
+            "the toggle owns no state of its own; it drives the scoped ThemeService"));
+    }
+
+    [Fact]
+    public async Task ThemeServiceChange_RerendersTheToggle()
+    {
+        var themeService = Services.GetRequiredService<ThemeService>();
+        var cut = RenderUnderTest<ThemeToggle>(_ => { });
+        string lightMarkup = cut.Markup;
+
+        await cut.InvokeAsync(() => themeService.SetDarkModeAsync(true));
+
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().NotBe(
+            lightMarkup, "both the icon and the aria-label read from ThemeService.IsDarkMode"));
+    }
+
+    [Fact]
+    public async Task Dispose_UnsubscribesFromTheThemeServiceOnChangeEvent()
+    {
+        var themeService = Services.GetRequiredService<ThemeService>();
+        RenderUnderTest<ThemeToggle>(_ => { });
+        OnChangeField.GetValue(themeService).Should().NotBeNull("the component subscribes in OnInitialized");
+
+        await DisposeComponentsAsync();
+
+        OnChangeField.GetValue(themeService).Should().BeNull(
+            "the scoped ThemeService outlives the component, so Dispose must unsubscribe");
+    }
+
+    [Fact]
+    public async Task ThemeChangeRaisedAfterDisposal_DoesNotThrow()
+    {
+        var themeService = Services.GetRequiredService<ThemeService>();
+        RenderUnderTest<ThemeToggle>(_ => { });
+
+        // OnChange is raised synchronously and its invocation list is captured at the raise, so a
+        // subscriber disposed partway through the chain (one scoped ThemeService feeds both ThemeToggle
+        // placements and MmcaThemeProviders) still gets called. Capture the delegate to replay that race.
+        var subscribers = (EventHandler?)OnChangeField.GetValue(themeService);
+        subscribers.Should().NotBeNull();
+
+        await DisposeComponentsAsync();
+
+        var raise = () => subscribers!.Invoke(themeService, EventArgs.Empty);
+
+        raise.Should().NotThrow(
+            "a rerender dispatched onto a disposed component must not surface to the publisher "
+            + "and cut off the subscribers queued behind it");
+    }
+}


### PR DESCRIPTION
## Summary

Second and final MMCA.Common BugHunt remediation PR (waves W3 API boundary, W4 shared contracts, W5 query/caching/UI). Every item was adversarially re-verified before implementation. Rebased on main after PR C-1 (#179); full suite green on the combined tree (2667 tests).

| Item | Fix |
|---|---|
| M30 | Push-device DELETE verifies installation ownership via the user tag; unknown and not-owned ids both 204 (no existence oracle). Additive user-scoped IPushDeviceRegistrar member with default implementation. |
| M36 | Registration race losing the unique-index race surfaces Auth.EmailAlreadyExists (broad catch + re-check; Application cannot name DbUpdateException). |
| M11 | 2xx StatusCodeResult (204) responses are stored/replayed by the idempotency filter, body-less replays carry no content type. |
| M12 | New IDistributedLock (Redis SET NX PX + owner-token Lua release; exact-key in-process fallback) closes the cross-replica idempotency window; hosts without Redis keep today's behavior. |
| M13 | Empty-Errors ResultFailureException surfaces its message as the gRPC detail, preserving StatusCode.Internal, in all four call shapes. |
| M9 | Shared CurrencyJsonConverter rejects non-string tokens with JsonException (API-converter parity). |
| M33 | Money's JsonConstructor null-guards currency (fail-fast instead of a later NRE); Store's EF converters already materialize the sentinel. |
| M34 | Additive TryParse companion to the deliberately coercing Parse; docs steer bool/enum callers. |
| M3 | Sort validation consults DTOToEntityPropertyMap (parity with filters). |
| M4+M35 | Pagination metadata built through the validating ctor with floors at all three sites; overflow sentinel no longer reports PageSize=0. |
| M37 | Decorator failure factories build lazily; non-Result handlers resolve instead of TypeInitializationException. |
| M38 | Client-keyed projection/accessor caches capped at 512; past-cap skips projection (never compiles per request). |
| M5 | Prefix eviction scans all non-replica Redis servers, deletes per key (cross-slot DEL throws on the prod OSS-cluster topology). |
| M31 | MemoryCacheService per-key mutual exclusion + eviction-callback entry tokens close the untracked-live-entry race. |
| M14 | MobileInfiniteScrollList reset cancels in-flight fetches; a generation counter discards stale appends/duplicate pages. |
| M39 | ThemeToggle + MmcaThemeProviders rerenders guarded against disposal. |

## Verification

- Combined branch (rebased on #179): `dotnet build MMCA.Common.slnx` clean, full `dotnet test --solution MMCA.Common.slnx`: 2667 passed, 0 failed
- Per-wave: Release builds clean, suites 2567/2599/2646 green, FACTS check up to date each wave
- 100+ new regression tests, including a restored-pre-fix spot check proving the M14 test fails against the old code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aXCqcfqf5Ka4hKWQphh3i