### PR TITLE
docs: correct MTP single-test filter syntax in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ MMCA.Common is a .NET 10 NuGet package framework for building modular monolith a
 ```bash
 dotnet build MMCA.Common.slnx -c Release
 dotnet test --solution MMCA.Common.slnx -c Release                                # all tests
-dotnet test --project Tests/Presentation/MMCA.Common.API.Tests -- -method "*IdempotencyFilterTests*"   # single test (MTP filter; -class works too)
+dotnet test --project Tests/Presentation/MMCA.Common.API.Tests -- --filter-method "*IdempotencyFilterTests*"   # single test (MTP filter; --filter-class works too)
 dotnet test --project Tests/Architecture/MMCA.Common.Architecture.Tests           # NetArchTest layer/purity rules (fast, no DB)
 dotnet test --project Tests/Presentation/MMCA.Common.UI.E2E.Tests/MMCA.Common.UI.E2E.Tests.csproj      # UI a11y + render smoke (NOT in slnx; needs `playwright install chromium` once)
 dotnet run -c Release --project Tests/Performance/MMCA.Common.Benchmarks          # BenchmarkDotNet smoke; append `-- --job Dry` for a fast correctness pass


### PR DESCRIPTION
## What

Corrects the single-test filter syntax documented in `CLAUDE.md`.

| | Before | After |
|---|---|---|
| by method | `-- -method "*Pattern*"` | `-- --filter-method "*Pattern*"` |
| by class | `-- -class "*Pattern*"` | `-- --filter-class "*Pattern*"` |

## Why

The documented flags are rejected by the xUnit v3 runner (3.2.2) that all four repos use under Microsoft Testing Platform. The run does not error loudly: it exits with code 5 having executed zero tests, which reads as "nothing matched my filter" rather than "my flag was wrong".

Verified in MMCA.Helpdesk against the architecture test project:

```
$ dotnet test --project Tests/Architecture/... -- --filter-class "*ModuleIsolationTests*"
Passed!  total: 6  failed: 0  succeeded: 6

$ dotnet test --project Tests/Architecture/... -- -class "*ModuleIsolationTests*"
total: 0  ...  Test run completed with non-success exit code: 5
```

## Scope

Docs-only, one line changed (two in MMCA.Helpdesk). The workspace root `CLAUDE.md` carries the same correction, applied outside this PR since it is not tracked in any repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
