### PR TITLE
docs: SeedAsync is IModuleSeeder, not an IModule member

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ An optional `Profiling` decorator pair is registered by a separate opt-in `AddAp
 
 ### Module System
 
-`IModule` implementations (with `Name`, `Dependencies`, `RequiresDependencies`, `Register()`, `SeedAsync()`, disabled-stub registration) are discovered via reflection and registered in topological order (Kahn's algorithm) by `ModuleLoader`. `ModulesSettings` (config section `Modules`) can disable modules; disabled modules receive stub registrations so cross-module interfaces stay resolvable. `ScanModuleApplicationServices<TAssemblyMarker>()` auto-registers domain event handlers (singleton), DTO/request mappers (scoped), command/query handlers (scoped), and validators. DI registration methods use C# preview extension types (`extension(IServiceCollection services)` blocks in `DependencyInjection.cs`).
+`IModule` implementations (five members: `Name`, `Dependencies`, `RequiresDependencies`, `Register()`, `RegisterDisabledStubs()`, the last three defaulted, so a leaf module is `Name` plus `Register`) are discovered via reflection and registered in topological order (Kahn's algorithm) by `ModuleLoader`. Seeding is a **separate** contract, `IModuleSeeder.SeedAsync(...)`, which `ModuleLoader` invokes in the same registration order; it is not a member of `IModule`. `ModulesSettings` (config section `Modules`) can disable modules; disabled modules receive stub registrations so cross-module interfaces stay resolvable. `ScanModuleApplicationServices<TAssemblyMarker>()` auto-registers domain event handlers (singleton), DTO/request mappers (scoped), command/query handlers (scoped), and validators. DI registration methods use C# preview extension types (`extension(IServiceCollection services)` blocks in `DependencyInjection.cs`).
 
 ### Entity Model
 


### PR DESCRIPTION
Documentation only, one line.

The Module System section listed `SeedAsync()` among `IModule`'s members. It is not one.

`IModule` has exactly **five** members, three of them defaulted, so a leaf module is `Name` plus `Register`:

| Member | Line |
|---|---|
| `string Name { get; }` | `Modules/IModule.cs:12` |
| `IReadOnlyList<string> Dependencies => []` | `:17` |
| `bool RequiresDependencies => false` | `:23` |
| `void Register(...)` | `:28` |
| `void RegisterDisabledStubs(...) { }` | `:34` |

Seeding is a **separate** contract: `IModuleSeeder.SeedAsync(...)` (`Modules/IModuleSeeder.cs:18`), which `ModuleLoader` invokes in the same registration order (`Modules/ModuleLoader.cs:264,274`).

The onboarding group-14 chapter already attributes it correctly, so this line was the only place that conflated the two. Found while re-verifying cross-repo doc claims against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)