### PR TITLE
fix: keep the sidebar pinned on scroll and stop duplicating the user name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 > ADR-016. An audit that reports the consumers as "several versions behind" for that window is
 > reading history, not a gap.
 
+### Fixed
+
+- **The desktop sidebar stays pinned while the page scrolls.** It is exactly one viewport tall and
+  relies on `position: sticky`, so on any page taller than the screen its background stopped one
+  viewport down and the page background showed beside the content. Sticky resolves against the
+  nearest ancestor scroll container, and two rules were creating dead ones that never scroll:
+  `html, body { overflow-y: auto }` in `app.css`, and `.page { overflow-x: hidden }` in
+  `MainLayout.razor.css` (a non-visible `overflow-x` forces the computed `overflow-y` from
+  `visible` to `auto`). The first is removed; the second is now `clip`, which bounds horizontal
+  overflow without establishing a scrollport. Consumers get the fix with no code change.
+
+### Changed
+
+- **The signed-in user name no longer repeats on the mobile top row.** `NavMenu`'s
+  `.toprow-user-name` span is removed. That row only ever renders below 1024px, which is exactly
+  where the hamburger menu's `.nav-auth-section` already shows the name above Logout, so it was
+  always a duplicate and it competed for room on the narrowest row in the layout. On a phone the
+  name is now visible after opening the menu rather than always on screen; hosts wanting an
+  always-visible indicator should add an avatar or account icon via their app-bar components.
+
 ## [1.135.0] - 2026-08-01
 
 The BugHunt remediation release: 24 verified defects fixed across persistence, event delivery,

--- a/Source/Presentation/MMCA.Common.UI/Layout/MainLayout.razor.css
+++ b/Source/Presentation/MMCA.Common.UI/Layout/MainLayout.razor.css
@@ -112,7 +112,14 @@ main {
         flex-wrap: wrap;
         width: 100%;
         max-width: 100vw;
-        overflow-x: hidden;
+        /* clip, NOT hidden: per spec a non-visible overflow-x forces the computed overflow-y
+           from visible to auto, which turns .page into a scroll container. The sticky sidebar
+           below then resolves against .page's scrollport instead of the viewport, and since
+           .page grows with its content and never scrolls itself, the sidebar never sticks: it
+           scrolled off with the document and its background stopped one viewport down. clip
+           bounds the horizontal overflow the same way without creating a scrollport. Same
+           reasoning as main's overflow-x below. */
+        overflow-x: clip;
     }
 
     /* Force the footer onto the next flex line so it spans full width instead of

--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
@@ -19,8 +19,11 @@
     </div>
     @* Mobile-only quick actions (CSS hides this row at >=1024px, where the MudAppBar takes over; the
        app bar itself is hidden below 1024px). Culture + theme must be available to everyone here,
-       authenticated or not (ADR-027/028); only the module app-bar components and the user name are
-       gated on authentication. *@
+       authenticated or not (ADR-027/028); only the module app-bar components are gated on
+       authentication. The signed-in user name deliberately does NOT repeat here: this row only ever
+       renders below 1024px, which is exactly where .nav-auth-section shows the name above Logout in
+       the hamburger menu, so a copy on the top row was pure duplication competing for the narrowest
+       row in the layout. *@
     <div class="toprow-actions" aria-label="@L["Nav.QuickActions.Aria"]">
         <CultureSwitcher />
         <ThemeToggle />
@@ -30,7 +33,6 @@
                 {
                     <DynamicComponent Type="componentType" />
                 }
-                <span class="toprow-user-name" title="@context.User.Identity?.Name">@context.User.Identity?.Name</span>
             </Authorized>
         </AuthorizeView>
     </div>

--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor.css
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor.css
@@ -197,10 +197,11 @@
        the absolutely positioned .navbar-toggler, but a shrinkable actions box (the previous
        min-width: 0 plus the default flex-shrink: 1) gets squeezed by the width:100% brand
        container and spills its nowrap, overflow-visible contents right into that reserve,
-       painting the theme icon over the hamburger. Signed in, .toprow-user-name absorbed the
-       squeeze by ellipsizing, so only the signed-out row (two fixed-width icon buttons, nothing
-       shrinkable) ever showed it. The brand is the element meant to give way instead:
-       .top-row .container-fluid is min-width: 0 and .navbar-brand already ellipsizes. */
+       painting the theme icon over the hamburger. The row now holds only fixed-width icon buttons
+       in every auth state (the ellipsizing user name that used to absorb the squeeze when signed
+       in has moved to the hamburger menu's .nav-auth-section), so nothing here can give way and
+       this must stay. The brand is the element meant to give way instead: .top-row
+       .container-fluid is min-width: 0 and .navbar-brand already ellipsizes. */
     flex: 0 0 auto;
     /* Prevent the top-row from clipping the badge above the icon */
     overflow: visible;
@@ -231,23 +232,6 @@
     padding: 0 5px !important;
     border: 2px solid var(--mmca-sidebar-bg-dark, #141B2D) !important;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3) !important;
-}
-
-.toprow-user-name {
-    font-size: 0.8125rem;
-    max-width: 7rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: rgba(255, 255, 255, 0.85);
-    padding: 0 0.25rem;
-}
-
-/* Very small phones: hide user name, keep icons */
-@media (max-width: 359.98px) {
-    .toprow-user-name {
-        display: none;
-    }
 }
 
 .top-row .container-fluid {

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
@@ -40,10 +40,14 @@
     --mmca-z-snackbar-mobile: 10000;
 }
 
+/* Deliberately no overflow-y here. With height: auto both boxes are already content-sized, so
+   overflow-y: auto changed nothing visually but made <body> a scroll container that never
+   scrolls (the viewport does). The layout's sticky sidebar then resolved against that dead
+   scrollport instead of the viewport and never stuck, so its background stopped one viewport
+   down on any page taller than the screen. Leave the default (visible). */
 html, body {
     font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
     height: auto;
-    overflow-y: auto;
 }
 
 a, .btn-link {

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/MobileTopRowE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/MobileTopRowE2ETests.cs
@@ -81,4 +81,35 @@ public sealed class MobileTopRowE2ETests : GalleryAxeTestBase
         await Expect(appBar.GetByRole(AriaRole.Button, new() { Name = "Language" })).ToBeVisibleAsync();
         await Expect(appBar.GetByTitle("Toggle light/dark theme")).ToBeVisibleAsync();
     }
+
+    /// <summary>
+    /// The signed-in user name belongs in exactly one place on a phone: the hamburger menu, above
+    /// Logout. The top-row actions span only ever renders below 1024px, so a copy there was always a
+    /// duplicate of the menu entry, and it competed for room on the narrowest row in the layout.
+    /// </summary>
+    [Fact]
+    public async Task PhoneViewport_ShowsUserName_OnlyInTheHamburgerMenu()
+    {
+        await Page.Context.AddCookiesAsync(
+        [
+            new Cookie { Name = "gallery_auth", Value = "1", Url = BaseUrl },
+        ]);
+
+        await Page.SetViewportSizeAsync(390, 844);
+        await Page.GotoAsync("/");
+        await Page.WaitForLoadStateAsync();
+
+        // Premise: the gallery cookie really did sign this scan in, so an absent name below is the
+        // top-row rule and not an anonymous render.
+        await Expect(Page.Locator(".nav-auth-section")).ToContainTextAsync("Gallery Visitor");
+
+        await Expect(Page.Locator(".toprow-actions")).ToBeVisibleAsync();
+        await Expect(Page.Locator(".toprow-actions")).Not.ToContainTextAsync("Gallery Visitor");
+
+        // Opening the menu is what surfaces the name to the user: .nav-scrollable is collapsed to
+        // max-height 0 until the toggler is checked.
+        await Page.Locator(".navbar-toggler").CheckAsync();
+        await Expect(Page.Locator(".nav-user-identity")).ToBeVisibleAsync();
+        await Expect(Page.Locator(".nav-user-identity")).ToContainTextAsync("Gallery Visitor");
+    }
 }

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/StickySidebarE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/StickySidebarE2ETests.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using MMCA.Common.Testing.E2E.Infrastructure;
+using MMCA.Common.UI.E2E.Tests.Infrastructure;
+using Xunit;
+
+namespace MMCA.Common.UI.E2E.Tests;
+
+/// <summary>
+/// Regression gate for the desktop sidebar staying pinned while the page scrolls. The sidebar is
+/// exactly one viewport tall and relies on <c>position: sticky</c> to cover the full height of a
+/// longer page; when it stops sticking, its dark background simply ends one viewport down and the
+/// page background shows beside the content.
+/// <para>
+/// Sticky resolves against the nearest ancestor scroll container, so ANY ancestor picking up a
+/// non-visible overflow silently disables it. Two rules did: <c>html, body { overflow-y: auto }</c>
+/// in app.css, and <c>.page { overflow-x: hidden }</c> in MainLayout.razor.css (a non-visible
+/// overflow-x forces the computed overflow-y from visible to auto). Both ancestors are content-
+/// sized and therefore never scroll themselves, so the sidebar resolved against a dead scrollport
+/// and scrolled away with the document. These assertions pin the behaviour rather than the CSS, so
+/// they catch any future ancestor that reintroduces a scrollport.
+/// </para>
+/// </summary>
+public sealed class StickySidebarE2ETests : GalleryAxeTestBase
+{
+    private const string SidebarTop = "() => Math.round(document.querySelector('aside.sidebar').getBoundingClientRect().top)";
+
+    public StickySidebarE2ETests(PlaywrightFixture playwright, GalleryHostFixture gallery)
+        : base(playwright, gallery)
+    {
+    }
+
+    [Fact]
+    public async Task DesktopViewport_SidebarStaysPinned_WhenPageIsScrolled()
+    {
+        await Page.SetViewportSizeAsync(1440, 900);
+        await Page.GotoAsync("/components");
+        await Page.WaitForLoadStateAsync();
+
+        // Guard the premise: a page shorter than the viewport cannot demonstrate the defect.
+        var scrollable = await Page.EvaluateAsync<int>(
+            "() => document.documentElement.scrollHeight - window.innerHeight");
+        Assert.True(
+            scrollable > 200,
+            string.Create(CultureInfo.InvariantCulture, $"Gallery page is not tall enough to scroll ({scrollable}px)."));
+
+        Assert.Equal(0, await Page.EvaluateAsync<int>(SidebarTop));
+
+        await Page.EvaluateAsync("() => window.scrollTo(0, document.documentElement.scrollHeight)");
+        await Page.WaitForTimeoutAsync(250);
+
+        // Pinned means the sidebar top is still flush with the viewport top, so its background
+        // continues to cover the full viewport height at the bottom of the page.
+        Assert.Equal(0, await Page.EvaluateAsync<int>(SidebarTop));
+    }
+
+    [Fact]
+    public async Task NoAncestorOfTheSidebar_EstablishesAScrollport()
+    {
+        await Page.SetViewportSizeAsync(1440, 900);
+        await Page.GotoAsync("/components");
+        await Page.WaitForLoadStateAsync();
+
+        var offenders = await Page.EvaluateAsync<string[]>(
+            "() => { const out = []; for (let e = document.querySelector('aside.sidebar').parentElement; e; e = e.parentElement) { const c = getComputedStyle(e); if (c.overflowY !== 'visible' || (c.overflowX !== 'visible' && c.overflowX !== 'clip')) { out.push(e.tagName + '.' + ((e.className || '').toString().split(' ')[0]) + ' overflow: ' + c.overflowX + ' ' + c.overflowY); } } return out; }");
+
+        Assert.Empty(offenders);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
@@ -49,6 +49,13 @@ public sealed class NavMenuTests : BunitTestBase
         cut.Markup.Should().Contain("Logout");
         cut.Markup.Should().Contain("Ada Lovelace");
         cut.Markup.Should().NotContain(">Login<");
+
+        // Exactly once: the name belongs to the hamburger menu's auth section only. The mobile
+        // top-row used to render a second copy (with a duplicate title attribute), which on a phone
+        // showed the same name twice and squeezed the narrowest row in the layout.
+        cut.FindAll(".nav-user-identity").Should().ContainSingle();
+        cut.FindAll(".toprow-actions").Should().ContainSingle();
+        cut.Find(".toprow-actions").TextContent.Should().NotContain("Ada Lovelace");
     }
 
     [Fact]


### PR DESCRIPTION
Two defects in the shared `MMCA.Common.UI` layout, both reported against MMCA.ADC but neither ADC-specific: they affect MMCA.Store and every page taller than the viewport.

## Sidebar background stops partway down the page

The desktop sidebar is exactly one viewport tall (`height: 100vh`) and relies on `position: sticky` to keep covering a longer page. Sticky resolves against the nearest **ancestor scroll container**, and two rules were quietly creating ones that never scroll:

- `app.css` -- `html, body { overflow-y: auto }`. Both boxes are `height: auto`, so this changed nothing visually but made `<body>` a scroll container (the viewport is what actually scrolls).
- `MainLayout.razor.css` -- `.page { overflow-x: hidden }`. Per spec a non-visible `overflow-x` forces the computed `overflow-y` from `visible` to `auto`, so `.page` became one too. The `main` rule directly below it already carries a comment explaining this exact trap and uses `clip` for that reason; `.page` was missed.

With nothing real to stick to, the sidebar scrolled off with the document. Measured on the rendered gallery layout: at the bottom of the page the sidebar top was at **-832px**, leaving 68px on screen and bare page background below. After the fix it stays at **0** at full scroll.

Fixing only `.page` was not enough, which is why the new test asserts on the whole ancestor chain rather than on either rule.

## Signed-in user name rendered twice on a phone

`NavMenu` showed the name in the mobile top row (`.toprow-user-name`) and again in the hamburger menu above Logout (`.nav-auth-section`). `.toprow-actions` is already `display: none` at >=1024px, so that span only ever rendered below 1024px, which is exactly the range where the menu also shows the name. It was never the only copy at any breakpoint, so it is removed outright rather than hidden behind another media query. Its CSS rule and the `@media (max-width: 359.98px)` block that existed only to hide it on very small phones are deleted too.

**Behavior change worth noting:** on a phone the name is now visible after opening the menu rather than always on screen. Hosts wanting an always-visible signed-in indicator should add an avatar or account icon through their app-bar components, which costs far less width than a name.

## Tests

The signed-in mobile row had no coverage at all (every gallery scan was anonymous), so:

- `StickySidebarE2ETests` (new) -- the sidebar stays pinned at full scroll, and no ancestor of it establishes a scrollport. Both assert behavior rather than specific CSS, so any future ancestor reintroducing a scrollport fails the build.
- `MobileTopRowE2ETests.PhoneViewport_ShowsUserName_OnlyInTheHamburgerMenu` (new) -- signs in via the `gallery_auth` cookie at 390x844, asserts the top row is visible but does not contain the name, then opens the menu and asserts it does. Verified non-vacuous: temporarily restoring the span makes it fail.
- `NavMenuTests.WhenAuthenticated_ShowsLogoutAndUserName_NotLogin` -- extended from "markup contains the name" to pinning a single `.nav-user-identity` and no name inside `.toprow-actions`. The previous assertion passed with the duplicate present.

## Verification

- UI E2E suite 27/27 (includes the axe WCAG 2.1 AA scans and dark mode).
- Full suite `dotnet test --solution MMCA.Common.slnx -c Release` 2667/2667.
- `dotnet build MMCA.Common.slnx -c Release` clean, 0 warnings.
- Grepped all four repos: nothing overrides `.toprow-user-name`, so no consumer breaks.

Consumers pick both fixes up on the next lockstep pin bump with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)