### PR TITLE
release: v1.136.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 > ADR-016. An audit that reports the consumers as "several versions behind" for that window is
 > reading history, not a gap.
 
+## [1.136.0] - 2026-08-03
+
+A shared-layout fix release: the desktop sidebar now stays pinned while the page scrolls,
+and the signed-in user name no longer renders twice on a phone. Both are pure UI changes in
+MMCA.Common.UI; consumers pick them up with the pin bump and no code change.
+
 ### Fixed
 
 - **The desktop sidebar stays pinned while the page scrolls.** It is exactly one viewport tall and


### PR DESCRIPTION
Docs-only release PR for **v1.136.0**: promotes the Unreleased entries under a dated heading. No source changes ride here.

## What ships in v1.136.0

Both from #187 (already merged to `main`), in the shared `MMCA.Common.UI` layout:

- **The desktop sidebar stays pinned while the page scrolls.** It is one viewport tall and relies on `position: sticky`, so on any page taller than the screen its background stopped one viewport down. Two rules were creating ancestor scroll containers that never scroll (`html, body { overflow-y: auto }` in `app.css`, and `.page { overflow-x: hidden }` in `MainLayout.razor.css`, where a non-visible `overflow-x` forces the computed `overflow-y` to `auto`). Fixed by removing the first and switching the second to `clip`.
- **The signed-in user name no longer repeats on the mobile top row.** `NavMenu`'s `.toprow-user-name` span only ever rendered below 1024px, exactly where the hamburger menu already shows the name above Logout. Removed, with its now-dead CSS.

No public API surface change, so consumers take this with the pin bump alone and no code edits.

One behavior change for hosts to be aware of: on a phone the signed-in name is now visible after opening the hamburger menu rather than always on screen.

FACTS.md is deliberately untouched here; it is regenerated post-tag so the drift gate computes the same version it pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)