### PR TITLE
feat: close production gaps in resilience, idempotency and observability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,11 @@
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <!-- Shared DataProtection key ring (MMCA.Common.Aspire.AddCommonDataProtection). Blobs persists
+         the key ring so every replica decrypts the same auth cookies and antiforgery tokens; Keys is
+         the optional at-rest encryption of that key ring. Both reuse the Azure.Identity pin above. -->
+    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.3" />
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,6 +69,11 @@
          the optional at-rest encryption of that key ring. Both reuse the Azure.Identity pin above. -->
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.6.3" />
+    <!-- Pinned directly to force transitive resolution to the patched servicing version: the
+         DataProtection.Blobs/Keys chain otherwise pulls 10.0.7 (five high advisories, NU1903).
+         Projects with the AspNetCore framework reference prune this away; consumers WITHOUT it
+         (Aspire AppHosts) resolve the transitive as a real package and need the lifted version. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />

--- a/Source/Core/MMCA.Common.Application/Auth/SoftDeletedUserCache.cs
+++ b/Source/Core/MMCA.Common.Application/Auth/SoftDeletedUserCache.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using MMCA.Common.Application.Interfaces;
+
+namespace MMCA.Common.Application.Auth;
+
+/// <summary>
+/// Shared cache contract for the soft-deleted user marker (BR-133). The API middleware
+/// reads this marker on every authenticated request; the module that soft-deletes a user
+/// writes it so the deletion takes effect before the next database lookup would notice.
+/// </summary>
+/// <remarks>
+/// Both the key shape and the marker lifetime live here rather than inside the middleware,
+/// because a downstream application that deletes an account has to write the exact same key
+/// the middleware reads, and a private constant in the presentation layer is unreachable
+/// from an application-layer command handler.
+/// </remarks>
+public static class SoftDeletedUserCache
+{
+    /// <summary>
+    /// Lifetime of the deleted-user marker.
+    /// </summary>
+    /// <remarks>
+    /// The marker only has to outlive the window between the delete committing and the next
+    /// token validation: once the marker expires, the validator query is the source of truth
+    /// again and reports the same answer. Short-lived access tokens (15 minutes) bound the
+    /// rest of the exposure, so a longer marker would buy nothing and would only keep stale
+    /// entries alive for users who were never deleted.
+    /// </remarks>
+    public static TimeSpan MarkerDuration => TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Builds the cache key holding the soft-deleted marker for a user.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <returns>The cache key for that user's soft-deleted marker.</returns>
+    /// <remarks>
+    /// Formatted with <see cref="CultureInfo.InvariantCulture"/> on purpose: the identifier
+    /// renders differently under some cultures (digit shapes and group separators), so a
+    /// culture-sensitive key would be written under one request's culture and missed under
+    /// another, silently letting a deleted user keep making requests.
+    /// </remarks>
+    public static string KeyFor(UserIdentifierType userId) =>
+        string.Create(CultureInfo.InvariantCulture, $"user:deleted:{userId}");
+
+    /// <summary>
+    /// Writes the soft-deleted marker for a user, so authenticated requests bearing an
+    /// already-issued token are rejected without waiting for a database lookup.
+    /// </summary>
+    /// <param name="cache">The cache service to write to.</param>
+    /// <param name="userId">The user identifier that was soft-deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task MarkDeletedAsync(
+        ICacheService cache,
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+
+        return cache.SetAsync(KeyFor(userId), true, MarkerDuration, cancellationToken);
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationCommand.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationCommand.cs
@@ -10,4 +10,14 @@ namespace MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
 /// </summary>
 public sealed record SendPushNotificationCommand(
     SendPushNotificationRequest Request,
-    UserIdentifierType SentByUserId) : ICommandWithRequest<SendPushNotificationRequest>;
+    UserIdentifierType SentByUserId) : ICommandWithRequest<SendPushNotificationRequest>
+{
+    /// <summary>
+    /// Gets an optional deduplication key for the send (typically the caller's
+    /// <c>Idempotency-Key</c> header). When present, a send whose key has already been seen
+    /// returns the existing notification instead of creating a second one and sending again,
+    /// so a retried request cannot deliver the same notification twice. When null (the default,
+    /// which is what every existing caller gets) the send behaves exactly as before.
+    /// </summary>
+    public string? DedupKey { get; init; }
+}

--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationHandler.cs
@@ -27,6 +27,19 @@ public sealed partial class SendPushNotificationHandler(
         SendPushNotificationCommand command,
         CancellationToken cancellationToken = default)
     {
+        // Deduplication (opt-in): a retried send carrying the same key must not deliver twice.
+        // Whitespace is treated as absent so a blank header cannot claim the single "empty" key.
+        string? dedupKey = string.IsNullOrWhiteSpace(command.DedupKey) ? null : command.DedupKey;
+        if (dedupKey is not null)
+        {
+            PushNotification? alreadySent = await FindByDedupKeyAsync(dedupKey, cancellationToken).ConfigureAwait(false);
+            if (alreadySent is not null)
+            {
+                LogDedupHit(logger, alreadySent.Id, dedupKey);
+                return Result.Success(dtoMapper.MapToDTO(alreadySent));
+            }
+        }
+
         // Query all recipient user IDs via the app-specific provider
         IReadOnlyList<UserIdentifierType> recipientIds = await recipientProvider
             .GetRecipientUserIdsAsync(cancellationToken).ConfigureAwait(false);
@@ -44,7 +57,8 @@ public sealed partial class SendPushNotificationHandler(
             command.Request.Title,
             command.Request.Body,
             command.SentByUserId,
-            recipientIds.Count);
+            recipientIds.Count,
+            dedupKey);
         if (createResult.IsFailure)
         {
             return Result.Failure<PushNotificationDTO>(createResult.Errors);
@@ -53,7 +67,39 @@ public sealed partial class SendPushNotificationHandler(
         PushNotification notification = createResult.Value!;
         var repository = unitOfWork.GetRepository<PushNotification, PushNotificationIdentifierType>();
         await repository.AddAsync(notification, cancellationToken).ConfigureAwait(false);
-        await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types: the persistence exception is not visible from this layer (see below)
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            // The dedup lookup above is a check-then-act: two concurrent retries of the same send
+            // both pass it, and the loser only fails here, on the insert, against the filtered
+            // unique index on DedupKey. Swallow-and-requery is the same shape EfInboxStore uses on
+            // its InboxMessage.MessageId unique index; the difference is only which exception can
+            // be named. Application has no EF Core dependency (layer rule), so DbUpdateException
+            // is not a type this file can reference, and the requery is what narrows the broad
+            // catch: if the key exists now, the concurrent send is the cause and the caller gets
+            // that notification; anything else rethrows untouched so a genuine persistence fault
+            // still reaches the exception middleware.
+            //
+            // CancellationToken.None: the requery has to run even when the caller's token is what
+            // aborted the save, otherwise a cancelled save could never be classified.
+            if (dedupKey is not null)
+            {
+                PushNotification? winner = await FindByDedupKeyAsync(dedupKey, CancellationToken.None).ConfigureAwait(false);
+                if (winner is not null)
+                {
+                    LogDedupRaceRequery(logger, winner.Id, dedupKey);
+                    return Result.Success(dtoMapper.MapToDTO(winner));
+                }
+            }
+
+            throw;
+        }
 
         // Create per-user inbox records so recipients can retrieve missed notifications
         var userNotificationRepo = unitOfWork.GetRepository<UserNotification, UserNotificationIdentifierType>();
@@ -109,6 +155,22 @@ public sealed partial class SendPushNotificationHandler(
         return Result.Success(dtoMapper.MapToDTO(notification));
     }
 
+    /// <summary>
+    /// Looks up an already-persisted notification by its deduplication key. Uses the read
+    /// repository from the unit of work (never an injected <c>IRepository</c>), so the lookup runs
+    /// against the same data source as the write above.
+    /// </summary>
+    private async Task<PushNotification?> FindByDedupKeyAsync(string dedupKey, CancellationToken cancellationToken)
+    {
+        var readRepository = unitOfWork.GetReadRepository<PushNotification, PushNotificationIdentifierType>();
+        IReadOnlyCollection<PushNotification> matches = await readRepository.GetAllAsync(
+            [],
+            where: n => n.DedupKey == dedupKey,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return matches.FirstOrDefault();
+    }
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Push notification {NotificationId} sent to {RecipientCount} recipients")]
     private static partial void LogNotificationSent(ILogger logger, PushNotificationIdentifierType notificationId, int recipientCount);
 
@@ -117,4 +179,10 @@ public sealed partial class SendPushNotificationHandler(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Push notification {NotificationId} native (OS-level) delivery failed; inbox and SignalR legs unaffected")]
     private static partial void LogNativePushFailed(ILogger logger, PushNotificationIdentifierType notificationId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Push notification {NotificationId} already exists for dedup key {DedupKey}; returning it without sending again")]
+    private static partial void LogDedupHit(ILogger logger, PushNotificationIdentifierType notificationId, string dedupKey);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Push notification {NotificationId} won the unique-index race on dedup key {DedupKey}; returning the existing notification without sending again")]
+    private static partial void LogDedupRaceRequery(ILogger logger, PushNotificationIdentifierType notificationId, string dedupKey);
 }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingQueryDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingQueryDecorator.cs
@@ -13,10 +13,13 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// cache and return the fresh entry instead of re-running the query. Cache keys are shared
 /// process-wide, so the lock table lives in a non-generic holder.
 /// <para>
-/// Populating the cache after a miss is best-effort: the read has already succeeded by that point,
-/// so a cache fault is logged at warning level and swallowed rather than failing the query. Only the
-/// populate is guarded; the two read paths are left to propagate, and a genuinely cancelled request
-/// still surfaces <see cref="OperationCanceledException"/> exactly as the inner handler would.
+/// Every cache call is fail-open: the cache is an optimization, never the system of record, so a
+/// cache outage must degrade the application to uncached reads rather than turn every cacheable
+/// query into a 500. Both reads and the populate log at warning level and swallow the fault. A
+/// failed read is treated as a miss and falls through to the inner handler, so the query still
+/// answers correctly, just uncached; a failed populate returns the handler's result uncached. Only
+/// <see cref="OperationCanceledException"/> is excluded from the guard, so a genuinely cancelled
+/// request still surfaces exactly as the inner handler would.
 /// </para>
 /// </summary>
 /// <typeparam name="TQuery">The query type.</typeparam>
@@ -48,21 +51,35 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
         if (query is not IQueryCacheable cacheable)
             return await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
 
+        var queryName = typeof(TQuery).Name;
+
         // Fast path: no lock on a hit.
-        var cached = await cacheService.GetAsync<TResult>(cacheable.CacheKey, cancellationToken)
-            .ConfigureAwait(false);
+        var cached = await TryReadAsync(cacheable, queryName, cancellationToken).ConfigureAwait(false);
         if (cached is not null)
+        {
+            CqrsMetrics.RecordCacheHit(queryName);
             return cached;
+        }
 
         // Slow path: per-key double-check locking (same pattern as IdempotencyFilter). On
         // expiry of a hot key only one concurrent request runs the handler; the rest wait
         // and are served the freshly cached entry.
         using (await QueryCacheKeyLocks.Locks.AcquireAsync(cacheable.CacheKey, cancellationToken).ConfigureAwait(false))
         {
-            cached = await cacheService.GetAsync<TResult>(cacheable.CacheKey, cancellationToken)
-                .ConfigureAwait(false);
+            cached = await TryReadAsync(cacheable, queryName, cancellationToken).ConfigureAwait(false);
             if (cached is not null)
+            {
+                CqrsMetrics.RecordCacheHit(queryName);
                 return cached;
+            }
+
+            // One miss per executed query, recorded here rather than at either read: a request that
+            // misses the fast path, takes the lock and misses the double-check has read the cache
+            // twice but executed once, so counting at the reads would double-count it. This single
+            // point is reached exactly when execution falls through to the inner handler. A read
+            // that FAILED (cache outage, swallowed by TryReadAsync) also lands here and counts as a
+            // miss, which is correct: the query went uncached either way.
+            CqrsMetrics.RecordCacheMiss(queryName);
 
             var result = await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
 
@@ -76,9 +93,10 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    // The read already succeeded, so a cache blip must not fail the query. The
-                    // request token is kept, so real cancellation still propagates through the filter.
-                    LogCachePopulateFailed(logger, cacheable.CacheKey, typeof(TQuery).Name, ex);
+                    // The handler already produced the answer, so a cache blip must not fail the
+                    // query. The request token is kept, so real cancellation still propagates
+                    // through the filter.
+                    LogCachePopulateFailed(logger, cacheable.CacheKey, queryName, ex);
                 }
             }
 
@@ -94,6 +112,40 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
         string cacheKey,
         string queryName,
         Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Cache read failed for key '{CacheKey}' on query '{QueryName}'; the read is treated as a miss and the query runs uncached")]
+    private static partial void LogCacheReadFailed(
+        ILogger logger,
+        string cacheKey,
+        string queryName,
+        Exception exception);
+
+    /// <summary>
+    /// Reads the cache fail-open: a cache fault is logged at warning level and reported as a miss
+    /// so the caller falls through to the inner handler. Cancellation is deliberately not caught.
+    /// </summary>
+    /// <param name="cacheable">The cacheable query carrying the key.</param>
+    /// <param name="queryName">The query type name, used for logging.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cached value, or the default when the key is absent or the cache is unreachable.</returns>
+    private async Task<TResult?> TryReadAsync(
+        IQueryCacheable cacheable,
+        string queryName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await cacheService.GetAsync<TResult>(cacheable.CacheKey, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogCacheReadFailed(logger, cacheable.CacheKey, queryName, ex);
+            return default;
+        }
+    }
 }
 
 /// <summary>
@@ -111,7 +163,7 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
 /// </para>
 /// <para>
 /// The lock is per-process: with multiple app instances over a shared distributed cache
-/// (e.g. Redis), stampede protection is best-effort — at most one handler execution per
+/// (e.g. Redis), stampede protection is best-effort: at most one handler execution per
 /// instance, not one cluster-wide. That duplication is harmless (last write wins with equal
 /// content); a cluster-wide guarantee would need a distributed lock and is deliberately
 /// not attempted here.

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CqrsMetrics.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CqrsMetrics.cs
@@ -5,9 +5,13 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// <summary>
 /// RED (Rate / Errors / Duration) metrics for the CQRS pipeline, emitted by the logging
 /// decorators. Count gives rate, the <c>outcome</c> tag gives errors, and the histogram gives
-/// duration. A host exports these by registering the <see cref="MeterName"/> meter — the Aspire
-/// service defaults (<c>ConfigureOpenTelemetry</c>) do this. The meter name is duplicated as a
+/// duration. A host exports these by registering the <see cref="MeterName"/> meter (the Aspire
+/// service defaults, <c>ConfigureOpenTelemetry</c>, do this). The meter name is duplicated as a
 /// literal in MMCA.Common.Aspire because that package has no reference to Application.
+/// <para>
+/// The caching query decorator adds the cache hit/miss counters below, so a host can chart the
+/// hit ratio per query and spot a cache that has stopped serving reads.
+/// </para>
 /// </summary>
 internal static class CqrsMetrics
 {
@@ -27,4 +31,26 @@ internal static class CqrsMetrics
         "cqrs.query.duration",
         unit: "ms",
         description: "Duration of CQRS query handling, tagged by query name and outcome.");
+
+    /// <summary>Cacheable queries served from the cache without executing the handler, tagged by <c>query</c>.</summary>
+    internal static readonly Counter<long> QueryCacheHits = Meter.CreateCounter<long>(
+        "cqrs.query.cache.hit",
+        unit: "{query}",
+        description: "Count of cacheable queries served from the cache, tagged by query name.");
+
+    /// <summary>Cacheable queries that fell through to the handler, tagged by <c>query</c>.</summary>
+    internal static readonly Counter<long> QueryCacheMisses = Meter.CreateCounter<long>(
+        "cqrs.query.cache.miss",
+        unit: "{query}",
+        description: "Count of cacheable queries that executed the handler because the cache did not serve them, tagged by query name.");
+
+    /// <summary>Records one cache hit for the named query.</summary>
+    /// <param name="queryName">The query type name.</param>
+    internal static void RecordCacheHit(string queryName) =>
+        QueryCacheHits.Add(1, new KeyValuePair<string, object?>("query", queryName));
+
+    /// <summary>Records one cache miss for the named query.</summary>
+    /// <param name="queryName">The query type name.</param>
+    internal static void RecordCacheMiss(string queryName) =>
+        QueryCacheMisses.Add(1, new KeyValuePair<string, object?>("query", queryName));
 }

--- a/Source/Core/MMCA.Common.Domain/Notifications/PushNotifications/PushNotification.cs
+++ b/Source/Core/MMCA.Common.Domain/Notifications/PushNotifications/PushNotification.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using MMCA.Common.Domain.Attributes;
 using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Invariants;
 using MMCA.Common.Domain.Notifications.PushNotifications.DomainEvents;
 using MMCA.Common.Domain.Notifications.PushNotifications.Invariants;
 using MMCA.Common.Shared.Abstractions;
@@ -13,6 +15,9 @@ namespace MMCA.Common.Domain.Notifications.PushNotifications;
 [IdValueGenerated]
 public sealed class PushNotification : AuditableAggregateRootEntity<PushNotificationIdentifierType>
 {
+    /// <summary>Maximum allowed length for the deduplication key.</summary>
+    public const int DedupKeyMaxLength = 128;
+
     /// <summary>Gets the notification title.</summary>
     public string Title { get; private set; }
 
@@ -28,6 +33,14 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
     /// <summary>Gets the delivery status of the notification.</summary>
     public PushNotificationStatus Status { get; private set; }
 
+    /// <summary>
+    /// Gets the optional deduplication key supplied by the caller (typically the
+    /// <c>Idempotency-Key</c> header). A filtered unique index on this column lets the database
+    /// arbitrate a race between two retried sends, so the same notification is never delivered
+    /// twice. Null for every send that does not carry a key.
+    /// </summary>
+    public string? DedupKey { get; private set; }
+
     /// <summary>EF Core parameterless constructor.</summary>
     private PushNotification()
     {
@@ -35,13 +48,19 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
         Body = string.Empty;
     }
 
-    private PushNotification(string title, string body, UserIdentifierType sentByUserId, int recipientCount)
+    private PushNotification(
+        string title,
+        string body,
+        UserIdentifierType sentByUserId,
+        int recipientCount,
+        string? dedupKey)
     {
         Title = title;
         Body = body;
         SentByUserId = sentByUserId;
         RecipientCount = recipientCount;
         Status = PushNotificationStatus.Pending;
+        DedupKey = string.IsNullOrWhiteSpace(dedupKey) ? null : dedupKey;
     }
 
     /// <summary>
@@ -52,22 +71,34 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
     /// <param name="body">The notification body (max 2000 chars).</param>
     /// <param name="sentByUserId">The sender user identifier.</param>
     /// <param name="recipientCount">The number of targeted recipients.</param>
+    /// <param name="dedupKey">
+    /// Optional deduplication key (max 128 chars); null (the default) keeps the legacy behaviour
+    /// where every send creates a new notification.
+    /// </param>
     /// <returns>A <see cref="Result{T}"/> containing the created notification, or validation errors.</returns>
     public static Result<PushNotification> Create(
         string title,
         string body,
         UserIdentifierType sentByUserId,
-        int recipientCount)
+        int recipientCount,
+        string? dedupKey = null)
     {
         var result = Result.Combine(
             PushNotificationInvariants.EnsureTitleIsValid(title, nameof(Create)),
-            PushNotificationInvariants.EnsureBodyIsValid(body, nameof(Create)));
+            PushNotificationInvariants.EnsureBodyIsValid(body, nameof(Create)),
+            CommonInvariants.EnsureStringMaxLength(
+                dedupKey,
+                DedupKeyMaxLength,
+                "PushNotification.DedupKey.TooLong",
+                string.Create(CultureInfo.InvariantCulture, $"Notification dedup key cannot exceed {DedupKeyMaxLength} characters."),
+                nameof(Create),
+                nameof(dedupKey)));
         if (result.IsFailure)
         {
             return Result.Failure<PushNotification>(result.Errors);
         }
 
-        var notification = new PushNotification(title, body, sentByUserId, recipientCount)
+        var notification = new PushNotification(title, body, sentByUserId, recipientCount, dedupKey)
         {
             Id = default
         };

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -111,6 +111,13 @@ public static class DependencyInjection
 
             services.AddCaching(configuration);
 
+            // Relational persistence tuning (SQL command timeout). Optional: the defaults reproduce
+            // the framework's previous implicit behavior, so a host that omits the section is unchanged.
+            services.AddOptions<PersistenceSettings>()
+                .Bind(configuration.GetSection(PersistenceSettings.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
             services.AddOptions<OutboxSettings>()
                 .Bind(configuration.GetSection(OutboxSettings.SectionName))
                 .ValidateDataAnnotations()

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
@@ -42,5 +42,18 @@ internal sealed class PushNotificationConfiguration
             .IsRequired()
             .HasConversion<string>()
             .HasMaxLength(20);
+
+        builder.Property(p => p.DedupKey)
+            .HasMaxLength(PushNotification.DedupKeyMaxLength);
+
+        // Filtered unique index: at most one notification per deduplication key, while the many
+        // sends that carry no key (NULL) coexist freely. This is what makes a retried send safe,
+        // the database arbitrates the race that a check-then-act lookup in the handler cannot.
+        // "[DedupKey] IS NOT NULL" is SQL Server filter syntax and matches this configuration's
+        // engine base class (EntityTypeConfigurationSQLServer); the Cosmos context strips
+        // relational indexes, so no other engine sees it.
+        builder.HasIndex(p => p.DedupKey)
+            .IsUnique()
+            .HasFilter("[DedupKey] IS NOT NULL");
     }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/SQLServerDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/SQLServerDbContext.cs
@@ -1,7 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Settings;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 
@@ -17,6 +20,22 @@ public sealed class SQLServerDbContext(
     PhysicalDataSource physicalDataSource)
     : ApplicationDbContext(options, serviceProvider, assemblyProvider, physicalDataSource)
 {
+    /// <summary>
+    /// Resolved once per instance in a field initializer rather than read from the primary
+    /// constructor parameter inside <see cref="OnConfiguring"/>: referencing the parameter from a
+    /// member body would capture it into this type's state while the base constructor also receives
+    /// it (CS9107). Caching per instance is safe and not pooling: these contexts are deliberately
+    /// never pooled (see <c>PhysicalDbContextFactory</c>), so an instance is short lived and always
+    /// reads the options current at its creation.
+    /// <para>
+    /// GetService, NOT GetRequiredService: the design-time provider behind <c>dotnet ef</c>
+    /// registers no options at all and must not be made to throw. A missing registration and a null
+    /// value both fall back to the defaults, which reproduce the previous implicit behavior.
+    /// </para>
+    /// </summary>
+    private readonly PersistenceSettings _persistenceSettings =
+        serviceProvider.GetService<IOptions<PersistenceSettings>>()?.Value ?? new PersistenceSettings();
+
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -31,6 +50,10 @@ public sealed class SQLServerDbContext(
                     {
                         sql.MigrationsAssembly(PhysicalSource.SqlServerMigrationsAssembly);
                     }
+
+                    // Without this every command silently inherits ADO.NET's 30 second default with
+                    // no way to tune it per environment.
+                    sql.CommandTimeout(_persistenceSettings.CommandTimeoutSeconds);
 
                     // Retry transient SQL Server failures (timeouts, transient network drops,
                     // throttling, deadlocks). Required so cold-replica startup connection attempts

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxMetrics.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxMetrics.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics.Metrics;
+
+namespace MMCA.Common.Infrastructure.Persistence.Outbox;
+
+/// <summary>
+/// OpenTelemetry instruments for the outbox pipeline, emitted by <see cref="OutboxProcessor"/>.
+/// A host exports them by registering the <see cref="MeterName"/> meter: the Aspire service
+/// defaults (<c>ConfigureOpenTelemetry</c>) already do. The meter name is duplicated as a literal
+/// in MMCA.Common.Aspire because that package has no reference to Infrastructure.
+/// <para>
+/// One meter serves every outbox instrument: dead letters, successful dispatches, dispatch lag,
+/// and observed backlog depth. Never create a second <see cref="Meter"/> with this name.
+/// </para>
+/// </summary>
+internal static class OutboxMetrics
+{
+    /// <summary>OpenTelemetry meter name for outbox metrics.</summary>
+    internal const string MeterName = "MMCA.Common.Outbox";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    /// <summary>
+    /// Backing store for <see cref="PendingDepthGauge"/>: the backlog this process observed at the
+    /// start of its most recent processing cycle, summed across every outbox source it drains.
+    /// </summary>
+    private static long _pendingDepth;
+
+    /// <summary>
+    /// Messages dead-lettered, tagged by <c>event_type</c> and by <c>reason</c>
+    /// (<c>type_unresolvable</c> or <c>retries_exhausted</c>).
+    /// </summary>
+    internal static readonly Counter<long> DeadLetterCounter = Meter.CreateCounter<long>(
+        "outbox.dead_letter.count",
+        "messages",
+        "Number of outbox messages dead-lettered due to unresolvable event types");
+
+    /// <summary>Messages dispatched successfully and stamped processed, tagged by <c>event_type</c>.</summary>
+    internal static readonly Counter<long> ProcessedCounter = Meter.CreateCounter<long>(
+        "outbox.processed.count",
+        unit: "messages",
+        description: "Number of outbox messages dispatched successfully, tagged by event type.");
+
+    /// <summary>
+    /// End-to-end delivery lag in SECONDS: the interval between an event being written to the
+    /// outbox (<c>OccurredOn</c>) and being stamped <c>ProcessedOn</c>, tagged by <c>event_type</c>.
+    /// This is the number that answers "how far behind is eventual consistency right now".
+    /// </summary>
+    internal static readonly Histogram<double> DispatchLagHistogram = Meter.CreateHistogram<double>(
+        "outbox.dispatch.lag",
+        unit: "s",
+        description: "Seconds between an outbox message being written and being dispatched, tagged by event type.");
+
+    /// <summary>
+    /// Backlog depth observed at the start of the most recent processing cycle, summed across
+    /// every outbox source this host drains.
+    /// </summary>
+    /// <remarks>
+    /// This gauge assumes a SINGLE hosted processor instance per process (the deployment
+    /// convention for the outbox processor). It reports what THIS instance last observed, not a
+    /// cluster-wide depth: with several replicas running, each publishes its own view and the
+    /// values must be read per instance, never summed into a fleet total. The count uses the same
+    /// predicate as the poll (unprocessed, retries not exhausted, not under an unexpired lease),
+    /// so rows another replica currently holds are excluded, and a source whose database is
+    /// unreachable contributes zero for that cycle rather than holding a stale value.
+    /// </remarks>
+    internal static readonly ObservableGauge<long> PendingDepthGauge = Meter.CreateObservableGauge(
+        "outbox.pending.depth",
+        () => Interlocked.Read(ref _pendingDepth),
+        unit: "messages",
+        description: "Outbox rows awaiting dispatch, as observed by this processor instance on its last cycle.");
+
+    /// <summary>
+    /// Publishes the backlog depth observed by the processor for the cycle that just ran.
+    /// </summary>
+    /// <param name="depth">Pending rows summed across every source drained this cycle.</param>
+    internal static void SetPendingDepth(long depth) => Interlocked.Exchange(ref _pendingDepth, depth);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -74,11 +73,6 @@ public sealed partial class OutboxProcessor(
     private static readonly TimeSpan ShutdownSaveTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly ActivitySource OutboxActivitySource = new("MMCA.Common.Outbox");
-    private static readonly Meter OutboxMeter = new("MMCA.Common.Outbox");
-    private static readonly Counter<long> DeadLetterCounter = OutboxMeter.CreateCounter<long>(
-        "outbox.dead_letter.count",
-        "messages",
-        "Number of outbox messages dead-lettered due to unresolvable event types");
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -174,19 +168,23 @@ public sealed partial class OutboxProcessor(
 
     /// <summary>
     /// Drains every outbox source once and aggregates the per-source results: any source with
-    /// more eligible work triggers an immediate re-poll, and the earliest pending timestamp
-    /// across all sources drives the smart wait.
+    /// more eligible work triggers an immediate re-poll, the earliest pending timestamp
+    /// across all sources drives the smart wait, and the backlog observed across all sources is
+    /// published to the <c>outbox.pending.depth</c> gauge.
     /// </summary>
     internal async Task<OutboxCycleResult> ProcessPendingMessagesAsync(CancellationToken cancellationToken)
     {
         var hasMoreEligibleWork = false;
         DateTime? earliestPendingOccurredOn = null;
+        var pendingDepth = 0L;
 
         foreach (var source in GetOutboxSources())
         {
             try
             {
-                var result = await ProcessSourceAsync(source, cancellationToken).ConfigureAwait(false);
+                (OutboxCycleResult result, long sourcePendingDepth) =
+                    await ProcessSourceAsync(source, cancellationToken).ConfigureAwait(false);
+                pendingDepth += sourcePendingDepth;
                 hasMoreEligibleWork |= result.HasMoreEligibleWork;
                 if (result.EarliestPendingOccurredOn is { } pending
                     && (earliestPendingOccurredOn is null || pending < earliestPendingOccurredOn))
@@ -207,10 +205,20 @@ public sealed partial class OutboxProcessor(
             }
         }
 
+        // Publish what THIS instance observed this cycle. A source that threw contributes zero, so
+        // an outage reads as a drop rather than as a stale plateau (see the gauge's remarks).
+        OutboxMetrics.SetPendingDepth(pendingDepth);
+
         return new OutboxCycleResult(hasMoreEligibleWork, earliestPendingOccurredOn);
     }
 
-    private async Task<OutboxCycleResult> ProcessSourceAsync(DataSourceKey source, CancellationToken cancellationToken)
+    /// <summary>
+    /// Drains one source and reports both its cycle result and the backlog it observed, so the
+    /// caller can sum the depth across sources for the <c>outbox.pending.depth</c> gauge.
+    /// </summary>
+    private async Task<(OutboxCycleResult Cycle, long PendingDepth)> ProcessSourceAsync(
+        DataSourceKey source,
+        CancellationToken cancellationToken)
     {
         var sourceName = source.ToString();
         using var scope = scopeFactory.CreateScope();
@@ -223,6 +231,8 @@ public sealed partial class OutboxProcessor(
         var cutoff = now.Subtract(TimeSpan.FromSeconds(_settings.ProcessingDelaySeconds));
 
         var messages = await FetchCandidatesAsync(context, sourceName, now, cancellationToken).ConfigureAwait(false);
+        var pendingDepth = await CountPendingAsync(context, sourceName, messages.Count, now, cancellationToken)
+            .ConfigureAwait(false);
 
         // Split the ordered batch: the eligible prefix is processed now; the pending remainder
         // only informs how long to wait before the next cycle.
@@ -236,7 +246,7 @@ public sealed partial class OutboxProcessor(
 
         if (eligibleCount == 0)
         {
-            return new OutboxCycleResult(HasMoreEligibleWork: false, earliestPending);
+            return (new OutboxCycleResult(HasMoreEligibleWork: false, earliestPending), pendingDepth);
         }
 
         var toProcess = await ClaimEligibleAsync(context, messages, eligibleCount, now, cancellationToken)
@@ -245,7 +255,7 @@ public sealed partial class OutboxProcessor(
         if (toProcess.Count == 0)
         {
             // Another replica claimed the whole prefix between fetch and claim.
-            return new OutboxCycleResult(HasMoreEligibleWork: false, earliestPending);
+            return (new OutboxCycleResult(HasMoreEligibleWork: false, earliestPending), pendingDepth);
         }
 
         LogProcessingBatch(logger, toProcess.Count, sourceName);
@@ -276,9 +286,42 @@ public sealed partial class OutboxProcessor(
 
         // A full eligible batch with progress means more eligible rows may be waiting; the
         // progress requirement stops a fully-failing batch from hot-spinning the processor.
-        return new OutboxCycleResult(
-            HasMoreEligibleWork: eligibleCount == _settings.BatchSize && processedAny,
-            earliestPending);
+        return (
+            new OutboxCycleResult(
+                HasMoreEligibleWork: eligibleCount == _settings.BatchSize && processedAny,
+                earliestPending),
+            pendingDepth);
+    }
+
+    /// <summary>
+    /// Backlog depth for one source, derived from the fetch wherever it can be: a batch that came
+    /// back short IS the whole backlog, so the steady state costs nothing extra. Only a saturated
+    /// batch (exactly the state an operator alerts on) pays for a COUNT, and that query runs inside
+    /// its own <c>OutboxPoll</c> activity so OutboxPollFilterProcessor suppresses it from export
+    /// exactly like the poll itself. The predicate mirrors <see cref="FetchCandidatesAsync"/> so
+    /// the gauge counts the rows this processor considers workable.
+    /// </summary>
+    private async Task<long> CountPendingAsync(
+        ApplicationDbContext context,
+        string sourceName,
+        int fetchedCount,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        if (fetchedCount < _settings.BatchSize)
+        {
+            return fetchedCount;
+        }
+
+        using var pollActivity = OutboxActivitySource.StartActivity(PollActivityName);
+        pollActivity?.SetTag("messaging.outbox.data_source", sourceName);
+
+        return await context.Set<OutboxMessage>()
+            .Where(m => m.ProcessedOn == null
+                && m.RetryCount < _settings.MaxRetries
+                && (m.LockedUntil == null || m.LockedUntil < now))
+            .LongCountAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -405,7 +448,7 @@ public sealed partial class OutboxProcessor(
                     message.LastError = $"Cannot resolve type: {message.EventType}";
                     message.ProcessedOn = _timeProvider.GetUtcNow().UtcDateTime;
                     processedAny = true;
-                    DeadLetterCounter.Add(
+                    OutboxMetrics.DeadLetterCounter.Add(
                         1,
                         new KeyValuePair<string, object?>("event_type", message.EventType),
                         new KeyValuePair<string, object?>("reason", "type_unresolvable"));
@@ -425,8 +468,20 @@ public sealed partial class OutboxProcessor(
                     await dispatcher.DispatchAsync([domainEvent], cancellationToken).ConfigureAwait(false);
                 }
 
-                message.ProcessedOn = _timeProvider.GetUtcNow().UtcDateTime;
+                var processedOn = _timeProvider.GetUtcNow().UtcDateTime;
+                message.ProcessedOn = processedOn;
                 processedAny = true;
+
+                var eventTypeTag = new KeyValuePair<string, object?>("event_type", message.EventType);
+                OutboxMetrics.ProcessedCounter.Add(1, eventTypeTag);
+
+                // End-to-end delivery lag in seconds. Clamped at zero: OccurredOn is stamped by the
+                // writing host and ProcessedOn by this one, so clock skew between them must not
+                // publish a negative duration into the histogram.
+                OutboxMetrics.DispatchLagHistogram.Record(
+                    Math.Max((processedOn - message.OccurredOn).TotalSeconds, 0),
+                    eventTypeTag);
+
                 LogMessageProcessed(logger, message.Id, message.EventType);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -458,7 +513,7 @@ public sealed partial class OutboxProcessor(
                     // The moment of exhaustion is the operator's last loud signal: from here the
                     // row leaves the poll (RetryCount filter) and is eventually purged by
                     // OutboxCleanupService after the dead-letter retention window.
-                    DeadLetterCounter.Add(
+                    OutboxMetrics.DeadLetterCounter.Add(
                         1,
                         new KeyValuePair<string, object?>("event_type", message.EventType),
                         new KeyValuePair<string, object?>("reason", "retries_exhausted"));
@@ -475,8 +530,11 @@ public sealed partial class OutboxProcessor(
     }
 
     /// <summary>
-    /// Exponential backoff for a failed message: <c>base * 2^(retryCount - 1)</c>, capped at the
-    /// lease so a failing row never holds its claim longer than a dead replica's rows would.
+    /// Exponential backoff for a failed message: <c>base * 2^(retryCount - 1)</c>, multiplied by a
+    /// random jitter factor in <c>[0.8, 1.2]</c> and then capped at the lease so a failing row never
+    /// holds its claim longer than a dead replica's rows would. The jitter is what keeps a batch
+    /// that failed together (one dependency outage fails all 50 rows in the same instant) from
+    /// retrying in lockstep and re-hammering that dependency on a single shared schedule.
     /// </summary>
     internal double ComputeRetryBackoffSeconds(int retryCount)
     {
@@ -486,7 +544,12 @@ public sealed partial class OutboxProcessor(
         var exponent = Math.Min(Math.Max(retryCount - 1, 0), 16);
         var backoff = _settings.RetryBackoffBaseSeconds * Math.Pow(2, exponent);
 
-        return Math.Min(backoff, _settings.LeaseSeconds);
+        // Jitter is applied BEFORE the cap so a capped backoff stays exactly at the lease bound.
+#pragma warning disable S2245, CA5394 // Random spaces retry attempts apart (jitter); it feeds no security, token, key or cryptographic decision, so a pseudorandom generator is the correct tool here.
+        var jitter = 0.8 + Random.Shared.NextDouble() * 0.4;
+#pragma warning restore S2245, CA5394
+
+        return Math.Min(backoff * jitter, _settings.LeaseSeconds);
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/PersistenceSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/PersistenceSettings.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// Configuration for relational persistence behavior, bound from the <c>Persistence</c> section.
+/// Every property defaults to the value the framework applied implicitly before the section
+/// existed, so the section is optional in <c>appsettings.json</c>.
+/// </summary>
+public sealed class PersistenceSettings
+{
+    /// <summary>Configuration section name used for options binding.</summary>
+    public static readonly string SectionName = "Persistence";
+
+    /// <summary>
+    /// Gets the command timeout, in seconds, applied to every SQL command the SQL Server context
+    /// issues. The default of <c>30</c> matches the previous implicit ADO.NET default, so an app
+    /// that sets nothing sees no behavior change; raise it for reporting-style workloads whose
+    /// queries legitimately run longer than half a minute.
+    /// </summary>
+    [Range(1, 600)]
+    public int CommandTimeoutSeconds { get; init; } = 30;
+}

--- a/Source/Core/MMCA.Common.Shared/Http/IdempotencyHeaders.cs
+++ b/Source/Core/MMCA.Common.Shared/Http/IdempotencyHeaders.cs
@@ -1,0 +1,26 @@
+namespace MMCA.Common.Shared.Http;
+
+/// <summary>
+/// Well-known HTTP header names for the idempotency protocol, shared by the server-side filter
+/// that consumes them and the client-side service bases that emit them.
+/// </summary>
+/// <remarks>
+/// Lives in Shared because both ends need the same literal: the API filter
+/// (<c>MMCA.Common.API</c>) reads it and the UI service bases (<c>MMCA.Common.UI</c>) write it,
+/// and those two packages have no reference to one another. Hard-coding the string in both places
+/// is exactly the drift this constant exists to prevent.
+/// </remarks>
+public static class IdempotencyHeaders
+{
+    /// <summary>
+    /// The header carrying the client-provided idempotency key. A server that has already seen the
+    /// key replays the original response instead of executing the action a second time.
+    /// </summary>
+    public const string IdempotencyKey = "Idempotency-Key";
+
+    /// <summary>
+    /// The response header the server appends when the body it returned came from the idempotency
+    /// cache rather than a fresh execution.
+    /// </summary>
+    public const string IdempotentReplay = "X-Idempotent-Replay";
+}

--- a/Source/Hosting/MMCA.Common.Aspire/DataProtection/DataProtectionExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/DataProtection/DataProtectionExtensions.cs
@@ -1,0 +1,90 @@
+using Azure.Identity;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MMCA.Common.Aspire;
+
+/// <summary>
+/// Registration extension for a shared ASP.NET Core DataProtection key ring.
+/// <para>
+/// The framework default keeps the key ring in memory, which is correct for a single-process host
+/// and wrong for a scaled-out one: every replica generates its own keys, so an auth cookie or an
+/// antiforgery token minted by replica A cannot be decrypted by replica B. The user sees random
+/// sign-outs and "The antiforgery token could not be decrypted" errors that follow no pattern
+/// because they follow the load balancer. Persisting the key ring to a single blob gives every
+/// replica the same keys, which is what makes cookies and tokens portable across the deployment.
+/// </para>
+/// </summary>
+public static class DataProtectionExtensions
+{
+    extension<TBuilder>(TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        /// <summary>
+        /// Persists the DataProtection key ring to Azure Blob Storage so that every replica of a
+        /// scaled-out host shares one key ring, and optionally encrypts that key ring at rest with
+        /// an Azure Key Vault key.
+        /// <para>
+        /// Configuration keys:
+        /// <list type="bullet">
+        ///   <item><c>DataProtection:BlobStorageUri</c> (the gate): full URI of the blob that holds
+        ///     the key ring XML, e.g.
+        ///     <c>https://mystorage.blob.core.windows.net/dataprotection/keys.xml</c>. When absent
+        ///     or whitespace this method does nothing at all, so local development and tests keep
+        ///     the in-memory default and take no Azure dependency at startup.</item>
+        ///   <item><c>DataProtection:ApplicationName</c> (optional): the application discriminator
+        ///     that isolates one application's keys from another's when several share a blob or a
+        ///     key ring directory. Defaults to the host application name.</item>
+        ///   <item><c>DataProtection:KeyVaultKeyUri</c> (optional): full URI of the Key Vault key
+        ///     used to encrypt the key ring at rest, e.g.
+        ///     <c>https://myvault.vault.azure.net/keys/dataprotection</c>.</item>
+        /// </list>
+        /// </para>
+        /// <para>
+        /// Authentication uses <see cref="DefaultAzureCredential"/>, so a deployed host authenticates
+        /// with its managed identity and a developer machine falls back to the local Azure CLI or
+        /// Visual Studio sign-in. The identity needs Storage Blob Data Contributor on the container,
+        /// and Key Vault Crypto User on the key when the optional key-vault step is configured.
+        /// </para>
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddCommonDataProtection()
+        {
+            var blobStorageUri = builder.Configuration["DataProtection:BlobStorageUri"];
+
+            // Gate 1 (blob persistence). Absent means "do nothing": a developer machine, a test host,
+            // and the Helpdesk seed all run single-process, where the in-memory default is correct and
+            // an unconditional Azure dependency at startup would be a liability, not a feature.
+            if (string.IsNullOrWhiteSpace(blobStorageUri))
+            {
+                return builder;
+            }
+
+            var applicationName = builder.Configuration["DataProtection:ApplicationName"]
+                ?? builder.Environment.ApplicationName;
+
+            // One credential instance for both sinks so they share a single token cache.
+            var credential = new DefaultAzureCredential();
+
+            var dataProtection = builder.Services.AddDataProtection()
+                .SetApplicationName(applicationName)
+                .PersistKeysToAzureBlobStorage(new Uri(blobStorageUri), credential);
+
+            // Gate 2 (encrypt the key ring at rest) is DELIBERATELY separate from gate 1, not folded
+            // into it. Blob persistence is the part that fixes cross-replica cookie and antiforgery
+            // decryption, and it has to work on its own, WITHOUT the Key Vault Crypto User role,
+            // because that role assignment is granted out of band and can lag the deployment.
+            // Encrypting the key ring at rest is an independent hardening step. Coupling the two
+            // would mean a missing or delayed role assignment breaks authentication entirely, turning
+            // an optional hardening gap into a total outage.
+            var keyVaultKeyUri = builder.Configuration["DataProtection:KeyVaultKeyUri"];
+            if (!string.IsNullOrWhiteSpace(keyVaultKeyUri))
+            {
+                dataProtection.ProtectKeysWithAzureKeyVault(new Uri(keyVaultKeyUri), credential);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -152,10 +152,13 @@ public static class Extensions
                         metrics.AddRuntimeInstrumentation();
                     }
 
-                    // MMCA.Common meters (literal names — Aspire has no reference to the defining
-                    // assemblies): outbox dead-letter counter and CQRS RED histograms.
+                    // MMCA.Common meters (literal names, because Aspire has no reference to the
+                    // defining assemblies): outbox counters and dispatch lag, CQRS RED histograms
+                    // plus query cache hit/miss, and the idempotency filter's replay, conflict and
+                    // degraded counters.
                     metrics.AddMeter("MMCA.Common.Outbox")
-                        .AddMeter("MMCA.Common.Cqrs");
+                        .AddMeter("MMCA.Common.Cqrs")
+                        .AddMeter("MMCA.Common.Idempotency");
                 })
                 .WithTracing(tracing =>
                 {

--- a/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
@@ -12,6 +12,13 @@
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
+    <!-- Shared DataProtection key ring: blob persistence (required for multi-replica cookie and
+         antiforgery decryption) plus the optional Key Vault at-rest encryption, both config-gated
+         in DataProtection/DataProtectionExtensions.cs. Azure.Identity supplies the
+         DefaultAzureCredential used by both sinks. -->
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />

--- a/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
@@ -3,6 +3,10 @@
     <PackageId>MMCA.Common.Aspire</PackageId>
     <Description>MMCA framework Aspire service defaults: OpenTelemetry, health checks, service discovery, HTTP resilience</Description>
     <IsAspireSharedProject>true</IsAspireSharedProject>
+    <!-- Pruning disabled so the System.Security.Cryptography.Xml advisory lift below stays a real
+         dependency and reaches the packed nuspec; pruned references never reach pack, and consumers
+         without the AspNetCore framework reference (Aspire AppHosts) need the lifted version. -->
+    <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -28,6 +32,11 @@
     </PackageReference>
     <!-- Direct reference to force transitive OpenTelemetry.Api resolution to non-vulnerable 1.15.3. -->
     <PackageReference Include="OpenTelemetry.Api" />
+    <!-- Direct reference lifting the DataProtection.Blobs/Keys transitive off vulnerable 10.0.7
+         (NU1903) for consumers without the AspNetCore framework reference, i.e. Aspire AppHosts,
+         where nothing prunes the package. Requires the pruning opt-out above to survive into the
+         nuspec; framework-referencing consumers still prune the resulting transitive on their side. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -29,6 +29,35 @@
           "Microsoft.Data.SqlClient": "5.2.2"
         }
       },
+      "Azure.Extensions.AspNetCore.DataProtection.Blobs": {
+        "type": "Direct",
+        "requested": "[1.5.3, )",
+        "resolved": "1.5.3",
+        "contentHash": "owDEPihK2GwyOUWsj6Ae1M5dXqcJyKTWwPx1kYb7FWemMLB4Iox3xrcb2ev6dBTSQjpQWcsVFwpIuAGmOD8RXw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Blobs": "12.26.0"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Keys": {
+        "type": "Direct",
+        "requested": "[1.6.3, )",
+        "resolved": "1.6.3",
+        "contentHash": "zALqsKe49Jde/fWGv0yCW5awfql23ZpWdhVVhOeF46h6SQGg843cJGUHiHjWn+sQPly6c6V1+2n+/pCXA7CVGw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Security.KeyVault.Keys": "4.10.0"
+        }
+      },
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Monitor.OpenTelemetry.AspNetCore": {
         "type": "Direct",
         "requested": "[1.6.0, )",
@@ -171,6 +200,23 @@
           "Azure.Core": "1.60.0",
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.PersistentStorage.FileSystem": "1.0.3"
+        }
+      },
+      "Azure.Security.KeyVault.Keys": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "R5iW7mH0EXdl3wqLQ7qglFQXl5JPGmmYXxDxKFT/TraCw6yRhlt5/G3NCc0Wb98P2P3lRZEI8lqF3BY0m9RkNA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.25.0",
+        "contentHash": "MHGWp4aLHRo0BdLj25U2qYdYK//Zz21k4bs3SVyNQEmJbBl3qZ8GuOmTSXJ+Zad93HnFXfvD8kyMr0gjA8Ftpw==",
+        "dependencies": {
+          "Azure.Core": "1.47.3",
+          "System.IO.Hashing": "8.0.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -395,6 +441,11 @@
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         }
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ne1843evDugl0md7Fjzy6QjJrzsjh46ZKbhf8GwBXb5f/gw97J4bxMs0NQKifDuThh/f0bZ0e62NPl1jzTuRqA=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -416,16 +467,14 @@
       "mmca.common.shared": {
         "type": "Project"
       },
-      "Azure.Identity": {
+      "Azure.Storage.Blobs": {
         "type": "CentralTransitive",
-        "requested": "[1.21.0, )",
-        "resolved": "1.11.4",
-        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
+        "requested": "[12.29.1, )",
+        "resolved": "12.26.0",
+        "contentHash": "EBRSHmI0eNzdufcIS1Rf7Ez9M8V1Jl7pMV4UWDERDMCv513KtAVsgz2ez2FQP9Qnwg7uEQrP+Uc7vBtumlr7sQ==",
         "dependencies": {
-          "Azure.Core": "1.38.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "System.Security.Cryptography.ProtectedData": "4.7.0"
+          "Azure.Core": "1.47.3",
+          "Azure.Storage.Common": "12.25.0"
         }
       },
       "Microsoft.Data.SqlClient": {

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -8,6 +8,7 @@
         "resolved": "9.0.0",
         "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
         "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "RabbitMQ.Client": "7.0.0"
         }
       },
@@ -17,6 +18,7 @@
         "resolved": "9.0.0",
         "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
         "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "StackExchange.Redis": "2.7.4"
         }
       },
@@ -26,7 +28,8 @@
         "resolved": "9.0.0",
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
-          "Microsoft.Data.SqlClient": "5.2.2"
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
         }
       },
       "Azure.Extensions.AspNetCore.DataProtection.Blobs": {
@@ -36,7 +39,8 @@
         "contentHash": "owDEPihK2GwyOUWsj6Ae1M5dXqcJyKTWwPx1kYb7FWemMLB4Iox3xrcb2ev6dBTSQjpQWcsVFwpIuAGmOD8RXw==",
         "dependencies": {
           "Azure.Core": "1.55.0",
-          "Azure.Storage.Blobs": "12.26.0"
+          "Azure.Storage.Blobs": "12.26.0",
+          "Microsoft.AspNetCore.DataProtection": "10.0.7"
         }
       },
       "Azure.Extensions.AspNetCore.DataProtection.Keys": {
@@ -46,7 +50,8 @@
         "contentHash": "zALqsKe49Jde/fWGv0yCW5awfql23ZpWdhVVhOeF46h6SQGg843cJGUHiHjWn+sQPly6c6V1+2n+/pCXA7CVGw==",
         "dependencies": {
           "Azure.Core": "1.55.0",
-          "Azure.Security.KeyVault.Keys": "4.10.0"
+          "Azure.Security.KeyVault.Keys": "4.10.0",
+          "Microsoft.AspNetCore.DataProtection": "10.0.7"
         }
       },
       "Azure.Identity": {
@@ -84,6 +89,7 @@
         "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
           "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
           "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
@@ -93,6 +99,7 @@
         "resolved": "10.8.0",
         "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.10",
           "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
@@ -129,6 +136,7 @@
         "resolved": "1.17.0",
         "contentHash": "t1OwL/4qgboGMobYVT+UV5zgWnFqCp4Pw8lcsmzh8m2K8PQsTKkyxrC32tqYTMYny3GOW4q5cltE3dTVzLmRew==",
         "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "OpenTelemetry": "1.17.0"
         }
       },
@@ -147,6 +155,8 @@
         "resolved": "1.17.0",
         "contentHash": "uTwVtxIJ/xB96wGYTaDsbkJVeCFdUxTwvrlDUn2YJixy0UuKc8DvQMzwKNJMTzNFiiyYO9c40id6tUHTmWs33A==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.17.0, 2.0.0)"
         }
       },
@@ -180,12 +190,23 @@
           "StyleCop.Analyzers.Unstable": "1.2.0.556"
         }
       },
+      "System.Security.Cryptography.Xml": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "Mz6Y+s+uMQKj1H2BUF0OhlmaOQkLgSG34/IrUaBDirYBQ6bgwcFvO/XtXWcoDlBLFoFB0uKqDNhybHOd+fQK1A==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "10.0.10"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.60.0",
         "contentHash": "qCa5DLAq0w14aTl9/bvMZNA/QxPzYj1a4zakrpeudxWd4D4YliRHRfccD3yFECeHkMkvQjMmyWLggb8bzhDVKA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
           "Microsoft.Identity.Client": "4.84.2",
           "Microsoft.Identity.Client.Extensions.Msal": "4.84.2",
           "System.ClientModel": "1.14.0",
@@ -219,10 +240,39 @@
           "System.IO.Hashing": "8.0.0"
         }
       },
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "unTeI3bPmzsl5Xo2Irg7jW8osCjo/H2rBT5sTqopUUI0gbLyTYuTjDyxoKjykjS/nS2jUdAKVFWFoGF1s1g4HQ=="
+      },
+      "Microsoft.AspNetCore.DataProtection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "ETphwQ9b2gvTK0ET6cYQY77StbIvSmYHZJdsEOf5AY4YNmol5uIncdqLCJzFgE/KEH1ukRdXTkwSC27hNnltOw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.7",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Security.Cryptography.Xml": "10.0.7"
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "SitkANPwiW0Z2w9bWAFwZ/MxFDDloBkNZCK+SfFJ+/IMUTMvrczBrHmy66+EdQTd2ybRzCm12aKAztQkDGyH6A=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ=="
       },
       "Microsoft.Data.SqlClient.SNI.runtime": {
         "type": "Transitive",
@@ -232,37 +282,219 @@
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Transitive",
+        "resolved": "8.0.11",
+        "contentHash": "zLgN22Zp9pk8RHlwssRTexw4+a6wqOnKWN+VejdPn5Yhjql4XiBhkFo35Nu8mmqHIk/UEmmCnMGLWq75aFfkOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "8.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.11",
+        "contentHash": "So3JUdRxozRjvQ3cxU6F3nI/i4emDnjane6yMYcJhvTTTu29ltlIdoXjkFGRceIWz8yKvuEpzXItZ0x5GvN2nQ=="
+      },
+      "Microsoft.Extensions.Features": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "4Zdm7n1vxXAXpHOhGQVpGd5KCdcI1EWk66ilgdrDt2I+928ND+u/F+EVrzYi9pmRR+XeAE47kjuVEmkP0b0mBw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
+        }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
         "resolved": "10.8.0",
         "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.10",
           "Microsoft.Extensions.Telemetry": "10.8.0"
         }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "cLrqxkuEfcilZ8SjK+9KAnpLk9lOoMPaOokF+wRUYie+iUEcdX4/p/+gJkt0BYgWLthjpBUCkVTBI6Kxg0nsOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tx0R6PY9MNSh0mDKSxbpHLuuec93IxF1cel+1ithQnMNr/vbfLSSHOQHGHIppAJCGfPcEo/wO1Ylj+QpXtzo3A=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
         "resolved": "10.8.0",
         "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
           "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10",
           "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
@@ -271,7 +503,16 @@
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Features": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
@@ -280,6 +521,8 @@
         "dependencies": {
           "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
           "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
@@ -288,7 +531,10 @@
         "resolved": "10.8.0",
         "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Identity.Client": {
@@ -296,7 +542,8 @@
         "resolved": "4.84.2",
         "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+          "Microsoft.IdentityModel.Abstractions": "8.14.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -318,7 +565,10 @@
         "resolved": "6.35.0",
         "contentHash": "9wxai3hKgZUb4/NjdRKfQd0QJvtXKDlvmGMYACbEC8DFaicMFCFhQFZq9ZET1kJLwZahf2lfY5Gtcpsx8zYzbg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "6.35.0"
+          "Microsoft.IdentityModel.Tokens": "6.35.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encodings.Web": "4.7.2",
+          "System.Text.Json": "4.7.2"
         }
       },
       "Microsoft.IdentityModel.Logging": {
@@ -352,8 +602,20 @@
         "resolved": "6.35.0",
         "contentHash": "RN7lvp7s3Boucg1NaNAbqDbxtlLj5Qeb+4uSS1TeK5FSBVM40P4DKaTKChT43sHyKfh7V0zkrMph6DdHvyA4bg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "6.35.0"
+          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.IdentityModel.Logging": "6.35.0",
+          "System.Security.Cryptography.Cng": "4.5.0"
         }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
       },
       "Microsoft.SqlServer.Server": {
         "type": "Transitive",
@@ -365,6 +627,9 @@
         "resolved": "1.17.0",
         "contentHash": "rMLOTftlMlTm7+MSrvXDHnJRjVkROFNKXHZrYjOsX+LankaFG7QSflx7qRRGjoqZoirohnxmJQ7GEb9occO4Gg==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.17.0"
         }
       },
@@ -373,6 +638,7 @@
         "resolved": "1.17.0",
         "contentHash": "Xgc3Qf9B9TFMFpx6exTdGqMWuYIT2miNzkdMPutVvT9YuMFaEovXWke1Gb6z8NxYaQbbGF38vYLuSg1JCeui5Q==",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "OpenTelemetry.Api": "1.17.0"
         }
       },
@@ -392,7 +658,10 @@
       "Pipelines.Sockets.Unofficial": {
         "type": "Transitive",
         "resolved": "2.2.8",
-        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ==",
+        "dependencies": {
+          "System.IO.Pipelines": "5.0.1"
+        }
       },
       "Polly.Core": {
         "type": "Transitive",
@@ -404,6 +673,8 @@
         "resolved": "8.4.2",
         "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
           "Polly.Core": "8.4.2"
         }
       },
@@ -412,13 +683,18 @@
         "resolved": "8.4.2",
         "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
         "dependencies": {
-          "Polly.Core": "8.4.2"
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
         }
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
         "resolved": "7.0.0",
-        "contentHash": "8YJz22mOSMtkbIVuVSz2HbJwbpKwRoXQ1uqbczDUt1w1Ds8dxFs6dkV/oZ8AlTmkErZjtQelHv+oBu52ud00WA=="
+        "contentHash": "8YJz22mOSMtkbIVuVSz2HbJwbpKwRoXQ1uqbczDUt1w1Ds8dxFs6dkV/oZ8AlTmkErZjtQelHv+oBu52ud00WA==",
+        "dependencies": {
+          "System.IO.Pipelines": "8.0.0",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
@@ -430,6 +706,9 @@
         "resolved": "1.14.0",
         "contentHash": "yhIJHDW3Hh5kcvhHv3ww1T8qvya06Nlwo/SR/rke4/fHXtyKiqQV/9b/VDhnVI7QUcMnpfvh4pIEFhNsTDLeKQ==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
           "System.Memory.Data": "10.0.3"
         }
       },
@@ -438,18 +717,46 @@
         "resolved": "8.0.0",
         "contentHash": "JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
         "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.0",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "fdYxcRjQqTTacKId/2IECojlDSFvp7LP5N78+0z/xH7v/Tuw5ZAxu23Y6PTCRinqyu2ePx+Gn1098NC6jM6d+A=="
       },
       "System.IO.Hashing": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "ne1843evDugl0md7Fjzy6QjJrzsjh46ZKbhf8GwBXb5f/gw97J4bxMs0NQKifDuThh/f0bZ0e62NPl1jzTuRqA=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "YweovHiLUoEdbr2Xv8eRqCSkTu1vMms4a6xBHaQiMSFVy32PL+hXv6Vhol2NWOmLHjaVgTyhJ3R52U6JxS6w3Q=="
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
       },
       "System.Runtime.Caching": {
         "type": "Transitive",
@@ -459,10 +766,50 @@
           "System.Configuration.ConfigurationManager": "8.0.0"
         }
       },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "WG3r7EyjUe9CMPFSs6bty5doUqT+q9pbI80hlNzo2SkPkZ4VTuZkGWjpp77JB8+uaL4DFPRdBsAY+DX3dBK92A=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "KG8t5RHczdgB3IWvRndpI0nE1DSo7ikDYSDbITxfgRFyIvnYiKzuPjaZOsPnwFQ1aOGUl9sEulJul9wlHLEUoA=="
+      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "4.7.2",
+        "contentHash": "iTUgB/WtrZ1sWZs84F2hwyQhiRH6QNjQv2DkwrH+WP6RoFga2Q1m3f9/Q7FG8cck8AdHitQkmkXSY8qylcDmuA=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "4.7.2",
+        "contentHash": "TcMd95wcrubm9nHvJEQs70rC0H/8omiSGGpU4FQ/ZA1URIqD4pjmFJh2Mfv1yH1eHgJDWTi2hMDXwTET+zOOyg=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "mmca.common.shared": {
         "type": "Project"
@@ -493,12 +840,36 @@
           "System.Runtime.Caching": "8.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "DuEBLw2y7ZBfilnaJtlge8f2M49932v43t7j1InceXVjcZzxNrSEkobYXdgZkXuPFnFbKcbWpAS+fZgYEW1BhA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
       "StackExchange.Redis": {
         "type": "CentralTransitive",
         "requested": "[2.13.17, )",
         "resolved": "2.7.4",
         "contentHash": "lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
         }
       },

--- a/Source/Presentation/MMCA.Common.API/Controllers/Notifications/NotificationsController.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/Notifications/NotificationsController.cs
@@ -6,11 +6,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.FeatureManagement.Mvc;
 using MMCA.Common.API.Authorization;
+using MMCA.Common.API.Idempotency;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Notifications.PushNotifications.UseCases.GetHistory;
 using MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
 using MMCA.Common.Application.UseCases;
 using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Http;
 using MMCA.Common.Shared.Notifications;
 using MMCA.Common.Shared.Notifications.PushNotifications;
 
@@ -30,8 +32,16 @@ public sealed class NotificationsController(
     IQueryHandler<GetNotificationHistoryQuery, Result<PagedCollectionResult<PushNotificationDTO>>> historyHandler,
     ICurrentUserService currentUserService) : ApiControllerBase
 {
-    /// <summary>Sends a push notification to all recipients (POST /api/notifications).</summary>
+    /// <summary>
+    /// Sends a push notification to all recipients (POST /api/notifications).
+    /// Retry-safe on two levels that work together: <see cref="IdempotentAttribute"/> replays the
+    /// original HTTP response for a repeated <c>Idempotency-Key</c>, and the same key is passed on
+    /// as the command's <c>DedupKey</c> so the domain refuses a second send even when the filter's
+    /// cache is cold, evicted, or degraded (a restarted host, an expired 24h entry, an unreachable
+    /// distributed cache). The filter alone protects the response; the DedupKey protects delivery.
+    /// </summary>
     [HttpPost]
+    [Idempotent]
     [ProducesResponseType(typeof(PushNotificationDTO), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ProblemDetails))]
@@ -45,7 +55,18 @@ public sealed class NotificationsController(
             return HandleFailure([Error.Unauthorized("Notification.Unauthorized", "User is not authenticated.")]);
         }
 
-        var command = new SendPushNotificationCommand(request, userId.Value);
+        // Carry the client's idempotency key into the domain. Absent or whitespace-only stays null,
+        // which is exactly the legacy behaviour (every send creates a new notification).
+        string? dedupKey = null;
+#pragma warning disable S6932 // Idempotency-Key is protocol plumbing shared with IdempotencyFilter, not an action parameter: binding it with [FromHeader] would add it to the generated OpenAPI contract.
+        if (Request.Headers.TryGetValue(IdempotencyHeaders.IdempotencyKey, out var keyValues))
+        {
+            string headerValue = keyValues.ToString();
+            dedupKey = string.IsNullOrWhiteSpace(headerValue) ? null : headerValue;
+        }
+#pragma warning restore S6932
+
+        var command = new SendPushNotificationCommand(request, userId.Value) { DedupKey = dedupKey };
         Result<PushNotificationDTO> result = await sendHandler.HandleAsync(command, cancellationToken).ConfigureAwait(false);
 
         return result.IsFailure

--- a/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyFilter.cs
+++ b/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyFilter.cs
@@ -5,14 +5,16 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Shared.Concurrency;
+using MMCA.Common.Shared.Http;
 
 namespace MMCA.Common.API.Idempotency;
 
 /// <summary>
-/// Action filter that provides idempotency for write operations (POST, PUT, PATCH).
+/// Filter that provides idempotency for write operations (POST, PUT, PATCH).
 /// Clients include an <c>Idempotency-Key</c> header; the first response is cached
 /// and replayed for subsequent requests with the same key within a 24-hour window.
 /// </summary>
@@ -38,6 +40,22 @@ namespace MMCA.Common.API.Idempotency;
 /// distinguish cached responses from original executions.
 /// </para>
 /// <para>
+/// The filter runs at BOTH the resource stage and the action stage. The resource stage runs before
+/// model binding, which is the only point at which the request body can still be made re-readable,
+/// so that is where <c>EnableBuffering</c> is
+/// called (only when the header is present, so ordinary traffic pays nothing). The action stage
+/// then hashes the buffered body and binds it to the cached record: replaying a stored response to
+/// a request that carries a DIFFERENT payload would silently swallow a genuinely new write, so a
+/// key reused with a different body is answered 422 rather than replayed.
+/// </para>
+/// <para>
+/// The cache and the lock are treated as best-effort infrastructure. A cache read, a cache write or
+/// a lock acquisition that faults is logged, counted on <c>idempotency.degraded</c>, and swallowed:
+/// the request executes without the idempotency guarantee instead of failing. Deduplication is an
+/// optimization over an at-least-once client retry, so a cache outage must not become an outage of
+/// every write endpoint that carries the attribute.
+/// </para>
+/// <para>
 /// SECURITY: the cache key is derived from the caller's identity, the HTTP method and the route
 /// template in addition to the client-supplied key, so a key value is only ever replayed to the
 /// caller that produced it, on the same endpoint. Keying on the bare client value would let two
@@ -45,12 +63,13 @@ namespace MMCA.Common.API.Idempotency;
 /// response body to another.
 /// </para>
 /// </remarks>
-public sealed class IdempotencyFilter : IAsyncActionFilter
+public sealed partial class IdempotencyFilter(ILogger<IdempotencyFilter> logger)
+    : IAsyncActionFilter, IAsyncResourceFilter
 {
     /// <summary>
     /// Gets the name of the HTTP header that carries the client-provided idempotency key.
     /// </summary>
-    public static string IdempotencyKeyHeader => "Idempotency-Key";
+    public static string IdempotencyKeyHeader => IdempotencyHeaders.IdempotencyKey;
 
     private static string CacheKeyPrefix => "idempotency:";
 
@@ -86,22 +105,44 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
     /// </summary>
     private static readonly TimeSpan LockWait = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// Hash of a zero-length payload, used for body-less requests and for the request whose body
+    /// stream cannot be rewound (nothing to compare, so every such request agrees with itself).
+    /// </summary>
+    private static readonly string EmptyBodyHash =
+        Convert.ToHexStringLower(SHA256.HashData([]));
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Runs before model binding, which is the last point at which the body can be made replayable.
+    /// Buffering is enabled only for requests that actually carry an idempotency key: turning it on
+    /// unconditionally would spool every request body of every action the filter is attached to.
+    /// </remarks>
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        if (ReadIdempotencyKey(context.HttpContext.Request) is not null)
+            context.HttpContext.Request.EnableBuffering();
+
+        await next().ConfigureAwait(false);
+    }
+
     /// <inheritdoc />
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         // No idempotency key header: execute normally without deduplication
-        if (!context.HttpContext.Request.Headers.TryGetValue(IdempotencyKeyHeader, out var keyValues)
-            || string.IsNullOrWhiteSpace(keyValues.ToString()))
+        var idempotencyKey = ReadIdempotencyKey(context.HttpContext.Request);
+        if (idempotencyKey is null)
         {
             await next().ConfigureAwait(false);
             return;
         }
 
-        var cacheKey = BuildCacheKey(context, keyValues.ToString());
+        var cacheKey = BuildCacheKey(context, idempotencyKey);
+        var requestBodyHash = await ComputeRequestBodyHashAsync(context.HttpContext).ConfigureAwait(false);
         var cache = context.HttpContext.RequestServices.GetRequiredService<ICacheService>();
 
         // Fast path: return cached response without acquiring a lock
-        if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
+        if (await TryReplayAsync(context, cache, cacheKey, requestBodyHash).ConfigureAwait(false))
             return;
 
         // Slow path. The lock has to span execute-and-store, so a duplicate cannot slip in between
@@ -109,30 +150,68 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
         var distributedLock = context.HttpContext.RequestServices.GetService<IDistributedLock>();
         if (distributedLock is null)
         {
-            await ExecuteUnderProcessLockAsync(context, next, cache, cacheKey).ConfigureAwait(false);
+            await ExecuteUnderProcessLockAsync(context, next, cache, cacheKey, requestBodyHash).ConfigureAwait(false);
             return;
         }
 
-        await ExecuteUnderDistributedLockAsync(context, next, cache, cacheKey, distributedLock).ConfigureAwait(false);
+        await ExecuteUnderDistributedLockAsync(context, next, cache, cacheKey, requestBodyHash, distributedLock)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the client-supplied idempotency key, or <see langword="null"/> when the header is
+    /// absent or blank. Both filter stages go through this so they agree on what "has a key" means.
+    /// </summary>
+    private static string? ReadIdempotencyKey(HttpRequest request)
+    {
+        if (!request.Headers.TryGetValue(IdempotencyHeaders.IdempotencyKey, out var keyValues))
+            return null;
+
+        var key = keyValues.ToString();
+        return string.IsNullOrWhiteSpace(key) ? null : key;
+    }
+
+    /// <summary>
+    /// Hashes the request body so a replay can be refused when the same key arrives with a
+    /// different payload.
+    /// </summary>
+    /// <remarks>
+    /// The stream is rewound before reading AND after hashing, because model binding (or any later
+    /// reader) still has to see the whole body. A stream that cannot seek was never buffered, so
+    /// there is nothing to hash and nothing to compare against: it takes the empty-body hash rather
+    /// than throwing, which leaves such a request exactly as idempotent as it was before.
+    /// </remarks>
+    private static async Task<string> ComputeRequestBodyHashAsync(HttpContext httpContext)
+    {
+        var body = httpContext.Request.Body;
+        if (!body.CanSeek)
+            return EmptyBodyHash;
+
+        body.Position = 0;
+        var hash = await SHA256.HashDataAsync(body, httpContext.RequestAborted).ConfigureAwait(false);
+        body.Position = 0;
+
+        return Convert.ToHexStringLower(hash);
     }
 
     /// <summary>
     /// Runs the guarded section under the per-process stripe. Used when the host registers no
     /// <see cref="IDistributedLock"/>, which is the whole of a single-replica or test host.
     /// </summary>
-    private static async Task ExecuteUnderProcessLockAsync(
+    private async Task ExecuteUnderProcessLockAsync(
         ActionExecutingContext context,
         ActionExecutionDelegate next,
         ICacheService cache,
-        string cacheKey)
+        string cacheKey,
+        string requestBodyHash)
     {
         using (await KeyLocks.AcquireAsync(cacheKey, context.HttpContext.RequestAborted).ConfigureAwait(false))
         {
             // Double-check: another request may have completed and cached while we waited
-            if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
+            if (await TryReplayAsync(context, cache, cacheKey, requestBodyHash).ConfigureAwait(false))
                 return;
 
-            await ExecuteAndStoreAsync(context, next, cache, cacheKey).ConfigureAwait(false);
+            await ExecuteAndStoreAsync(context, next, cache, cacheKey, requestBodyHash).ConfigureAwait(false);
         }
     }
 
@@ -152,22 +231,45 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
     /// request is in flight. It gets 409 Conflict, which is retryable and honest, rather than a
     /// duplicate write.
     /// </para>
+    /// <para>
+    /// A lock backend that FAULTS is a different case from a lock that is held: there is no holder
+    /// to wait for and no answer to replay, so refusing the request would turn a Redis blip into a
+    /// write outage. The action runs unguarded and the degradation is counted instead.
+    /// </para>
     /// </remarks>
-    private static async Task ExecuteUnderDistributedLockAsync(
+    private async Task ExecuteUnderDistributedLockAsync(
         ActionExecutingContext context,
         ActionExecutionDelegate next,
         ICacheService cache,
         string cacheKey,
+        string requestBodyHash,
         IDistributedLock distributedLock)
     {
-        IAsyncDisposable? handle = await distributedLock
-            .TryAcquireAsync(cacheKey, LockTimeToLive, LockWait, context.HttpContext.RequestAborted)
-            .ConfigureAwait(false);
+        IAsyncDisposable? handle;
+        try
+        {
+            handle = await distributedLock
+                .TryAcquireAsync(cacheKey, LockTimeToLive, LockWait, context.HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            IdempotencyMetrics.RecordDegraded();
+            LogLockUnavailable(cacheKey, ex);
+            await ExecuteAndStoreAsync(context, next, cache, cacheKey, requestBodyHash).ConfigureAwait(false);
+            return;
+        }
 
         if (handle is null)
         {
-            if (!await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
+            LogLockWaitTimedOut(cacheKey);
+
+            if (!await TryReplayAsync(context, cache, cacheKey, requestBodyHash).ConfigureAwait(false))
+            {
+                IdempotencyMetrics.RecordConflict(IdempotencyMetrics.ConflictKindInFlight);
+                LogDuplicateInFlight(cacheKey);
                 context.Result = InFlightDuplicateResult();
+            }
 
             return;
         }
@@ -175,22 +277,23 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
         await using (handle.ConfigureAwait(false))
         {
             // Double-check: the previous holder may have completed and cached while we waited
-            if (await TryReplayAsync(context, cache, cacheKey).ConfigureAwait(false))
+            if (await TryReplayAsync(context, cache, cacheKey, requestBodyHash).ConfigureAwait(false))
                 return;
 
-            await ExecuteAndStoreAsync(context, next, cache, cacheKey).ConfigureAwait(false);
+            await ExecuteAndStoreAsync(context, next, cache, cacheKey, requestBodyHash).ConfigureAwait(false);
         }
     }
 
     /// <summary>Executes the action and caches its response.</summary>
-    private static async Task ExecuteAndStoreAsync(
+    private async Task ExecuteAndStoreAsync(
         ActionExecutingContext context,
         ActionExecutionDelegate next,
         ICacheService cache,
-        string cacheKey)
+        string cacheKey,
+        string requestBodyHash)
     {
         var executedContext = await next().ConfigureAwait(false);
-        await TryStoreAsync(context, cache, cacheKey, executedContext).ConfigureAwait(false);
+        await TryStoreAsync(context, cache, cacheKey, requestBodyHash, executedContext).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -209,6 +312,27 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
         };
 
     /// <summary>
+    /// The response for a key that already answered a DIFFERENT payload. Replaying the stored
+    /// response here would tell the client its new write succeeded when nothing ran, so the reuse
+    /// is reported instead.
+    /// </summary>
+    /// <remarks>
+    /// 422 rather than 409: this filter already spends 409 on "the original is still in flight",
+    /// which is a retry-with-the-same-key situation. Key reuse with a different body is not
+    /// retryable at all until the client picks a new key, so the two need distinct status codes.
+    /// </remarks>
+    private static ObjectResult BodyMismatchResult() =>
+        new(new ProblemDetails
+        {
+            Status = StatusCodes.Status422UnprocessableEntity,
+            Title = "Idempotency-Key reuse",
+            Detail = "The Idempotency-Key was already used with a different request body.",
+        })
+        {
+            StatusCode = StatusCodes.Status422UnprocessableEntity,
+        };
+
+    /// <summary>
     /// Serves the cached response for <paramref name="cacheKey"/> when one exists, returning
     /// whether the request was short-circuited.
     /// </summary>
@@ -217,17 +341,50 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
     /// so it replays as a plain status code. Answering it as a <see cref="ContentResult"/> with
     /// <c>application/json</c> would put a content type on a response with no content, which the
     /// original did not have.
+    /// <para>
+    /// A record whose <see cref="IdempotencyRecord.RequestBodyHash"/> is <see langword="null"/> was
+    /// written before the body was bound to the key, so there is nothing to compare and it replays
+    /// unconditionally. Those entries expire with the retention window.
+    /// </para>
+    /// <para>
+    /// A cache read that faults is reported as "nothing stored" so the request executes: an
+    /// unavailable cache must degrade deduplication, not the endpoint.
+    /// </para>
     /// </remarks>
-    private static async Task<bool> TryReplayAsync(
+    private async Task<bool> TryReplayAsync(
         ActionExecutingContext context,
         ICacheService cache,
-        string cacheKey)
+        string cacheKey,
+        string requestBodyHash)
     {
-        var cached = await cache.GetAsync<IdempotencyRecord>(cacheKey).ConfigureAwait(false);
+        IdempotencyRecord? cached;
+        try
+        {
+            cached = await cache.GetAsync<IdempotencyRecord>(cacheKey).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            IdempotencyMetrics.RecordDegraded();
+            LogCacheReadFailed(cacheKey, ex);
+            return false;
+        }
+
         if (cached is null)
             return false;
 
-        context.HttpContext.Response.Headers.Append("X-Idempotent-Replay", "true");
+        if (cached.RequestBodyHash is not null
+            && !string.Equals(cached.RequestBodyHash, requestBodyHash, StringComparison.Ordinal))
+        {
+            IdempotencyMetrics.RecordConflict(IdempotencyMetrics.ConflictKindBodyMismatch);
+            LogRequestBodyMismatch(cacheKey);
+            context.Result = BodyMismatchResult();
+            return true;
+        }
+
+        IdempotencyMetrics.RecordReplayed();
+        LogReplayServed(cacheKey, cached.StatusCode);
+
+        context.HttpContext.Response.Headers.Append(IdempotencyHeaders.IdempotentReplay, "true");
         context.Result = string.IsNullOrEmpty(cached.ResponseBody)
             ? new StatusCodeResult(cached.StatusCode)
             : new ContentResult
@@ -254,14 +411,20 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
     /// with no stored response at all: a duplicate re-executed the action instead of replaying, so
     /// the endpoints most likely to be retried (the body-less writes) were the ones idempotency did
     /// not actually cover.
+    /// <para>
+    /// A store that faults is swallowed. The action already ran and its response is already the
+    /// client's answer; failing here would turn a successful write into an error the client would
+    /// retry, which is the duplicate this filter exists to prevent.
+    /// </para>
     /// </remarks>
-    private static async Task TryStoreAsync(
+    private async Task TryStoreAsync(
         ActionExecutingContext context,
         ICacheService cache,
         string cacheKey,
+        string requestBodyHash,
         ActionExecutedContext executedContext)
     {
-        var record = BuildRecord(executedContext.Result);
+        var record = BuildRecord(executedContext.Result, requestBodyHash);
         if (record is null)
             return;
 
@@ -271,14 +434,22 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
             ? TimeSpan.FromHours(idempotencySettings.Value.CacheExpirationHours)
             : DefaultExpiration;
 
-        await cache.SetAsync(cacheKey, record, expiration).ConfigureAwait(false);
+        try
+        {
+            await cache.SetAsync(cacheKey, record, expiration).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            IdempotencyMetrics.RecordDegraded();
+            LogCacheStoreFailed(cacheKey, ex);
+        }
     }
 
     /// <summary>
     /// Builds the cacheable snapshot of a result, or <see langword="null"/> when the result is not
     /// one this record shape can represent.
     /// </summary>
-    private static IdempotencyRecord? BuildRecord(IActionResult? result)
+    private static IdempotencyRecord? BuildRecord(IActionResult? result, string requestBodyHash)
     {
         switch (result)
         {
@@ -288,7 +459,8 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
                 return IsSuccess(objectStatus)
                     ? new IdempotencyRecord(
                         objectStatus,
-                        JsonSerializer.Serialize(objectResult.Value, JsonSerializerOptions.Web))
+                        JsonSerializer.Serialize(objectResult.Value, JsonSerializerOptions.Web),
+                        requestBodyHash)
                     : null;
 #pragma warning restore VSTHRD103
 
@@ -297,7 +469,7 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
             // the empty string and TryReplayAsync replays it without a content type.
             case StatusCodeResult statusCodeResult:
                 return IsSuccess(statusCodeResult.StatusCode)
-                    ? new IdempotencyRecord(statusCodeResult.StatusCode, string.Empty)
+                    ? new IdempotencyRecord(statusCodeResult.StatusCode, string.Empty, requestBodyHash)
                     : null;
 
             default:
@@ -329,4 +501,57 @@ public sealed class IdempotencyFilter : IAsyncActionFilter
 
         return string.Concat(CacheKeyPrefix, Convert.ToHexStringLower(hash));
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Idempotency replay served for key {CacheKey} with status {StatusCode}.")]
+    private static partial void LogReplayServed(ILogger logger, string cacheKey, int statusCode);
+
+    private void LogReplayServed(string cacheKey, int statusCode) =>
+        LogReplayServed(logger, cacheKey, statusCode);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency key {CacheKey} was reused with a different request body; the request was rejected instead of replayed.")]
+    private static partial void LogRequestBodyMismatch(ILogger logger, string cacheKey);
+
+    private void LogRequestBodyMismatch(string cacheKey) => LogRequestBodyMismatch(logger, cacheKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency key {CacheKey} is still being processed elsewhere and nothing is stored yet; the duplicate was told to retry.")]
+    private static partial void LogDuplicateInFlight(ILogger logger, string cacheKey);
+
+    private void LogDuplicateInFlight(string cacheKey) => LogDuplicateInFlight(logger, cacheKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Timed out waiting for the idempotency lock on key {CacheKey}.")]
+    private static partial void LogLockWaitTimedOut(ILogger logger, string cacheKey);
+
+    private void LogLockWaitTimedOut(string cacheKey) => LogLockWaitTimedOut(logger, cacheKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency cache read failed for key {CacheKey}; the request will execute without deduplication.")]
+    private static partial void LogCacheReadFailed(ILogger logger, string cacheKey, Exception exception);
+
+    private void LogCacheReadFailed(string cacheKey, Exception exception) =>
+        LogCacheReadFailed(logger, cacheKey, exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency cache store failed for key {CacheKey}; the response was returned but a duplicate will re-execute.")]
+    private static partial void LogCacheStoreFailed(ILogger logger, string cacheKey, Exception exception);
+
+    private void LogCacheStoreFailed(string cacheKey, Exception exception) =>
+        LogCacheStoreFailed(logger, cacheKey, exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Idempotency lock could not be acquired for key {CacheKey}; the action ran without the idempotency guarantee.")]
+    private static partial void LogLockUnavailable(ILogger logger, string cacheKey, Exception exception);
+
+    private void LogLockUnavailable(string cacheKey, Exception exception) =>
+        LogLockUnavailable(logger, cacheKey, exception);
 }

--- a/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyMetrics.cs
+++ b/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyMetrics.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.Metrics;
+
+namespace MMCA.Common.API.Idempotency;
+
+/// <summary>
+/// Counters for the idempotency filter: how often a stored response is replayed, how often a
+/// duplicate is rejected, and how often the filter degrades because its cache or lock is unhealthy.
+/// A host exports these by registering the <see cref="MeterName"/> meter, which the Aspire service
+/// defaults do. The meter name is duplicated as a literal in MMCA.Common.Aspire because that
+/// package has no reference to this one.
+/// </summary>
+/// <remarks>
+/// The filter never touches the instruments directly: it calls the helpers below, so the tag names
+/// and instrument names live in exactly one place.
+/// </remarks>
+internal static class IdempotencyMetrics
+{
+    /// <summary>OpenTelemetry meter name for the idempotency instruments.</summary>
+    internal const string MeterName = "MMCA.Common.Idempotency";
+
+    /// <summary>
+    /// Conflict tag value for a key replayed with a payload different from the stored one.
+    /// </summary>
+    internal const string ConflictKindBodyMismatch = "body_mismatch";
+
+    /// <summary>
+    /// Conflict tag value for a duplicate that arrived while the original was still executing.
+    /// </summary>
+    internal const string ConflictKindInFlight = "in_flight";
+
+    /// <summary>Tag name carrying which of the two conflict shapes was recorded.</summary>
+    private const string ConflictKindTag = "kind";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> ReplayedCounter = Meter.CreateCounter<long>(
+        "idempotency.replayed",
+        unit: "{request}",
+        description: "Requests answered from the idempotency cache instead of executing the action.");
+
+    private static readonly Counter<long> ConflictCounter = Meter.CreateCounter<long>(
+        "idempotency.conflict",
+        unit: "{request}",
+        description: "Duplicate requests rejected, tagged by kind (body_mismatch or in_flight).");
+
+    private static readonly Counter<long> DegradedCounter = Meter.CreateCounter<long>(
+        "idempotency.degraded",
+        unit: "{request}",
+        description: "Requests that ran without the idempotency guarantee because the cache or lock faulted.");
+
+    /// <summary>Records that a stored response was replayed to a duplicate request.</summary>
+    internal static void RecordReplayed() => ReplayedCounter.Add(1);
+
+    /// <summary>
+    /// Records that a duplicate was rejected rather than replayed or executed.
+    /// </summary>
+    /// <param name="kind">
+    /// <see cref="ConflictKindBodyMismatch"/> for a key reused with a different payload,
+    /// <see cref="ConflictKindInFlight"/> for a duplicate whose original is still running.
+    /// </param>
+    internal static void RecordConflict(string kind) =>
+        ConflictCounter.Add(1, new KeyValuePair<string, object?>(ConflictKindTag, kind));
+
+    /// <summary>
+    /// Records that a cache or lock fault was swallowed and the request proceeded without the
+    /// idempotency guarantee. A sustained non-zero rate here means deduplication is effectively off.
+    /// </summary>
+    internal static void RecordDegraded() => DegradedCounter.Add(1);
+}

--- a/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyRecord.cs
+++ b/Source/Presentation/MMCA.Common.API/Idempotency/IdempotencyRecord.cs
@@ -6,4 +6,12 @@ namespace MMCA.Common.API.Idempotency;
 /// </summary>
 /// <param name="StatusCode">The HTTP status code of the original response.</param>
 /// <param name="ResponseBody">The JSON-serialized response body.</param>
-public sealed record IdempotencyRecord(int StatusCode, string ResponseBody);
+/// <param name="RequestBodyHash">
+/// Lowercase hex SHA-256 of the request body that produced the stored response, used to reject a
+/// key that is replayed with a different payload. <see langword="null"/> means the record is a
+/// legacy entry written before this field existed, in which case the comparison is skipped and the
+/// response replays as it always did. The default keeps the field optional so two-property JSON
+/// already in the cache still deserializes, which is what makes the rollout safe: entries written
+/// by the previous version simply age out of the live 24-hour retention window.
+/// </param>
+public sealed record IdempotencyRecord(int StatusCode, string ResponseBody, string? RequestBodyHash = null);

--- a/Source/Presentation/MMCA.Common.API/Middleware/SoftDeletedUserMiddleware.cs
+++ b/Source/Presentation/MMCA.Common.API/Middleware/SoftDeletedUserMiddleware.cs
@@ -1,6 +1,7 @@
-using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Auth;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 
@@ -9,41 +10,62 @@ namespace MMCA.Common.API.Middleware;
 /// <summary>
 /// Middleware that validates authenticated users have not been soft-deleted (BR-133).
 /// If <c>User.IsDeleted = true</c> for the authenticated user's ID, the request is rejected with HTTP 401.
-/// Uses a 30-second cache to minimize per-request database lookups.
+/// Uses a 30-second cache (<see cref="SoftDeletedUserCache"/>) to minimize per-request database lookups.
 /// </summary>
 /// <param name="next">The next middleware in the pipeline.</param>
-public sealed class SoftDeletedUserMiddleware(RequestDelegate next)
+/// <remarks>
+/// <para>
+/// This check fails OPEN: if the cache or the validator query throws, the failure is logged and
+/// the request proceeds instead of being rejected. That is a deliberate security trade-off.
+/// </para>
+/// <para>
+/// Failing closed would convert any cache or database blip into a complete outage for every
+/// authenticated request across the application, since this middleware runs on the hot path of
+/// all of them. The exposure it buys back is bounded: access tokens live 15 minutes, so a deleted
+/// user's token is dead within that window regardless of what this middleware decides, and the
+/// deletion itself already revoked the refresh token, so no new access token can be minted.
+/// The residual risk is therefore a deleted user continuing to be served for at most the remaining
+/// lifetime of one already-issued access token, and only while the cache or database is unhealthy.
+/// </para>
+/// </remarks>
+public sealed partial class SoftDeletedUserMiddleware(RequestDelegate next)
 {
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
-
     /// <summary>
     /// Checks if the authenticated user has been soft-deleted and rejects the request if so.
     /// </summary>
     /// <param name="context">The HTTP context for the current request.</param>
     /// <param name="currentUserService">Service to access the current user's identity.</param>
     /// <param name="cacheService">Cache service for caching deleted user lookups.</param>
+    /// <param name="logger">Logger used to report cache or validator failures that were failed open.</param>
     /// <returns>A task representing the middleware execution.</returns>
     /// <remarks>
+    /// <para>
     /// <see cref="ISoftDeletedUserValidator"/> is resolved lazily via
     /// <see cref="IServiceProvider.GetService(Type)"/> instead of being declared as an
     /// InvokeAsync parameter. The validator is implemented by the Identity module; in
     /// extracted services that do not host Identity (e.g., the Catalog microservice),
     /// no implementation is registered. Resolving lazily means the middleware no-ops
     /// in those services for unauthenticated requests, and only fails for authenticated
-    /// requests with a clear error — instead of 500-ing every request before any
+    /// requests with a clear error, instead of 500-ing every request before any
     /// downstream gRPC/REST endpoint runs.
+    /// </para>
+    /// <para>
+    /// The logger is an InvokeAsync parameter (per-invoke injection) rather than a constructor
+    /// parameter, matching how this convention-based middleware already takes its other services.
+    /// </para>
     /// </remarks>
     public async Task InvokeAsync(
         HttpContext context,
         ICurrentUserService currentUserService,
-        ICacheService cacheService)
+        ICacheService cacheService,
+        ILogger<SoftDeletedUserMiddleware> logger)
     {
         ArgumentNullException.ThrowIfNull(context);
 
         var userId = currentUserService.UserId;
         if (userId is null)
         {
-            // Unauthenticated request — pass through. This is the common path in extracted
+            // Unauthenticated request, pass through. This is the common path in extracted
             // services that don't host Identity: they receive only internal gRPC/HTTP traffic
             // without an authenticated user, so the middleware never needs the validator.
             await next(context).ConfigureAwait(false);
@@ -53,17 +75,30 @@ public sealed class SoftDeletedUserMiddleware(RequestDelegate next)
         var softDeletedUserValidator = context.RequestServices.GetService<ISoftDeletedUserValidator>();
         if (softDeletedUserValidator is null)
         {
-            // No validator registered — this service does not host Identity. Treat the
+            // No validator registered: this service does not host Identity. Treat the
             // user as not soft-deleted (Identity is the source of truth and presumably
             // already validated the token before the request reached us). Continue.
             await next(context).ConfigureAwait(false);
             return;
         }
 
-        var cacheKey = string.Create(CultureInfo.InvariantCulture, $"user:deleted:{userId.Value}");
+        var cacheKey = SoftDeletedUserCache.KeyFor(userId.Value);
 
-        // Check cache first
-        var cachedResult = await cacheService.GetAsync<bool?>(cacheKey, context.RequestAborted).ConfigureAwait(false);
+        bool? cachedResult;
+        var cacheReachable = true;
+        try
+        {
+            cachedResult = await cacheService.GetAsync<bool?>(cacheKey, context.RequestAborted).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Fail open onto the validator query: a cache outage must not take down every
+            // authenticated request. The write is skipped too, since the same store is down.
+            LogCacheReadFailed(logger, cacheKey, ex);
+            cachedResult = null;
+            cacheReachable = false;
+        }
+
         if (cachedResult is true)
         {
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -72,9 +107,38 @@ public sealed class SoftDeletedUserMiddleware(RequestDelegate next)
 
         if (cachedResult is null)
         {
-            // Cache miss — check database
-            var isDeleted = await softDeletedUserValidator.IsUserSoftDeletedAsync(userId.Value, context.RequestAborted).ConfigureAwait(false);
-            await cacheService.SetAsync(cacheKey, isDeleted, CacheDuration, context.RequestAborted).ConfigureAwait(false);
+            // Cache miss (or unreachable cache): check the database.
+            bool isDeleted;
+            try
+            {
+                isDeleted = await softDeletedUserValidator
+                    .IsUserSoftDeletedAsync(userId.Value, context.RequestAborted)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Both lookups are unavailable, so there is no evidence either way. Proceed
+                // (see the fail-open rationale on the class), bounded by access-token lifetime.
+                LogValidatorFailed(logger, userId.Value, ex);
+                await next(context).ConfigureAwait(false);
+                return;
+            }
+
+            if (cacheReachable)
+            {
+                try
+                {
+                    await cacheService
+                        .SetAsync(cacheKey, isDeleted, SoftDeletedUserCache.MarkerDuration, context.RequestAborted)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // The authoritative answer is already in hand, so a failed cache write only
+                    // costs the next request another database lookup. The request proceeds.
+                    LogCacheWriteFailed(logger, cacheKey, ex);
+                }
+            }
 
             if (isDeleted)
             {
@@ -85,4 +149,28 @@ public sealed class SoftDeletedUserMiddleware(RequestDelegate next)
 
         await next(context).ConfigureAwait(false);
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Soft-deleted user cache read failed for key '{CacheKey}'; falling back to the validator query")]
+    private static partial void LogCacheReadFailed(
+        ILogger logger,
+        string cacheKey,
+        Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Soft-deleted user cache write failed for key '{CacheKey}'; the request proceeds uncached")]
+    private static partial void LogCacheWriteFailed(
+        ILogger logger,
+        string cacheKey,
+        Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Soft-deleted user validation failed for user '{UserId}'; the request is allowed through (fail open)")]
+    private static partial void LogValidatorFailed(
+        ILogger logger,
+        UserIdentifierType userId,
+        Exception exception);
 }

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -95,6 +95,14 @@
           "OpenTelemetry.PersistentStorage.FileSystem": "1.0.3"
         }
       },
+      "Azure.Security.KeyVault.Keys": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "R5iW7mH0EXdl3wqLQ7qglFQXl5JPGmmYXxDxKFT/TraCw6yRhlt5/G3NCc0Wb98P2P3lRZEI8lqF3BY0m9RkNA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
+        }
+      },
       "Azure.Storage.Common": {
         "type": "Transitive",
         "resolved": "12.28.0",
@@ -535,6 +543,9 @@
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
+          "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.3, )",
+          "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.3, )",
+          "Azure.Identity": "[1.21.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
@@ -639,6 +650,26 @@
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.3, )",
+        "resolved": "1.5.3",
+        "contentHash": "owDEPihK2GwyOUWsj6Ae1M5dXqcJyKTWwPx1kYb7FWemMLB4Iox3xrcb2ev6dBTSQjpQWcsVFwpIuAGmOD8RXw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Blobs": "12.26.0"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Keys": {
+        "type": "CentralTransitive",
+        "requested": "[1.6.3, )",
+        "resolved": "1.6.3",
+        "contentHash": "zALqsKe49Jde/fWGv0yCW5awfql23ZpWdhVVhOeF46h6SQGg843cJGUHiHjWn+sQPly6c6V1+2n+/pCXA7CVGw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Security.KeyVault.Keys": "4.10.0"
         }
       },
       "Azure.Identity": {

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
+using MMCA.Common.Shared.Resilience;
 using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Globalization;
 using MMCA.Common.UI.Services;
@@ -67,6 +68,12 @@ public static class DependencyInjection
                 }
 
                 client.BaseAddress = new Uri(apiSettings.ApiEndpoint, UriKind.Absolute);
+
+                // HttpClient's own default is 100s, chosen by the BCL with no knowledge of the
+                // resilience budget: it would cut a call off mid-policy at an arbitrary point.
+                // Pinning it to the shared total-request timeout (90s) keeps the two coordinated,
+                // so the budget decides when to give up and the transport never pre-empts it.
+                client.Timeout = HttpResilienceDefaults.TotalRequestTimeout;
                 client.DefaultRequestHeaders.Clear();
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
             })

--- a/Source/Presentation/MMCA.Common.UI/Services/AuthenticatedServiceBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/AuthenticatedServiceBase.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using MMCA.Common.UI.Services.Auth;
 using Polly;
@@ -7,25 +8,45 @@ namespace MMCA.Common.UI.Services;
 
 /// <summary>
 /// Shared base class for HTTP services that need authenticated API calls.
-/// Provides a Polly retry policy (exponential backoff, 3 retries on transient/5xx errors)
-/// and a helper to create an <see cref="HttpClient"/> with the JWT Bearer token from
+/// Provides a Polly retry policy (exponential backoff with jitter, 3 retries on transient
+/// failures) and a helper to create an <see cref="HttpClient"/> with the JWT Bearer token from
 /// the circuit-scoped <see cref="ITokenStorageService"/>.
 /// </summary>
 public abstract class AuthenticatedServiceBase(
     IHttpClientFactory httpClientFactory,
     ITokenStorageService tokenStorageService)
 {
+#pragma warning disable S2245, CA5394 // Random only spaces retry attempts apart (jitter); it feeds no security, token, key or cryptographic decision, so a pseudorandom generator is the correct tool here.
+
     /// <summary>
-    /// Polly retry policy: retries on <see cref="HttpRequestException"/> or 5xx status codes,
-    /// with exponential backoff (2s, 4s, 8s).
+    /// Polly retry policy: 3 retries on <see cref="HttpRequestException"/> or a retryable response
+    /// status (see <c>IsRetryableResponse</c>), with exponential backoff (2s, 4s, 8s) plus up to
+    /// one second of random jitter so a fleet of clients does not re-converge on the same instant.
     /// </summary>
     protected static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy = Policy
         .Handle<HttpRequestException>()
-        .OrResult<HttpResponseMessage>(r => (int)r.StatusCode >= 500)
-        .WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
+        .OrResult<HttpResponseMessage>(IsRetryableResponse)
+        .WaitAndRetryAsync(
+            3,
+            attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt))
+                + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000)));
+#pragma warning restore S2245
 
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
     private readonly ITokenStorageService _tokenStorageService = tokenStorageService ?? throw new ArgumentNullException(nameof(tokenStorageService));
+
+    /// <summary>
+    /// Creates a fresh idempotency key for one logical write operation.
+    /// </summary>
+    /// <remarks>
+    /// The value is generated ONCE per logical operation and then reused across every retry
+    /// attempt of that operation. That reuse is the whole point: the server-side idempotency
+    /// filter keys its cached response off this value, so a retried create collapses into a single
+    /// execution plus a replayed response. Generating a new key per attempt would defeat the
+    /// dedup entirely and let a retry create a duplicate record.
+    /// </remarks>
+    /// <returns>A new key: a GUID in compact ("N") form.</returns>
+    protected static string NewIdempotencyKey() => Guid.NewGuid().ToString("N");
 
     /// <summary>
     /// Creates an HttpClient with the JWT Bearer token applied from the circuit-scoped
@@ -48,9 +69,31 @@ public abstract class AuthenticatedServiceBase(
         }
         catch (InvalidOperationException)
         {
-            // JS interop not available during SSR prerender — proceed without token
+            // JS interop not available during SSR prerender: proceed without token
         }
 
         return httpClient;
+    }
+
+    /// <summary>
+    /// Decides whether a response is worth another attempt: server-side failures (5xx) except the
+    /// two that are permanent verdicts about the request itself, plus the two explicit
+    /// "come back later" codes.
+    /// </summary>
+    /// <remarks>
+    /// 501 (Not Implemented) and 505 (HTTP Version Not Supported) are permanent: the endpoint or
+    /// protocol will not start working within the retry window, so retrying only burns the budget
+    /// and delays the error the caller needs to see. 408 (Request Timeout) and 429 (Too Many
+    /// Requests) are the server explicitly inviting a later attempt, which the backoff supplies.
+    /// </remarks>
+    private static bool IsRetryableResponse(HttpResponseMessage response)
+    {
+        if (response.StatusCode is HttpStatusCode.NotImplemented or HttpStatusCode.HttpVersionNotSupported)
+        {
+            return false;
+        }
+
+        return (int)response.StatusCode >= 500
+            || response.StatusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests;
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/EntityServiceBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/EntityServiceBase.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Json;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.DTOs;
+using MMCA.Common.Shared.Http;
 using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Services.Auth;
 
@@ -12,7 +13,8 @@ namespace MMCA.Common.UI.Services;
 /// Base HTTP service implementing <see cref="IEntityService{TEntityDTO, TIdentifierType}"/>.
 /// Provides CRUD operations over the WebAPI with:
 /// <list type="bullet">
-///   <item>Polly exponential-backoff retry (3 attempts) for transient/server errors</item>
+///   <item>Polly exponential-backoff-with-jitter retry (3 retries) for transient/server errors</item>
+///   <item>An <c>Idempotency-Key</c> on creates, held constant across every retry attempt</item>
 ///   <item>Automatic domain exception extraction via <see cref="ServiceExceptionHelper"/></item>
 ///   <item>Named <c>"APIClient"</c> HttpClient with pre-configured base address and auth handler</item>
 /// </list>
@@ -122,10 +124,15 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         CancellationToken cancellationToken = default)
     {
         var url = $"{Endpoint}";
+
+        // Creates are the one CRUD verb that is not naturally idempotent: a retried POST whose
+        // first attempt actually reached the server would create a second record. The key makes the
+        // server collapse the duplicate; reads, updates (full PUT) and deletes need no key.
         return await SendRequestAsync<TEntityDTO>(
             httpClient => httpClient.PostAsJsonAsync(new Uri(url, UriKind.Relative), entity, cancellationToken),
             cancellationToken,
-            throwIfNull: true
+            throwIfNull: true,
+            idempotencyKey: NewIdempotencyKey()
         ) ?? throw new InvalidOperationException($"No {typeof(TEntityDTO).Name} returned from API.");
     }
 
@@ -168,16 +175,33 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
     /// <param name="treatNotFoundAsDefault">When <see langword="true"/>, 404 returns default instead of throwing.</param>
     /// <param name="throwIfNull">When <see langword="true"/>, throws if deserialized result is <see langword="null"/>.</param>
     /// <param name="expectContent">When <see langword="false"/>, skips deserialization (PUT/DELETE with no body).</param>
+    /// <param name="idempotencyKey">
+    /// Optional idempotency key sent as the <c>Idempotency-Key</c> header (see
+    /// <see cref="AuthenticatedServiceBase.NewIdempotencyKey"/>). Supply one for non-idempotent
+    /// writes (creates); leave <see langword="null"/> for reads and naturally idempotent writes.
+    /// </param>
     protected async Task<T?> SendRequestAsync<T>(
         Func<HttpClient, Task<HttpResponseMessage>> httpAction,
         CancellationToken cancellationToken,
         bool treatNotFoundAsDefault = false,
         bool throwIfNull = false,
-        bool expectContent = true)
+        bool expectContent = true,
+        string? idempotencyKey = null)
     {
         using var httpClient = await CreateAuthenticatedClientAsync();
 
-        var response = await RetryPolicy.ExecuteAsync(() => httpAction(httpClient));
+        if (!string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            // This client is created once per logical operation and then serves EVERY retry attempt
+            // made by the policy below, so a default header set here rides along on each attempt
+            // with the same value. That is exactly the property the server needs: same key across
+            // attempts means the duplicate arrivals dedup instead of creating extra records.
+            httpClient.DefaultRequestHeaders.Add(IdempotencyHeaders.IdempotencyKey, idempotencyKey);
+        }
+
+        // The token flows into the policy so cancellation aborts the wait between attempts instead
+        // of letting an abandoned operation sleep out its full backoff budget.
+        var response = await RetryPolicy.ExecuteAsync(_ => httpAction(httpClient), cancellationToken);
 
         if (treatNotFoundAsDefault && response.StatusCode == HttpStatusCode.NotFound)
             return default;

--- a/Tests/Core/MMCA.Common.Application.Tests/Auth/SoftDeletedUserCacheTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Auth/SoftDeletedUserCacheTests.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using AwesomeAssertions;
+using MMCA.Common.Application.Auth;
+using MMCA.Common.Application.Interfaces;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Auth;
+
+/// <summary>
+/// Verifies the shared soft-deleted user marker contract: the key shape the API middleware
+/// reads, its culture invariance, and the write helper a delete handler calls.
+/// </summary>
+public sealed class SoftDeletedUserCacheTests
+{
+    // ── Key shape ──
+    [Fact]
+    public void KeyFor_ReturnsTheExpectedKeyShape() =>
+        SoftDeletedUserCache.KeyFor(42).Should().Be("user:deleted:42");
+
+    [Fact]
+    public void KeyFor_IsIdenticalUnderANonInvariantCurrentCulture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var expectedPositive = SoftDeletedUserCache.KeyFor(1234567);
+        var expectedNegative = SoftDeletedUserCache.KeyFor(-42);
+
+        try
+        {
+            CultureInfo.CurrentCulture = CreateNonInvariantCulture();
+
+            SoftDeletedUserCache.KeyFor(1234567).Should().Be(expectedPositive).And.Be("user:deleted:1234567");
+            SoftDeletedUserCache.KeyFor(-42).Should().Be(expectedNegative).And.Be("user:deleted:-42");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    // ── Marker duration ──
+    [Fact]
+    public void MarkerDuration_IsThirtySeconds() =>
+        SoftDeletedUserCache.MarkerDuration.Should().Be(TimeSpan.FromSeconds(30));
+
+    // ── Write helper ──
+    [Fact]
+    public async Task MarkDeletedAsync_WritesTheTrueMarkerUnderTheKeyForThirtySeconds()
+    {
+        var cache = new Mock<ICacheService>();
+
+        await SoftDeletedUserCache.MarkDeletedAsync(cache.Object, 7);
+
+        cache.Verify(
+            c => c.SetAsync(
+                "user:deleted:7",
+                true,
+                TimeSpan.FromSeconds(30),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkDeletedAsync_ForwardsTheCancellationToken()
+    {
+        var cache = new Mock<ICacheService>();
+        using var cts = new CancellationTokenSource();
+
+        await SoftDeletedUserCache.MarkDeletedAsync(cache.Object, 7, cts.Token);
+
+        cache.Verify(
+            c => c.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<TimeSpan?>(),
+                cts.Token),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkDeletedAsync_NullCache_Throws()
+    {
+        var act = async () => await SoftDeletedUserCache.MarkDeletedAsync(null!, 7);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ── Helpers ──
+
+    /// <summary>
+    /// Builds a culture whose number formatting differs from the invariant culture, so a
+    /// culture-sensitive key would visibly change shape under it.
+    /// </summary>
+    private static CultureInfo CreateNonInvariantCulture()
+    {
+        var culture = (CultureInfo)CultureInfo.GetCultureInfo("fr-FR").Clone();
+        culture.NumberFormat.NegativeSign = "MINUS";
+        culture.NumberFormat.NumberGroupSeparator = "_";
+        return culture;
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingQueryDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingQueryDecoratorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Application.Interfaces;
@@ -10,6 +11,50 @@ namespace MMCA.Common.Application.Tests.Decorators;
 
 public sealed class CachingQueryDecoratorTests
 {
+    // Duplicated literal: CqrsMetrics.MeterName is internal, so the counters are observed exactly
+    // the way an OpenTelemetry exporter observes them (by meter name).
+    private const string MeterName = "MMCA.Common.Cqrs";
+
+    private sealed record CapturedCounter(string InstrumentName, long Value, Dictionary<string, object?> Tags);
+
+    // ── Counter capture helper ──
+    // The meter is a process-wide static shared with tests running in parallel, so measurements are
+    // filtered down to this file's probe query types by the "query" tag.
+    private static async Task<List<CapturedCounter>> CaptureCountersAsync(Func<Task> act, string queryTagValue)
+    {
+        var gate = new System.Threading.Lock();
+        var captured = new List<CapturedCounter>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, MeterName, StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            var tagDictionary = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                tagDictionary[tag.Key] = tag.Value;
+            }
+
+            lock (gate)
+            {
+                captured.Add(new CapturedCounter(instrument.Name, value, tagDictionary));
+            }
+        });
+        listener.Start();
+
+        await act();
+
+        lock (gate)
+        {
+            return [.. captured.Where(m => m.Tags.TryGetValue("query", out var v) && Equals(v, queryTagValue))];
+        }
+    }
+
     // ── Non-cacheable query passes through ──
     [Fact]
     public async Task HandleAsync_NonCacheableQuery_PassesThroughToInnerHandler()
@@ -168,6 +213,161 @@ public sealed class CachingQueryDecoratorTests
         result.Value.Should().Be("fresh-data");
         inner.Verify(x => x.HandleAsync(It.IsAny<CacheableTestQuery>(), It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    // ── A cache outage on the READ paths degrades to an uncached query, not a 500 ──
+    [Fact]
+    public async Task HandleAsync_WhenCacheReadThrows_ExecutesInnerHandlerAndReturnsResult()
+    {
+        var inner = new Mock<IQueryHandler<CacheReadFailureQuery, Result<string>>>();
+        var cacheService = new Mock<ICacheService>();
+
+        // Throws on BOTH reads: the fast path and the double-check inside the per-key lock.
+        cacheService.Setup(x => x.GetAsync<Result<string>>("cache-read-failure-key", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache unreachable"));
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheReadFailureQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("fresh-data"));
+
+        var sut = new CachingQueryDecorator<CacheReadFailureQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheReadFailureQuery, Result<string>>>.Instance);
+
+        Result<string> result = await sut.HandleAsync(new CacheReadFailureQuery());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("fresh-data");
+        inner.Verify(x => x.HandleAsync(It.IsAny<CacheReadFailureQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        cacheService.Verify(
+            x => x.GetAsync<Result<string>>("cache-read-failure-key", It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    // ── Genuine cancellation from the cache still propagates ──
+    [Fact]
+    public async Task HandleAsync_WhenCacheReadThrowsOperationCanceled_Propagates()
+    {
+        var inner = new Mock<IQueryHandler<CacheReadCanceledQuery, Result<string>>>();
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>("cache-read-canceled-key", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var sut = new CachingQueryDecorator<CacheReadCanceledQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheReadCanceledQuery, Result<string>>>.Instance);
+
+        var invoke = () => sut.HandleAsync(new CacheReadCanceledQuery());
+
+        await invoke.Should().ThrowAsync<OperationCanceledException>();
+        inner.Verify(x => x.HandleAsync(It.IsAny<CacheReadCanceledQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Miss counter: exactly one per executed query ──
+    [Fact]
+    public async Task HandleAsync_OnCacheMiss_RecordsExactlyOneMissAndNoHit()
+    {
+        var inner = new Mock<IQueryHandler<CacheMissMetricQuery, Result<string>>>();
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>("cache-miss-metric-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null);
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheMissMetricQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("fresh-data"));
+
+        var sut = new CachingQueryDecorator<CacheMissMetricQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheMissMetricQuery, Result<string>>>.Instance);
+
+        var measurements = await CaptureCountersAsync(
+            () => sut.HandleAsync(new CacheMissMetricQuery()),
+            nameof(CacheMissMetricQuery));
+
+        // Two reads (fast path + double-check) both missed, but only ONE query executed, so the
+        // counter must read 1, not 2.
+        var measurement = measurements.Should().ContainSingle().Which;
+        measurement.InstrumentName.Should().Be("cqrs.query.cache.miss");
+        measurement.Value.Should().Be(1);
+    }
+
+    // ── Miss counter: a FAILED read counts as one miss, not two ──
+    [Fact]
+    public async Task HandleAsync_WhenCacheReadThrows_RecordsExactlyOneMiss()
+    {
+        var inner = new Mock<IQueryHandler<CacheReadFailureMetricQuery, Result<string>>>();
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>(
+                "cache-read-failure-metric-key", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache unreachable"));
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheReadFailureMetricQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("fresh-data"));
+
+        var sut = new CachingQueryDecorator<CacheReadFailureMetricQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheReadFailureMetricQuery, Result<string>>>.Instance);
+
+        var measurements = await CaptureCountersAsync(
+            () => sut.HandleAsync(new CacheReadFailureMetricQuery()),
+            nameof(CacheReadFailureMetricQuery));
+
+        var measurement = measurements.Should().ContainSingle().Which;
+        measurement.InstrumentName.Should().Be("cqrs.query.cache.miss");
+        measurement.Value.Should().Be(1);
+    }
+
+    // ── Hit counter: fast-path hit ──
+    [Fact]
+    public async Task HandleAsync_OnFastPathCacheHit_RecordsExactlyOneHitAndNoMiss()
+    {
+        var inner = new Mock<IQueryHandler<CacheHitMetricQuery, Result<string>>>();
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>("cache-hit-metric-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("cached-data"));
+
+        var sut = new CachingQueryDecorator<CacheHitMetricQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheHitMetricQuery, Result<string>>>.Instance);
+
+        var measurements = await CaptureCountersAsync(
+            () => sut.HandleAsync(new CacheHitMetricQuery()),
+            nameof(CacheHitMetricQuery));
+
+        var measurement = measurements.Should().ContainSingle().Which;
+        measurement.InstrumentName.Should().Be("cqrs.query.cache.hit");
+        measurement.Value.Should().Be(1);
+        inner.Verify(x => x.HandleAsync(It.IsAny<CacheHitMetricQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Hit counter: the double-check hit inside the lock counts too ──
+    [Fact]
+    public async Task HandleAsync_OnDoubleCheckCacheHit_RecordsExactlyOneHitAndNoMiss()
+    {
+        var inner = new Mock<IQueryHandler<CacheDoubleCheckMetricQuery, Result<string>>>();
+        var cacheService = new Mock<ICacheService>();
+
+        // Fast path misses, the double-check inside the lock is served by a concurrent populate.
+        cacheService.SetupSequence(x => x.GetAsync<Result<string>>(
+                "cache-double-check-metric-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null)
+            .ReturnsAsync(Result.Success("cached-data"));
+
+        var sut = new CachingQueryDecorator<CacheDoubleCheckMetricQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheDoubleCheckMetricQuery, Result<string>>>.Instance);
+
+        var measurements = await CaptureCountersAsync(
+            () => sut.HandleAsync(new CacheDoubleCheckMetricQuery()),
+            nameof(CacheDoubleCheckMetricQuery));
+
+        var measurement = measurements.Should().ContainSingle().Which;
+        measurement.InstrumentName.Should().Be("cqrs.query.cache.hit");
+        measurement.Value.Should().Be(1);
+        inner.Verify(
+            x => x.HandleAsync(It.IsAny<CacheDoubleCheckMetricQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }
 
 // ── Test helpers ──
@@ -182,5 +382,44 @@ public sealed record CacheableTestQuery : IQueryCacheable
 public sealed record StampedeTestQuery : IQueryCacheable
 {
     public string CacheKey => "stampede-cache-key";
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+// ── Fail-open + counter probes (one type per test so the "query" tag isolates the measurements
+// from parallel tests sharing the process-wide static meter, and one cache key per type so the
+// process-wide per-key lock table cannot couple them) ──
+public sealed record CacheReadFailureQuery : IQueryCacheable
+{
+    public string CacheKey => "cache-read-failure-key";
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public sealed record CacheReadCanceledQuery : IQueryCacheable
+{
+    public string CacheKey => "cache-read-canceled-key";
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public sealed record CacheMissMetricQuery : IQueryCacheable
+{
+    public string CacheKey => "cache-miss-metric-key";
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public sealed record CacheReadFailureMetricQuery : IQueryCacheable
+{
+    public string CacheKey => "cache-read-failure-metric-key";
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public sealed record CacheHitMetricQuery : IQueryCacheable
+{
+    public string CacheKey => "cache-hit-metric-key";
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public sealed record CacheDoubleCheckMetricQuery : IQueryCacheable
+{
+    public string CacheKey => "cache-double-check-metric-key";
     public TimeSpan CacheDuration => TimeSpan.FromMinutes(5);
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -146,13 +147,134 @@ public class SendPushNotificationHandlerTests
         result.Value!.Status.Should().Be(nameof(PushNotificationStatus.Sent));
     }
 
+    // -- HandleAsync: deduplication (gap 12) --
+    [Fact]
+    public async Task HandleAsync_WithDedupKeyAlreadySent_ReturnsExistingDTOWithoutAddOrSend()
+    {
+        PushNotification existing = CreateExisting("Existing Title", "Existing Body", "key-1");
+        var (sut, mocks) = CreateSut(existingByDedupKey: existing);
+
+        SendPushNotificationCommand command = CreateCommand() with { DedupKey = "key-1" };
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Title.Should().Be("Existing Title");
+        result.Value.Body.Should().Be("Existing Body");
+
+        mocks.NotificationRepo.Verify(
+            x => x.AddAsync(It.IsAny<PushNotification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        VerifyNoSend(mocks);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithUnseenDedupKey_SendsNormally()
+    {
+        var (sut, mocks) = CreateSut();
+
+        SendPushNotificationCommand command = CreateCommand() with { DedupKey = "key-unseen" };
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(PushNotificationStatus.Sent));
+        mocks.NotificationRepo.Verify(
+            x => x.AddAsync(It.IsAny<PushNotification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNullDedupKey_TakesLegacyPathAndNeverQueriesForDuplicates()
+    {
+        var (sut, mocks) = CreateSut();
+
+        SendPushNotificationCommand command = CreateCommand();
+        command.DedupKey.Should().BeNull();
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(PushNotificationStatus.Sent));
+        mocks.ReadRepo.Verify(AnyDedupLookup(), Times.Never);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(3));
+        mocks.PushNotificationSender.Verify(
+            x => x.SendToUsersAsync(
+                It.IsAny<IEnumerable<UserIdentifierType>>(),
+                "Test Title",
+                "Test Body",
+                null,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSaveHitsDedupUniqueIndex_RequeriesAndReturnsExistingDTO()
+    {
+        PushNotification winner = CreateExisting("Winner Title", "Winner Body", "key-2");
+        var (sut, mocks) = CreateSut(saveThrows: true, dedupWinnerOnRequery: winner);
+
+        SendPushNotificationCommand command = CreateCommand() with { DedupKey = "key-2" };
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Title.Should().Be("Winner Title");
+        VerifyNoSend(mocks);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenSaveFailsAndDedupKeyIsStillAbsent_Rethrows()
+    {
+        var (sut, _) = CreateSut(saveThrows: true);
+
+        SendPushNotificationCommand command = CreateCommand() with { DedupKey = "key-3" };
+
+        Func<Task> act = () => sut.HandleAsync(command);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
     // -- Helpers --
     private sealed record HandlerMocks(
         Mock<IUnitOfWork> UnitOfWork,
         Mock<IRepository<PushNotification, PushNotificationIdentifierType>> NotificationRepo,
+        Mock<IReadRepository<PushNotification, PushNotificationIdentifierType>> ReadRepo,
         Mock<INotificationRecipientProvider> RecipientProvider,
         Mock<IPushNotificationSender> PushNotificationSender,
         Mock<INativePushSender> NativePushSender);
+
+    private static PushNotification CreateExisting(string title, string body, string dedupKey) =>
+        PushNotification.Create(title, body, sentByUserId: 7, recipientCount: 5, dedupKey: dedupKey).Value!;
+
+    private static void VerifyNoSend(HandlerMocks mocks)
+    {
+        mocks.PushNotificationSender.Verify(
+            x => x.SendToUsersAsync(
+                It.IsAny<IEnumerable<UserIdentifierType>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        mocks.NativePushSender.Verify(
+            x => x.SendToUsersAsync(
+                It.IsAny<IEnumerable<UserIdentifierType>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static Expression<Func<
+        IReadRepository<PushNotification, PushNotificationIdentifierType>,
+        Task<IReadOnlyCollection<PushNotification>>>> AnyDedupLookup() =>
+        r => r.GetAllAsync(
+            It.IsAny<IEnumerable<string>>(),
+            It.IsAny<Expression<Func<PushNotification, bool>>>(),
+            It.IsAny<Expression<Func<PushNotification, string>>>(),
+            It.IsAny<Expression<Func<PushNotification, PushNotification>>>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>());
 
     private static SendPushNotificationCommand CreateCommand() =>
         new(new SendPushNotificationRequest("Test Title", "Test Body"), SentByUserId: 1);
@@ -160,17 +282,50 @@ public class SendPushNotificationHandlerTests
     private static (SendPushNotificationHandler Sut, HandlerMocks Mocks) CreateSut(
         int recipientCount = 3,
         bool sendThrows = false,
-        bool nativeSendThrows = false)
+        bool nativeSendThrows = false,
+        PushNotification? existingByDedupKey = null,
+        bool saveThrows = false,
+        PushNotification? dedupWinnerOnRequery = null)
     {
         var unitOfWork = new Mock<IUnitOfWork>();
         var notificationRepo = new Mock<IRepository<PushNotification, PushNotificationIdentifierType>>();
         var userNotificationRepo = new Mock<IRepository<UserNotification, UserNotificationIdentifierType>>();
+        var readRepo = new Mock<IReadRepository<PushNotification, PushNotificationIdentifierType>>();
         unitOfWork.Setup(x => x.GetRepository<PushNotification, PushNotificationIdentifierType>())
             .Returns(notificationRepo.Object);
         unitOfWork.Setup(x => x.GetRepository<UserNotification, UserNotificationIdentifierType>())
             .Returns(userNotificationRepo.Object);
-        unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1);
+        unitOfWork.Setup(x => x.GetReadRepository<PushNotification, PushNotificationIdentifierType>())
+            .Returns(readRepo.Object);
+
+        if (saveThrows)
+        {
+            // Only the first save fails (the DedupKey unique-index violation); later saves succeed.
+            unitOfWork.SetupSequence(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Violation of UNIQUE KEY constraint on DedupKey"))
+                .ReturnsAsync(1);
+        }
+        else
+        {
+            unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+        }
+
+        if (dedupWinnerOnRequery is null)
+        {
+            IReadOnlyCollection<PushNotification> dedupMatches =
+                existingByDedupKey is null ? [] : [existingByDedupKey];
+            readRepo.Setup(AnyDedupLookup()).ReturnsAsync(dedupMatches);
+        }
+        else
+        {
+            // First lookup (the pre-check) sees nothing; the post-violation requery finds the winner.
+            IReadOnlyCollection<PushNotification> noMatch = [];
+            IReadOnlyCollection<PushNotification> winnerMatch = [dedupWinnerOnRequery];
+            readRepo.SetupSequence(AnyDedupLookup())
+                .ReturnsAsync(noMatch)
+                .ReturnsAsync(winnerMatch);
+        }
 
         var recipientProvider = new Mock<INotificationRecipientProvider>();
         IReadOnlyList<UserIdentifierType> recipientIds = [.. Enumerable.Range(100, recipientCount)];
@@ -214,6 +369,7 @@ public class SendPushNotificationHandlerTests
         var mocks = new HandlerMocks(
             unitOfWork,
             notificationRepo,
+            readRepo,
             recipientProvider,
             pushNotificationSender,
             nativePushSender);

--- a/Tests/Core/MMCA.Common.Domain.Tests/Notifications/PushNotificationTests.cs
+++ b/Tests/Core/MMCA.Common.Domain.Tests/Notifications/PushNotificationTests.cs
@@ -58,6 +58,56 @@ public class PushNotificationTests
         result.Errors.Should().Contain(e => e.Code == "PushNotification.Body.TooLong");
     }
 
+    // -- Create: dedup key --
+    [Fact]
+    public void Create_WithoutDedupKey_LeavesDedupKeyNull()
+    {
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 50);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.DedupKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithDedupKey_StoresDedupKey()
+    {
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 50, dedupKey: "key-123");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.DedupKey.Should().Be("key-123");
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceDedupKey_NormalizesToNull()
+    {
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 50, dedupKey: "   ");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.DedupKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithDedupKeyExceedingMaxLength_ReturnsFailure()
+    {
+        string longKey = new('x', PushNotification.DedupKeyMaxLength + 1);
+
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 10, dedupKey: longKey);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Code == "PushNotification.DedupKey.TooLong");
+    }
+
+    [Fact]
+    public void Create_WithDedupKeyAtMaxLength_ReturnsSuccess()
+    {
+        string maxKey = new('x', PushNotification.DedupKeyMaxLength);
+
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 10, dedupKey: maxKey);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.DedupKey.Should().Be(maxKey);
+    }
+
     [Fact]
     public void Create_RaisesPushNotificationCreatedEvent()
     {

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/OutboxProcessorTests.cs
@@ -134,6 +134,52 @@ public sealed class OutboxProcessorTests : IDisposable
         _sut.ProcessPendingMessagesAsync(CancellationToken.None);
 
     /// <summary>
+    /// Starts a <see cref="MeterListener"/> scoped to one instrument on the outbox meter and
+    /// collects every measurement plus its <c>event_type</c> tag into <paramref name="sink"/>.
+    /// A raw listener rather than <c>MetricCollector&lt;T&gt;</c>: the test project does not
+    /// reference Microsoft.Extensions.Diagnostics.Testing, and package versions are centrally
+    /// managed, so the listener is the dependency-free option (it is also what the dead-letter
+    /// test above already uses).
+    /// </summary>
+    private static MeterListener StartOutboxListener<T>(
+        string instrumentName,
+        System.Threading.Lock gate,
+        List<(T Value, string? EventType)> sink)
+        where T : struct
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (string.Equals(instrument.Meter.Name, "MMCA.Common.Outbox", StringComparison.Ordinal)
+                    && string.Equals(instrument.Name, instrumentName, StringComparison.Ordinal))
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<T>((_, value, tags, _) =>
+        {
+            string? eventType = null;
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                if (string.Equals(tag.Key, "event_type", StringComparison.Ordinal))
+                {
+                    eventType = tag.Value as string;
+                }
+            }
+
+            lock (gate)
+            {
+                sink.Add((value, eventType));
+            }
+        });
+
+        listener.Start();
+        return listener;
+    }
+
+    /// <summary>
     /// Creates an outbox message eligible for processing (old enough, unprocessed, zero retries).
     /// </summary>
     private static OutboxMessage CreateEligibleMessage(
@@ -628,6 +674,156 @@ public sealed class OutboxProcessorTests : IDisposable
             "a best-effort save failure must never replace the propagating cancellation");
 
         _dbContext.FailSaves = false;
+    }
+
+    // ── Metrics: processed count, dispatch lag, and observed backlog depth ──
+    [Fact]
+    public async Task DispatchedMessages_IncrementTheProcessedCounter_TaggedByEventType()
+    {
+        // Arrange
+        var gate = new System.Threading.Lock();
+        var measurements = new List<(long Value, string? EventType)>();
+        using MeterListener listener = StartOutboxListener("outbox.processed.count", gate, measurements);
+
+        var messages = Enumerable.Range(0, 3).Select(_ => CreateEligibleMessage()).ToArray();
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(messages);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await InvokeProcessPendingMessagesAsync();
+
+        // Assert: one increment of 1 per dispatched message, carrying the event type tag.
+        var expectedEventType = typeof(TestDomainEvent).AssemblyQualifiedName;
+        lock (gate)
+        {
+            var forThisEventType = measurements
+                .Where(m => string.Equals(m.EventType, expectedEventType, StringComparison.Ordinal))
+                .ToList();
+
+            forThisEventType.Should().HaveCountGreaterThanOrEqualTo(
+                3,
+                "the counter increments once per message stamped processed");
+            forThisEventType.Should().AllSatisfy(m => m.Value.Should().Be(1));
+        }
+    }
+
+    [Fact]
+    public async Task DispatchedMessages_RecordTheDispatchLagInSeconds_TaggedByEventType()
+    {
+        // Arrange: a fake clock makes the lag exact. The row was written 10 minutes (600s) before
+        // the instant the processor stamps it.
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        using OutboxProcessor processor = CreateProcessor(new OutboxSettings(), timeProvider);
+
+        var gate = new System.Threading.Lock();
+        var measurements = new List<(double Value, string? EventType)>();
+        using MeterListener listener = StartOutboxListener("outbox.dispatch.lag", gate, measurements);
+
+        OutboxMessage message = CreateEligibleMessage(occurredOn: now.AddMinutes(-10));
+        _dbContext.Set<OutboxMessage>().Add(message);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await processor.ProcessPendingMessagesAsync(CancellationToken.None);
+
+        // Assert
+        var expectedEventType = typeof(TestDomainEvent).AssemblyQualifiedName;
+        lock (gate)
+        {
+            measurements.Should().AllSatisfy(
+                m => m.Value.Should().BeGreaterThanOrEqualTo(0, "a delivery lag is never negative"));
+            measurements.Should().Contain(
+                m => m.Value > 599.9 && m.Value < 600.1
+                    && string.Equals(m.EventType, expectedEventType, StringComparison.Ordinal),
+                "the histogram records ProcessedOn minus OccurredOn in seconds");
+        }
+    }
+
+    [Fact]
+    public async Task PendingDepthGauge_ReportsTheBacklogObservedInTheLastCycle()
+    {
+        // Arrange: one eligible row plus two still inside the processing delay, so the cycle
+        // polls a backlog of three.
+        var gate = new System.Threading.Lock();
+        var measurements = new List<(long Value, string? EventType)>();
+        using MeterListener listener = StartOutboxListener("outbox.pending.depth", gate, measurements);
+
+        OutboxMessage eligible = CreateEligibleMessage();
+        OutboxMessage pendingA = CreateEligibleMessage(occurredOn: DateTime.UtcNow);
+        OutboxMessage pendingB = CreateEligibleMessage(occurredOn: DateTime.UtcNow);
+        await _dbContext.Set<OutboxMessage>().AddRangeAsync(eligible, pendingA, pendingB);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        await InvokeProcessPendingMessagesAsync();
+        listener.RecordObservableInstruments();
+
+        // Assert: the gauge is observed once and reports what this instance saw.
+        lock (gate)
+        {
+            measurements.Should()
+                .ContainSingle("an observable gauge yields one measurement per observation")
+                .Which.Value.Should().Be(3);
+        }
+    }
+
+    // ── Retry backoff: jittered so a batch that failed together does not retry in lockstep ──
+    [Theory]
+    [InlineData(1, 10d)]
+    [InlineData(2, 20d)]
+    [InlineData(3, 40d)]
+    [InlineData(4, 80d)]
+    public void RetryBackoff_StaysWithinTheJitterBandOfTheDeterministicBase(int retryCount, double deterministic)
+    {
+        // The backoff is no longer a single exact value: it is base * 2^(n-1) multiplied by a
+        // random factor in [0.8, 1.2], so the contract is a band, not an equality.
+        var settings = new OutboxSettings { RetryBackoffBaseSeconds = 10, LeaseSeconds = 3600 };
+        using OutboxProcessor processor = CreateProcessor(settings);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var backoff = processor.ComputeRetryBackoffSeconds(retryCount);
+
+            backoff.Should().BeInRange(
+                deterministic * 0.8,
+                deterministic * 1.2,
+                "the jitter factor is bounded to plus or minus 20 percent of the deterministic backoff");
+        }
+    }
+
+    [Fact]
+    public void RetryBackoff_RemainsCappedAtTheLease_EvenAtTheTopOfTheJitterBand()
+    {
+        // Jitter is applied BEFORE the cap, so a backoff that overruns the lease still lands
+        // exactly on it: a failing row never holds its claim longer than a dead replica's rows.
+        var settings = new OutboxSettings { RetryBackoffBaseSeconds = 10, LeaseSeconds = 300 };
+        using OutboxProcessor processor = CreateProcessor(settings);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var backoff = processor.ComputeRetryBackoffSeconds(10);
+
+            backoff.Should().BeLessThanOrEqualTo(settings.LeaseSeconds);
+            backoff.Should().BeApproximately(settings.LeaseSeconds, 1e-9);
+        }
+    }
+
+    [Fact]
+    public void RetryBackoff_VariesBetweenCalls_SoSimultaneousFailuresDoNotRetryTogether()
+    {
+        // The whole point of the jitter: 50 rows that failed in the same instant must not all
+        // become claimable again at the same instant.
+        var settings = new OutboxSettings { RetryBackoffBaseSeconds = 10, LeaseSeconds = 3600 };
+        using OutboxProcessor processor = CreateProcessor(settings);
+
+        var samples = Enumerable.Range(0, 50)
+            .Select(_ => processor.ComputeRetryBackoffSeconds(3))
+            .ToList();
+
+        samples.Distinct().Should().HaveCountGreaterThan(
+            1,
+            "a deterministic backoff would make a whole failed batch retry in lockstep");
     }
 
     // ── Test doubles ──

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/SQLServerDbContextTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/SQLServerDbContextTests.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// The SQL command timeout is configured in <c>OnConfiguring</c> from
+/// <see cref="PersistenceSettings"/>. It is resolved with <c>GetService</c> rather than
+/// <c>GetRequiredService</c> so the design-time provider behind <c>dotnet ef</c> (which registers
+/// no options) keeps working, and it is never cached statically because these contexts are
+/// deliberately never pooled.
+/// </summary>
+public sealed class SQLServerDbContextTests
+{
+    [Fact]
+    public void CommandTimeout_OptionsRegistered_UsesTheConfiguredValue()
+    {
+        using var serviceProvider = BuildServiceProvider(new PersistenceSettings { CommandTimeoutSeconds = 45 });
+        using var context = CreateContext(serviceProvider);
+
+        context.Database.GetCommandTimeout().Should().Be(45);
+    }
+
+    [Fact]
+    public void CommandTimeout_NoOptionsRegistered_FallsBackToThirty()
+    {
+        using var serviceProvider = BuildServiceProvider(settings: null);
+        using var context = CreateContext(serviceProvider);
+
+        context.Database.GetCommandTimeout().Should().Be(
+            30,
+            "a design-time provider registers no options, and the fallback must reproduce the previous implicit ADO.NET default");
+    }
+
+    private static SQLServerDbContext CreateContext(IServiceProvider serviceProvider) =>
+        new(
+            new DbContextOptionsBuilder<SQLServerDbContext>().Options,
+            serviceProvider,
+            new EmptyAssemblyProvider(),
+            TestPhysicalDataSources.SqlServer());
+
+    private static ServiceProvider BuildServiceProvider(PersistenceSettings? settings)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<ILoggerFactory, NullLoggerFactory>()
+            .AddSingleton(typeof(ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<IDomainEventDispatcher>())
+            .AddSingleton<IOutboxSignal, OutboxSignal>()
+            .AddSingleton<AuditSaveChangesInterceptor>()
+            .AddSingleton<DomainEventSaveChangesInterceptor>()
+            .AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+
+        if (settings is not null)
+        {
+            services.AddSingleton<IOptions<PersistenceSettings>>(Options.Create(settings));
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class EmptyAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Settings/PersistenceSettingsTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Settings/PersistenceSettingsTests.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Settings;
+
+/// <summary>
+/// The command timeout is bound and validated through the options pipeline, so the annotated
+/// range is what stops a host booting with an unusable value. These tests pin the default (which
+/// must reproduce the previous implicit ADO.NET behavior) and both ends of that range.
+/// </summary>
+public class PersistenceSettingsTests
+{
+    [Fact]
+    public void SectionName_IsPersistence() =>
+        PersistenceSettings.SectionName.Should().Be("Persistence");
+
+    [Fact]
+    public void Default_CommandTimeoutSeconds_Is30() =>
+        new PersistenceSettings().CommandTimeoutSeconds.Should().Be(
+            30,
+            "the default must match the previous implicit ADO.NET timeout so nothing changes for an app that sets nothing");
+
+    [Fact]
+    public void Properties_RoundTrip()
+    {
+        var sut = new PersistenceSettings { CommandTimeoutSeconds = 120 };
+        sut.CommandTimeoutSeconds.Should().Be(120);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(600)]
+    public void CommandTimeoutSeconds_InRange_PassesValidation(int seconds) =>
+        Validate(new PersistenceSettings { CommandTimeoutSeconds = seconds }).Should().BeEmpty();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(601)]
+    public void CommandTimeoutSeconds_OutOfRange_FailsValidation(int seconds) =>
+        Validate(new PersistenceSettings { CommandTimeoutSeconds = seconds })
+            .Should().ContainSingle()
+            .Which.MemberNames.Should().Contain(nameof(PersistenceSettings.CommandTimeoutSeconds));
+
+    private static List<ValidationResult> Validate(object model)
+    {
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(model, new ValidationContext(model), results, validateAllProperties: true);
+        return results;
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/DataProtection/DataProtectionExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/DataProtection/DataProtectionExtensionsTests.cs
@@ -1,0 +1,75 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace MMCA.Common.Aspire.Tests.DataProtection;
+
+/// <summary>
+/// Guards the two-stage configuration gate on <c>AddCommonDataProtection</c>: no
+/// <c>DataProtection:BlobStorageUri</c> means the host keeps the in-memory default and takes no
+/// Azure dependency at startup, while a configured URI swaps the key-ring repository for the blob
+/// one so every replica shares a key ring. Both tests assert on the resolved options of a built
+/// service provider, so neither needs Azure credentials nor any network access: the blob client is
+/// constructed lazily by the repository, never at registration time.
+/// </summary>
+public sealed class DataProtectionExtensionsTests
+{
+    [Fact]
+    public void AddCommonDataProtection_WithoutBlobStorageUri_RegistersNothing()
+    {
+        var builder = BuilderWith([]);
+
+        builder.AddCommonDataProtection();
+
+        builder.Services.Any(d => d.ServiceType == typeof(IDataProtectionProvider))
+            .Should().BeFalse(
+                because: "an unconfigured host must not pull in DataProtection services at all, so local development and tests stay Azure-free");
+
+        builder.Services.BuildServiceProvider()
+            .GetRequiredService<IOptions<KeyManagementOptions>>()
+            .Value.XmlRepository
+            .Should().BeNull(
+                because: "no key-ring repository is configured when the gate key is absent");
+    }
+
+    [Fact]
+    public void AddCommonDataProtection_WithBlobStorageUri_PersistsTheKeyRingToBlobStorage()
+    {
+        var builder = BuilderWith(new()
+        {
+            ["DataProtection:BlobStorageUri"] = "https://example.blob.core.windows.net/dataprotection/keys.xml",
+            ["DataProtection:ApplicationName"] = "mmca-data-protection-tests",
+        });
+
+        builder.AddCommonDataProtection();
+
+        var provider = builder.Services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<DataProtectionOptions>>()
+            .Value.ApplicationDiscriminator
+            .Should().Be(
+                "mmca-data-protection-tests",
+                because: "the discriminator is what keeps two applications sharing one blob or directory from reading each other's keys");
+
+        var repository = provider.GetRequiredService<IOptions<KeyManagementOptions>>().Value.XmlRepository;
+
+        repository.Should().NotBeNull(
+            because: "a configured blob URI must replace the in-memory default key-ring repository");
+
+        repository!.GetType().Assembly.GetName().Name
+            .Should().Be(
+                "Azure.Extensions.AspNetCore.DataProtection.Blobs",
+                because: "the replacement has to be the blob repository specifically: any other repository leaves each replica with its own keys");
+    }
+
+    private static HostApplicationBuilder BuilderWith(Dictionary<string, string?> settings)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(settings);
+        return builder;
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj
@@ -5,6 +5,13 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Matches the FrameworkReference on MMCA.Common.Aspire itself. Without it the ASP.NET Core
+         pieces the tested code touches (DataProtection above all) resolve as standalone packages
+         instead of being pruned to the shared framework, which drags in a vulnerable
+         System.Security.Cryptography.Xml that the framework itself does not ship. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="coverlet.collector">

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
@@ -62,8 +62,6 @@
         "contentHash": "qCa5DLAq0w14aTl9/bvMZNA/QxPzYj1a4zakrpeudxWd4D4YliRHRfccD3yFECeHkMkvQjMmyWLggb8bzhDVKA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
           "Microsoft.Identity.Client": "4.84.2",
           "Microsoft.Identity.Client.Extensions.Msal": "4.84.2",
           "System.ClientModel": "1.14.0",
@@ -78,6 +76,23 @@
           "Azure.Core": "1.60.0",
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.PersistentStorage.FileSystem": "1.0.3"
+        }
+      },
+      "Azure.Security.KeyVault.Keys": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "R5iW7mH0EXdl3wqLQ7qglFQXl5JPGmmYXxDxKFT/TraCw6yRhlt5/G3NCc0Wb98P2P3lRZEI8lqF3BY0m9RkNA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.25.0",
+        "contentHash": "MHGWp4aLHRo0BdLj25U2qYdYK//Zz21k4bs3SVyNQEmJbBl3qZ8GuOmTSXJ+Zad93HnFXfvD8kyMr0gjA8Ftpw==",
+        "dependencies": {
+          "Azure.Core": "1.47.3",
+          "System.IO.Hashing": "8.0.0"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -98,219 +113,37 @@
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.10",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
-        }
+        "contentHash": "/FYCIyhRLrDwIg29tB/21/Rp7XMaEP/gWR5Cxyi4GgWcN/v/XXUpU52yhQux0s2SQy1Z0C1wnhptCMvLaaT45Q=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.ObjectPool": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Primitives": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.10",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
-        "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.10",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10"
-        }
+        "contentHash": "LXwOAsnrflu2ln+Bxj7y3Zc/Pn4HquCCRzW81oOIuRsM8F75TxwA/ZpSFZ5E1+YkVpndz7BcHY4ThFSjjA4vbQ=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "Transitive",
-        "resolved": "8.0.11",
-        "contentHash": "zLgN22Zp9pk8RHlwssRTexw4+a6wqOnKWN+VejdPn5Yhjql4XiBhkFo35Nu8mmqHIk/UEmmCnMGLWq75aFfkOw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "8.0.11",
-          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Options": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "8.0.11",
-        "contentHash": "So3JUdRxozRjvQ3cxU6F3nI/i4emDnjane6yMYcJhvTTTu29ltlIdoXjkFGRceIWz8yKvuEpzXItZ0x5GvN2nQ=="
-      },
-      "Microsoft.Extensions.Features": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "4Zdm7n1vxXAXpHOhGQVpGd5KCdcI1EWk66ilgdrDt2I+928ND+u/F+EVrzYi9pmRR+XeAE47kjuVEmkP0b0mBw=="
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
-        }
+        "contentHash": "tXmzwQeWgiycaLOtvSFnz0TPkJxXTyZrkwSVPTr83FgSiMj3BD/8eIbvrpGi5rzc2AgfKyegKo1ntJlJFey1Zg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
         "resolved": "10.8.0",
         "contentHash": "2pYnolFkigH7N6A5WHdGx93iZ8dIhrBnu4ZkjvB6RwbHzYmIy/iXVe12pdrViNDdeBSmKZ5FA9YP/xhwLT7q7A==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "10.0.10",
           "Microsoft.Extensions.Telemetry": "10.8.0"
         }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.10",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "cLrqxkuEfcilZ8SjK+9KAnpLk9lOoMPaOokF+wRUYie+iUEcdX4/p/+gJkt0BYgWLthjpBUCkVTBI6Kxg0nsOw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.10",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Logging": "10.0.10",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.ObjectPool": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "Tx0R6PY9MNSh0mDKSxbpHLuuec93IxF1cel+1ithQnMNr/vbfLSSHOQHGHIppAJCGfPcEo/wO1Ylj+QpXtzo3A=="
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Primitives": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10",
-          "Microsoft.Extensions.Primitives": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.10",
-        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
         "resolved": "10.8.0",
         "contentHash": "RH/gv0ZcCnQ3d30lxb8+T2o661TwZq/K5eMwp488goQLX1QYqWN3i8L8XlN9DhrqP2Zcf0EtsWaKpJO3yHDUTw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics": "10.0.10",
           "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.8.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10",
           "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
@@ -319,16 +152,7 @@
       "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
         "type": "Transitive",
         "resolved": "10.8.0",
-        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Features": "10.0.10",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10",
-          "Microsoft.Extensions.Primitives": "10.0.10"
-        }
+        "contentHash": "FR1eyZTR6W6Ura43aQ+Kpcogb7aS4EAsMh8sMfOyZHx0PUBzmooIni/GvJBpXjgBUboWCgoDrdbLwCmN7DxHCA=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "Transitive",
@@ -337,8 +161,6 @@
         "dependencies": {
           "Microsoft.Extensions.AmbientMetadata.Application": "10.8.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
-          "Microsoft.Extensions.ObjectPool": "10.0.10",
           "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
         }
       },
@@ -347,10 +169,7 @@
         "resolved": "10.8.0",
         "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
-          "Microsoft.Extensions.ObjectPool": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0"
         }
       },
       "Microsoft.Identity.Client": {
@@ -462,9 +281,6 @@
         "resolved": "1.17.0",
         "contentHash": "rMLOTftlMlTm7+MSrvXDHnJRjVkROFNKXHZrYjOsX+LankaFG7QSflx7qRRGjoqZoirohnxmJQ7GEb9occO4Gg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.17.0"
         }
       },
@@ -473,7 +289,6 @@
         "resolved": "1.17.0",
         "contentHash": "Xgc3Qf9B9TFMFpx6exTdGqMWuYIT2miNzkdMPutVvT9YuMFaEovXWke1Gb6z8NxYaQbbGF38vYLuSg1JCeui5Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "OpenTelemetry.Api": "1.17.0"
         }
       },
@@ -505,8 +320,6 @@
         "resolved": "8.4.2",
         "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
           "Polly.Core": "8.4.2"
         }
       },
@@ -515,17 +328,13 @@
         "resolved": "8.4.2",
         "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
         "dependencies": {
-          "Polly.Core": "8.4.2",
-          "System.Threading.RateLimiting": "8.0.0"
+          "Polly.Core": "8.4.2"
         }
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
         "resolved": "7.0.0",
-        "contentHash": "8YJz22mOSMtkbIVuVSz2HbJwbpKwRoXQ1uqbczDUt1w1Ds8dxFs6dkV/oZ8AlTmkErZjtQelHv+oBu52ud00WA==",
-        "dependencies": {
-          "System.Threading.RateLimiting": "8.0.0"
-        }
+        "contentHash": "8YJz22mOSMtkbIVuVSz2HbJwbpKwRoXQ1uqbczDUt1w1Ds8dxFs6dkV/oZ8AlTmkErZjtQelHv+oBu52ud00WA=="
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
@@ -537,9 +346,6 @@
         "resolved": "1.14.0",
         "contentHash": "yhIJHDW3Hh5kcvhHv3ww1T8qvya06Nlwo/SR/rke4/fHXtyKiqQV/9b/VDhnVI7QUcMnpfvh4pIEFhNsTDLeKQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
           "System.Memory.Data": "10.0.3"
         }
       },
@@ -548,14 +354,13 @@
         "resolved": "8.0.0",
         "contentHash": "JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
         "dependencies": {
-          "System.Diagnostics.EventLog": "8.0.0",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         }
       },
-      "System.Diagnostics.EventLog": {
+      "System.IO.Hashing": {
         "type": "Transitive",
         "resolved": "8.0.0",
-        "contentHash": "fdYxcRjQqTTacKId/2IECojlDSFvp7LP5N78+0z/xH7v/Tuw5ZAxu23Y6PTCRinqyu2ePx+Gn1098NC6jM6d+A=="
+        "contentHash": "ne1843evDugl0md7Fjzy6QjJrzsjh46ZKbhf8GwBXb5f/gw97J4bxMs0NQKifDuThh/f0bZ0e62NPl1jzTuRqA=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -574,11 +379,6 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
-      },
-      "System.Threading.RateLimiting": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "xunit.analyzers": {
         "type": "Transitive",
@@ -645,6 +445,9 @@
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
+          "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.3, )",
+          "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.3, )",
+          "Azure.Identity": "[1.21.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
@@ -666,7 +469,6 @@
         "resolved": "9.0.0",
         "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "RabbitMQ.Client": "7.0.0"
         }
       },
@@ -676,7 +478,6 @@
         "resolved": "9.0.0",
         "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "StackExchange.Redis": "2.7.4"
         }
       },
@@ -686,20 +487,36 @@
         "resolved": "9.0.0",
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
-          "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
+          "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.3, )",
+        "resolved": "1.5.3",
+        "contentHash": "owDEPihK2GwyOUWsj6Ae1M5dXqcJyKTWwPx1kYb7FWemMLB4Iox3xrcb2ev6dBTSQjpQWcsVFwpIuAGmOD8RXw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Blobs": "12.26.0"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Keys": {
+        "type": "CentralTransitive",
+        "requested": "[1.6.3, )",
+        "resolved": "1.6.3",
+        "contentHash": "zALqsKe49Jde/fWGv0yCW5awfql23ZpWdhVVhOeF46h6SQGg843cJGUHiHjWn+sQPly6c6V1+2n+/pCXA7CVGw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Security.KeyVault.Keys": "4.10.0"
         }
       },
       "Azure.Identity": {
         "type": "CentralTransitive",
         "requested": "[1.21.0, )",
-        "resolved": "1.11.4",
-        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
-          "Azure.Core": "1.38.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "System.Security.Cryptography.ProtectedData": "4.7.0"
+          "Azure.Core": "1.53.0"
         }
       },
       "Azure.Monitor.OpenTelemetry.AspNetCore": {
@@ -713,6 +530,16 @@
           "OpenTelemetry.Extensions.Hosting": "1.15.3",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.15.2",
           "OpenTelemetry.Instrumentation.Http": "1.15.1"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.29.1, )",
+        "resolved": "12.26.0",
+        "contentHash": "EBRSHmI0eNzdufcIS1Rf7Ez9M8V1Jl7pMV4UWDERDMCv513KtAVsgz2ez2FQP9Qnwg7uEQrP+Uc7vBtumlr7sQ==",
+        "dependencies": {
+          "Azure.Core": "1.47.3",
+          "Azure.Storage.Common": "12.25.0"
         }
       },
       "Microsoft.Data.SqlClient": {
@@ -731,29 +558,6 @@
           "System.Runtime.Caching": "8.0.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.10, )",
-        "resolved": "10.0.10",
-        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.10"
-        }
-      },
-      "Microsoft.Extensions.Http": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.10, )",
-        "resolved": "10.0.10",
-        "contentHash": "DuEBLw2y7ZBfilnaJtlge8f2M49932v43t7j1InceXVjcZzxNrSEkobYXdgZkXuPFnFbKcbWpAS+fZgYEW1BhA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Diagnostics": "10.0.10",
-          "Microsoft.Extensions.Logging": "10.0.10",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
-          "Microsoft.Extensions.Options": "10.0.10"
-        }
-      },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "CentralTransitive",
         "requested": "[10.8.0, )",
@@ -761,7 +565,6 @@
         "contentHash": "XtbZyYVxSNn1Aj2Z0PA8yauS12hPszTWDZ3GtZ5Vww7Ai3d8Pm841jMBnTvoTf1t9mRf3eSB38V5KUWxH6/4oQ==",
         "dependencies": {
           "Microsoft.Extensions.Http.Diagnostics": "10.8.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.10",
           "Microsoft.Extensions.Resilience": "10.8.0"
         }
       },
@@ -771,7 +574,6 @@
         "resolved": "10.8.0",
         "contentHash": "OflwReySDxjF/zVe2mo0ZqmZjVVPCJ68CoT91CG+j+gjeK4nByslvr8LFd7DcOs2VKHZZsKxfIejcysjEMG3Ng==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "10.0.10",
           "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.8.0"
         }
       },
@@ -796,7 +598,6 @@
         "resolved": "1.17.0",
         "contentHash": "t1OwL/4qgboGMobYVT+UV5zgWnFqCp4Pw8lcsmzh8m2K8PQsTKkyxrC32tqYTMYny3GOW4q5cltE3dTVzLmRew==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "OpenTelemetry": "1.17.0"
         }
       },
@@ -815,8 +616,6 @@
         "resolved": "1.17.0",
         "contentHash": "uTwVtxIJ/xB96wGYTaDsbkJVeCFdUxTwvrlDUn2YJixy0UuKc8DvQMzwKNJMTzNFiiyYO9c40id6tUHTmWs33A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.17.0, 2.0.0)"
         }
       },
@@ -835,7 +634,6 @@
         "resolved": "2.7.4",
         "contentHash": "lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
         }
       },

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/NotificationsControllerTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/NotificationsControllerTests.cs
@@ -7,6 +7,7 @@ using MMCA.Common.Application.Notifications.PushNotifications.UseCases.GetHistor
 using MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
 using MMCA.Common.Application.UseCases;
 using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Http;
 using MMCA.Common.Shared.Notifications.PushNotifications;
 using Moq;
 
@@ -18,14 +19,37 @@ public sealed class NotificationsControllerTests
     private readonly Mock<IQueryHandler<GetNotificationHistoryQuery, Result<PagedCollectionResult<PushNotificationDTO>>>> _historyHandler = new();
     private readonly Mock<ICurrentUserService> _currentUserService = new();
 
-    private NotificationsController CreateController() =>
-        new(_sendHandler.Object, _historyHandler.Object, _currentUserService.Object)
+    private SendPushNotificationCommand? _captured;
+
+    /// <summary>
+    /// Arranges an authenticated caller and a successful handler that records the command it
+    /// received, so a test can assert on what the controller built.
+    /// </summary>
+    private void ArrangeCapture()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(42);
+        _sendHandler
+            .Setup(h => h.HandleAsync(It.IsAny<SendPushNotificationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<SendPushNotificationCommand, CancellationToken>((command, _) => _captured = command)
+            .ReturnsAsync(Result.Success(CreateDto()));
+    }
+
+    private NotificationsController CreateController(string? idempotencyKey = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (idempotencyKey is not null)
+        {
+            httpContext.Request.Headers[IdempotencyHeaders.IdempotencyKey] = idempotencyKey;
+        }
+
+        return new NotificationsController(_sendHandler.Object, _historyHandler.Object, _currentUserService.Object)
         {
             ControllerContext = new ControllerContext
             {
-                HttpContext = new DefaultHttpContext(),
+                HttpContext = httpContext,
             },
         };
+    }
 
     private static PushNotificationDTO CreateDto() =>
         new()
@@ -89,6 +113,43 @@ public sealed class NotificationsControllerTests
         var objectResult = result.Result as ObjectResult;
         objectResult.Should().NotBeNull();
         objectResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // ── SendAsync: idempotency key to DedupKey (gap 12) ──
+    [Fact]
+    public async Task SendAsync_WithIdempotencyKeyHeader_PopulatesCommandDedupKey()
+    {
+        ArrangeCapture();
+        NotificationsController sut = CreateController("idem-key-1");
+
+        await sut.SendAsync(new SendPushNotificationRequest("Title", "Body"));
+
+        _captured.Should().NotBeNull();
+        _captured!.DedupKey.Should().Be("idem-key-1");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutIdempotencyKeyHeader_LeavesDedupKeyNull()
+    {
+        ArrangeCapture();
+        NotificationsController sut = CreateController();
+
+        await sut.SendAsync(new SendPushNotificationRequest("Title", "Body"));
+
+        _captured.Should().NotBeNull();
+        _captured!.DedupKey.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_WithWhitespaceIdempotencyKeyHeader_LeavesDedupKeyNull()
+    {
+        ArrangeCapture();
+        NotificationsController sut = CreateController("   ");
+
+        await sut.SendAsync(new SendPushNotificationRequest("Title", "Body"));
+
+        _captured.Should().NotBeNull();
+        _captured!.DedupKey.Should().BeNull();
     }
 
     // ── GetHistoryAsync ──

--- a/Tests/Presentation/MMCA.Common.API.Tests/Idempotency/IdempotencyFilterTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Idempotency/IdempotencyFilterTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Security.Claims;
+using System.Text;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.API.Idempotency;
 using MMCA.Common.Application.Interfaces;
 using Moq;
@@ -16,13 +18,17 @@ namespace MMCA.Common.API.Tests.Idempotency;
 
 public sealed class IdempotencyFilterTests
 {
+    /// <summary>The filter takes an <c>ILogger</c> so a swallowed cache fault is still reported.</summary>
+    private static IdempotencyFilter CreateSut() => new(NullLogger<IdempotencyFilter>.Instance);
+
     private static (ActionExecutingContext Context, Mock<ICacheService> Cache) CreateContext(
         string? idempotencyKey = null,
         string? userId = null,
         string method = "POST",
         string? routeTemplate = null,
         Mock<ICacheService>? sharedCache = null,
-        IDistributedLock? distributedLock = null)
+        IDistributedLock? distributedLock = null,
+        string? body = null)
     {
         var cache = sharedCache ?? new Mock<ICacheService>();
         var services = new ServiceCollection();
@@ -34,6 +40,9 @@ public sealed class IdempotencyFilterTests
 
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
         httpContext.Request.Method = method;
+        if (body is not null)
+            httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+
         if (idempotencyKey is not null)
             httpContext.Request.Headers[IdempotencyFilter.IdempotencyKeyHeader] = idempotencyKey;
 
@@ -60,7 +69,7 @@ public sealed class IdempotencyFilterTests
             .Callback<string, CancellationToken>((key, _) => observedKey ??= key)
             .ReturnsAsync((IdempotencyRecord?)null);
 
-        await new IdempotencyFilter().OnActionExecutionAsync(context, () =>
+        await CreateSut().OnActionExecutionAsync(context, () =>
             Task.FromResult(new ActionExecutedContext(
                 new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
                 [], null!)));
@@ -72,7 +81,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task OnActionExecutionAsync_NoIdempotencyKey_ExecutesNext()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, _) = CreateContext();
         var nextCalled = false;
 
@@ -90,7 +99,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task OnActionExecutionAsync_CachedResult_ReturnsCachedResponse()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext("unique-key-1");
 
         var cachedRecord = new IdempotencyRecord(200, "{\"id\":1}");
@@ -118,7 +127,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task OnActionExecutionAsync_NewRequest_ExecutesAndCaches()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext("new-key-2");
 
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -178,8 +187,8 @@ public sealed class IdempotencyFilterTests
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var filter1 = new IdempotencyFilter();
-        var filter2 = new IdempotencyFilter();
+        var filter1 = CreateSut();
+        var filter2 = CreateSut();
 
         async Task<ActionExecutedContext> NextDelegate1()
         {
@@ -225,7 +234,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task EmptyIdempotencyKey_ExecutesNormally()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext("   ");
         var nextCalled = false;
 
@@ -247,7 +256,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task NonObjectResult_NotCached()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var idempotencyKey = $"non-object-result-{Guid.NewGuid()}";
         var (context, cache) = CreateContext(idempotencyKey);
 
@@ -278,7 +287,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task CachedResponse_IncludesReplayHeader_OnDoubleCheckPath()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var idempotencyKey = $"double-check-replay-{Guid.NewGuid()}";
         var (context, cache) = CreateContext(idempotencyKey);
 
@@ -286,7 +295,7 @@ public sealed class IdempotencyFilterTests
         var getCallCount = 0;
 
         // First GetAsync returns null (fast path misses), second returns cached record
-        // (double-check inside the lock finds it — another request completed while waiting)
+        // (double-check inside the lock finds it: another request completed while waiting)
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
@@ -395,7 +404,7 @@ public sealed class IdempotencyFilterTests
     [InlineData(500)]
     public async Task FailureResponse_NotCached(int statusCode)
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext(string.Create(CultureInfo.InvariantCulture, $"failure-{statusCode}-{Guid.NewGuid()}"));
 
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -428,7 +437,7 @@ public sealed class IdempotencyFilterTests
     [InlineData(202)]
     public async Task SuccessResponse_IsCached(int statusCode)
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext(string.Create(CultureInfo.InvariantCulture, $"success-{statusCode}-{Guid.NewGuid()}"));
 
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -461,7 +470,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task NoContentResponse_IsCachedWithAnEmptyBody()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext($"no-content-{Guid.NewGuid()}");
 
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -487,7 +496,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task FailureStatusCodeResult_NotCached()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext($"status-failure-{Guid.NewGuid()}");
 
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -514,7 +523,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task CachedEmptyBody_ReplaysAsAStatusCodeWithNoContentType()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var (context, cache) = CreateContext($"replay-no-content-{Guid.NewGuid()}");
 
         cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -543,7 +552,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task DistributedLock_WhenAcquired_ExecutesOnceAndReleases()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var handle = new TrackingHandle();
         var distributedLock = new Mock<IDistributedLock>();
         distributedLock
@@ -583,7 +592,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task DistributedLock_WhenHeldElsewhereAndTheHolderStored_ReplaysWithoutExecuting()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var distributedLock = new Mock<IDistributedLock>();
         distributedLock
             .Setup(x => x.TryAcquireAsync(
@@ -618,7 +627,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task DistributedLock_WhenHeldElsewhereAndNothingStored_ReportsTheDuplicateInFlight()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var distributedLock = new Mock<IDistributedLock>();
         distributedLock
             .Setup(x => x.TryAcquireAsync(
@@ -654,7 +663,7 @@ public sealed class IdempotencyFilterTests
     [Fact]
     public async Task DistributedLock_IsAskedForABoundedWaitAndACrashGuardTtl()
     {
-        var sut = new IdempotencyFilter();
+        var sut = CreateSut();
         var distributedLock = new Mock<IDistributedLock>();
         distributedLock
             .Setup(x => x.TryAcquireAsync(
@@ -678,6 +687,323 @@ public sealed class IdempotencyFilterTests
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "the lock is taken on the same key the response is cached under, with a finite wait");
+    }
+
+    // ── Request-body binding ──
+    // The key alone used to decide a replay, so a client that reused a key with a DIFFERENT payload
+    // was handed the first response and its second write silently never ran. The stored record now
+    // carries a hash of the body that produced it.
+    [Fact]
+    public async Task SameRequestBody_ReplaysTheCachedResponse()
+    {
+        const string body = "{\"amount\":10}";
+        var idempotencyKey = $"same-body-{Guid.NewGuid()}";
+
+        var stored = await CaptureStoredRecordAsync(
+            idempotencyKey, body, new ObjectResult(new { id = 42 }) { StatusCode = 201 });
+
+        stored.Should().NotBeNull();
+
+        var record = stored!;
+        record.RequestBodyHash.Should().NotBeNull("the stored record binds the payload to the key");
+
+        var (context, cache) = CreateContext(idempotencyKey, userId: "1", routeTemplate: "Orders", body: body);
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(record);
+
+        var nextCalled = false;
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse("an identical retry is the case idempotency exists to serve");
+        context.Result.Should().BeOfType<ContentResult>()
+            .Which.Content.Should().Be(record.ResponseBody);
+        context.HttpContext.Response.Headers["X-Idempotent-Replay"].ToString().Should().Be("true");
+    }
+
+    [Fact]
+    public async Task DifferentRequestBody_SameKey_IsRejectedAsUnprocessable()
+    {
+        var idempotencyKey = $"different-body-{Guid.NewGuid()}";
+
+        var stored = await CaptureStoredRecordAsync(
+            idempotencyKey, "{\"amount\":10}", new ObjectResult(new { id = 42 }) { StatusCode = 201 });
+
+        var (context, cache) = CreateContext(
+            idempotencyKey, userId: "1", routeTemplate: "Orders", body: "{\"amount\":99}");
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+
+        var nextCalled = false;
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse();
+        context.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity,
+                "409 already means the original is in flight, so key reuse needs its own status");
+        ((ProblemDetails)((ObjectResult)context.Result!).Value!).Detail
+            .Should().Be("The Idempotency-Key was already used with a different request body.");
+        context.HttpContext.Response.Headers.ContainsKey("X-Idempotent-Replay")
+            .Should().BeFalse("a rejected reuse is not a replay");
+    }
+
+    [Fact]
+    public async Task LegacyCachedRecord_WithNoStoredHash_ReplaysWithoutComparison()
+    {
+        var (context, cache) = CreateContext(
+            $"legacy-record-{Guid.NewGuid()}", userId: "1", routeTemplate: "Orders", body: "{\"amount\":99}");
+
+        // Written by the version before the hash existed: two properties, no RequestBodyHash.
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IdempotencyRecord(200, "{\"id\":1}"));
+
+        var nextCalled = false;
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse();
+        context.Result.Should().BeOfType<ContentResult>(
+            "entries cached before the hash existed must keep replaying until they age out");
+        ((ContentResult)context.Result!).Content.Should().Be("{\"id\":1}");
+    }
+
+    [Fact]
+    public async Task BodylessRequest_StoresAndReplays()
+    {
+        var idempotencyKey = $"bodyless-{Guid.NewGuid()}";
+
+        var stored = await CaptureStoredRecordAsync(idempotencyKey, body: null, new NoContentResult());
+
+        stored.Should().NotBeNull();
+        stored!.RequestBodyHash.Should().NotBeNull("a body-less request hashes the empty payload");
+
+        var (context, cache) = CreateContext(idempotencyKey, userId: "1", routeTemplate: "Orders");
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+
+        var nextCalled = false;
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!));
+        });
+
+        nextCalled.Should().BeFalse();
+        context.Result.Should().BeOfType<StatusCodeResult>()
+            .Which.StatusCode.Should().Be(204);
+    }
+
+    // ── Resource stage ──
+    // Hashing the body means reading it, and the only point at which it can still be made
+    // re-readable is before model binding. Buffering is not free, so it is enabled only for the
+    // requests that actually carry a key.
+    [Fact]
+    public async Task ResourceStage_WithIdempotencyKey_EnablesBuffering()
+    {
+        var body = new NonSeekableStream(Encoding.UTF8.GetBytes("{\"amount\":10}"));
+        var context = CreateResourceContext($"buffering-on-{Guid.NewGuid()}", body);
+
+        await CreateSut().OnResourceExecutionAsync(
+            context,
+            () => Task.FromResult(new ResourceExecutedContext(context, context.Filters)));
+
+        context.HttpContext.Request.Body.Should().NotBeSameAs(body);
+        context.HttpContext.Request.Body.CanSeek.Should().BeTrue(
+            "the action stage has to be able to rewind the body to hash it");
+    }
+
+    [Fact]
+    public async Task ResourceStage_WithoutIdempotencyKey_LeavesTheBodyAlone()
+    {
+        var body = new NonSeekableStream(Encoding.UTF8.GetBytes("{\"amount\":10}"));
+        var context = CreateResourceContext(idempotencyKey: null, body);
+
+        await CreateSut().OnResourceExecutionAsync(
+            context,
+            () => Task.FromResult(new ResourceExecutedContext(context, context.Filters)));
+
+        context.HttpContext.Request.Body.Should().BeSameAs(body,
+            "ordinary traffic must not pay for buffering it never uses");
+    }
+
+    // ── Fail-open cache ──
+    // Deduplication is an optimization over an at-least-once client retry. A cache outage must
+    // degrade it, never turn every write endpoint carrying the attribute into a 500.
+    [Fact]
+    public async Task CacheReadFailure_StillExecutesTheActionAndKeepsItsResult()
+    {
+        var (context, cache) = CreateContext($"cache-read-fault-{Guid.NewGuid()}");
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache unreachable"));
+        cache.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var expected = new ObjectResult(new { id = 7 }) { StatusCode = 201 };
+        ActionExecutedContext? executed = null;
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+        {
+            executed = new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = expected
+            };
+            return Task.FromResult(executed);
+        });
+
+        executed.Should().NotBeNull("a failing cache read must be treated as a miss, not as an error");
+        executed!.Result.Should().BeSameAs(expected);
+        context.Result.Should().BeNull("the filter must not short-circuit a request it could not deduplicate");
+    }
+
+    [Fact]
+    public async Task CacheStoreFailure_StillReturnsTheActionResponse()
+    {
+        var (context, cache) = CreateContext($"cache-store-fault-{Guid.NewGuid()}");
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+        cache.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache unreachable"));
+
+        var expected = new ObjectResult(new { id = 9 }) { StatusCode = 201 };
+        ActionExecutedContext? executed = null;
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+        {
+            executed = new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = expected
+            };
+            return Task.FromResult(executed);
+        });
+
+        executed.Should().NotBeNull();
+        executed!.Result.Should().BeSameAs(expected,
+            "the write already happened; failing here would make the client retry it");
+        context.Result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Runs the filter once against a cache miss and returns the record it stored, so a test can
+    /// replay a genuinely produced record instead of duplicating the hashing rule.
+    /// </summary>
+    private static async Task<IdempotencyRecord?> CaptureStoredRecordAsync(
+        string idempotencyKey,
+        string? body,
+        IActionResult result)
+    {
+        var (context, cache) = CreateContext(idempotencyKey, userId: "1", routeTemplate: "Orders", body: body);
+
+        IdempotencyRecord? stored = null;
+        cache.Setup(x => x.GetAsync<IdempotencyRecord>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IdempotencyRecord?)null);
+        cache.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<IdempotencyRecord>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IdempotencyRecord, TimeSpan?, CancellationToken>((_, record, _, _) => stored = record)
+            .Returns(Task.CompletedTask);
+
+        await CreateSut().OnActionExecutionAsync(context, () =>
+            Task.FromResult(new ActionExecutedContext(
+                new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor),
+                [], null!)
+            {
+                Result = result
+            }));
+
+        return stored;
+    }
+
+    /// <summary>Builds the resource-stage context, which runs before model binding.</summary>
+    private static ResourceExecutingContext CreateResourceContext(string? idempotencyKey, Stream body)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Mock<ICacheService>().Object);
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Body = body;
+        if (idempotencyKey is not null)
+            httpContext.Request.Headers[IdempotencyFilter.IdempotencyKeyHeader] = idempotencyKey;
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        return new ResourceExecutingContext(actionContext, [], []);
+    }
+
+    /// <summary>
+    /// A request body as the server first sees it: forward-only. Buffering is what makes it
+    /// seekable, so this is the only way to observe whether the filter turned buffering on.
+    /// </summary>
+    private sealed class NonSeekableStream(byte[] content) : Stream
+    {
+        private readonly MemoryStream _inner = new(content);
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+
+            base.Dispose(disposing);
+        }
     }
 
     /// <summary>Lock handle that records how many times it was released.</summary>

--- a/Tests/Presentation/MMCA.Common.API.Tests/Middleware/SoftDeletedUserMiddlewareTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Middleware/SoftDeletedUserMiddlewareTests.cs
@@ -1,7 +1,9 @@
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.API.Middleware;
+using MMCA.Common.Application.Auth;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using Moq;
@@ -10,9 +12,278 @@ namespace MMCA.Common.API.Tests.Middleware;
 
 public sealed class SoftDeletedUserMiddlewareTests
 {
+    private const int UserId = 1;
+
+    private static readonly string CacheKey = SoftDeletedUserCache.KeyFor(UserId);
+
     private readonly Mock<ICurrentUserService> _currentUserService = new();
     private readonly Mock<ICacheService> _cacheService = new();
     private readonly Mock<ISoftDeletedUserValidator> _validator = new();
+
+    // ── Anonymous request passes through ──
+    [Fact]
+    public async Task InvokeAsync_AnonymousRequest_PassesThrough()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns((int?)null);
+        var nextCalled = false;
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, CreateContext());
+
+        nextCalled.Should().BeTrue();
+    }
+
+    // ── No validator registered (e.g. Catalog service): authenticated request passes through ──
+    [Fact]
+    public async Task InvokeAsync_NoValidatorRegistered_PassesThrough()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        var nextCalled = false;
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, CreateContext(includeValidator: false));
+
+        nextCalled.Should().BeTrue();
+        _cacheService.Verify(
+            c => c.GetAsync<bool?>(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Non-deleted user passes through ──
+    [Fact]
+    public async Task InvokeAsync_NonDeletedUser_PassesThrough()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((bool?)null);
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var nextCalled = false;
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, CreateContext());
+
+        nextCalled.Should().BeTrue();
+        _cacheService.Verify(
+            c => c.SetAsync(CacheKey, false, SoftDeletedUserCache.MarkerDuration, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Deleted user returns 401 ──
+    [Fact]
+    public async Task InvokeAsync_DeletedUser_Returns401()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((bool?)null);
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ => Task.CompletedTask);
+
+        await InvokeAsync(sut, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ── Cached deleted user returns 401 without DB call ──
+    [Fact]
+    public async Task InvokeAsync_CachedDeletedUser_Returns401WithoutDbCall()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ => Task.CompletedTask);
+
+        await InvokeAsync(sut, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        _validator.Verify(
+            v => v.IsUserSoftDeletedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Cached non-deleted user passes without DB call ──
+    [Fact]
+    public async Task InvokeAsync_CachedNonDeletedUser_PassesThroughWithoutDbCall()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var nextCalled = false;
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, CreateContext());
+
+        nextCalled.Should().BeTrue();
+        _validator.Verify(
+            v => v.IsUserSoftDeletedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Fail open: cache outage falls back to the validator query ──
+    [Fact]
+    public async Task InvokeAsync_CacheReadThrowsAndUserIsDeleted_Returns401()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache down"));
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ => Task.CompletedTask);
+
+        await InvokeAsync(sut, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        _validator.Verify(
+            v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_CacheReadThrowsAndUserIsLive_PassesThroughWithoutWritingTheCache()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache down"));
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var nextCalled = false;
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, CreateContext());
+
+        nextCalled.Should().BeTrue();
+        _cacheService.Verify(
+            c => c.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Fail open: cache AND validator both unavailable ──
+    [Fact]
+    public async Task InvokeAsync_CacheAndValidatorBothThrow_PassesThrough()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache down"));
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database down"));
+        var nextCalled = false;
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ── Fail open: only the validator is unavailable ──
+    [Fact]
+    public async Task InvokeAsync_ValidatorThrows_PassesThrough()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((bool?)null);
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("database down"));
+        var nextCalled = false;
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ── Fail open: a failed cache write does not fail the request ──
+    [Fact]
+    public async Task InvokeAsync_CacheWriteThrows_PassesThrough()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((bool?)null);
+        _cacheService.Setup(c => c.SetAsync(
+                CacheKey,
+                It.IsAny<bool>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache down"));
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var nextCalled = false;
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await InvokeAsync(sut, context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ── A deleted user is still rejected when only the cache write fails ──
+    [Fact]
+    public async Task InvokeAsync_CacheWriteThrowsForDeletedUser_Returns401()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(UserId);
+        _cacheService.Setup(c => c.GetAsync<bool?>(CacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((bool?)null);
+        _cacheService.Setup(c => c.SetAsync(
+                CacheKey,
+                It.IsAny<bool>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache down"));
+        _validator.Setup(v => v.IsUserSoftDeletedAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var context = CreateContext();
+        var sut = new SoftDeletedUserMiddleware(_ => Task.CompletedTask);
+
+        await InvokeAsync(sut, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ── Helpers ──
 
     /// <summary>
     /// Builds a <see cref="DefaultHttpContext"/> whose <see cref="HttpContext.RequestServices"/>
@@ -33,118 +304,14 @@ public sealed class SoftDeletedUserMiddlewareTests
         };
     }
 
-    // ── Anonymous request passes through ──
-    [Fact]
-    public async Task InvokeAsync_AnonymousRequest_PassesThrough()
-    {
-        _currentUserService.Setup(s => s.UserId).Returns((int?)null);
-        var nextCalled = false;
-        var sut = new SoftDeletedUserMiddleware(_ =>
-        {
-            nextCalled = true;
-            return Task.CompletedTask;
-        });
-
-        await sut.InvokeAsync(CreateContext(), _currentUserService.Object, _cacheService.Object);
-
-        nextCalled.Should().BeTrue();
-    }
-
-    // ── No validator registered (e.g. Catalog service) — authenticated request passes through ──
-    [Fact]
-    public async Task InvokeAsync_NoValidatorRegistered_PassesThrough()
-    {
-        _currentUserService.Setup(s => s.UserId).Returns(1);
-        var nextCalled = false;
-        var sut = new SoftDeletedUserMiddleware(_ =>
-        {
-            nextCalled = true;
-            return Task.CompletedTask;
-        });
-
-        await sut.InvokeAsync(CreateContext(includeValidator: false), _currentUserService.Object, _cacheService.Object);
-
-        nextCalled.Should().BeTrue();
-        _cacheService.Verify(
-            c => c.GetAsync<bool?>(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
-
-    // ── Non-deleted user passes through ──
-    [Fact]
-    public async Task InvokeAsync_NonDeletedUser_PassesThrough()
-    {
-        _currentUserService.Setup(s => s.UserId).Returns(1);
-        _cacheService.Setup(c => c.GetAsync<bool?>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((bool?)null);
-        _validator.Setup(v => v.IsUserSoftDeletedAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-        var nextCalled = false;
-        var sut = new SoftDeletedUserMiddleware(_ =>
-        {
-            nextCalled = true;
-            return Task.CompletedTask;
-        });
-
-        await sut.InvokeAsync(CreateContext(), _currentUserService.Object, _cacheService.Object);
-
-        nextCalled.Should().BeTrue();
-    }
-
-    // ── Deleted user returns 401 ──
-    [Fact]
-    public async Task InvokeAsync_DeletedUser_Returns401()
-    {
-        _currentUserService.Setup(s => s.UserId).Returns(1);
-        _cacheService.Setup(c => c.GetAsync<bool?>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((bool?)null);
-        _validator.Setup(v => v.IsUserSoftDeletedAsync(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-        var context = CreateContext();
-        var sut = new SoftDeletedUserMiddleware(_ => Task.CompletedTask);
-
-        await sut.InvokeAsync(context, _currentUserService.Object, _cacheService.Object);
-
-        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-    }
-
-    // ── Cached deleted user returns 401 without DB call ──
-    [Fact]
-    public async Task InvokeAsync_CachedDeletedUser_Returns401WithoutDbCall()
-    {
-        _currentUserService.Setup(s => s.UserId).Returns(1);
-        _cacheService.Setup(c => c.GetAsync<bool?>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-        var context = CreateContext();
-        var sut = new SoftDeletedUserMiddleware(_ => Task.CompletedTask);
-
-        await sut.InvokeAsync(context, _currentUserService.Object, _cacheService.Object);
-
-        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-        _validator.Verify(
-            v => v.IsUserSoftDeletedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
-
-    // ── Cached non-deleted user passes without DB call ──
-    [Fact]
-    public async Task InvokeAsync_CachedNonDeletedUser_PassesThroughWithoutDbCall()
-    {
-        _currentUserService.Setup(s => s.UserId).Returns(1);
-        _cacheService.Setup(c => c.GetAsync<bool?>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
-        var nextCalled = false;
-        var sut = new SoftDeletedUserMiddleware(_ =>
-        {
-            nextCalled = true;
-            return Task.CompletedTask;
-        });
-
-        await sut.InvokeAsync(CreateContext(), _currentUserService.Object, _cacheService.Object);
-
-        nextCalled.Should().BeTrue();
-        _validator.Verify(
-            v => v.IsUserSoftDeletedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
+    /// <summary>
+    /// Invokes the middleware with the shared mocks and a no-op logger (the logger is a
+    /// per-invoke injected parameter, so every call has to supply one).
+    /// </summary>
+    private Task InvokeAsync(SoftDeletedUserMiddleware sut, HttpContext context) =>
+        sut.InvokeAsync(
+            context,
+            _currentUserService.Object,
+            _cacheService.Object,
+            NullLogger<SoftDeletedUserMiddleware>.Instance);
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/ApiClientRegistrationTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/ApiClientRegistrationTests.cs
@@ -1,0 +1,58 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.Shared.Resilience;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Services.Auth;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// Pins the resilience-relevant configuration of the named <c>"APIClient"</c> registered by
+/// <c>AddUIShared</c>: its total timeout must come from the shared budget rather than
+/// <see cref="HttpClient"/>'s uncoordinated 100s default, which would otherwise cut a call off at
+/// an arbitrary point inside the retry pipeline.
+/// </summary>
+public sealed class ApiClientRegistrationTests
+{
+    private static ServiceProvider BuildProvider()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Api:ApiEndpoint"] = "https://localhost:6001" })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+
+        // The APIClient pipeline resolves AuthDelegatingHandler, which needs token storage.
+        services.AddSingleton<ITokenStorageService>(new StubTokenStorageService());
+        services.AddUIShared(configuration);
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void ApiClient_Timeout_MatchesTheSharedTotalRequestBudget()
+    {
+        using var provider = BuildProvider();
+
+        using var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("APIClient");
+
+        client.Timeout.Should().Be(TimeSpan.FromSeconds(90));
+        client.Timeout.Should().Be(
+            HttpResilienceDefaults.TotalRequestTimeout,
+            "the transport timeout and the resilience budget must move together");
+    }
+
+    [Fact]
+    public void ApiClient_KeepsItsConfiguredBaseAddressAndJsonAccept()
+    {
+        using var provider = BuildProvider();
+
+        using var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("APIClient");
+
+        client.BaseAddress.Should().Be(new Uri("https://localhost:6001", UriKind.Absolute));
+        client.DefaultRequestHeaders.Accept.Should().ContainSingle()
+            .Which.MediaType.Should().Be("application/json");
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/EntityServiceBaseIdempotencyRetryTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/EntityServiceBaseIdempotencyRetryTests.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using System.Text;
+using AwesomeAssertions;
+using MMCA.Common.Shared.DTOs;
+using MMCA.Common.Shared.Http;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Auth;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// Pins the write-safety half of <see cref="EntityServiceBase{TEntityDTO, TId}"/>: the
+/// <c>Idempotency-Key</c> emitted on creates (and only on creates), the key staying identical
+/// across every retry attempt of one logical operation, and the shape of the retry predicate
+/// (5xx yes, 501 no, 429 yes) plus cancellation aborting the pipeline. The retried cases pay the
+/// real Polly backoff (2s, then 4s), so each one is driven through the smallest attempt count that
+/// proves the behavior and asserts on the handler's captured attempts, never on wall-clock timing.
+/// </summary>
+public sealed class EntityServiceBaseIdempotencyRetryTests
+{
+    private const string WidgetJson = """{"id":7,"name":"Blue"}""";
+
+    private sealed record WidgetDto : IBaseDTO<int>
+    {
+        public required int Id { get; init; }
+
+        public string? Name { get; init; }
+    }
+
+    private sealed class WidgetService(IHttpClientFactory httpClientFactory, ITokenStorageService tokenStorageService)
+        : EntityServiceBase<WidgetDto, int>("widgets", httpClientFactory, tokenStorageService);
+
+    /// <summary>
+    /// Records the <c>Idempotency-Key</c> header of every attempt (null when absent) and answers
+    /// with a scripted status sequence; the last scripted status repeats if the policy asks for
+    /// more attempts than the script supplies. A fresh response is built per attempt so a retry
+    /// never reuses a consumed <see cref="HttpContent"/>. The local double exists because the
+    /// shared capturing handlers record only the Authorization header.
+    /// </summary>
+    private sealed class ScriptedHandler(string? json, params HttpStatusCode[] statuses) : HttpMessageHandler
+    {
+        private int _attempt;
+
+        public List<string?> CapturedKeys { get; } = [];
+
+        public int AttemptCount => CapturedKeys.Count;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedKeys.Add(
+                request.Headers.TryGetValues(IdempotencyHeaders.IdempotencyKey, out var values)
+                    ? string.Join(",", values)
+                    : null);
+
+            var status = statuses[Math.Min(_attempt, statuses.Length - 1)];
+            _attempt++;
+
+            var response = new HttpResponseMessage(status);
+            if (json is not null)
+            {
+                response.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private static (WidgetService Sut, ScriptedHandler Handler) CreateSut(string? json, params HttpStatusCode[] statuses)
+    {
+        var handler = new ScriptedHandler(json, statuses);
+        var factory = new FreshApiClientFactory(handler, new Uri("http://localhost/"));
+        return (new WidgetService(factory, new StubTokenStorageService()), handler);
+    }
+
+    private static WidgetDto NewWidget() => new() { Id = 0, Name = "Blue" };
+
+    // == Idempotency key on creates ==
+    [Fact]
+    public async Task AddAsync_SendsAnIdempotencyKeyHeader()
+    {
+        var (sut, handler) = CreateSut(WidgetJson, HttpStatusCode.OK);
+
+        await sut.AddAsync(NewWidget(), TestContext.Current.CancellationToken);
+
+        handler.AttemptCount.Should().Be(1);
+        handler.CapturedKeys[0].Should().MatchRegex("^[0-9a-f]{32}$", "the key is a compact-form GUID");
+    }
+
+    [Fact]
+    public async Task AddAsync_WhenAttemptsFail_ReusesTheSameKeyOnEveryRetry()
+    {
+        var (sut, handler) = CreateSut(
+            WidgetJson,
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.OK);
+
+        var result = await sut.AddAsync(NewWidget(), TestContext.Current.CancellationToken);
+
+        var firstKey = handler.CapturedKeys[0];
+        result.Id.Should().Be(7);
+        handler.AttemptCount.Should().Be(3);
+        firstKey.Should().MatchRegex("^[0-9a-f]{32}$");
+        handler.CapturedKeys.Should().OnlyContain(
+            capturedKey => capturedKey == firstKey,
+            "a fresh key per attempt would let a retried create insert a second record");
+    }
+
+    // == No key on reads and naturally idempotent writes ==
+    [Fact]
+    public async Task GetAllAsync_SendsNoIdempotencyKey()
+    {
+        var (sut, handler) = CreateSut("null", HttpStatusCode.OK);
+
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        handler.AttemptCount.Should().Be(1);
+        handler.CapturedKeys[0].Should().BeNull("a read changes nothing, so it needs no dedup key");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SendsNoIdempotencyKey()
+    {
+        var (sut, handler) = CreateSut(null, HttpStatusCode.NoContent);
+
+        await sut.UpdateAsync(new WidgetDto { Id = 7, Name = "Renamed" }, TestContext.Current.CancellationToken);
+
+        handler.AttemptCount.Should().Be(1);
+        handler.CapturedKeys[0].Should().BeNull("a full PUT is already idempotent");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SendsNoIdempotencyKey()
+    {
+        var (sut, handler) = CreateSut(null, HttpStatusCode.NoContent);
+
+        await sut.DeleteAsync(7, TestContext.Current.CancellationToken);
+
+        handler.AttemptCount.Should().Be(1);
+        handler.CapturedKeys[0].Should().BeNull("a repeated DELETE of the same id is already idempotent");
+    }
+
+    // == Retry predicate ==
+    [Fact]
+    public async Task NotImplementedResponse_IsNotRetried()
+    {
+        var (sut, handler) = CreateSut(null, HttpStatusCode.NotImplemented);
+
+        var act = () => sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.AttemptCount.Should().Be(
+            1, "501 is a permanent verdict, so retrying only burns the budget and delays the error");
+    }
+
+    [Fact]
+    public async Task TooManyRequestsResponse_IsRetried()
+    {
+        var (sut, handler) = CreateSut("null", HttpStatusCode.TooManyRequests, HttpStatusCode.OK);
+
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        handler.AttemptCount.Should().Be(2, "429 is the server explicitly inviting a later attempt");
+    }
+
+    // == Cancellation ==
+    [Fact]
+    public async Task AlreadyCancelledToken_AbortsWithoutExhaustingTheRetries()
+    {
+        var (sut, handler) = CreateSut(WidgetJson, HttpStatusCode.InternalServerError);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => sut.AddAsync(NewWidget(), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        handler.AttemptCount.Should().Be(
+            0, "the token reaches the policy, so an abandoned operation never sleeps out its backoff budget");
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -119,6 +119,14 @@
           "OpenTelemetry.PersistentStorage.FileSystem": "1.0.3"
         }
       },
+      "Azure.Security.KeyVault.Keys": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "R5iW7mH0EXdl3wqLQ7qglFQXl5JPGmmYXxDxKFT/TraCw6yRhlt5/G3NCc0Wb98P2P3lRZEI8lqF3BY0m9RkNA==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
+        }
+      },
       "Azure.Storage.Common": {
         "type": "Transitive",
         "resolved": "12.28.0",
@@ -663,6 +671,9 @@
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
+          "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.3, )",
+          "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.3, )",
+          "Azure.Identity": "[1.21.0, )",
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
@@ -775,6 +786,26 @@
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.3, )",
+        "resolved": "1.5.3",
+        "contentHash": "owDEPihK2GwyOUWsj6Ae1M5dXqcJyKTWwPx1kYb7FWemMLB4Iox3xrcb2ev6dBTSQjpQWcsVFwpIuAGmOD8RXw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Blobs": "12.26.0"
+        }
+      },
+      "Azure.Extensions.AspNetCore.DataProtection.Keys": {
+        "type": "CentralTransitive",
+        "requested": "[1.6.3, )",
+        "resolved": "1.6.3",
+        "contentHash": "zALqsKe49Jde/fWGv0yCW5awfql23ZpWdhVVhOeF46h6SQGg843cJGUHiHjWn+sQPly6c6V1+2n+/pCXA7CVGw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Security.KeyVault.Keys": "4.10.0"
         }
       },
       "Azure.Identity": {


### PR DESCRIPTION
## Summary

Closes the high and medium impact gaps from the 2026-08-03 production-patterns audit (wave A, framework side). Targets the next release (v1.137.0); ADC consumes via the usual version sweep.

- **DataProtection**: new opt-in `AddCommonDataProtection()` in MMCA.Common.Aspire (Azure Blob key persistence + optional Key Vault key wrap, config-gated so local dev keeps framework defaults).
- **Idempotency**: `IdempotencyFilter` now stores a SHA-256 request-body hash and returns 422 when a key is reused with a different body (legacy null-hash records still replay); adds structured logging and a `MMCA.Common.Idempotency` meter (replayed / conflict / degraded).
- **Fail-open cache reads**: `CachingQueryDecorator`, `IdempotencyFilter`, and `SoftDeletedUserMiddleware` degrade gracefully on cache faults instead of failing the request; soft-delete middleware falls back to the validator query, then fail-open (15-minute token lifetime bounds the exposure; reasoning recorded in XML remarks).
- **SQL command timeout**: new `Persistence:CommandTimeoutSeconds` setting (default 30) applied in `SQLServerDbContext`.
- **Outbox and cache metrics**: `outbox.processed.count`, `outbox.dispatch.lag`, `outbox.pending.depth`, plus `cqrs.query.cache.hit`/`.miss` on the existing CQRS meter.
- **Retry quality**: UI retry policy gains jitter, drops 501/505, adds 408/429, and honors the caller's CancellationToken; outbox backoff gains jitter within [0.8, 1.2].
- **Client idempotency keys**: shared `IdempotencyHeaders` constant; `EntityServiceBase.AddAsync` emits a stable `Idempotency-Key` reused across retry attempts.
- **APIClient timeout**: shared UI client bounded at `HttpResilienceDefaults.TotalRequestTimeout` (90s).
- **Soft-delete marker**: new `SoftDeletedUserCache` helper centralizes the `user:deleted:{id}` key shape for write-through by consumers.
- **Push send dedup**: optional `DedupKey` on `SendPushNotificationCommand`/`PushNotification` with a filtered unique index; `NotificationsController.SendAsync` is `[Idempotent]` and maps the header into the command.

Note: the DataProtection packages pull `System.Security.Cryptography.Xml` with active advisories; resolved by adding `FrameworkReference Microsoft.AspNetCore.App` to the affected test project so it prunes to the shared framework.

## Test plan

- `dotnet build MMCA.Common.slnx -c Release`: 0 errors / 0 warnings
- `dotnet test --solution MMCA.Common.slnx`: 2738 passed, 0 failed
- FACTS drift gate: up to date, no regeneration needed

Follow-ups (deliberate, not in this PR): durable idempotency table, Key Vault key-wrap URI (needs out-of-band Crypto User grant), ADR text updates (017/026/047/052) in the Website repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX