### PR TITLE
feat: Wave 5 move-to-Common extraction

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -106,6 +106,9 @@
          Lifecycle 2.9.2.x); newer builds (.32+) pull AndroidX versions past the Ktx packages'
          upper bounds and fail restore with NU1608. Bump together with Microsoft.Maui.Controls. -->
     <PackageVersion Include="Xamarin.AndroidX.Biometric" Version="1.1.0.30" />
+    <!-- BlazorWebView host support for UI.Maui (Wave 5: MainPageBase / NativeThemeSync);
+         versions on the MAUI train, bump together with Microsoft.Maui.Controls. -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.80" />
     <!-- Analyzers -->
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.133" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
@@ -130,6 +133,10 @@
          Microsoft.Extensions.Caching.StackExchangeRedis supplies the concrete RedisCache the shipped
          code only sees as IDistributedCache. -->
     <PackageVersion Include="Testcontainers.Redis" Version="4.8.0" />
+    <!-- Multi-host cross-service fixture base in MMCA.Common.Testing (Wave 5.8): SQL Server +
+         RabbitMQ containers for consumer cross-service integration tiers. Test-tier only. -->
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.8.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
     <PackageVersion Include="NetArchTest.eNhancedEdition" Version="1.4.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-08-03 (framework v1.137.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-08-04 (framework v1.137.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -41,10 +41,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **96 test methods across 31 abstract `*TestsBase` classes**, shipped once in the
+- **100 test methods across 32 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **61** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **78** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -298,6 +298,7 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
 
         return Result.Success(await Repository.GetAllForLookupAsync(
                 nameProperty,
+                where: where,
                 asTracking: asTracking,
                 cancellationToken: cancellationToken).ConfigureAwait(false));
     }

--- a/Source/Core/MMCA.Common.Application/Users/IUserOwnedRequest.cs
+++ b/Source/Core/MMCA.Common.Application/Users/IUserOwnedRequest.cs
@@ -1,0 +1,15 @@
+namespace MMCA.Common.Application.Users;
+
+/// <summary>
+/// A user-scoped command or query that also carries the authenticated caller, so the shared
+/// owner-or-privileged-role check (<see cref="UserOwnershipRule"/>) can be applied uniformly by the
+/// account deletion and data-export use cases.
+/// </summary>
+public interface IUserOwnedRequest : IUserScopedRequest
+{
+    /// <summary>The authenticated user making the request.</summary>
+    UserIdentifierType CurrentUserId { get; }
+
+    /// <summary>The role claim of the authenticated user; may be <see langword="null"/>.</summary>
+    string? CurrentUserRole { get; }
+}

--- a/Source/Core/MMCA.Common.Application/Users/IUserScopedCommand.cs
+++ b/Source/Core/MMCA.Common.Application/Users/IUserScopedCommand.cs
@@ -1,0 +1,17 @@
+namespace MMCA.Common.Application.Users;
+
+/// <summary>
+/// A user-scoped command that carries a request payload.
+/// </summary>
+/// <remarks>
+/// Deliberately separate from <c>ICommandWithRequest&lt;TRequest&gt;</c>: that marker also
+/// opts the command into automatic <c>CommandRequestValidator</c> registration, which is a per-app
+/// decision (ADC and Store agree on it for the password change and disagree on it for preferences).
+/// A command may implement both; implementing this one alone changes no pipeline behavior.
+/// </remarks>
+/// <typeparam name="TRequest">The embedded request payload type.</typeparam>
+public interface IUserScopedCommand<out TRequest> : IUserScopedRequest
+{
+    /// <summary>The embedded request payload.</summary>
+    TRequest Request { get; }
+}

--- a/Source/Core/MMCA.Common.Application/Users/IUserScopedRequest.cs
+++ b/Source/Core/MMCA.Common.Application/Users/IUserScopedRequest.cs
@@ -1,0 +1,12 @@
+namespace MMCA.Common.Application.Users;
+
+/// <summary>
+/// A command or query addressed at a single user account. The shared Users use-case bases read the
+/// target account only through this contract, so each app keeps its own command/query record (with
+/// its own <c>ICacheInvalidating</c> choice and its own XML docs) and simply adds this interface.
+/// </summary>
+public interface IUserScopedRequest
+{
+    /// <summary>The account the command or query targets.</summary>
+    UserIdentifierType UserId { get; }
+}

--- a/Source/Core/MMCA.Common.Application/Users/SoftDeletedUserValidator.cs
+++ b/Source/Core/MMCA.Common.Application/Users/SoftDeletedUserValidator.cs
@@ -1,0 +1,35 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+
+namespace MMCA.Common.Application.Users;
+
+/// <summary>
+/// Identity-module implementation of <see cref="ISoftDeletedUserValidator"/> (BR-133): checks whether
+/// a user row exists AND is soft-deleted, in a single query that bypasses the global soft-delete
+/// query filter.
+/// </summary>
+/// <remarks>
+/// Closed over the app's <c>User</c> aggregate at registration
+/// (<c>services.TryAddScoped&lt;ISoftDeletedUserValidator, SoftDeletedUserValidator&lt;User&gt;&gt;()</c>),
+/// so no per-app subclass is needed. The predicate is expressed against <typeparamref name="TUser"/>
+/// and closes over the concrete entity type at run time, so EF translation is what it was before the
+/// hoist.
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+public sealed class SoftDeletedUserValidator<TUser>(IUnitOfWork unitOfWork) : ISoftDeletedUserValidator
+    where TUser : AuditableAggregateRootEntity<UserIdentifierType>
+{
+    /// <inheritdoc />
+    public async Task<bool> IsUserSoftDeletedAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default)
+    {
+        var repository = unitOfWork.GetRepository<TUser, UserIdentifierType>();
+
+        // Single query: check if user exists AND is soft-deleted, bypassing the global query filter.
+        return await repository.ExistsAsync(
+            u => u.Id == userId && u.IsDeleted,
+            ignoreQueryFilters: true,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/ChangePassword/ChangePasswordHandlerBase.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/ChangePassword/ChangePasswordHandlerBase.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Auth;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+
+namespace MMCA.Common.Application.Users.UseCases.ChangePassword;
+
+/// <summary>
+/// The shared password-change workflow (ADR-032): verify the current password, hash the new one, let
+/// the aggregate apply its own invariants, persist only on success. The app Identity modules carried
+/// line-identical copies of this handler; only the log message text differed.
+/// </summary>
+/// <remarks>
+/// The command record stays app-side (<typeparamref name="TCommand"/>): ADC marks it
+/// <c>ICacheInvalidating</c> with a cache prefix built from its own <c>User</c> type and Store does
+/// not, so a single shared record could not preserve both behaviors. The base reads the command only
+/// through <see cref="IUserScopedCommand{TRequest}"/>.
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+/// <typeparam name="TCommand">The app's change-password command record.</typeparam>
+public abstract class ChangePasswordHandlerBase<TUser, TCommand>(
+    IUnitOfWork unitOfWork,
+    IPasswordHasher passwordHasher,
+    ILogger logger) : ICommandHandler<TCommand, Result>
+    where TUser : AuditableAggregateRootEntity<UserIdentifierType>, IPasswordChangeableUser
+    where TCommand : IUserScopedCommand<ChangePasswordRequest>
+{
+    /// <summary>The unit of work (exposed for app-level extensions).</summary>
+    protected IUnitOfWork UnitOfWork => unitOfWork;
+
+    /// <summary>
+    /// The name reported as the <c>source</c> of any error this handler returns. Defaults to the
+    /// runtime type name, so an app subclass that keeps the pre-hoist class name
+    /// (<c>ChangePasswordHandler</c>) reports the identical error payload it did before.
+    /// </summary>
+    protected virtual string HandlerName => GetType().Name;
+
+    /// <inheritdoc />
+    public async Task<Result> HandleAsync(
+        TCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var repository = unitOfWork.GetRepository<TUser, UserIdentifierType>();
+        var user = await repository.GetByIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        if (user is null)
+        {
+            return Result.Failure(Error.NotFound.WithSource(HandlerName).WithTarget(typeof(TUser).Name));
+        }
+
+        if (!passwordHasher.VerifyPassword(command.Request.CurrentPassword, user.PasswordHash, user.PasswordSalt))
+        {
+            return Result.Failure(
+                Error.Unauthorized("Auth.InvalidCurrentPassword", "Current password is incorrect.", HandlerName));
+        }
+
+        var (newHash, newSalt) = passwordHasher.HashPassword(command.Request.NewPassword);
+        var result = user.ChangePassword(newHash, newSalt);
+        if (result.IsSuccess)
+        {
+            await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            UserUseCaseLog.PasswordChanged(logger, command.UserId);
+        }
+
+        return result;
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/ChangePreferences/ChangePreferencesHandlerBase.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/ChangePreferences/ChangePreferencesHandlerBase.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Auth;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+
+namespace MMCA.Common.Application.Users.UseCases.ChangePreferences;
+
+/// <summary>
+/// The shared preference-write workflow (ADR-027 culture / ADR-028 theme). Each request field defaults
+/// to the stored value when <see langword="null"/>, so updating one preference never clears the other.
+/// The app Identity modules carried line-identical copies of this handler.
+/// </summary>
+/// <remarks>
+/// The command record stays app-side (<typeparamref name="TCommand"/>) because ADC marks it
+/// <c>ICacheInvalidating</c> and Store does not; the payload record
+/// (<see cref="ChangePreferencesRequest"/>) was byte-identical in both apps and is now shared.
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+/// <typeparam name="TCommand">The app's change-preferences command record.</typeparam>
+public abstract class ChangePreferencesHandlerBase<TUser, TCommand>(
+    IUnitOfWork unitOfWork,
+    ILogger logger) : ICommandHandler<TCommand, Result>
+    where TUser : AuditableAggregateRootEntity<UserIdentifierType>, IUserPreferences
+    where TCommand : IUserScopedCommand<ChangePreferencesRequest>
+{
+    /// <summary>The unit of work (exposed for app-level extensions).</summary>
+    protected IUnitOfWork UnitOfWork => unitOfWork;
+
+    /// <summary>
+    /// The name reported as the <c>source</c> of any error this handler returns. Defaults to the
+    /// runtime type name, so an app subclass that keeps the pre-hoist class name
+    /// (<c>ChangePreferencesHandler</c>) reports the identical error payload it did before.
+    /// </summary>
+    protected virtual string HandlerName => GetType().Name;
+
+    /// <inheritdoc />
+    public async Task<Result> HandleAsync(
+        TCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var repository = unitOfWork.GetRepository<TUser, UserIdentifierType>();
+        var user = await repository.GetByIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        if (user is null)
+        {
+            return Result.Failure(Error.NotFound.WithSource(HandlerName).WithTarget(typeof(TUser).Name));
+        }
+
+        var result = user.UpdatePreferences(
+            command.Request.Culture ?? user.PreferredCulture,
+            command.Request.Theme ?? user.PreferredTheme);
+        if (result.IsSuccess)
+        {
+            await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            UserUseCaseLog.PreferencesChanged(logger, command.UserId);
+        }
+
+        return result;
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/DeleteUser/DeleteUserHandlerBase.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/DeleteUser/DeleteUserHandlerBase.cs
@@ -1,0 +1,148 @@
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Auth;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Application.Users.UseCases.DeleteUser;
+
+/// <summary>
+/// The shared account-erasure workflow: owner-or-privileged-role authorization, soft-delete the
+/// account, irreversibly anonymize its personal data in place (ADR-005), persist, then run whatever
+/// post-commit tail the app added. Keeping the row preserves cross-context scalar references and the
+/// audit trail while still satisfying the GDPR/CCPA "delete within 30 days" erasure promise.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything genuinely app-specific stays in the subclass:
+/// <list type="bullet">
+///   <item><see cref="HasDeletePrivilege"/> - the role that bypasses ownership (Organizer vs Admin).</item>
+///   <item><see cref="OnAfterSoftDeleteAsync"/> - the app's tail. It runs after <c>Delete()</c> and
+///     before <c>Anonymize()</c>, which is the only point where an app can both read personal data
+///     that anonymization is about to erase (ADC captures the avatar blob name) and enlist further
+///     aggregates in the same unit of work (Store cascades to its linked <c>Customer</c>). Work that
+///     must wait for the commit is enqueued on the <c>afterCommit</c> collection instead of being run
+///     inline, so the override can hand values it captured here to a post-commit closure without
+///     parking them in mutable handler state.</item>
+/// </list>
+/// </para>
+/// <para>
+/// The hook deliberately runs <b>after</b> <c>user.Delete()</c> rather than before it, so an
+/// already-deleted account still fails with the account's own <c>AlreadyDeleted</c> error rather than
+/// with an error raised by a cascaded aggregate.
+/// </para>
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+/// <typeparam name="TCommand">The app's delete-user command record.</typeparam>
+public abstract class DeleteUserHandlerBase<TUser, TCommand>(
+    IUnitOfWork unitOfWork,
+    ILogger logger) : ICommandHandler<TCommand, Result>
+    where TUser : AuditableAggregateRootEntity<UserIdentifierType>, IErasableUser
+    where TCommand : IUserOwnedRequest
+{
+    /// <summary>The unit of work (exposed so a subclass hook can enlist further aggregates).</summary>
+    protected IUnitOfWork UnitOfWork => unitOfWork;
+
+    /// <summary>
+    /// The name reported as the <c>source</c> of any error this handler returns. Defaults to the
+    /// runtime type name, so an app subclass that keeps the pre-hoist class name
+    /// (<c>DeleteUserHandler</c>) reports the identical error payload it did before.
+    /// </summary>
+    protected virtual string HandlerName => GetType().Name;
+
+    /// <inheritdoc />
+    public async Task<Result> HandleAsync(
+        TCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // Authorization: owner or the app's privileged role (case-insensitive; claims may carry any casing).
+        var forbidden = UserOwnershipRule.CheckOwnership(
+            command,
+            HasDeletePrivilege(command.CurrentUserRole),
+            code: "User.DeleteForbidden",
+            message: "You can only delete your own account.",
+            source: HandlerName);
+        if (forbidden is not null)
+        {
+            return Result.Failure(forbidden);
+        }
+
+        var repository = unitOfWork.GetRepository<TUser, UserIdentifierType>();
+        var user = await repository.GetByIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        if (user is null)
+        {
+            return Result.Failure(Error.NotFound.WithSource(HandlerName).WithTarget(typeof(TUser).Name));
+        }
+
+        // Soft-delete (sets IsDeleted = true, plus whatever the aggregate couples to deletion, e.g.
+        // revoking the refresh token so outstanding sessions die immediately).
+        //
+        // Called through IErasableUser deliberately, and the cast is load-bearing: member lookup on a
+        // type parameter prefers the members of its CLASS constraint, so a bare user.Delete() would
+        // bind to AuditableBaseEntity<TId>.Delete() and a User that HIDES that method
+        // (public new Result Delete(), as ADC's does) would have its own version skipped. Interface
+        // dispatch resolves to the member the app type actually maps onto IErasableUser.
+        IErasableUser erasable = user;
+        var deleteResult = erasable.Delete();
+        if (deleteResult.IsFailure)
+        {
+            return deleteResult;
+        }
+
+        var afterCommit = new List<Func<CancellationToken, Task>>();
+        var tailResult = await OnAfterSoftDeleteAsync(user, command, afterCommit, cancellationToken).ConfigureAwait(false);
+        if (tailResult.IsFailure)
+        {
+            return tailResult;
+        }
+
+        // Irreversibly erase the personal data on the deletion request (anonymize-in-place, ADR-005).
+        var anonymizeResult = erasable.Anonymize();
+        if (anonymizeResult.IsFailure)
+        {
+            return anonymizeResult;
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var action in afterCommit)
+        {
+            await action(cancellationToken).ConfigureAwait(false);
+        }
+
+        UserUseCaseLog.UserErased(logger, command.UserId);
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Whether the caller's role bypasses the ownership requirement (e.g.
+    /// <c>UserRole.IsOrganizer(currentUserRole)</c> for ADC, <c>UserRole.IsAdmin(...)</c> for Store).
+    /// </summary>
+    /// <param name="currentUserRole">The caller's role claim; may be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when the caller may delete any account.</returns>
+    protected abstract bool HasDeletePrivilege(string? currentUserRole);
+
+    /// <summary>
+    /// The app's erasure tail, invoked after the account was soft-deleted and before it is anonymized
+    /// (default: nothing). Returning a failure aborts the erasure before anything is persisted.
+    /// </summary>
+    /// <param name="user">The tracked user being erased; its personal data is still intact here.</param>
+    /// <param name="command">The originating command.</param>
+    /// <param name="afterCommit">
+    /// Actions to run, in order, once the erasure has been committed. Use this for side effects that
+    /// must not happen if the save fails (deleting a blob, writing a cache marker); a post-commit
+    /// action owns its own failure handling, since the erasure has already succeeded by then.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A success result, or the failure that aborts the erasure.</returns>
+    protected virtual Task<Result> OnAfterSoftDeleteAsync(
+        TUser user,
+        TCommand command,
+        ICollection<Func<CancellationToken, Task>> afterCommit,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(Result.Success());
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/GetPreferences/GetUserPreferencesHandlerBase.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/GetPreferences/GetUserPreferencesHandlerBase.cs
@@ -1,0 +1,46 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Auth;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+
+namespace MMCA.Common.Application.Users.UseCases.GetPreferences;
+
+/// <summary>
+/// The shared preference-read workflow (ADR-027 / ADR-028). The query and the response were
+/// byte-identical in both app Identity modules and are now shared types, so the base is generic in the
+/// <c>User</c> aggregate only.
+/// </summary>
+/// <remarks>
+/// The lookup goes through <c>GetReadRepository</c>. The two app copies disagreed here (ADC read,
+/// Store write) and the read repository is the correct choice for a query handler, which never calls
+/// <c>SaveChangesAsync</c>: Store gains a no-tracking read on adoption.
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+public abstract class GetUserPreferencesHandlerBase<TUser>(IUnitOfWork unitOfWork)
+    : IQueryHandler<GetUserPreferencesQuery, Result<UserPreferencesResponse>>
+    where TUser : AuditableBaseEntity<UserIdentifierType>, IUserPreferences
+{
+    /// <summary>
+    /// The name reported as the <c>source</c> of any error this handler returns. Defaults to the
+    /// runtime type name, so an app subclass that keeps the pre-hoist class name
+    /// (<c>GetUserPreferencesHandler</c>) reports the identical error payload it did before.
+    /// </summary>
+    protected virtual string HandlerName => GetType().Name;
+
+    /// <inheritdoc />
+    public async Task<Result<UserPreferencesResponse>> HandleAsync(
+        GetUserPreferencesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var repository = unitOfWork.GetReadRepository<TUser, UserIdentifierType>();
+        var user = await repository.GetByIdAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+        return user is null
+            ? Result.Failure<UserPreferencesResponse>(
+                Error.NotFound.WithSource(HandlerName).WithTarget(typeof(TUser).Name))
+            : Result.Success(new UserPreferencesResponse(user.PreferredCulture, user.PreferredTheme));
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/GetPreferences/GetUserPreferencesQuery.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/GetPreferences/GetUserPreferencesQuery.cs
@@ -1,0 +1,5 @@
+namespace MMCA.Common.Application.Users.UseCases.GetPreferences;
+
+/// <summary>Query for the given user's stored UI preferences (ADR-027 / ADR-028).</summary>
+/// <param name="UserId">The user whose preferences to read.</param>
+public sealed record GetUserPreferencesQuery(UserIdentifierType UserId) : IUserScopedRequest;

--- a/Source/Core/MMCA.Common.Application/Users/UserOwnershipRule.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UserOwnershipRule.cs
@@ -1,0 +1,55 @@
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Application.Users;
+
+/// <summary>
+/// The self-service authorization rule shared by every use case that acts on one account on behalf
+/// of its owner: the caller must be the account owner, or hold the app's privileged role.
+/// </summary>
+/// <remarks>
+/// The idiom (<c>CurrentUserId != UserId &amp;&amp; !role-bypass -&gt; Error.Forbidden</c>) was written
+/// out four times across the two apps (account deletion and data export, in each). It is hoisted as a
+/// plain helper rather than folded into a base class because the two data-export handlers stay
+/// app-level (their projections are entirely app-specific) and still need the identical decision and
+/// the identical error shape.
+/// <para>
+/// The role test is passed in already evaluated: each app owns its own role vocabulary
+/// (<c>UserRole.IsOrganizer</c> vs <c>UserRole.IsAdmin</c>), and both are case-insensitive because a
+/// role claim may carry any casing.
+/// </para>
+/// </remarks>
+public static class UserOwnershipRule
+{
+    /// <summary>
+    /// Evaluates the owner-or-privileged-role rule.
+    /// </summary>
+    /// <param name="request">The user-scoped request carrying the target and the caller.</param>
+    /// <param name="callerHasPrivilegedRole">
+    /// Whether the caller's role bypasses the ownership requirement (evaluated by the app, e.g.
+    /// <c>UserRole.IsOrganizer(request.CurrentUserRole)</c>).
+    /// </param>
+    /// <param name="code">The error code to report when the rule rejects (e.g. "User.DeleteForbidden").</param>
+    /// <param name="message">The message to report when the rule rejects.</param>
+    /// <param name="source">The reporting handler name.</param>
+    /// <returns>
+    /// <see langword="null"/> when the caller is allowed; otherwise the <see cref="ErrorType.Forbidden"/>
+    /// error the caller should be failed with.
+    /// </returns>
+    public static Error? CheckOwnership(
+        IUserOwnedRequest request,
+        bool callerHasPrivilegedRole,
+        string code,
+        string message,
+        string source)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return request.CurrentUserId == request.UserId || callerHasPrivilegedRole
+            ? null
+            : Error.Forbidden(
+                code: code,
+                message: message,
+                source: source,
+                target: nameof(IUserOwnedRequest.UserId));
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Users/UserUseCaseLog.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UserUseCaseLog.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace MMCA.Common.Application.Users;
+
+/// <summary>
+/// The compile-time-generated log messages the shared Users use-case bases emit. Declared once in a
+/// non-generic holder so every app subclass writes the same message text; the category still comes
+/// from the <c>ILogger&lt;TApphandler&gt;</c> the subclass injects, so log filtering by handler keeps
+/// working exactly as before the hoist.
+/// </summary>
+internal static partial class UserUseCaseLog
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "User {UserId} password changed")]
+    internal static partial void PasswordChanged(ILogger logger, UserIdentifierType userId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "User {UserId} preferences changed")]
+    internal static partial void PreferencesChanged(ILogger logger, UserIdentifierType userId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "User {UserId} account deleted and personal data anonymized")]
+    internal static partial void UserErased(ILogger logger, UserIdentifierType userId);
+}

--- a/Source/Core/MMCA.Common.Domain/Auth/IErasableUser.cs
+++ b/Source/Core/MMCA.Common.Domain/Auth/IErasableUser.cs
@@ -1,0 +1,38 @@
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Domain.Auth;
+
+/// <summary>
+/// The erasure surface an Identity module's <c>User</c> aggregate exposes to the shared
+/// <c>DeleteUserHandlerBase&lt;TUser, TCommand&gt;</c> workflow: soft-delete the row, then
+/// irreversibly anonymize the personal data it still holds (anonymize-in-place, ADR-005).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Delete"/> is redeclared here rather than reached through
+/// <c>AuditableBaseEntity&lt;TId&gt;.Delete()</c> on purpose, and the distinction is load-bearing.
+/// An app <c>User</c> may <b>hide</b> the base method (<c>public new Result Delete()</c>) to add
+/// account-specific behavior such as revoking the refresh token, and a hidden method is not an
+/// override: a shared workflow that called the base member through the entity constraint would
+/// silently run the base implementation and skip that behavior. Because the app <c>User</c> lists
+/// this interface in its own base list, the interface map resolves to the most derived
+/// <c>Delete()</c> declared on the app type, so the shared workflow calls exactly the member the
+/// pre-hoist handler called. The workflow must invoke it <b>through this interface</b> (member lookup
+/// on a generic type parameter prefers the members of its class constraint, which would silently
+/// select the hidden base method).
+/// </para>
+/// <para>
+/// The base entity deliberately does not implement this interface, so a consumer that forgets to
+/// add it fails the generic constraint at compile time rather than losing behavior at run time.
+/// </para>
+/// </remarks>
+public interface IErasableUser : IAnonymizable
+{
+    /// <summary>
+    /// Soft-deletes the account (sets <c>IsDeleted</c>), plus whatever the app couples to deletion
+    /// (typically revoking the refresh token so outstanding sessions die immediately).
+    /// </summary>
+    /// <returns>A success result, or a failure if the account is already deleted.</returns>
+    Result Delete();
+}

--- a/Source/Core/MMCA.Common.Domain/Auth/IPasswordChangeableUser.cs
+++ b/Source/Core/MMCA.Common.Domain/Auth/IPasswordChangeableUser.cs
@@ -1,0 +1,20 @@
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Domain.Auth;
+
+/// <summary>
+/// The password-rotation surface an Identity module's <c>User</c> aggregate exposes to the shared
+/// <c>ChangePasswordHandlerBase&lt;TUser, TCommand&gt;</c> workflow (ADR-032). Extends
+/// <see cref="IAuthUser"/> because the workflow verifies the current credential material before it
+/// writes the new one.
+/// </summary>
+public interface IPasswordChangeableUser : IAuthUser
+{
+    /// <summary>
+    /// Replaces the stored password material after the current password has been verified.
+    /// </summary>
+    /// <param name="newPasswordHash">The new PBKDF2 hash.</param>
+    /// <param name="newPasswordSalt">The salt paired with <paramref name="newPasswordHash"/>.</param>
+    /// <returns>A success result, or the aggregate's invariant failure.</returns>
+    Result ChangePassword(byte[] newPasswordHash, byte[] newPasswordSalt);
+}

--- a/Source/Core/MMCA.Common.Domain/Auth/IUserPreferences.cs
+++ b/Source/Core/MMCA.Common.Domain/Auth/IUserPreferences.cs
@@ -1,0 +1,26 @@
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Domain.Auth;
+
+/// <summary>
+/// The stored UI-preference surface an Identity module's <c>User</c> aggregate exposes to the shared
+/// preference read/write workflows (ADR-027 culture, ADR-028 theme). A <see langword="null"/> value
+/// means the user has not chosen that preference.
+/// </summary>
+public interface IUserPreferences
+{
+    /// <summary>The preferred culture (e.g. "es"), or <see langword="null"/> when unset.</summary>
+    string? PreferredCulture { get; }
+
+    /// <summary>The preferred theme ("light"/"dark"), or <see langword="null"/> when unset.</summary>
+    string? PreferredTheme { get; }
+
+    /// <summary>
+    /// Replaces both preferences. The shared workflow always passes the stored value for a field the
+    /// request left <see langword="null"/>, so writing one preference never clears the other.
+    /// </summary>
+    /// <param name="preferredCulture">The culture to store, or <see langword="null"/> to clear it.</param>
+    /// <param name="preferredTheme">The theme to store, or <see langword="null"/> to clear it.</param>
+    /// <returns>A success result, or the aggregate's invariant failure.</returns>
+    Result UpdatePreferences(string? preferredCulture, string? preferredTheme);
+}

--- a/Source/Core/MMCA.Common.Domain/Invariants/CommonInvariants.cs
+++ b/Source/Core/MMCA.Common.Domain/Invariants/CommonInvariants.cs
@@ -1,4 +1,6 @@
 using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Globalization;
+using MMCA.Common.Shared.ValueObjects;
 
 namespace MMCA.Common.Domain.Invariants;
 
@@ -9,6 +11,12 @@ namespace MMCA.Common.Domain.Invariants;
 /// </summary>
 public static class CommonInvariants
 {
+    /// <summary>The light theme value accepted by <see cref="EnsurePreferredThemeIsValid"/>.</summary>
+    public const string LightTheme = "light";
+
+    /// <summary>The dark theme value accepted by <see cref="EnsurePreferredThemeIsValid"/>.</summary>
+    public const string DarkTheme = "dark";
+
     /// <summary>
     /// Validates that a string value is not null, empty, or whitespace.
     /// </summary>
@@ -72,4 +80,85 @@ public static class CommonInvariants
         => value is null || value.Length == 0
             ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
             : Result.Success();
+
+    /// <summary>
+    /// Validates that an integer value is greater than zero.
+    /// </summary>
+    /// <param name="value">The integer value to validate.</param>
+    /// <param name="code">The error code (e.g., "Order.Line.Quantity.NotPositive").</param>
+    /// <param name="message">The error message (e.g., "Quantity must be positive.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureIntIsPositive(
+        int value, string code, string message, string source, string target)
+        => value <= 0
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that a monetary amount is not negative. Zero passes (e.g., free items);
+    /// a <see langword="null"/> value fails, matching <see cref="EnsureBytesAreNotEmpty"/>.
+    /// </summary>
+    /// <param name="value">The monetary amount to validate.</param>
+    /// <param name="code">The error code (e.g., "Order.Line.Price.Negative").</param>
+    /// <param name="message">The error message (e.g., "Price cannot be negative.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureMoneyIsNotNegative(
+        Money value, string code, string message, string source, string target)
+        => value is null || value.IsNegative
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that a collection is not null and contains at least one element.
+    /// </summary>
+    /// <typeparam name="T">The collection element type.</typeparam>
+    /// <param name="value">The collection to validate.</param>
+    /// <param name="code">The error code (e.g., "Order.Lines.Empty").</param>
+    /// <param name="message">The error message (e.g., "Order must not be empty.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureCollectionIsNotEmpty<T>(
+        IReadOnlyCollection<T> value, string code, string message, string source, string target)
+        => value is null || value.Count == 0
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that a preferred culture is <see langword="null"/> (follow the request default)
+    /// or one of the framework's supported cultures (ADR-027).
+    /// </summary>
+    /// <param name="culture">The culture name to validate (e.g., "es").</param>
+    /// <param name="code">The error code (e.g., "User.PreferredCulture.Invalid").</param>
+    /// <param name="message">The error message (e.g., "Culture 'xx' is not supported.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsurePreferredCultureIsValid(
+        string? culture, string code, string message, string source, string target)
+        => culture is null || SupportedCultures.IsSupported(culture)
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that a preferred theme is <see langword="null"/> (follow the system preference),
+    /// <see cref="LightTheme"/>, or <see cref="DarkTheme"/>, matched case-insensitively (ADR-028).
+    /// </summary>
+    /// <param name="theme">The theme name to validate.</param>
+    /// <param name="code">The error code (e.g., "User.PreferredTheme.Invalid").</param>
+    /// <param name="message">The error message (e.g., "Theme 'neon' is not valid.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsurePreferredThemeIsValid(
+        string? theme, string code, string message, string source, string target)
+        => theme is null
+           || string.Equals(theme, LightTheme, StringComparison.OrdinalIgnoreCase)
+           || string.Equals(theme, DarkTheme, StringComparison.OrdinalIgnoreCase)
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
 }

--- a/Source/Core/MMCA.Common.Domain/Specifications/OwnedByUserSpecification.cs
+++ b/Source/Core/MMCA.Common.Domain/Specifications/OwnedByUserSpecification.cs
@@ -1,0 +1,31 @@
+using System.Linq.Expressions;
+using MMCA.Common.Domain.Entities;
+
+namespace MMCA.Common.Domain.Specifications;
+
+/// <summary>
+/// Specification that restricts a query to the rows created by a single user, using the
+/// audit field <see cref="AuditableBaseEntity{TIdentifierType}.CreatedBy"/> as the ownership
+/// marker. Use it for "my own records" reads (an attendee sees only the answers they submitted);
+/// callers with a bypass role simply do not apply it.
+/// </summary>
+/// <remarks>
+/// The constraint is the concrete <see cref="AuditableBaseEntity{TIdentifierType}"/> base class
+/// rather than <c>IAuditableEntity</c> on purpose: the criteria must stay EF-translatable, and a
+/// member access declared on an interface is not guaranteed to map to the entity's audit column.
+/// </remarks>
+/// <typeparam name="TEntity">The auditable entity type this specification applies to.</typeparam>
+/// <typeparam name="TIdentifierType">The entity's identifier type.</typeparam>
+/// <param name="userId">The owning user's identifier.</param>
+public sealed class OwnedByUserSpecification<TEntity, TIdentifierType>(UserIdentifierType userId)
+    : Specification<TEntity, TIdentifierType>
+    where TEntity : AuditableBaseEntity<TIdentifierType>
+    where TIdentifierType : notnull
+{
+    /// <summary>Gets the owning user's identifier this specification filters on.</summary>
+    public UserIdentifierType UserId { get; } = userId;
+
+    /// <inheritdoc />
+    public override Expression<Func<TEntity, bool>> Criteria =>
+        e => e.CreatedBy == UserId;
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeBuilderExtensions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeBuilderExtensions.cs
@@ -1,0 +1,83 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Persistence.Configuration;
+
+/// <summary>
+/// Extension members for <see cref="EntityTypeBuilder{TEntity}"/> used from entity type
+/// configurations.
+/// </summary>
+public static class EntityTypeBuilderExtensions
+{
+    /// <summary>
+    /// Read-leg fallback for the Currency value converter: the "no currency" sentinel that
+    /// <see cref="Money.Zero()"/> carries, whose Code is the empty string. That sentinel is internal
+    /// to MMCA.Common.Shared, so a zero Money is the only public handle on it.
+    /// </summary>
+    private static readonly Currency NoCurrency = Money.Zero().Currency;
+
+    extension<TOwner>(EntityTypeBuilder<TOwner> builder)
+        where TOwner : class
+    {
+        /// <summary>
+        /// Maps a <see cref="Money"/> property as an owned type flattened into two columns on the
+        /// owner's table: the decimal amount and the ISO 4217 currency code.
+        /// <code>
+        /// builder.OwnsMoney(p => p.Total, "TotalAmount", "TotalCurrency", required: false);
+        /// </code>
+        /// <para>
+        /// <b>Round-trip contract:</b> every value the WRITE leg can produce must materialize back
+        /// into a non-null Currency, including the empty code a zero <see cref="Money"/> persists
+        /// and any code that is no longer in <c>Currency.All</c>. An aggregate can seed a zero total
+        /// (<see cref="Money.Zero()"/>, whose Code is the empty string) and leave it there, so the
+        /// write leg genuinely persists codes that <see cref="Currency.FromCode"/> rejects. A bare
+        /// <c>.Value!</c> turned those rows into a null Currency inside <see cref="Money"/>, which is
+        /// a materialization-time <see cref="NullReferenceException"/> waiting for the first read.
+        /// Falling back to the sentinel keeps them readable.
+        /// </para>
+        /// </summary>
+        /// <param name="navigationExpression">The <see cref="Money"/> navigation to map.</param>
+        /// <param name="amountColumnName">Column name for <see cref="Money.Amount"/>.</param>
+        /// <param name="currencyColumnName">Column name for the ISO 4217 code of <see cref="Money.Currency"/>.</param>
+        /// <param name="required">
+        /// Whether the navigation itself is required. <see langword="true"/> (the default) matches a
+        /// price that must always be present; pass <see langword="false"/> for a total the owner can
+        /// leave unset. This is the only facet that differs across the existing call sites, so it is
+        /// the only one parameterized beyond the two column names.
+        /// </param>
+        /// <returns>The same builder instance for chaining.</returns>
+        public EntityTypeBuilder<TOwner> OwnsMoney(
+            Expression<Func<TOwner, Money?>> navigationExpression,
+            string amountColumnName,
+            string currencyColumnName,
+            bool required = true)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(navigationExpression);
+            ArgumentException.ThrowIfNullOrWhiteSpace(amountColumnName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(currencyColumnName);
+
+            builder.OwnsOne(navigationExpression, moneyBuilder =>
+            {
+                moneyBuilder.Property(m => m.Amount)
+                    .HasColumnName(amountColumnName)
+                    .IsRequired();
+
+                moneyBuilder.Property(m => m.Currency)
+                    .HasConversion(
+                        currency => currency.Code,
+                        code => Currency.FromCode(code).Value ?? NoCurrency)
+                    .HasMaxLength(3)
+                    .IsUnicode(false)
+                    .HasColumnName(currencyColumnName)
+                    .IsRequired();
+            });
+
+            builder.Navigation(navigationExpression).IsRequired(required);
+
+            return builder;
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/IndexBuilderExtensions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/IndexBuilderExtensions.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Persistence.Configuration;
+
+/// <summary>
+/// Extension members for <see cref="IndexBuilder"/> used from entity type configurations.
+/// </summary>
+public static class IndexBuilderExtensions
+{
+    extension(IndexBuilder indexBuilder)
+    {
+        /// <summary>
+        /// Filters the index to non-deleted rows. Soft-deleted rows are invisible to the
+        /// application (the global query filter hides them) but they still occupy index pages and
+        /// still count towards a unique constraint, so an index that serves a live-row query wants
+        /// the same <c>IsDeleted = 0</c> predicate the query carries.
+        /// <para>
+        /// <see cref="Conventions.SoftDeleteUniqueIndexConvention"/> already applies this predicate
+        /// to every UNIQUE index on a soft-deletable entity. This extension point is for the other
+        /// case, a hand-authored NON-unique index, which the convention deliberately leaves alone:
+        /// <code>
+        /// builder.HasIndex(p => new { p.CustomerId, p.CreatedOn })
+        ///     .HasSoftDeleteFilter();
+        /// </code>
+        /// It replaces the literal <c>HasFilter("[IsDeleted] = 0")</c>: the column name is read from
+        /// the model (so a renamed column follows automatically) and the identifier quoting comes
+        /// from the engine rather than from a SQL-Server-shaped string literal.
+        /// </para>
+        /// <para>
+        /// <b>Ordering:</b> unlike the convention, which runs at model finalizing, this reads the
+        /// column name when it is called, so a <c>HasColumnName</c> on the soft-delete property must
+        /// come first. That only matters for a model that renames the column.
+        /// </para>
+        /// </summary>
+        /// <param name="engine">
+        /// The engine of the model being built. Defaults to <see cref="DataSource.SQLServer"/>,
+        /// matching <c>EntityTypeConfigurationSQLServer</c>; pass <see cref="DataSource.Sqlite"/>
+        /// from a SQLite configuration. For <see cref="DataSource.CosmosDB"/> the call is a no-op,
+        /// exactly as the convention skips Cosmos.
+        /// </param>
+        /// <param name="additionalFilter">
+        /// Optional predicate to combine with the soft-delete predicate using <c>AND</c>, for an
+        /// index that is also filtered on something else (for example
+        /// <c>"[StripeSessionId] IS NOT NULL"</c>). The two are joined in that order, so the
+        /// produced SQL matches the hand-authored literal it replaces.
+        /// </param>
+        /// <returns>The same builder instance for chaining.</returns>
+        public IndexBuilder HasSoftDeleteFilter(
+            DataSource engine = DataSource.SQLServer,
+            string? additionalFilter = null)
+        {
+            ArgumentNullException.ThrowIfNull(indexBuilder);
+
+            var filterSql = SoftDeleteFilterSql.Build(engine, indexBuilder.Metadata.DeclaringEntityType);
+            if (filterSql is null)
+                return indexBuilder;
+
+            return indexBuilder.HasFilter(
+                string.IsNullOrWhiteSpace(additionalFilter)
+                    ? filterSql
+                    : $"{additionalFilter} AND {filterSql}");
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Conventions/SoftDeleteUniqueIndexConvention.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Conventions/SoftDeleteUniqueIndexConvention.cs
@@ -42,12 +42,11 @@ public sealed class SoftDeleteUniqueIndexConvention(DataSource engine) : IModelF
 
     private void ApplyFilterToUniqueIndexes(IConventionEntityType entityType)
     {
-        var isDeletedColumn = entityType.FindProperty(nameof(IAuditableEntity.IsDeleted))?.GetColumnName()
-            ?? nameof(IAuditableEntity.IsDeleted);
-
-        var filterSql = engine == DataSource.SQLServer
-            ? $"[{isDeletedColumn}] = 0"
-            : $"\"{isDeletedColumn}\" = 0";
+        // Same predicate builder a hand-authored index reaches through HasSoftDeleteFilter(), so the
+        // automatic and the opt-in path can never disagree about quoting or column name.
+        var filterSql = SoftDeleteFilterSql.Build(engine, entityType);
+        if (filterSql is null)
+            return;
 
         foreach (var index in entityType.GetIndexes())
         {

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Conversions/EmailValueConverter.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Conversions/EmailValueConverter.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Persistence.Conversions;
+
+/// <summary>
+/// EF Core value converter that stores an <see cref="Email"/> as its normalized string value and
+/// rebuilds the value object on read. Mapping through <c>HasConversion</c> rather than
+/// <c>OwnsOne</c> keeps the backing column a plain string column, so adopting the value object on a
+/// property that used to be a <see cref="string"/> is not a schema change.
+/// <para>
+/// <b>Usage:</b> apply to a non-nullable <see cref="Email"/> property in an entity configuration:
+/// <code>
+/// builder.Property(p => p.Email)
+///     .HasConversion(new EmailValueConverter())
+///     .HasMaxLength(EmailInvariants.MaxLength)
+///     .IsUnicode(false)
+///     .IsRequired();
+/// </code>
+/// Column facets (max length, unicode, requiredness) deliberately stay at the call site: they
+/// differ per entity and are not the converter's business. Use
+/// <see cref="NullableEmailValueConverter"/> for an optional <c>Email?</c> property.
+/// </para>
+/// <para>
+/// <b>Read-leg contract:</b> the read leg trusts the column. <see cref="Email.Create"/> returns a
+/// failed <c>Result</c> for a value that does not validate, and the null-forgiving
+/// <c>.Value!</c> then materializes a <see langword="null"/> reference for that row. Every value the
+/// write leg can produce round-trips, because the write leg can only persist an already-validated
+/// <see cref="Email"/>; only a value written outside EF (a manual script, a data fix) can break the
+/// contract.
+/// </para>
+/// </summary>
+public sealed class EmailValueConverter : ValueConverter<Email, string>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailValueConverter"/> class.
+    /// </summary>
+    public EmailValueConverter()
+        : base(
+            email => email.Value,
+            value => Email.Create(value).Value!)
+    {
+    }
+}
+
+/// <summary>
+/// Nullable counterpart of <see cref="EmailValueConverter"/> for an optional <c>Email?</c> property.
+/// Both legs pass <see langword="null"/> straight through, so "no email" stays a NULL column value
+/// rather than becoming an empty string or a failed <see cref="Email.Create"/> call.
+/// <para>
+/// <b>Usage:</b>
+/// <code>
+/// builder.Property(p => p.Email)
+///     .HasConversion(new NullableEmailValueConverter())
+///     .HasMaxLength(SpeakerInvariants.EmailMaxLength)
+///     .IsRequired(false);
+/// </code>
+/// </para>
+/// </summary>
+public sealed class NullableEmailValueConverter : ValueConverter<Email?, string?>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableEmailValueConverter"/> class.
+    /// </summary>
+    public NullableEmailValueConverter()
+        : base(
+            email => email == null ? null : email.Value,
+            value => value == null ? null : Email.Create(value).Value)
+    {
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Conversions/PhoneNumberValueConverter.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Conversions/PhoneNumberValueConverter.cs
@@ -1,0 +1,72 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Persistence.Conversions;
+
+/// <summary>
+/// EF Core value converter that stores a <see cref="PhoneNumber"/> as its trimmed string value and
+/// rebuilds the value object on read. Mapping through <c>HasConversion</c> rather than
+/// <c>OwnsOne</c> keeps the backing column a plain string column, so adopting the value object on a
+/// property that used to be a <see cref="string"/> is not a schema change.
+/// <para>
+/// <b>Usage:</b> apply to a non-nullable <see cref="PhoneNumber"/> property in an entity configuration:
+/// <code>
+/// builder.Property(p => p.PhoneNumber)
+///     .HasConversion(new PhoneNumberValueConverter())
+///     .HasMaxLength(PhoneNumberInvariants.MaxLength)
+///     .IsUnicode(false)
+///     .IsRequired();
+/// </code>
+/// Column facets (max length, unicode, requiredness) deliberately stay at the call site: they
+/// differ per entity and are not the converter's business. Use
+/// <see cref="NullablePhoneNumberValueConverter"/> for an optional <c>PhoneNumber?</c> property.
+/// </para>
+/// <para>
+/// <b>Read-leg contract:</b> the read leg trusts the column. <see cref="PhoneNumber.Create"/>
+/// returns a failed <c>Result</c> for a value that does not validate, and the null-forgiving
+/// <c>.Value!</c> then materializes a <see langword="null"/> reference for that row. Every value the
+/// write leg can produce round-trips, because the write leg can only persist an already-validated
+/// <see cref="PhoneNumber"/>; only a value written outside EF (a manual script, a data fix) can
+/// break the contract.
+/// </para>
+/// </summary>
+public sealed class PhoneNumberValueConverter : ValueConverter<PhoneNumber, string>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PhoneNumberValueConverter"/> class.
+    /// </summary>
+    public PhoneNumberValueConverter()
+        : base(
+            phoneNumber => phoneNumber.Value,
+            value => PhoneNumber.Create(value).Value!)
+    {
+    }
+}
+
+/// <summary>
+/// Nullable counterpart of <see cref="PhoneNumberValueConverter"/> for an optional
+/// <c>PhoneNumber?</c> property. Both legs pass <see langword="null"/> straight through, so "no
+/// phone number" stays a NULL column value rather than becoming an empty string or a failed
+/// <see cref="PhoneNumber.Create"/> call.
+/// <para>
+/// <b>Usage:</b>
+/// <code>
+/// builder.Property(p => p.PhoneNumber)
+///     .HasConversion(new NullablePhoneNumberValueConverter())
+///     .HasMaxLength(PhoneNumberInvariants.MaxLength)
+///     .IsRequired(false);
+/// </code>
+/// </para>
+/// </summary>
+public sealed class NullablePhoneNumberValueConverter : ValueConverter<PhoneNumber?, string?>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullablePhoneNumberValueConverter"/> class.
+    /// </summary>
+    public NullablePhoneNumberValueConverter()
+        : base(
+            phoneNumber => phoneNumber == null ? null : phoneNumber.Value,
+            value => value == null ? null : PhoneNumber.Create(value).Value)
+    {
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Seeding/IdentityModuleDbSeederBase.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Seeding/IdentityModuleDbSeederBase.cs
@@ -1,0 +1,114 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Seeding;
+
+/// <summary>
+/// Seeds an app-supplied list of development/test user accounts. The per-account idiom
+/// (normalize the email, skip if it already exists, hash the password, build the aggregate, add,
+/// save) was written out five times across the two app Identity modules; it lives here once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two things stay app-specific and are reached only through hooks:
+/// <list type="bullet">
+///   <item><see cref="CreateUser"/> - the apps' <c>User.Create(...)</c> factories take the same
+///     values in <b>different parameter orders</b>, and only the app can spell its own role
+///     vocabulary, so the base never constructs the aggregate itself.</item>
+///   <item><see cref="EmailExistsAsync"/> - the existence predicate is written against the app's
+///     concrete <c>User</c> (never an interface member), so EF translation is byte-for-byte what it
+///     was before the hoist. This mirrors <c>AuthenticationServiceBase&lt;TUser&gt;</c>.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <see cref="ShouldSeed"/> is the opt-in gate: it defaults to <see langword="true"/> (seed
+/// unconditionally, Store's behavior), and an app that gates its sample accounts on configuration
+/// (ADC's <c>Seeding:IncludeSampleUsers</c>, default false) overrides it. Each account is saved
+/// individually, exactly as before, so one invalid account cannot roll back the others.
+/// </para>
+/// <para>
+/// <strong>Security notice:</strong> seed credentials are deliberately weak plaintext values for
+/// local development convenience. Deployed environments must disable seeding or supply
+/// environment-sourced secrets.
+/// </para>
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+public abstract class IdentityModuleDbSeederBase<TUser>(
+    IUnitOfWork unitOfWork,
+    IPasswordHasher passwordHasher) : DbSeeder
+    where TUser : AuditableAggregateRootEntity<UserIdentifierType>
+{
+    /// <summary>The unit of work the accounts are written through.</summary>
+    protected IUnitOfWork UnitOfWork { get; } = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+
+    /// <summary>The hasher applied to each account's plaintext seed password (ADR-032).</summary>
+    protected IPasswordHasher PasswordHasher { get; } = passwordHasher ?? throw new ArgumentNullException(nameof(passwordHasher));
+
+    /// <summary>The accounts to seed, in order.</summary>
+    protected abstract IReadOnlyList<SeedAccount> Accounts { get; }
+
+    /// <summary>
+    /// Whether to seed at all (default: yes). Override to reproduce a configuration gate such as
+    /// ADC's <c>Seeding:IncludeSampleUsers</c>, which defaults to false so a production host that
+    /// sets nothing seeds no accounts.
+    /// </summary>
+    protected virtual bool ShouldSeed => true;
+
+    /// <inheritdoc />
+    public override async Task SeedAsync(CancellationToken cancellationToken)
+    {
+        if (!ShouldSeed)
+        {
+            return;
+        }
+
+        foreach (var account in Accounts)
+        {
+            await SeedAccountAsync(account, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Whether an account with this email already exists. Implement with a predicate on the app's
+    /// concrete <c>User</c> (e.g. <c>u =&gt; u.Email == email</c>).
+    /// </summary>
+    /// <param name="email">The normalized email value object; <see langword="null"/> when the seed
+    /// address failed validation, in which case no user can match it.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when the account is already seeded.</returns>
+    protected abstract Task<bool> EmailExistsAsync(Email? email, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates the app's <c>User</c> from a seed account via its own domain factory.
+    /// </summary>
+    /// <param name="account">The account being seeded.</param>
+    /// <param name="passwordHash">The hash of <see cref="SeedAccount.Password"/>.</param>
+    /// <param name="passwordSalt">The salt paired with <paramref name="passwordHash"/>.</param>
+    /// <returns>The created aggregate, or a failure (which skips this account silently, as before).</returns>
+    protected abstract Result<TUser> CreateUser(SeedAccount account, byte[] passwordHash, byte[] passwordSalt);
+
+    private async Task SeedAccountAsync(SeedAccount account, CancellationToken cancellationToken)
+    {
+        // Normalize to the Email value object so the EF predicate compares same-typed converted values.
+        var email = Email.Create(account.Email).Value;
+
+        var exists = await EmailExistsAsync(email, cancellationToken).ConfigureAwait(false);
+        if (exists)
+        {
+            return;
+        }
+
+        var (hash, salt) = PasswordHasher.HashPassword(account.Password);
+        var userResult = CreateUser(account, hash, salt);
+        if (userResult.IsFailure)
+        {
+            return;
+        }
+
+        var repository = UnitOfWork.GetRepository<TUser, UserIdentifierType>();
+        await repository.AddAsync(userResult.Value!, cancellationToken).ConfigureAwait(false);
+        await UnitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Seeding/SeedAccount.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Seeding/SeedAccount.cs
@@ -1,0 +1,22 @@
+namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Seeding;
+
+/// <summary>
+/// One development/test account for <see cref="IdentityModuleDbSeederBase{TUser}"/> to create.
+/// </summary>
+/// <remarks>
+/// <strong>Security notice:</strong> seed credentials are plaintext by construction, so the list an
+/// app supplies is development-only data. Gate it (see
+/// <see cref="IdentityModuleDbSeederBase{TUser}.ShouldSeed"/>) or replace it with
+/// environment-sourced secrets before running a seeder in a deployed environment.
+/// </remarks>
+/// <param name="Email">The account email; also the idempotency key ("already seeded?" check).</param>
+/// <param name="Password">The plaintext password, hashed by the seeder before persistence.</param>
+/// <param name="Role">The role to create the account with, as the app's role vocabulary spells it.</param>
+/// <param name="FirstName">The given name, when the app's <c>User</c> carries one.</param>
+/// <param name="LastName">The family name, when the app's <c>User</c> carries one.</param>
+public sealed record SeedAccount(
+    string Email,
+    string Password,
+    string Role,
+    string? FirstName = null,
+    string? LastName = null);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/SoftDeleteFilterSql.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/SoftDeleteFilterSql.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Infrastructure.Persistence;
+
+/// <summary>
+/// Builds the <c>IsDeleted = 0</c> index predicate for a given engine. Shared by
+/// <see cref="Conventions.SoftDeleteUniqueIndexConvention"/> (which applies it automatically to
+/// unique indexes) and by
+/// <see cref="Configuration.IndexBuilderExtensions.HasSoftDeleteFilter(Microsoft.EntityFrameworkCore.Metadata.Builders.IndexBuilder, DataSource, string?)"/>
+/// (which a hand-authored non-unique index opts into), so the two never disagree about identifier
+/// quoting or about which column carries the soft-delete flag.
+/// </summary>
+internal static class SoftDeleteFilterSql
+{
+    /// <summary>
+    /// Builds the filter predicate for the soft-delete flag of <paramref name="entityType"/>.
+    /// </summary>
+    /// <param name="engine">The engine of the model being built (identifier quoting differs per provider).</param>
+    /// <param name="entityType">The entity type owning the index.</param>
+    /// <returns>
+    /// The predicate SQL, or <see langword="null"/> for an engine with no filtered-index support
+    /// (Cosmos), where the caller must leave the index untouched.
+    /// </returns>
+    internal static string? Build(DataSource engine, IReadOnlyEntityType entityType)
+    {
+        if (engine == DataSource.CosmosDB)
+            return null;
+
+        var isDeletedColumn = entityType.FindProperty(nameof(IAuditableEntity.IsDeleted))?.GetColumnName()
+            ?? nameof(IAuditableEntity.IsDeleted);
+
+        return engine == DataSource.SQLServer
+            ? $"[{isDeletedColumn}] = 0"
+            : $"\"{isDeletedColumn}\" = 0";
+    }
+}

--- a/Source/Core/MMCA.Common.Shared/Auth/ChangePreferencesRequest.cs
+++ b/Source/Core/MMCA.Common.Shared/Auth/ChangePreferencesRequest.cs
@@ -1,0 +1,10 @@
+namespace MMCA.Common.Shared.Auth;
+
+/// <summary>
+/// Request payload to update the current user's UI preferences (ADR-027 / ADR-028). A <see langword="null"/>
+/// field leaves that preference unchanged, so the app-bar switcher (culture only) and theme toggle
+/// (theme only) can each persist their own field without clobbering the other.
+/// </summary>
+/// <param name="Culture">Preferred culture (e.g. "es"), or <see langword="null"/> to leave unchanged.</param>
+/// <param name="Theme">Preferred theme ("light"/"dark"), or <see langword="null"/> to leave unchanged.</param>
+public sealed record ChangePreferencesRequest(string? Culture, string? Theme);

--- a/Source/Core/MMCA.Common.Shared/Auth/UserPreferencesResponse.cs
+++ b/Source/Core/MMCA.Common.Shared/Auth/UserPreferencesResponse.cs
@@ -1,0 +1,9 @@
+namespace MMCA.Common.Shared.Auth;
+
+/// <summary>
+/// The current user's stored UI preferences (ADR-027 / ADR-028). A <see langword="null"/> field means
+/// the user has not chosen that preference.
+/// </summary>
+/// <param name="Culture">The preferred culture (e.g. "es"), or <see langword="null"/>.</param>
+/// <param name="Theme">The preferred theme ("light"/"dark"), or <see langword="null"/>.</param>
+public sealed record UserPreferencesResponse(string? Culture, string? Theme);

--- a/Source/Core/MMCA.Common.Shared/ValueObjects/Email.cs
+++ b/Source/Core/MMCA.Common.Shared/ValueObjects/Email.cs
@@ -7,7 +7,10 @@ namespace MMCA.Common.Shared.ValueObjects;
 /// <summary>
 /// Immutable value object representing a validated email address. The value is normalized
 /// to lowercase at creation time. Configured in EF via <c>HasConversion</c> (not <c>OwnsOne</c>)
-/// so the backing column remains <c>nvarchar</c>.
+/// so the backing column remains <c>nvarchar</c>: pass the shipped
+/// <c>MMCA.Common.Infrastructure.Persistence.Conversions.EmailValueConverter</c>, or
+/// <c>NullableEmailValueConverter</c> for an optional <c>Email?</c> property, rather than
+/// hand-rolling the lambda pair per entity configuration.
 /// </summary>
 [DataContract]
 public sealed record Email : ValueObject

--- a/Source/Core/MMCA.Common.Shared/ValueObjects/Money.cs
+++ b/Source/Core/MMCA.Common.Shared/ValueObjects/Money.cs
@@ -12,7 +12,10 @@ namespace MMCA.Common.Shared.ValueObjects;
 /// of the target currency.
 /// </summary>
 /// <remarks>
-/// Configured as an EF owned type via <c>OwnsOne</c> in entity configurations.
+/// Configured as an EF owned type via <c>OwnsOne</c> in entity configurations; prefer the shipped
+/// <c>MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeBuilderExtensions.OwnsMoney</c>
+/// helper, which produces that mapping (amount column plus ISO 4217 code column) together with the
+/// currency round-trip fallback every hand-rolled block has to repeat.
 /// </remarks>
 [DataContract]
 public sealed record Money : ValueObject

--- a/Source/Core/MMCA.Common.Shared/ValueObjects/PhoneNumber.cs
+++ b/Source/Core/MMCA.Common.Shared/ValueObjects/PhoneNumber.cs
@@ -7,7 +7,10 @@ namespace MMCA.Common.Shared.ValueObjects;
 /// <summary>
 /// Immutable value object representing a validated phone number. Whitespace is trimmed
 /// at creation time. Configured in EF via <c>HasConversion</c> (not <c>OwnsOne</c>)
-/// so the backing column remains <c>nvarchar</c>.
+/// so the backing column remains <c>nvarchar</c>: pass the shipped
+/// <c>MMCA.Common.Infrastructure.Persistence.Conversions.PhoneNumberValueConverter</c>, or
+/// <c>NullablePhoneNumberValueConverter</c> for an optional <c>PhoneNumber?</c> property, rather
+/// than hand-rolling the lambda pair per entity configuration.
 /// </summary>
 [DataContract]
 public sealed record PhoneNumber : ValueObject

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Aspire.Hosting;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -25,6 +26,13 @@ public static class Extensions
     /// Default Aspire resource name used for the RabbitMQ container.
     /// </summary>
     public const string DefaultBrokerResourceName = "rabbitmq";
+
+    /// <summary>
+    /// Registrations per IP per hour allowed while an E2E suite is running (see
+    /// <c>WithE2eRegistrationThrottleLift</c>). High enough that no suite can reach it; production
+    /// keeps the real anti-abuse throttle.
+    /// </summary>
+    public const int E2eRegistrationsPerIpPerHour = 1000;
 
     extension(IDistributedApplicationBuilder builder)
     {
@@ -141,6 +149,45 @@ public static class Extensions
                 .WithEnvironment("Jwt__RsaPrivateKeyPem", privateKey)
                 .WithEnvironment("Jwt__RsaPublicKeyPem", publicKey)
                 .WithEnvironment("Jwks__RsaPublicKeyPem", publicKey);
+        }
+
+        /// <summary>
+        /// CI/E2E only: lifts the per-IP registration throttle on the Identity service
+        /// (<c>LoginProtectionSettings.MaxRegistrationsPerIpPerHour</c>, default 10) to
+        /// <see cref="E2eRegistrationsPerIpPerHour"/> when the E2E workflow asks for it. An E2E suite
+        /// registers far more than ten accounts from a single localhost IP, so the production default
+        /// refuses every register test past the tenth and the failures look like broken registration
+        /// rather than the anti-abuse control doing its job. Mirrors the value the integration
+        /// fixtures use.
+        /// <para>
+        /// The trigger is the <c>E2E_LIFT_REGISTRATION_THROTTLE</c> environment variable (set by the
+        /// E2E workflow, absent locally and in production, so this is a no-op there),
+        /// OR <paramref name="alsoLiftWhen"/> for an AppHost that implies the lift from another E2E
+        /// switch of its own.
+        /// </para>
+        /// </summary>
+        /// <param name="alsoLiftWhen">
+        /// An extra trigger evaluated at the call site and OR-ed with the environment variable. Pass
+        /// the AppHost's own E2E flag (for example a forced-render-mode switch that implies the same
+        /// registration volume); defaults to <see langword="false"/>, leaving the environment
+        /// variable as the only trigger.
+        /// </param>
+        /// <returns>The Identity resource builder for chaining.</returns>
+        public IResourceBuilder<ProjectResource> WithE2eRegistrationThrottleLift(bool alsoLiftWhen = false)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+
+            var lift = alsoLiftWhen
+                || string.Equals(
+                    Environment.GetEnvironmentVariable("E2E_LIFT_REGISTRATION_THROTTLE"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
+
+            return lift
+                ? identity.WithEnvironment(
+                    "LoginProtection__MaxRegistrationsPerIpPerHour",
+                    E2eRegistrationsPerIpPerHour.ToString(CultureInfo.InvariantCulture))
+                : identity;
         }
     }
 

--- a/Source/Hosting/MMCA.Common.Aspire/Kestrel/KestrelEndpointExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Kestrel/KestrelEndpointExtensions.cs
@@ -1,0 +1,133 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+
+namespace MMCA.Common.Aspire.Kestrel;
+
+/// <summary>
+/// Kestrel endpoint wiring for an extracted service host: one protocol profile for the default
+/// endpoints plus an optional dedicated HTTP/1.1 listener for platform health probes.
+/// <para>
+/// Two operational facts drive this. First, a service that serves inbound gRPC on cleartext must
+/// answer HTTP/2 with prior knowledge (h2c): there is no TLS, so there is no ALPN to negotiate
+/// with, and the typed gRPC clients from <c>MMCA.Common.Grpc</c> speak h2c directly. Second, the
+/// Azure Container Apps <c>httpGet</c> probes speak HTTP/1.1, which an Http2-only endpoint rejects
+/// with GOAWAY <c>HTTP_1_1_REQUIRED</c>: that is why those probes used to be TCP-only and never
+/// consulted the real, dependency-aware health checks. A separate Http1-only listener on a port
+/// that is never published through ingress gives the platform a probe target while the service
+/// endpoints stay on their own profile, and <c>MapDefaultEndpoints()</c> maps <c>/health</c>,
+/// <c>/alive</c> and <c>/health/ready</c> on every listener, so the probe listener serves the real
+/// health pipeline.
+/// </para>
+/// </summary>
+public static class KestrelEndpointExtensions
+{
+    /// <summary>
+    /// Configuration key carrying the dedicated health-probe port. Deployment infrastructure injects
+    /// it as <c>HealthProbe__Port</c>; it is deliberately absent locally so Aspire's dynamic ports
+    /// keep working and co-hosted services cannot collide on one machine.
+    /// </summary>
+    public const string HealthProbePortConfigKey = "HealthProbe:Port";
+
+    /// <summary>
+    /// The cleartext port a containerized service listens on (the platform's own default, which
+    /// explicit <c>Listen</c> calls otherwise override).
+    /// </summary>
+    public const int DefaultCleartextPort = 8080;
+
+    extension(WebApplicationBuilder builder)
+    {
+        /// <summary>
+        /// Applies <paramref name="defaultProtocols"/> to every Kestrel endpoint default and, when
+        /// <see cref="HealthProbePortConfigKey"/> is configured, adds a dedicated Http1-only listener
+        /// for the platform health probes.
+        /// <para>
+        /// Both deployed profiles are this one call with a different protocol set:
+        /// </para>
+        /// <list type="bullet">
+        ///   <item>REST/gRPC services pass <see cref="HttpProtocols.Http2"/> and keep
+        ///   <paramref name="redeclareCleartextEndpoint"/> at its default. Explicit
+        ///   <c>Listen</c> calls override the container's <c>ASPNETCORE_HTTP_PORTS</c> default
+        ///   binding, so the main h2c endpoint has to be re-declared alongside the probe port.</item>
+        ///   <item>A host with config-declared Kestrel endpoints (for example a SignalR host running
+        ///   the mixed profile: an <c>Http1AndHttp2</c> endpoint for the WebSocket Upgrade handshake
+        ///   plus an Http2-only gRPC endpoint, both from <c>appsettings.json</c>) passes
+        ///   <see cref="HttpProtocols.Http1AndHttp2"/> and <paramref name="redeclareCleartextEndpoint"/>
+        ///   <see langword="false"/>. Config-declared endpoints and explicit <c>Listen</c> calls
+        ///   coexist, so the probe listener is then strictly additive and nothing re-binds a port
+        ///   the configuration already owns.</item>
+        /// </list>
+        /// </summary>
+        /// <param name="defaultProtocols">Protocols applied to the endpoint defaults, and to the
+        /// re-declared cleartext endpoint when there is one.</param>
+        /// <param name="redeclareCleartextEndpoint">
+        /// When <see langword="true"/> (the default) and a probe port is configured, re-declares the
+        /// main cleartext listener so the explicit probe <c>Listen</c> call does not silently replace
+        /// it. Pass <see langword="false"/> for a host whose endpoints come from configuration.
+        /// </param>
+        /// <param name="cleartextPort">The main cleartext port to re-declare (defaults to
+        /// <see cref="DefaultCleartextPort"/>).</param>
+        /// <returns>The same builder instance for chaining.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The configured health-probe port is not an integer. Failing at startup is deliberate: a
+        /// mistyped probe port that silently produced no listener would leave the platform probing a
+        /// closed port and the revision would never come up.
+        /// </exception>
+        public WebApplicationBuilder ConfigureEndpointsWithHealthProbe(
+            HttpProtocols defaultProtocols,
+            bool redeclareCleartextEndpoint = true,
+            int cleartextPort = DefaultCleartextPort)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            var listeners = BuildListenerPlan(
+                builder.Configuration,
+                defaultProtocols,
+                redeclareCleartextEndpoint,
+                cleartextPort);
+
+            builder.WebHost.ConfigureKestrel(kestrel =>
+            {
+                kestrel.ConfigureEndpointDefaults(endpoint => endpoint.Protocols = defaultProtocols);
+
+                foreach (var listener in listeners)
+                {
+                    kestrel.ListenAnyIP(listener.Port, endpoint => endpoint.Protocols = listener.Protocols);
+                }
+            });
+
+            return builder;
+        }
+    }
+
+    /// <summary>
+    /// Computes the explicit listeners to declare. Empty when no health-probe port is configured
+    /// (the local and test case: endpoint defaults alone, so Aspire's dynamic ports keep working).
+    /// </summary>
+    /// <param name="configuration">Configuration carrying <see cref="HealthProbePortConfigKey"/>.</param>
+    /// <param name="defaultProtocols">Protocols for the re-declared cleartext endpoint.</param>
+    /// <param name="redeclareCleartextEndpoint">Whether the cleartext endpoint is re-declared.</param>
+    /// <param name="cleartextPort">The main cleartext port.</param>
+    /// <returns>The listeners to declare, in declaration order.</returns>
+    internal static IReadOnlyList<KestrelListenerSpec> BuildListenerPlan(
+        IConfiguration configuration,
+        HttpProtocols defaultProtocols,
+        bool redeclareCleartextEndpoint,
+        int cleartextPort)
+    {
+        if (configuration.GetValue<int?>(HealthProbePortConfigKey) is not int probePort)
+        {
+            return [];
+        }
+
+        return redeclareCleartextEndpoint
+            ? [new KestrelListenerSpec(cleartextPort, defaultProtocols), new KestrelListenerSpec(probePort, HttpProtocols.Http1)]
+            : [new KestrelListenerSpec(probePort, HttpProtocols.Http1)];
+    }
+
+    /// <summary>One explicit Kestrel listener: a port and the protocols it accepts.</summary>
+    /// <param name="Port">The port to listen on.</param>
+    /// <param name="Protocols">The protocols accepted on that port.</param>
+    internal sealed record KestrelListenerSpec(int Port, HttpProtocols Protocols);
+}

--- a/Source/Hosting/MMCA.Common.Aspire/Warmup/SelfHttpWarmupTaskBase.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Warmup/SelfHttpWarmupTaskBase.cs
@@ -1,0 +1,187 @@
+using System.Globalization;
+using System.Net;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MMCA.Common.Aspire.Warmup;
+
+/// <summary>
+/// Base class for the ADR-025 self-HTTP warm-up: once the server has started, replay a short list of
+/// hot read paths against this host's own Kestrel endpoint. That warms the FULL request path
+/// (ingress connection, Kestrel, output cache, routing, authentication, controller, EF Core, SQL),
+/// which is where the cold-start cost of an idle, CPU-throttled replica lives.
+/// <para>
+/// Register a derived task with <c>AddWarmupTask&lt;T&gt;()</c>; the <c>AddWarmupReadiness()</c>
+/// runner from <c>AddServiceDefaults()</c> executes it, so <c>/health/ready</c> stays not-ready until
+/// the warm-up has had its chance. Failures are logged and never fatal: the host falls back to lazy
+/// warm-up on the first real request rather than keeping the replica out of rotation.
+/// </para>
+/// </summary>
+/// <param name="server">The running server, used to discover the actual bound cleartext address.</param>
+/// <param name="configuration">Configuration consulted for the <c>ASPNETCORE_URLS</c> fallback.</param>
+/// <param name="environment">Host environment; the warm-up is skipped under the Testing environment.</param>
+/// <param name="lifetime">Host lifetime, awaited so the requests start only once Kestrel is listening.</param>
+/// <param name="logger">Logger for warm-up diagnostics.</param>
+public abstract partial class SelfHttpWarmupTaskBase(
+    IServer server,
+    IConfiguration configuration,
+    IHostEnvironment environment,
+    IHostApplicationLifetime lifetime,
+    ILogger logger) : IWarmupTask
+{
+    /// <summary>
+    /// Port used when neither the server nor <c>ASPNETCORE_URLS</c> yields a usable cleartext
+    /// address: the containerized default every deployed service listens on.
+    /// </summary>
+    public const int DefaultPort = 8080;
+
+    /// <summary>
+    /// The environment name whose hosts have no real Kestrel port. Integration tests boot a service
+    /// through <c>WebApplicationFactory</c>, whose in-memory TestServer never opens a socket, so a
+    /// self-HTTP request could only ever fail there.
+    /// </summary>
+    private const string TestingEnvironmentName = "Testing";
+
+    /// <inheritdoc />
+    public abstract string Name { get; }
+
+    /// <summary>
+    /// The paths to replay, relative to the host's own base address, in the order they are issued.
+    /// <para>
+    /// These must match the URLs real callers issue character for character in their VALUES, not
+    /// just their shape: an output-cache policy that varies by query string keys the entry on the
+    /// exact URL, so a warmed entry built from different values is an entry nothing ever reads.
+    /// </para>
+    /// </summary>
+    protected abstract IReadOnlyList<string> WarmupPaths { get; }
+
+    /// <summary>
+    /// HTTP version the warm-up requests are sent with. Defaults to HTTP/2, which is required on a
+    /// host whose cleartext endpoints are Http2-only (h2c prior knowledge): paired with
+    /// <see cref="RequestVersionPolicy"/> it prevents the silent downgrade to HTTP/1.1 that such an
+    /// endpoint rejects with 400 "An HTTP/1.x request was sent to an HTTP/2 only endpoint", which
+    /// would fail the warm-up on every single startup. A host that stays Http1AndHttp2 (no inbound
+    /// gRPC server) overrides both members with <see cref="HttpVersion.Version11"/> and
+    /// <see cref="HttpVersionPolicy.RequestVersionOrLower"/>.
+    /// </summary>
+    protected virtual Version RequestVersion => HttpVersion.Version20;
+
+    /// <summary>
+    /// Version-negotiation policy for the warm-up requests. Defaults to
+    /// <see cref="HttpVersionPolicy.RequestVersionExact"/> so <see cref="RequestVersion"/> is a pin,
+    /// not a preference.
+    /// </summary>
+    protected virtual HttpVersionPolicy RequestVersionPolicy => HttpVersionPolicy.RequestVersionExact;
+
+    /// <summary>
+    /// Whether a non-success status ends the warm-up. Defaults to <see langword="true"/>, which suits
+    /// an anonymous read whose response body is what populates the output cache.
+    /// <para>
+    /// Override with <see langword="false"/> for a protected endpoint: an unauthenticated
+    /// self-request against an <c>[Authorize]</c> route gets 401 BY DESIGN, and that refusal still
+    /// traverses Kestrel, routing, authentication and the middleware pipeline, which is the JIT cost
+    /// the warm-up exists to pay down. Treating it as a failure logs a spurious warning on every
+    /// startup and skips the remaining paths.
+    /// </para>
+    /// </summary>
+    protected virtual bool RequireSuccessStatusCode => true;
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        if (environment.IsEnvironment(TestingEnvironmentName))
+        {
+            return;
+        }
+
+        try
+        {
+            await WaitForServerStartedAsync(cancellationToken).ConfigureAwait(false);
+
+            var baseAddress = new UriBuilder
+            {
+                Scheme = Uri.UriSchemeHttp,
+                Host = "localhost",
+                Port = ResolveWarmupPort(server, configuration),
+            }.Uri;
+
+            using var handler = new SocketsHttpHandler();
+            using var httpClient = new HttpClient(handler, disposeHandler: false)
+            {
+                BaseAddress = baseAddress,
+                DefaultRequestVersion = RequestVersion,
+                DefaultVersionPolicy = RequestVersionPolicy,
+            };
+
+            foreach (var path in WarmupPaths)
+            {
+                using var response = await httpClient
+                    .GetAsync(new Uri(path, UriKind.Relative), cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (RequireSuccessStatusCode)
+                {
+                    response.EnsureSuccessStatusCode();
+
+                    // Draining the body is the point for an output-cache warm-up: the entry is only
+                    // worth priming if the whole response was produced and transferred.
+                    _ = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            LogWarmupCompleted(logger, Name, WarmupPaths.Count, baseAddress);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+#pragma warning disable CA1031 // warm-up failures are non-fatal by design: log and fall back to lazy warm-up
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            LogWarmupFailed(logger, ex, Name);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the port to self-request. Prefers the server's actual bound cleartext address, which
+    /// is the only correct answer under Aspire's dynamic ports, and falls back to the
+    /// <c>ASPNETCORE_URLS</c> value and finally to <see cref="DefaultPort"/>.
+    /// </summary>
+    /// <param name="server">The running server.</param>
+    /// <param name="configuration">Configuration carrying the <c>ASPNETCORE_URLS</c> fallback.</param>
+    /// <returns>The resolved cleartext port.</returns>
+    internal static int ResolveWarmupPort(IServer server, IConfiguration configuration)
+    {
+        var address = server.Features.Get<IServerAddressesFeature>()?.Addresses
+            .FirstOrDefault(a => a.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            ?? configuration["ASPNETCORE_URLS"];
+
+        return int.TryParse(address?.Split(':')[^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var port)
+            ? port
+            : DefaultPort;
+    }
+
+    // The warm-up runner is a hosted service that starts BEFORE Kestrel begins listening (the web
+    // host is the last hosted service), so wait for ApplicationStarted before self-requesting.
+    private async Task WaitForServerStartedAsync(CancellationToken cancellationToken)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var registration = lifetime.ApplicationStarted
+            .Register(() => started.TrySetResult())
+            .ConfigureAwait(false);
+
+        await started.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information,
+        Message = "HTTP warm-up {TaskName} completed: {PathCount} path(s) replayed against {BaseAddress}.")]
+    private static partial void LogWarmupCompleted(ILogger logger, string taskName, int pathCount, Uri baseAddress);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Warning,
+        Message = "HTTP warm-up {TaskName} failed: first requests may be slow.")]
+    private static partial void LogWarmupFailed(ILogger logger, Exception exception, string taskName);
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ModuleConformanceTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ModuleConformanceTestsBase.cs
@@ -1,0 +1,101 @@
+namespace MMCA.Common.Testing.Architecture;
+
+/// <summary>
+/// Per-module conformance fitness function (ADR-015): a module's <c>Name</c>, <c>Dependencies</c> and
+/// <c>RequiresDependencies</c> are the whole contract <c>ModuleLoader</c> registers on. It resolves the
+/// topological (Kahn) registration order from <c>Dependencies</c>, matches <c>ModulesSettings</c> entries by
+/// <c>Name</c>, and decides between a hard start failure and stub registration from
+/// <c>RequiresDependencies</c>. Drift in any of the three does not throw: it silently reorders registration,
+/// leaves a module permanently enabled, or swaps a real service for a disabled stub. Authored once here and
+/// re-run as a thin subclass per module, each supplying only its expectations.
+/// <para>
+/// The three members are read through the <c>IModule</c> contract by reflection rather than a compile-time
+/// cast, exactly as the rest of this package matches framework types by full name: it keeps the package free
+/// of the framework's transitive graph (see the csproj remark), and it deliberately dispatches to the
+/// DEFAULT interface implementations, so a leaf module that overrides neither <c>Dependencies</c> nor
+/// <c>RequiresDependencies</c> is still asserted against the framework's defaults. That is the same reach
+/// the hand-written consumer tests needed an explicit <c>(IModule)</c> cast for.
+/// </para>
+/// </summary>
+/// <typeparam name="TModule">The module under test; needs a public parameterless constructor.</typeparam>
+public abstract class ModuleConformanceTestsBase<TModule>
+    where TModule : class, new()
+{
+    private const string ModuleContractFullName = "MMCA.Common.Application.Modules.IModule";
+
+    /// <summary>The module's declared <c>Name</c>: the key <c>ModulesSettings</c> and the dependency graph match on.</summary>
+    protected abstract string ExpectedName { get; }
+
+    /// <summary>The modules this one declares as dependencies. Defaults to none (a leaf module).</summary>
+    protected virtual IReadOnlyCollection<string> ExpectedDependencies => [];
+
+    /// <summary>
+    /// Whether the module refuses to start when a declared dependency is disabled. Defaults to
+    /// <see langword="false"/>: disabled dependencies are tolerated and their stub services are used instead.
+    /// </summary>
+    protected virtual bool ExpectedRequiresDependencies => false;
+
+    [Fact]
+    public void Module_ShouldDeclare_ExpectedName() =>
+        ReadContractMember("Name").Should().Be(
+            ExpectedName,
+            because: "ModulesSettings entries and every Dependencies reference match a module by this exact name, so renaming it silently disables the module's configuration and drops it from other modules' dependency graphs");
+
+    [Fact]
+    public void Module_ShouldDeclare_ExpectedDependencies()
+    {
+        var dependencies = ReadContractMember("Dependencies") as IEnumerable<string>;
+
+        dependencies.Should().NotBeNull(
+            because: "IModule.Dependencies must be a string collection for ModuleLoader to topologically sort on");
+
+        dependencies.Should().BeEquivalentTo(
+            ExpectedDependencies,
+            because: "ModuleLoader registers modules in topological (Kahn) order over exactly this list, so a missing entry lets a module register before the services it consumes");
+    }
+
+    [Fact]
+    public void Module_ShouldDeclare_ExpectedRequiresDependencies() =>
+        ReadContractMember("RequiresDependencies").Should().Be(
+            ExpectedRequiresDependencies,
+            because: "this flag is the only thing that turns a disabled dependency into a startup failure instead of a silently substituted stub");
+
+    [Fact]
+    public void Module_ShouldRegister_ExpectedDisabledStubs() => AssertDisabledStubs(CreateModule());
+
+    /// <summary>Creates the module under test. Override when the module has no parameterless constructor.</summary>
+    /// <returns>A new module instance.</returns>
+    protected virtual TModule CreateModule() => new();
+
+    /// <summary>
+    /// Asserts what <c>RegisterDisabledStubs</c> puts in the container. Deliberately vacuous by default:
+    /// a module that exports no cross-module contract registers no stubs. Override for a module that does
+    /// (build a <c>ServiceCollection</c>, call <c>RegisterDisabledStubs</c>, assert the descriptor), so the
+    /// contract other modules resolve stays available while this one is disabled.
+    /// </summary>
+    /// <param name="module">The module under test.</param>
+    protected virtual void AssertDisabledStubs(TModule module)
+    {
+    }
+
+    private object? ReadContractMember(string memberName)
+    {
+        var module = CreateModule();
+
+        var contract = Array.Find(
+            module.GetType().GetInterfaces(),
+            i => string.Equals(i.FullName, ModuleContractFullName, StringComparison.Ordinal));
+
+        contract.Should().NotBeNull(
+            because: $"{typeof(TModule).FullName} must implement {ModuleContractFullName} to be discovered and registered by ModuleLoader");
+
+        var property = contract.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance);
+
+        property.Should().NotBeNull(
+            because: $"{ModuleContractFullName} must expose {memberName}");
+
+        // Reading through the INTERFACE property dispatches to the module's override when it has one and to
+        // the framework's default implementation when it does not.
+        return property.GetValue(module);
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/WebVitalsCollector.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/WebVitalsCollector.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using AwesomeAssertions;
 using Microsoft.Playwright;
 
 namespace MMCA.Common.Testing.E2E.Infrastructure;
@@ -10,9 +12,10 @@ namespace MMCA.Common.Testing.E2E.Infrastructure;
 /// (rubric §12). No third-party JS or network egress: an init script installs the observers before
 /// first paint and accumulates into <c>window.__vitals</c>, which <see cref="CollectAsync"/> reads back.
 /// LCP/CLS are Chromium-only metrics, so on Firefox/WebKit those fields stay 0 (the observers fail
-/// silently and the budget assertions pass) — this is the client-side analogue of a backend k6 load
-/// test, not a cross-engine field measurement. Consumers keep their own budget-asserting tests; this
-/// class is only the measurement infrastructure.
+/// silently and the budget assertions pass): this is the client-side analogue of a backend k6 load
+/// test, not a cross-engine field measurement. Consumers own which pages carry a budget and what the
+/// numbers are (their runners and hosting differ, so their calibrated maxima do too); this class is the
+/// measurement infrastructure and <see cref="WebVitalsBudget"/> is the shared assert mechanics.
 /// </summary>
 public static class WebVitalsCollector
 {
@@ -85,3 +88,71 @@ public sealed record WebVitalsSample
 
 /// <summary>The artifact envelope written to <c>web-vitals-{label}.json</c>.</summary>
 public sealed record WebVitalsArtifact(string Label, string Path, WebVitalsSample Vitals);
+
+/// <summary>
+/// A per-page Core Web Vitals budget plus the assertion mechanics shared by every consumer's budget test.
+/// The defaults are the Core Web Vitals "good" band (LCP 2500 / FCP 1800 / CLS 0.1) plus a TTFB ceiling and
+/// a single-interaction INP sample ceiling; a consumer whose measured CI maxima justify tighter numbers
+/// passes its own, which is the point of keeping the budget itself consumer-side.
+/// </summary>
+/// <param name="Lcp">Largest Contentful Paint ceiling, milliseconds.</param>
+/// <param name="Fcp">First Contentful Paint ceiling, milliseconds.</param>
+/// <param name="Ttfb">Time To First Byte ceiling, milliseconds.</param>
+/// <param name="Cls">Cumulative Layout Shift ceiling (unitless).</param>
+/// <param name="Inp">Single-interaction INP sample ceiling, milliseconds.</param>
+public sealed record WebVitalsBudget(
+    double Lcp = 2500,
+    double Fcp = 1800,
+    double Ttfb = 800,
+    double Cls = 0.1,
+    double Inp = 500)
+{
+    /// <summary>
+    /// Formats one sample as the single-line, artifact-citable log record the budget tests emit to test
+    /// output alongside the JSON artifact.
+    /// </summary>
+    /// <param name="label">The artifact label (e.g. <c>sessions</c>).</param>
+    /// <param name="path">The page path measured.</param>
+    /// <param name="sample">The measured sample.</param>
+    /// <returns>The formatted line.</returns>
+    public static string Describe(string label, string path, WebVitalsSample sample)
+    {
+        ArgumentNullException.ThrowIfNull(sample);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"[web-vitals:{label}] path={path} LCP={sample.Lcp:F0}ms FCP={sample.Fcp:F0}ms CLS={sample.Cls:F3} TTFB={sample.Ttfb:F0}ms INP-sample={sample.Inp:F0}ms");
+    }
+
+    /// <summary>
+    /// Writes the sample line (when <paramref name="writeLine"/> is supplied, normally
+    /// <c>ITestOutputHelper.WriteLine</c>) and asserts every metric is within budget. INP is asserted only
+    /// when a sample was actually recorded: no interaction clearing the 16 ms event threshold leaves it at
+    /// 0, and 0 must not read as a pass-by-absence nor as a failure.
+    /// </summary>
+    /// <param name="sample">The measured sample.</param>
+    /// <param name="label">The artifact label, echoed in the output line.</param>
+    /// <param name="path">The page path measured, echoed in every failure message.</param>
+    /// <param name="writeLine">Optional sink for the sample line.</param>
+    public void AssertWithinBudget(WebVitalsSample sample, string label, string path, Action<string>? writeLine = null)
+    {
+        ArgumentNullException.ThrowIfNull(sample);
+
+        writeLine?.Invoke(Describe(label, path, sample));
+
+        sample.Lcp.Should().BeLessThanOrEqualTo(Lcp, Message("LCP", sample.Lcp, Lcp, path));
+        sample.Fcp.Should().BeLessThanOrEqualTo(Fcp, Message("FCP", sample.Fcp, Fcp, path));
+        sample.Ttfb.Should().BeLessThanOrEqualTo(Ttfb, Message("TTFB", sample.Ttfb, Ttfb, path));
+        sample.Cls.Should().BeLessThanOrEqualTo(Cls, Message("CLS", sample.Cls, Cls, path, "F3"));
+
+        if (sample.Inp > 0)
+        {
+            sample.Inp.Should().BeLessThanOrEqualTo(Inp, Message("INP-sample", sample.Inp, Inp, path));
+        }
+    }
+
+    private static string Message(string metric, double measured, double budget, string path, string format = "F0") =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{metric} {measured.ToString(format, CultureInfo.InvariantCulture)} exceeded budget {budget} on {path}");
+}

--- a/Source/Hosting/MMCA.Common.Testing/CrossServiceFixtureBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing/CrossServiceFixtureBase.cs
@@ -1,0 +1,287 @@
+using Microsoft.Data.SqlClient;
+using Testcontainers.MsSql;
+using Testcontainers.RabbitMq;
+using Xunit;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// One logical data source a cross-service fixture routes to its own physical database: the logical name
+/// the framework's <c>DataSources</c> configuration section keys on (normally the module name) and the
+/// database that name resolves to on the shared SQL Server container.
+/// </summary>
+/// <param name="LogicalName">The logical source name (e.g. <c>Conference</c>), used as the config key.</param>
+/// <param name="DatabaseName">The physical database (e.g. <c>ADC_Conference</c>).</param>
+public sealed record CrossServiceDataSource(string LogicalName, string DatabaseName);
+
+/// <summary>
+/// Shared scaffolding for the cross-service <b>real-broker</b> integration tier: boots several service hosts
+/// in ONE process against a real Testcontainers SQL Server and a real Testcontainers RabbitMQ, so the
+/// genuine outbox to broker to consumer round-trip (and any real cross-service gRPC read) is exercised end
+/// to end. Unlike the per-service <see cref="SqlServerIntegrationTestFixtureBase{TEntryPoint}"/>, which
+/// boots ONE host with the cross-service edges faked and no broker, this base owns the container lifecycle,
+/// the pre-created databases, and the process-environment channel every host reads its settings from. The
+/// per-app parts (which databases, how many hosts and in what order, which extra settings) stay in the
+/// subclass through the hooks below.
+/// <para><b>Config channel (the load-bearing design decision).</b> Each host reads its connection string,
+/// <c>MessageBus</c> provider/connection string and JWT settings from <c>builder.Configuration</c> at
+/// <i>configure-time</i>, BEFORE <c>builder.Build()</c>, which is before
+/// <c>WebApplicationFactory.ConfigureAppConfiguration</c> deltas apply. So in-memory config injected via the
+/// WAF would arrive too late; <b>process environment variables</b> are the only override channel these
+/// hosts honour. Most keys are identical across hosts (broker provider/URI, dummy authority, test keys), so
+/// they do not collide. The one genuinely per-host key is
+/// <c>ConnectionStrings__SQLServerConnectionString</c> (each host's own database AND its outbox
+/// <c>Default</c> source), which is why hosts must be booted <b>strictly sequentially</b> in
+/// <see cref="BootHostsAsync"/>, calling <see cref="SetHostConnectionString"/> between boots: a host
+/// snapshots its connection at boot (DataSource resolver, DbContext factory, outbox processor and the
+/// MassTransit bus are all built during <c>StartAsync</c>), so mutating the environment for the next host
+/// cannot disturb an already-booted one.
+/// </para>
+/// </summary>
+public abstract class CrossServiceFixtureBase : IAsyncLifetime
+{
+    // Never fetched: the factories re-point real validation at the committed test key. It only has to be
+    // present so AddForwardedJwtBearer's authority guard passes.
+    private const string DummyBearerAuthority = "http://localhost";
+
+    private readonly Dictionary<string, string?> _originalEnvironment = [];
+
+    private MsSqlContainer? _sqlContainer;
+    private RabbitMqContainer? _rabbitContainer;
+
+    /// <summary>The Testcontainers RabbitMQ AMQP connection string wired into every host's broker.</summary>
+    public string RabbitMqConnectionString { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The logical sources this tier routes to their own databases, in the order the databases are created.
+    /// Drives both the pre-created database list and the per-module named-source routing described on
+    /// <see cref="SetSharedEnvironment"/>.
+    /// </summary>
+    protected abstract IReadOnlyList<CrossServiceDataSource> DataSources { get; }
+
+    /// <summary>
+    /// Assembly-name prefix of the repo's per-module migrations projects (e.g.
+    /// <c>MMCA.ADC.Migrations.SqlServer</c>); each named source gets
+    /// <c>{prefix}.{LogicalName}</c> as its <c>SQLServerMigrationsAssembly</c>, matching production.
+    /// </summary>
+    protected abstract string MigrationsAssemblyPrefix { get; }
+
+    /// <summary>The SQL Server container's base connection string (server, credentials, master catalog).</summary>
+    protected string SqlServerBaseConnectionString =>
+        (_sqlContainer ?? throw new InvalidOperationException("The SQL Server container has not started yet."))
+            .GetConnectionString();
+
+    /// <summary>
+    /// Overlays a catalog (and optionally an Application Name) onto a base connection string. Pure and
+    /// static so a fixture's connection-string composition is unit-testable without a container.
+    /// </summary>
+    /// <param name="baseConnectionString">The server's base connection string.</param>
+    /// <param name="databaseName">The catalog to point at.</param>
+    /// <param name="applicationName">Optional Application Name, used to keep a named source distinct.</param>
+    /// <returns>The composed connection string.</returns>
+    public static string ComposeConnectionString(string baseConnectionString, string databaseName, string? applicationName = null)
+    {
+        var builder = new SqlConnectionStringBuilder(baseConnectionString)
+        {
+            InitialCatalog = databaseName,
+            TrustServerCertificate = true,
+        };
+
+        if (!string.IsNullOrEmpty(applicationName))
+        {
+            builder.ApplicationName = applicationName;
+        }
+
+        return builder.ConnectionString;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask InitializeAsync()
+    {
+        (_sqlContainer, _rabbitContainer) = CreateContainers();
+        await Task.WhenAll(_sqlContainer.StartAsync(), _rabbitContainer.StartAsync()).ConfigureAwait(false);
+
+        RabbitMqConnectionString = _rabbitContainer.GetConnectionString();
+        await OnContainersStartedAsync().ConfigureAwait(false);
+
+        // Pre-create the databases so no host's EF MigrateAsync issues CREATE DATABASE. CREATE DATABASE
+        // runs BEFORE EF's migration lock (sp_getapplock) is acquired, so a host booted twice (the
+        // real-Kestrel double-boot pattern) would otherwise race itself; with the databases pre-created EF
+        // skips CREATE (Exists() is true) and the migration lock serializes the actual migration run.
+        await CreateDatabasesAsync().ConfigureAwait(false);
+
+        SetSharedEnvironment();
+
+        await BootHostsAsync().ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        await DisposeHostsAsync().ConfigureAwait(false);
+
+        if (_rabbitContainer is not null)
+        {
+            await _rabbitContainer.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_sqlContainer is not null)
+        {
+            await _sqlContainer.DisposeAsync().ConfigureAwait(false);
+        }
+
+        RestoreEnvironment();
+    }
+
+    /// <summary>
+    /// Boots the hosts, STRICTLY SEQUENTIALLY, calling <see cref="SetHostConnectionString"/> with each
+    /// host's own database before creating it (plus any per-host key, e.g. a peer's real Kestrel address
+    /// for a gRPC client). The host count and boot order are per-app, so they live here.
+    /// </summary>
+    protected abstract ValueTask BootHostsAsync();
+
+    /// <summary>Disposes the hosts (and their clients) booted by <see cref="BootHostsAsync"/>.</summary>
+    protected abstract ValueTask DisposeHostsAsync();
+
+    /// <summary>
+    /// Runs once both containers are up and <see cref="RabbitMqConnectionString"/> is known, before the
+    /// databases are created. Override to cache the per-database connection strings the tests read.
+    /// </summary>
+    protected virtual ValueTask OnContainersStartedAsync() => ValueTask.CompletedTask;
+
+    /// <summary>
+    /// Pushes the app-specific shared settings (test JWT/JWKS key material, throttle lifts, third-party
+    /// client stubs) after the base has pushed the environment, the named data sources, the broker and the
+    /// dummy Bearer authority. Every variable pushed through <paramref name="setEnvironmentVariable"/> is
+    /// restored on disposal.
+    /// </summary>
+    /// <param name="setEnvironmentVariable">The base's snapshot-taking environment setter.</param>
+    protected virtual void ConfigureSharedEnvironment(Action<string, string?> setEnvironmentVariable)
+    {
+    }
+
+    /// <summary>Composes a connection string for <paramref name="databaseName"/> on the SQL container.</summary>
+    /// <param name="databaseName">The database to point at.</param>
+    /// <returns>The composed connection string.</returns>
+    protected string BuildConnectionString(string databaseName) =>
+        ComposeConnectionString(SqlServerBaseConnectionString, databaseName);
+
+    /// <summary>
+    /// Points the shared top-level connection string (each host's own database AND its outbox
+    /// <c>Default</c> source) at <paramref name="connectionString"/>. Call this immediately before booting
+    /// each host: it is the one key that genuinely differs per host.
+    /// </summary>
+    /// <param name="connectionString">The next host's connection string.</param>
+    protected void SetHostConnectionString(string connectionString) =>
+        SetEnvironmentVariable("ConnectionStrings__SQLServerConnectionString", connectionString);
+
+    /// <summary>
+    /// Sets a process environment variable, snapshotting its ORIGINAL value for
+    /// <see cref="DisposeAsync"/> to restore. Only the FIRST original value is recorded, so re-pushing a
+    /// key (the per-host connection string) cannot clobber the restore point.
+    /// </summary>
+    /// <param name="key">The environment variable name.</param>
+    /// <param name="value">The value to set, or <see langword="null"/> to clear it.</param>
+    protected void SetEnvironmentVariable(string key, string? value)
+    {
+        if (!_originalEnvironment.ContainsKey(key))
+        {
+            _originalEnvironment[key] = Environment.GetEnvironmentVariable(key);
+        }
+
+        Environment.SetEnvironmentVariable(key, value);
+    }
+
+    // The parameterless module-builder ctors are [Obsolete] in Testcontainers 4.11 but fully functional
+    // (each uses its module's own default pinned image). Testcontainers is version-pinned, so this is
+    // stable; suppress the deprecation rather than couple to an image-ctor overload whose signature varies.
+    // Built here rather than in a field initializer so a subclass can be constructed (and its non-container
+    // logic unit-tested) on a machine with no Docker daemon.
+#pragma warning disable CS0618
+    private static (MsSqlContainer Sql, RabbitMqContainer Rabbit) CreateContainers() =>
+        (new MsSqlBuilder().Build(), new RabbitMqBuilder().Build());
+#pragma warning restore CS0618
+
+    private async Task CreateDatabasesAsync()
+    {
+        var connection = new SqlConnection(BuildConnectionString("master"));
+        await using (connection.ConfigureAwait(false))
+        {
+            await connection.OpenAsync().ConfigureAwait(false);
+            foreach (var databaseName in DataSources.Select(static source => source.DatabaseName))
+            {
+                var command = connection.CreateCommand();
+                await using (command.ConfigureAwait(false))
+                {
+#pragma warning disable CA2100 // Database names are the subclass's own compile-time constants, never user input; DB names can't be parameterized.
+                    command.CommandText = $"IF DB_ID(N'{databaseName}') IS NULL CREATE DATABASE [{databaseName}];";
+#pragma warning restore CA2100
+                    await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private void SetSharedEnvironment()
+    {
+        SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Testing");
+
+        // Per-module NAMED data sources (the multi-host-in-one-process fix).
+        // EF Core caches the model for a context type in a process-global service-provider cache.
+        // DataSourceModelCacheKeyFactory keys it by (contextType, DataSourceKey.Name). If every host let
+        // its entities collapse onto the "Default" source (as production does, one host per process), all
+        // hosts here would share ONE cached model and the first booted would win, so the others could not
+        // find their own entities. To keep each host's model distinct we route each module's entities to a
+        // NAMED source by giving DataSources:{LogicalName} a connection string that differs ORDINALLY from
+        // the top-level ConnectionStrings (same physical database, distinct Application Name) so the
+        // resolver does NOT collapse it onto Default. These keys are module-namespaced, so they do not
+        // collide across hosts and can all be set up front. Only the shared top-level ConnectionStrings key
+        // is mutated per sequential boot. OutboxMessage / InboxMessage are configured in every relational
+        // context, so a named source's model still has them.
+        foreach (var source in DataSources)
+        {
+            SetNamedDataSource(source);
+        }
+
+        // Real broker transport (identical for every host, no collision).
+        SetEnvironmentVariable("MessageBus__Provider", "RabbitMq");
+        SetEnvironmentVariable("ConnectionStrings__rabbitmq", RabbitMqConnectionString);
+
+        // Dummy authority so a host's AddForwardedJwtBearer does not throw on a missing
+        // Authentication:JwtBearer:Authority. Real validation is re-pointed at the committed test key by
+        // the factories (JwtTokenGenerator.ConfigureInProcessTokenValidation), so it is never fetched.
+        SetEnvironmentVariable("Authentication__JwtBearer__Authority", DummyBearerAuthority);
+
+        ConfigureSharedEnvironment(SetEnvironmentVariable);
+    }
+
+    // Routes a module's entities to a NAMED physical source pointing at its own database. The connection
+    // string carries a distinct Application Name so it differs ordinally from the top-level ConnectionStrings
+    // (same database) and the resolver keeps the "{LogicalName}" source instead of collapsing it onto
+    // Default, giving each host a distinct EF model-cache key. The per-module migrations assembly matches
+    // production.
+    private void SetNamedDataSource(CrossServiceDataSource source)
+    {
+        var connectionString = ComposeConnectionString(
+            SqlServerBaseConnectionString,
+            source.DatabaseName,
+            applicationName: $"MMCA-{source.LogicalName}");
+
+        SetEnvironmentVariable($"DataSources__{source.LogicalName}__SQLServerConnectionString", connectionString);
+        SetEnvironmentVariable(
+            $"DataSources__{source.LogicalName}__SQLServerMigrationsAssembly",
+            $"{MigrationsAssemblyPrefix}.{source.LogicalName}");
+    }
+
+    private void RestoreEnvironment()
+    {
+        foreach (var (key, value) in _originalEnvironment)
+        {
+            Environment.SetEnvironmentVariable(key, value);
+        }
+
+        _originalEnvironment.Clear();
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/DependencyInjectionAssert.cs
+++ b/Source/Hosting/MMCA.Common.Testing/DependencyInjectionAssert.cs
@@ -1,0 +1,33 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Assertions for the DI registration extension methods every module and layer exposes. The framework's
+/// registration methods are fluent: each returns the <b>same</b> <see cref="IServiceCollection"/> instance
+/// it was handed, so hosts can chain <c>AddApplication().AddInfrastructure(...).AddAPI(...)</c>. An
+/// extension that returns a new collection (or a differently-built one) silently drops every registration
+/// chained after it, which no other test catches because the dropped services are simply absent.
+/// </summary>
+public static class DependencyInjectionAssert
+{
+    /// <summary>
+    /// Asserts that <paramref name="register"/> hands back the very collection it was given, so the fluent
+    /// chain stays intact. Creates the collection itself, so a call site is one line:
+    /// <c>DependencyInjectionAssert.ReturnsSameCollection(s =&gt; s.AddCatalogModule(settings));</c>
+    /// </summary>
+    /// <param name="register">The registration extension under test.</param>
+    public static void ReturnsSameCollection(Func<IServiceCollection, IServiceCollection> register)
+    {
+        ArgumentNullException.ThrowIfNull(register);
+
+        var services = new ServiceCollection();
+
+        var result = register(services);
+
+        result.Should().BeSameAs(
+            services,
+            because: "a fluent registration extension must return the collection it was handed, or every call chained after it registers into a collection the host never builds");
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/JwtTokenGenerator.cs
+++ b/Source/Hosting/MMCA.Common.Testing/JwtTokenGenerator.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 
 namespace MMCA.Common.Testing;
@@ -149,5 +150,41 @@ public static class JwtTokenGenerator
             signingCredentials: credentials);
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    /// <summary>
+    /// Re-points a Bearer scheme at the in-memory <see cref="DefaultPublicKeyPem"/> RSA key so a test host
+    /// validates tokens minted by <see cref="GenerateToken"/> without any JWKS/OIDC endpoint being
+    /// reachable. Call it from a <c>PostConfigure&lt;JwtBearerOptions&gt;</c> in a
+    /// <c>WebApplicationFactory</c> override: <c>AddForwardedJwtBearer</c> otherwise fetches the issuer and
+    /// signing keys from the Identity service's JWKS document through the gateway, which no in-process test
+    /// topology serves. Nulling <see cref="JwtBearerOptions.Authority"/> and
+    /// <see cref="JwtBearerOptions.ConfigurationManager"/> stops that discovery; the handler then validates
+    /// against the static key set below.
+    /// </summary>
+    /// <param name="options">The Bearer options to re-point (the scheme the host already registered).</param>
+    /// <param name="audience">The audience the host issues and validates (its <c>Jwt:Audience</c>).</param>
+    public static void ConfigureInProcessTokenValidation(JwtBearerOptions options, string audience)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.Authority = null;
+        options.ConfigurationManager = null;
+        options.RequireHttpsMetadata = false;
+
+        RSAParameters parameters;
+        using (var rsa = RSA.Create())
+        {
+            rsa.ImportFromPem(DefaultPublicKeyPem);
+            parameters = rsa.ExportParameters(includePrivateParameters: false);
+        }
+
+        options.TokenValidationParameters.ValidateIssuerSigningKey = true;
+        options.TokenValidationParameters.IssuerSigningKey =
+            new RsaSecurityKey(parameters) { KeyId = DefaultKeyId };
+        options.TokenValidationParameters.ValidateIssuer = true;
+        options.TokenValidationParameters.ValidIssuer = DefaultIssuer;
+        options.TokenValidationParameters.ValidateAudience = true;
+        options.TokenValidationParameters.ValidAudience = audience;
     }
 }

--- a/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
+++ b/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
@@ -15,12 +15,20 @@
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AwesomeAssertions" />
+    <!-- JwtTokenGenerator.ConfigureInProcessTokenValidation re-points a host's JwtBearerOptions at the
+         committed test key, so the options type must be referenced here rather than in every test project. -->
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.FeatureManagement" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Respawn" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <!-- CrossServiceFixtureBase owns the SQL Server + RabbitMQ container lifecycle for the cross-service
+         real-broker tier. Consumers of that tier need a Docker daemon; the single-host
+         SqlServerIntegrationTestFixtureBase does not touch these. -->
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="Testcontainers.RabbitMq" />
     <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Hosting/MMCA.Common.Testing/TestPolling.cs
+++ b/Source/Hosting/MMCA.Common.Testing/TestPolling.cs
@@ -1,0 +1,42 @@
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Poll-with-timeout helper for asynchronous integration assertions. Anything that travels the outbox to a
+/// broker and back (or any other eventually-consistent path) arrives at a time the test cannot know, and a
+/// fixed pre-assert sleep is both slow and flaky: too short and the suite reds intermittently, too long and
+/// every green run pays the worst case. Polling returns as soon as the condition holds and bounds the wait.
+/// </summary>
+public static class TestPolling
+{
+    /// <summary>
+    /// Polls <paramref name="probe"/> until <paramref name="isSatisfied"/> holds or the timeout elapses,
+    /// returning the last probed value either way, so the caller still asserts on it (a timeout must fail
+    /// on the real assertion message, not on a bare timeout).
+    /// </summary>
+    /// <typeparam name="T">The probed value type.</typeparam>
+    /// <param name="probe">Reads the current value (an HTTP call, a repository read, a counter).</param>
+    /// <param name="isSatisfied">The condition that ends the poll.</param>
+    /// <param name="timeout">Total wait budget. Defaults to 60 seconds.</param>
+    /// <param name="interval">Delay between probes. Defaults to 500 milliseconds.</param>
+    /// <returns>The last probed value.</returns>
+    public static async Task<T> PollUntilAsync<T>(
+        Func<Task<T>> probe,
+        Func<T, bool> isSatisfied,
+        TimeSpan? timeout = null,
+        TimeSpan? interval = null)
+    {
+        ArgumentNullException.ThrowIfNull(probe);
+        ArgumentNullException.ThrowIfNull(isSatisfied);
+
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(60));
+        var delay = interval ?? TimeSpan.FromMilliseconds(500);
+        var last = await probe().ConfigureAwait(false);
+        while (!isSatisfied(last) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(delay).ConfigureAwait(false);
+            last = await probe().ConfigureAwait(false);
+        }
+
+        return last;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing/packages.lock.json
@@ -14,6 +14,15 @@
         "resolved": "3.0.133",
         "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "VAcqS42zb9WJd9DjPdkVTS5YrQENmNzPNJuRu8VAW7x3TEWUipc4d4hHzVJdFB0h/KLdr4XcXZzRHcUOKVanMQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.19.2"
+        }
+      },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
         "requested": "[10.0.10, )",
@@ -108,6 +117,24 @@
           "Microsoft.IdentityModel.Tokens": "8.21.0"
         }
       },
+      "Testcontainers.MsSql": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "NOPbOViWvaEXiuh+fg9KoPUYsxt3hOAra1volUPSeWlLFCuS+3HLavaYaocybNOVBtNr0IeTIcQk96OqcMfAwQ==",
+        "dependencies": {
+          "Testcontainers": "4.8.0"
+        }
+      },
+      "Testcontainers.RabbitMq": {
+        "type": "Direct",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "RwaylDN7aeud+eYAPb9TfBnC21W5Tb/jg7+w4oBr/PfkbDjQF8Y2pUGvPfcriHcKjc65FxXnZNvd880K+QePuA==",
+        "dependencies": {
+          "Testcontainers": "4.8.0"
+        }
+      },
       "xunit.v3.extensibility.core": {
         "type": "Direct",
         "requested": "[3.2.2, )",
@@ -127,10 +154,28 @@
           "System.Memory.Data": "8.0.1"
         }
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.4.0",
+        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
         "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.129.0",
+        "contentHash": "+mTwpvdnCs0366AfuofuBhUFGHuGraWX+4am+NX93sL1tmLTCX6idDS8stDA6JG/5SYdx+UFn7BNu8H5Fjhj9g=="
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.129.0",
+        "contentHash": "UxMlIB7XX9jZKWUGk/hosD1VGlnb9BTcMzBkhba9ZvN3PZn/bLlhLSDLLFa29Wh/WUfsngpSfz+zuyfChr7Dqw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.129.0"
+        }
       },
       "FluentValidation": {
         "type": "Transitive",
@@ -207,19 +252,19 @@
       },
       "Microsoft.IdentityModel.Protocols": {
         "type": "Transitive",
-        "resolved": "7.7.1",
-        "contentHash": "h+fHHBGokepmCX+QZXJk4Ij8OApCb2n2ktoDkNX5CXteXsOxTHMNgjPGpAwdJMFvAL7TtGarUnk3o97NmBq2QQ==",
+        "resolved": "8.19.2",
+        "contentHash": "sGxSsSrZXNmca6D+jHH2rVRyo2nNRd/g4H9CFbPmLLq0xgoH1U0orLWE5minfijw7+zq49tBs7txenbfAErRoQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "7.7.1"
+          "Microsoft.IdentityModel.Tokens": "8.19.2"
         }
       },
       "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
         "type": "Transitive",
-        "resolved": "7.7.1",
-        "contentHash": "yT2Hdj8LpPbcT9C9KlLVxXl09C8zjFaVSaApdOwuecMuoV4s6Sof/mnTDz/+F/lILPIBvrWugR9CC7iRVZgbfQ==",
+        "resolved": "8.19.2",
+        "contentHash": "1XOcyY36cVymzE3qKdzKaUEZ4Pzt7ZpSa14JZoPPK1NLFUkQDs85TCqpV6XDo0YjFXj6nVK00AfOHppjghjhtw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols": "7.7.1",
-          "System.IdentityModel.Tokens.Jwt": "7.7.1"
+          "Microsoft.IdentityModel.Protocols": "8.19.2",
+          "System.IdentityModel.Tokens.Jwt": "8.19.2"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
@@ -248,6 +293,19 @@
         "type": "Transitive",
         "resolved": "4.5.4",
         "contentHash": "f8ckFm/xTS8C2Bn4BdVc94dNvg+tRfk0e4XFaETOqRi6r0PUOyn3Z9jTQCVpB3R1pP5WiRsEIrqqxux95BVpTA=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2024.2.0",
+        "contentHash": "9r+4UF2P51lTztpd+H7SJywk7WgmlWB//Cm2o96c6uGVZU5r58ys2/cD9pCgTk0zCdSkfflWL1WtqQ9I4IVO9Q==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.4.0"
+        }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
@@ -284,6 +342,17 @@
         "type": "Transitive",
         "resolved": "9.0.4",
         "contentHash": "o94k2RKuAce3GeDMlUvIXlhVa1kWpJw95E6C9LwW0KlG0nj5+SgCiIxJ2Eroqb9sLtG1mEMbFttZIBZ13EJPvQ=="
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.8.0",
+        "contentHash": "P84aPfFCIxyc+yxwj8J1AjDyv+tnhDYosD3kouXdgxHTV2UPeRvck09l1WLqeVa170wyp6t319x9shzAx5wwvQ==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.129.0",
+          "Docker.DotNet.Enhanced.X509": "3.129.0",
+          "SSH.NET": "2024.2.0",
+          "SharpZipLib": "1.4.2"
+        }
       },
       "xunit.v3.common": {
         "type": "Transitive",

--- a/Source/Presentation/MMCA.Common.API/Controllers/UserAccountAuthControllerBase.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/UserAccountAuthControllerBase.cs
@@ -1,0 +1,157 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MMCA.Common.Application.Auth;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Application.Users;
+using MMCA.Common.Application.Users.UseCases.GetPreferences;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+
+namespace MMCA.Common.API.Controllers;
+
+/// <summary>
+/// Adds the self-service account endpoints (<c>PUT password</c>, <c>PUT preferences</c>,
+/// <c>GET preferences</c>) on top of <see cref="AuthControllerBase"/>. The app Identity modules
+/// carried line-identical copies of all three actions; only the command records they constructed
+/// differed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The commands stay app-side (<typeparamref name="TChangePasswordCommand"/> /
+/// <typeparamref name="TChangePreferencesCommand"/>): ADC marks them <c>ICacheInvalidating</c> with a
+/// cache prefix built from its own <c>User</c> type and Store does not, so a single shared record
+/// could not preserve both behaviors. This base therefore never constructs a command itself: the
+/// derived controller supplies one through <see cref="CreateChangePasswordCommand"/> and
+/// <see cref="CreateChangePreferencesCommand"/> (two one-line overrides), and the base reads it back
+/// only through <see cref="IUserScopedCommand{TRequest}"/>. The preferences QUERY has no such
+/// per-app detail, so <see cref="GetUserPreferencesQuery"/> is shared and constructed here.
+/// </para>
+/// <para>
+/// Inheriting this base instead of <see cref="AuthControllerBase"/> is purely additive: every
+/// inherited login/register/refresh/revoke action, including the default per-IP throttling and the
+/// ability to override <c>RegisterAsync</c> or attach an extra
+/// <c>[EnableRateLimiting]</c> policy app-side, behaves exactly as before.
+/// </para>
+/// </remarks>
+/// <typeparam name="TChangePasswordCommand">The app's change-password command record.</typeparam>
+/// <typeparam name="TChangePreferencesCommand">The app's change-preferences command record.</typeparam>
+public abstract class UserAccountAuthControllerBase<TChangePasswordCommand, TChangePreferencesCommand>(
+    IAuthenticationService authenticationService,
+    ICurrentUserService currentUserService,
+    ICommandHandler<TChangePasswordCommand, Result> changePasswordHandler,
+    ICommandHandler<TChangePreferencesCommand, Result> changePreferencesHandler,
+    IQueryHandler<GetUserPreferencesQuery, Result<UserPreferencesResponse>> getUserPreferencesHandler)
+    : AuthControllerBase(authenticationService, currentUserService)
+    where TChangePasswordCommand : IUserScopedCommand<ChangePasswordRequest>
+    where TChangePreferencesCommand : IUserScopedCommand<ChangePreferencesRequest>
+{
+    /// <summary>The change-password command handler for this controller.</summary>
+    protected ICommandHandler<TChangePasswordCommand, Result> ChangePasswordHandler { get; } = changePasswordHandler;
+
+    /// <summary>The change-preferences command handler for this controller.</summary>
+    protected ICommandHandler<TChangePreferencesCommand, Result> ChangePreferencesHandler { get; } = changePreferencesHandler;
+
+    /// <summary>The preferences query handler for this controller.</summary>
+    protected IQueryHandler<GetUserPreferencesQuery, Result<UserPreferencesResponse>> GetUserPreferencesHandler { get; } = getUserPreferencesHandler;
+
+    /// <summary>
+    /// Builds the app's change-password command. Implement as
+    /// <c>=&gt; new(userId, request);</c> in the derived controller.
+    /// </summary>
+    /// <param name="userId">The authenticated user the command targets.</param>
+    /// <param name="request">The validated request payload.</param>
+    /// <returns>The app command to dispatch through the decorator pipeline.</returns>
+    protected abstract TChangePasswordCommand CreateChangePasswordCommand(
+        UserIdentifierType userId,
+        ChangePasswordRequest request);
+
+    /// <summary>
+    /// Builds the app's change-preferences command. Implement as
+    /// <c>=&gt; new(userId, request);</c> in the derived controller.
+    /// </summary>
+    /// <param name="userId">The authenticated user the command targets.</param>
+    /// <param name="request">The validated request payload.</param>
+    /// <returns>The app command to dispatch through the decorator pipeline.</returns>
+    protected abstract TChangePreferencesCommand CreateChangePreferencesCommand(
+        UserIdentifierType userId,
+        ChangePreferencesRequest request);
+
+    /// <summary>
+    /// Changes the current user's password after verifying the existing password. Dispatches the
+    /// app's change-password command handler directly (through the decorator pipeline) rather than
+    /// brokering it via the authentication service.
+    /// </summary>
+    [HttpPut("password")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
+    public virtual async Task<ActionResult> ChangePasswordAsync(
+        [FromBody] ChangePasswordRequest request,
+        CancellationToken cancellationToken)
+    {
+        var userId = CurrentUserService.UserId;
+        if (userId is null)
+            return Unauthorized();
+
+        var result = await ChangePasswordHandler
+            .HandleAsync(CreateChangePasswordCommand(userId.Value, request), cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.IsFailure
+            ? HandleFailure(result.Errors)
+            : NoContent();
+    }
+
+    /// <summary>
+    /// Persists the current user's UI culture/theme preferences (ADR-027 / ADR-028) so they follow the
+    /// user across devices. A null field leaves that preference unchanged.
+    /// </summary>
+    [HttpPut("preferences")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
+    public virtual async Task<ActionResult> ChangePreferencesAsync(
+        [FromBody] ChangePreferencesRequest request,
+        CancellationToken cancellationToken)
+    {
+        var userId = CurrentUserService.UserId;
+        if (userId is null)
+            return Unauthorized();
+
+        var result = await ChangePreferencesHandler
+            .HandleAsync(CreateChangePreferencesCommand(userId.Value, request), cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.IsFailure
+            ? HandleFailure(result.Errors)
+            : NoContent();
+    }
+
+    /// <summary>
+    /// Returns the current user's stored UI culture/theme preferences (ADR-027 / ADR-028), used at login
+    /// to apply a returning user's choice across devices.
+    /// </summary>
+    [HttpGet("preferences")]
+    [Authorize]
+    [ProducesResponseType(typeof(UserPreferencesResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
+    public virtual async Task<ActionResult<UserPreferencesResponse>> GetPreferencesAsync(
+        CancellationToken cancellationToken)
+    {
+        var userId = CurrentUserService.UserId;
+        if (userId is null)
+            return Unauthorized();
+
+        var result = await GetUserPreferencesHandler
+            .HandleAsync(new GetUserPreferencesQuery(userId.Value), cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.IsFailure
+            ? HandleFailure(result.Errors)
+            : Ok(result.Value);
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/Components/NativeThemeSync.razor
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Components/NativeThemeSync.razor
@@ -1,0 +1,53 @@
+@using MMCA.Common.UI.Services
+@inject ThemeService ThemeService
+@implements IDisposable
+
+@* Renders nothing. Bridges the Blazor Day/Dark preference (ADR-028) to MAUI's own AppTheme so the
+   NATIVE chrome follows the in-app toggle. Without it the two disagree: ThemeService only drives the
+   MudThemeProvider inside the WebView, while Application.UserAppTheme was never set at all, so the
+   native side kept tracking the OS. Dark mode on a light-mode phone left the page background behind
+   the WebView (visible on cold start, and around the safe areas) rendering light.
+
+   It ships from MMCA.Common.UI.Maui rather than MMCA.Common.UI by necessity: Application and
+   MainThread are MAUI types, so the plain net10.0 MMCA.Common.UI (shared with the Blazor Web heads)
+   cannot reference them. Hybrid heads render it by listing it in an IUIModule's
+   LayoutComponentTypes. *@
+
+@code {
+    protected override void OnInitialized() => ThemeService.OnChange += OnThemeChanged;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        // MmcaThemeProviders resolves the stored preference on ITS first render and raises OnChange,
+        // which normally lands here. Layout components have no guaranteed order relative to it, so if
+        // that already happened before this component initialized, catch up now instead of waiting for
+        // a toggle that may never come.
+        if (firstRender && ThemeService.IsInitialized)
+        {
+            Apply();
+        }
+    }
+
+    private void OnThemeChanged(object? sender, EventArgs e) => Apply();
+
+    private void Apply()
+    {
+        var app = Microsoft.Maui.Controls.Application.Current;
+        if (app is null)
+        {
+            return;
+        }
+
+        var theme = ThemeService.IsDarkMode ? AppTheme.Dark : AppTheme.Light;
+        if (app.UserAppTheme == theme)
+        {
+            return;
+        }
+
+        // OnChange is raised from the renderer's dispatcher, which IS the MAUI UI thread, but
+        // InitializeAsync resumes off a JS interop await, so do not assume it.
+        MainThread.BeginInvokeOnMainThread(() => app.UserAppTheme = theme);
+    }
+
+    public void Dispose() => ThemeService.OnChange -= OnThemeChanged;
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
@@ -1,5 +1,7 @@
 using MMCA.Common.UI.Maui.Capabilities;
+using MMCA.Common.UI.Maui.Services;
 using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Auth;
 using MMCA.Common.UI.Services.Capabilities;
 
 namespace MMCA.Common.UI.Maui;
@@ -58,6 +60,18 @@ public static class DependencyInjection
             services.AddScoped<IExternalAuthBroker, MauiExternalAuthBroker>();
             return services;
         }
+
+        /// <summary>
+        /// Registers the OS-SecureStorage token storage (<see cref="MauiTokenStorageService"/> as
+        /// the scoped <c>ITokenStorageService</c>): the platform secure enclave holds both tokens,
+        /// and every read/write is guarded so an OS-invalidated keystore entry degrades to one
+        /// clean re-login instead of an unhandled throw on launch. The browser-host equivalents are
+        /// <c>AddCommonServerTokenStorage()</c> (MMCA.Common.UI.Web) and the WASM
+        /// <c>WasmTokenStorageService</c> (MMCA.Common.UI). Scoped rather than singleton to match
+        /// those siblings, so component code can depend on one lifetime across every head.
+        /// </summary>
+        public IServiceCollection AddCommonMauiTokenStorage() =>
+            services.AddScoped<ITokenStorageService, MauiTokenStorageService>();
 
         /// <summary>
         /// Registers the native <see cref="IFormFactor"/> (<see cref="MauiFormFactor"/>: DeviceInfo

--- a/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
+++ b/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
@@ -38,8 +38,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" />
     <!-- BlazorWebView: the control MainPageBase dispatches through to reach the renderer's
-         IJSRuntime. Versioned on the MAUI train in Directory.Packages.props. -->
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+         IJSRuntime. Versioned on the MAUI train in Directory.Packages.props.
+         ExcludeAssets=build/buildTransitive: with the Razor SDK, letting this package's
+         .targets run HERE makes the library a static-web-asset producer whose transitive
+         blazor.modules.json collides with the one every consuming MAUI Blazor head
+         generates itself (Conflicting assets with the same target path
+         '_framework/blazor.modules.json'). Compile-time assemblies still flow; the heads
+         reference this package directly, so its build targets run where they belong. -->
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Plugin.LocalNotification" />
     <PackageReference Include="CommunityToolkit.Maui" />
     <PackageReference Include="MinVer">

--- a/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
+++ b/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
@@ -1,4 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<!-- Razor SDK (not the plain Sdk) because this package now ships a .razor component
+     (Components/NativeThemeSync.razor): only the Razor SDK runs the component compiler.
+     The Microsoft.AspNetCore.Components assemblies it needs already flow in transitively
+     through the MMCA.Common.UI ProjectReference, so no framework reference is added here. -->
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <!-- Clear the single net10.0 TargetFramework inherited from Directory.Build.props;
@@ -11,7 +15,7 @@
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <PackageId>MMCA.Common.UI.Maui</PackageId>
-    <Description>MMCA framework: native device-capability implementations (share, clipboard, haptics, geolocation, local notifications, biometrics, deep links) for MAUI Blazor Hybrid heads; pairs with the capability contracts in MMCA.Common.UI</Description>
+    <Description>MMCA framework: native device-capability implementations (share, clipboard, haptics, geolocation, local notifications, biometrics, deep links) plus the hybrid host layer (back-navigation page base, SecureStorage token storage, native theme sync) for MAUI Blazor Hybrid heads; pairs with the capability contracts in MMCA.Common.UI</Description>
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
@@ -33,6 +37,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" />
+    <!-- BlazorWebView: the control MainPageBase dispatches through to reach the renderer's
+         IJSRuntime. Versioned on the MAUI train in Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
     <PackageReference Include="Plugin.LocalNotification" />
     <PackageReference Include="CommunityToolkit.Maui" />
     <PackageReference Include="MinVer">

--- a/Source/Presentation/MMCA.Common.UI.Maui/MainPageBase.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/MainPageBase.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.JSInterop;
+using MMCA.Common.UI.Services.Navigation;
+
+namespace MMCA.Common.UI.Maui;
+
+/// <summary>
+/// Base content page for a MAUI Blazor Hybrid head whose XAML hosts a single <c>BlazorWebView</c>.
+/// Intercepts the platform back-button gesture (Android hardware back, iOS swipe) and forwards it
+/// to the WebView's internal history stack via <see cref="MauiBackNavigationBridge"/>, exiting the
+/// app only when the WebView has nowhere to go back to.
+/// <para>
+/// The base owns no XAML of its own, so a head adopts it in two edits: point the XAML root element
+/// at this type (<c>&lt;maui:MainPageBase ... x:Class="MyApp.UI.MainPage"&gt;</c> with
+/// <c>xmlns:maui="clr-namespace:MMCA.Common.UI.Maui;assembly=MMCA.Common.UI.Maui"</c>), and reduce
+/// the code-behind to the partial class, <c>InitializeComponent()</c>, and a
+/// <see cref="HostWebView"/> override returning the <c>x:Name</c>d control.
+/// </para>
+/// </summary>
+public abstract class MainPageBase : ContentPage
+{
+    /// <summary>
+    /// The <c>BlazorWebView</c> declared in the derived page's XAML. Implemented as an expression
+    /// body over the generated <c>x:Name</c> field (e.g. <c>=&gt; blazorWebView;</c>): the field is
+    /// private to the derived partial class, so the base can only reach it through this override.
+    /// </summary>
+    protected abstract BlazorWebView HostWebView { get; }
+
+    /// <inheritdoc />
+    protected override bool OnBackButtonPressed()
+    {
+        // Consume the gesture and process the back navigation off the UI thread.
+        _ = HandleBackAsync();
+        return true;
+    }
+
+    private static void CaptureJsRuntime(IServiceProvider sp, TaskCompletionSource<IJSRuntime?> tcs) =>
+        tcs.TrySetResult(sp.GetService<IJSRuntime>());
+
+    private static void QuitApp() =>
+        MainThread.BeginInvokeOnMainThread(QuitOnMainThread);
+
+    private static void QuitOnMainThread() =>
+        Application.Current?.Quit();
+
+    private async Task HandleBackAsync()
+    {
+        try
+        {
+            // BlazorWebView only exposes the synchronous Action<IServiceProvider> dispatch
+            // overload, so capture the renderer-scoped IJSRuntime through a TaskCompletionSource
+            // and run the async interop work outside the dispatch context.
+            var tcs = new TaskCompletionSource<IJSRuntime?>();
+            var dispatched = await HostWebView.TryDispatchAsync(sp => CaptureJsRuntime(sp, tcs));
+
+            if (!dispatched)
+            {
+                QuitApp();
+                return;
+            }
+
+            var jsRuntime = await tcs.Task;
+            if (jsRuntime is null)
+            {
+                QuitApp();
+                return;
+            }
+
+            var result = await MauiBackNavigationBridge.HandleBackPressedAsync(jsRuntime);
+            if (result.AtRoot)
+            {
+                QuitApp();
+            }
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - the interop failure modes differ per platform and none of them are recoverable here
+        catch
+#pragma warning restore CA1031
+        {
+            // BlazorWebView not yet hydrated or interop failed: exit cleanly.
+            QuitApp();
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
@@ -1,0 +1,104 @@
+using MMCA.Common.UI.Services.Auth;
+
+namespace MMCA.Common.UI.Maui.Services;
+
+/// <summary>
+/// MAUI token storage using <see cref="SecureStorage"/>, which leverages platform-specific
+/// secure enclaves (Android Keystore, iOS Keychain, Windows DPAPI) to protect tokens at rest.
+/// Every call is guarded: the OS invalidates keystore entries on its own schedule (an Android
+/// backup/restore onto a new device, a security patch that rotates the master key, a biometric
+/// enrolment change), and the raw APIs then throw a platform exception instead of returning
+/// nothing. An unhandled throw here bricks the app on launch until it is reinstalled, so a read
+/// failure degrades to "no token stored" (which <see cref="ITokenStorageService"/> already
+/// documents) and drops the unreadable entry, forcing one clean re-login.
+/// <para>
+/// Register with <c>AddCommonMauiTokenStorage()</c>; the browser-host siblings are
+/// <c>WasmTokenStorageService</c> (MMCA.Common.UI) and <c>ServerTokenStorageService</c>
+/// (MMCA.Common.UI.Web).
+/// </para>
+/// </summary>
+public sealed class MauiTokenStorageService : ITokenStorageService
+{
+    private const string AccessTokenKey = "auth_access_token";
+    private const string RefreshTokenKey = "auth_refresh_token";
+
+    /// <inheritdoc />
+    public Task<string?> GetAccessTokenAsync() => GetAsync(AccessTokenKey);
+
+    /// <inheritdoc />
+    public Task<string?> GetRefreshTokenAsync() => GetAsync(RefreshTokenKey);
+
+    /// <inheritdoc />
+    public async Task SetTokensAsync(string accessToken, string refreshToken)
+    {
+        await SetAsync(AccessTokenKey, accessToken);
+        await SetAsync(RefreshTokenKey, refreshToken);
+    }
+
+    /// <inheritdoc />
+    public Task ClearTokensAsync()
+    {
+        // Logout must always succeed: an entry we cannot delete is one the OS already
+        // invalidated, which is the outcome the caller asked for.
+        TryRemove(AccessTokenKey);
+        TryRemove(RefreshTokenKey);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Reads one entry, degrading a corrupt or undecryptable entry to <see langword="null"/> and
+    /// dropping it so the next write starts from a clean key.
+    /// </summary>
+    private static async Task<string?> GetAsync(string key)
+    {
+        try
+        {
+            return await SecureStorage.Default.GetAsync(key);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - the platform exception type differs per OS and none of them are recoverable here
+        catch
+#pragma warning restore CA1031
+        {
+            // No logging facility exists in this host (nothing in the MAUI head takes an ILogger),
+            // so the swallow is documented here rather than reported: the user sees the normal
+            // signed-out state and logs in again.
+            TryRemove(key);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes one entry, retrying once against a freshly removed key. A second failure propagates:
+    /// the caller must never believe a token was persisted when it was not.
+    /// </summary>
+    private static async Task SetAsync(string key, string value)
+    {
+        try
+        {
+            await SecureStorage.Default.SetAsync(key, value);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; the retry below is the recovery
+        catch
+#pragma warning restore CA1031
+        {
+            TryRemove(key);
+            await SecureStorage.Default.SetAsync(key, value);
+        }
+    }
+
+    /// <summary>Best-effort delete of one entry; a delete that itself throws is already the goal.</summary>
+    private static void TryRemove(string key)
+    {
+        try
+        {
+            SecureStorage.Default.Remove(key);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync
+        catch
+#pragma warning restore CA1031
+        {
+            // Nothing left to do: the entry is unreadable and undeletable, and the next
+            // SetAsync overwrites it anyway.
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
@@ -18,6 +18,17 @@
         "resolved": "3.0.133",
         "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
+      "Microsoft.AspNetCore.Components.WebView.Maui": {
+        "type": "Direct",
+        "requested": "[10.0.80, )",
+        "resolved": "10.0.80",
+        "contentHash": "XEz/OJAtjaoyBVZIHim7sbQ20Khs/nwOAFTW9J9eB63Gax2rsoXCnFd6wHR1evKTVFKNxS+pqGgcPBh1fyXYpw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authorization": "10.0.0",
+          "Microsoft.AspNetCore.Components.WebView": "10.0.0",
+          "Microsoft.JSInterop": "10.0.0"
+        }
+      },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
         "requested": "[10.0.80, )",
@@ -165,6 +176,19 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.10",
           "Microsoft.Extensions.Validation": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Components.WebView": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "fdBlMj2W0Kv5qIsUKotipoaCUQT1LgWc9QVbS0dJpiFL5UWytp6JvKrB71dj6tuqCZwb2VpcKyIj6uQWfG5VLw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Composite": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions": {
@@ -376,6 +400,18 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -425,6 +461,38 @@
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "Microsoft.Extensions.FileProviders.Composite": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "oi6UKOtboSHd/sQRgiPN5BXMGHUWyBmgu/nC/khs+eJYdeitciqW7MWIvs9sZIG1rOTH2cuLjMu9VeK4bL0Jvg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Embedded": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "ECaTMB4NdV9W1es9J6tN0yoXRPUHKMi5+2L7hcVZ5k9zVdxccIx6+vMllwEYcdTaO0mCETEmdH4F0KxCqgnPaw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -1747,6 +1815,18 @@
           "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.Http": {
         "type": "CentralTransitive",
         "requested": "[10.0.10, )",
@@ -1853,6 +1933,17 @@
         "requested": "[3.0.133, )",
         "resolved": "3.0.133",
         "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+      },
+      "Microsoft.AspNetCore.Components.WebView.Maui": {
+        "type": "Direct",
+        "requested": "[10.0.80, )",
+        "resolved": "10.0.80",
+        "contentHash": "XEz/OJAtjaoyBVZIHim7sbQ20Khs/nwOAFTW9J9eB63Gax2rsoXCnFd6wHR1evKTVFKNxS+pqGgcPBh1fyXYpw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authorization": "10.0.0",
+          "Microsoft.AspNetCore.Components.WebView": "10.0.0",
+          "Microsoft.JSInterop": "10.0.0"
+        }
       },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
@@ -1984,6 +2075,19 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.10",
           "Microsoft.Extensions.Validation": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Components.WebView": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "fdBlMj2W0Kv5qIsUKotipoaCUQT1LgWc9QVbS0dJpiFL5UWytp6JvKrB71dj6tuqCZwb2VpcKyIj6uQWfG5VLw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Composite": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions": {
@@ -2195,6 +2299,18 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -2244,6 +2360,38 @@
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "Microsoft.Extensions.FileProviders.Composite": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "oi6UKOtboSHd/sQRgiPN5BXMGHUWyBmgu/nC/khs+eJYdeitciqW7MWIvs9sZIG1rOTH2cuLjMu9VeK4bL0Jvg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Embedded": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "ECaTMB4NdV9W1es9J6tN0yoXRPUHKMi5+2L7hcVZ5k9zVdxccIx6+vMllwEYcdTaO0mCETEmdH4F0KxCqgnPaw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -2524,6 +2672,18 @@
         "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Http": {
@@ -2633,6 +2793,17 @@
         "resolved": "3.0.133",
         "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
       },
+      "Microsoft.AspNetCore.Components.WebView.Maui": {
+        "type": "Direct",
+        "requested": "[10.0.80, )",
+        "resolved": "10.0.80",
+        "contentHash": "XEz/OJAtjaoyBVZIHim7sbQ20Khs/nwOAFTW9J9eB63Gax2rsoXCnFd6wHR1evKTVFKNxS+pqGgcPBh1fyXYpw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authorization": "10.0.0",
+          "Microsoft.AspNetCore.Components.WebView": "10.0.0",
+          "Microsoft.JSInterop": "10.0.0"
+        }
+      },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
         "requested": "[10.0.80, )",
@@ -2763,6 +2934,19 @@
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.10",
           "Microsoft.Extensions.Validation": "10.0.10"
+        }
+      },
+      "Microsoft.AspNetCore.Components.WebView": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "fdBlMj2W0Kv5qIsUKotipoaCUQT1LgWc9QVbS0dJpiFL5UWytp6JvKrB71dj6tuqCZwb2VpcKyIj6uQWfG5VLw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Composite": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions": {
@@ -2974,6 +3158,18 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -3023,6 +3219,38 @@
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "Microsoft.Extensions.FileProviders.Composite": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "oi6UKOtboSHd/sQRgiPN5BXMGHUWyBmgu/nC/khs+eJYdeitciqW7MWIvs9sZIG1rOTH2cuLjMu9VeK4bL0Jvg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Embedded": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "ECaTMB4NdV9W1es9J6tN0yoXRPUHKMi5+2L7hcVZ5k9zVdxccIx6+vMllwEYcdTaO0mCETEmdH4F0KxCqgnPaw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -3305,6 +3533,18 @@
           "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.Http": {
         "type": "CentralTransitive",
         "requested": "[10.0.10, )",
@@ -3411,6 +3651,17 @@
         "requested": "[3.0.133, )",
         "resolved": "3.0.133",
         "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+      },
+      "Microsoft.AspNetCore.Components.WebView.Maui": {
+        "type": "Direct",
+        "requested": "[10.0.80, )",
+        "resolved": "10.0.80",
+        "contentHash": "XEz/OJAtjaoyBVZIHim7sbQ20Khs/nwOAFTW9J9eB63Gax2rsoXCnFd6wHR1evKTVFKNxS+pqGgcPBh1fyXYpw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authorization": "10.0.0",
+          "Microsoft.AspNetCore.Components.WebView": "10.0.0",
+          "Microsoft.JSInterop": "10.0.0"
+        }
       },
       "Microsoft.Maui.Controls": {
         "type": "Direct",
@@ -3541,6 +3792,19 @@
           "Microsoft.Extensions.Validation": "10.0.10"
         }
       },
+      "Microsoft.AspNetCore.Components.WebView": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "fdBlMj2W0Kv5qIsUKotipoaCUQT1LgWc9QVbS0dJpiFL5UWytp6JvKrB71dj6tuqCZwb2VpcKyIj6uQWfG5VLw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Components.Web": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Composite": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Embedded": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
       "Microsoft.AspNetCore.Connections.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -3750,6 +4014,18 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -3799,6 +4075,38 @@
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
+      },
+      "Microsoft.Extensions.FileProviders.Composite": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "oi6UKOtboSHd/sQRgiPN5BXMGHUWyBmgu/nC/khs+eJYdeitciqW7MWIvs9sZIG1rOTH2cuLjMu9VeK4bL0Jvg==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Embedded": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "ECaTMB4NdV9W1es9J6tN0yoXRPUHKMi5+2L7hcVZ5k9zVdxccIx6+vMllwEYcdTaO0mCETEmdH4F0KxCqgnPaw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -4243,6 +4551,18 @@
         "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Shared.Resilience;
+using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Globalization;
 using MMCA.Common.UI.Services;
@@ -129,6 +130,36 @@ public static class DependencyInjection
         /// </summary>
         public IServiceCollection AddWasmFormFactor() =>
             services.AddSingleton<IFormFactor, WasmFormFactor>();
+
+        /// <summary>
+        /// Registers one UI module: the Scrutor scan that picks up every
+        /// <see cref="IEntityService{TEntityDTO, TIdentifierType}"/> implementation in
+        /// <typeparamref name="TModule"/>'s assembly, plus the module descriptor itself (nav items,
+        /// app-bar and layout components, and the assembly the router adds to
+        /// <c>AdditionalAssemblies</c>).
+        /// <para>
+        /// This is the two-step prologue every module's own <c>Add{Module}UI()</c> opens with;
+        /// calling it removes the copy of the scan from each of them. Module-specific services
+        /// (lookup services, state containers, custom contracts) are registered by the caller
+        /// afterwards, so a module whose services must win over a shared default still controls
+        /// its own registration order.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TModule">
+        /// The module descriptor type. Its assembly is the scan root, so it must live alongside the
+        /// module's entity services and Razor pages.
+        /// </typeparam>
+        public IServiceCollection AddUIModule<TModule>()
+            where TModule : class, IUIModule
+        {
+            services.Scan(scan => scan
+                .FromAssemblyOf<TModule>()
+                .AddClasses(classes => classes.AssignableTo(typeof(IEntityService<,>)))
+                .AsImplementedInterfaces()
+                .WithScopedLifetime());
+
+            return services.AddSingleton<IUIModule, TModule>();
+        }
     }
 }
 

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/ModuleConformanceTestsBaseTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/ModuleConformanceTestsBaseTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.Application.Modules;
+using MMCA.Common.Application.Settings;
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// A leaf module fixture: it overrides neither <c>Dependencies</c> nor <c>RequiresDependencies</c>, so the
+/// conformance base can only read them by dispatching to <c>IModule</c>'s DEFAULT implementations. That is
+/// the behaviour the hand-written consumer tests needed an explicit <c>(IModule)</c> cast for, and the one
+/// thing that would break silently across the package boundary.
+/// </summary>
+public sealed class FakeLeafModule : IModule
+{
+    public string Name => "FakeLeaf";
+
+    public void Register(IServiceCollection services, IConfigurationBuilder configuration, ApplicationSettings applicationSettings)
+    {
+    }
+}
+
+/// <summary>Cross-module export contract used to prove the disabled-stub hook reaches the real container.</summary>
+public interface IFakeExportService;
+
+/// <summary>The stub a disabled <see cref="FakeDependentModule"/> leaves behind.</summary>
+public sealed class DisabledFakeExportService : IFakeExportService;
+
+/// <summary>A dependent module fixture: declares dependencies, requires them, and registers a disabled stub.</summary>
+public sealed class FakeDependentModule : IModule
+{
+    public string Name => "FakeDependent";
+
+    public IReadOnlyList<string> Dependencies => ["FakeLeaf", "FakeOther"];
+
+    public bool RequiresDependencies => true;
+
+    public void Register(IServiceCollection services, IConfigurationBuilder configuration, ApplicationSettings applicationSettings)
+    {
+    }
+
+    public void RegisterDisabledStubs(IServiceCollection services) =>
+        services.AddSingleton<IFakeExportService, DisabledFakeExportService>();
+}
+
+/// <summary>
+/// Runs the shared <see cref="ModuleConformanceTestsBase{TModule}"/> against a leaf module, i.e. exactly the
+/// subclass shape the three byte-identical consumer <c>{X}ModuleTests</c> files collapse into.
+/// </summary>
+public sealed class FakeLeafModuleConformanceTests : ModuleConformanceTestsBase<FakeLeafModule>
+{
+    protected override string ExpectedName => "FakeLeaf";
+}
+
+/// <summary>
+/// Runs the shared base against a module that declares dependencies, requires them, and exports a stub,
+/// i.e. the two consumer subclasses (Store Sales, ADC Notification) that are not leaves.
+/// </summary>
+public sealed class FakeDependentModuleConformanceTests : ModuleConformanceTestsBase<FakeDependentModule>
+{
+    protected override string ExpectedName => "FakeDependent";
+
+    protected override IReadOnlyCollection<string> ExpectedDependencies => ["FakeOther", "FakeLeaf"];
+
+    protected override bool ExpectedRequiresDependencies => true;
+
+    protected override void AssertDisabledStubs(FakeDependentModule module)
+    {
+        var services = new ServiceCollection();
+
+        module.RegisterDisabledStubs(services);
+
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IFakeExportService));
+        descriptor.Should().NotBeNull();
+        descriptor.ImplementationType.Should().Be<DisabledFakeExportService>();
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
+    }
+}
+
+/// <summary>
+/// Adversarial coverage for the shared base itself: each assertion must actually FAIL on the drift it
+/// claims to catch. The drifted subclasses are private so xUnit does not collect their inherited facts as
+/// (deliberately failing) tests of their own.
+/// </summary>
+public class ModuleConformanceTestsBaseTests
+{
+    [Fact]
+    public void Base_Fails_WhenTheNameDrifts()
+    {
+        var assert = new DriftedTests().Module_ShouldDeclare_ExpectedName;
+
+        assert.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void Base_Fails_WhenADependencyIsMissing()
+    {
+        var assert = new DriftedTests().Module_ShouldDeclare_ExpectedDependencies;
+
+        assert.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void Base_Fails_WhenRequiresDependenciesDrifts()
+    {
+        var assert = new DriftedTests().Module_ShouldDeclare_ExpectedRequiresDependencies;
+
+        assert.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void Base_ReadsDefaultInterfaceImplementations_ForALeafModule()
+    {
+        // The leaf fixture declares neither member, so passing here proves the base reached IModule's
+        // defaults rather than the (absent) members on the concrete type.
+        var conformance = new FakeLeafModuleConformanceTests();
+
+        conformance.Module_ShouldDeclare_ExpectedDependencies();
+        conformance.Module_ShouldDeclare_ExpectedRequiresDependencies();
+    }
+
+    [Fact]
+    public void Base_DisabledStubHook_IsVacuous_ByDefault()
+    {
+        var assert = new FakeLeafModuleConformanceTests().Module_ShouldRegister_ExpectedDisabledStubs;
+
+        assert.Should().NotThrow();
+    }
+
+    private sealed class DriftedTests : ModuleConformanceTestsBase<FakeDependentModule>
+    {
+        protected override string ExpectedName => "NotTheDeclaredName";
+
+        protected override IReadOnlyCollection<string> ExpectedDependencies => ["FakeLeaf"];
+
+        protected override bool ExpectedRequiresDependencies => false;
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/EntityQueryServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using AwesomeAssertions;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -456,5 +457,138 @@ public sealed class EntityQueryServiceTests
         metadata.TotalItemCount.Should().Be(0);
         metadata.PageSize.Should().Be(0);
         metadata.CurrentPage.Should().Be(1);
+    }
+
+    // ── GetAllForLookupAsync forwards its predicate ──
+    // Regression guard: the `where` argument used to be accepted and then dropped, so every
+    // caller got the unfiltered lookup list and had to route around the service.
+    private static Mock<IReadRepository<FakeEntity, int>> CreateLookupRepositoryOver(params FakeEntity[] rows)
+    {
+        var repository = new Mock<IReadRepository<FakeEntity, int>>();
+        repository
+            .Setup(x => x.GetAllForLookupAsync(
+                It.IsAny<string>(),
+                It.IsAny<Expression<Func<FakeEntity, bool>>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((
+                string nameProperty,
+                Expression<Func<FakeEntity, bool>>? where,
+                bool asTracking,
+                CancellationToken cancellationToken) =>
+            {
+                // Mirrors EFReadRepository.GetAllForLookupAsync: the predicate narrows the
+                // query before the id/name projection is applied.
+                IEnumerable<FakeEntity> matched = where is null ? rows : rows.Where(where.Compile());
+
+                IReadOnlyCollection<BaseLookup<int>> lookups =
+                [
+                    .. matched
+                        .Select(e => new BaseLookup<int> { Id = e.Id, Name = e.Name })
+                        .OrderBy(l => l.Name, StringComparer.Ordinal)
+                ];
+
+                return lookups;
+            });
+
+        return repository;
+    }
+
+    private static EntityQueryService<FakeEntity, FakeEntityDTO, int> CreateLookupSut(
+        Mock<IReadRepository<FakeEntity, int>> repository)
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork.Setup(x => x.GetReadRepository<FakeEntity, int>()).Returns(repository.Object);
+
+        return new EntityQueryService<FakeEntity, FakeEntityDTO, int>(
+            unitOfWork.Object,
+            Mock.Of<INavigationMetadataProvider>(),
+            Mock.Of<IEntityQueryPipeline>(),
+            Mock.Of<IEntityDTOMapper<FakeEntity, FakeEntityDTO, int>>(),
+            Mock.Of<INavigationPopulator<FakeEntity>>());
+    }
+
+    [Fact]
+    public async Task GetAllForLookupAsync_WithPredicate_FiltersTheLookupRows()
+    {
+        var repository = CreateLookupRepositoryOver(
+            new FakeEntity { Id = 1, Name = "Alpha" },
+            new FakeEntity { Id = 2, Name = "Beta" },
+            new FakeEntity { Id = 3, Name = "Gamma" });
+
+        var sut = CreateLookupSut(repository);
+
+        Expression<Func<FakeEntity, bool>> where = e => e.Id != 2;
+
+        var result = await sut.GetAllForLookupAsync(nameof(FakeEntity.Name), where);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Should().HaveCount(2);
+        result.Value!.Should().Contain(l => l.Id == 1);
+        result.Value!.Should().Contain(l => l.Id == 3);
+        result.Value!.Should().NotContain(l => l.Name == "Beta");
+    }
+
+    [Fact]
+    public async Task GetAllForLookupAsync_WithPredicate_PassesTheSameExpressionToTheRepository()
+    {
+        var repository = CreateLookupRepositoryOver(new FakeEntity { Id = 1, Name = "Alpha" });
+        var sut = CreateLookupSut(repository);
+
+        Expression<Func<FakeEntity, bool>> where = e => e.Id == 1;
+
+        await sut.GetAllForLookupAsync(nameof(FakeEntity.Name), where, asTracking: true);
+
+        repository.Verify(
+            x => x.GetAllForLookupAsync(
+                nameof(FakeEntity.Name),
+                where,
+                true,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllForLookupAsync_WithoutPredicate_ReturnsEveryRow()
+    {
+        var repository = CreateLookupRepositoryOver(
+            new FakeEntity { Id = 1, Name = "Alpha" },
+            new FakeEntity { Id = 2, Name = "Beta" });
+
+        var sut = CreateLookupSut(repository);
+
+        var result = await sut.GetAllForLookupAsync(nameof(FakeEntity.Name));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Should().HaveCount(2);
+
+        repository.Verify(
+            x => x.GetAllForLookupAsync(
+                nameof(FakeEntity.Name),
+                null,
+                false,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllForLookupAsync_WithUnknownNameProperty_FailsBeforeTouchingTheRepository()
+    {
+        var repository = CreateLookupRepositoryOver(new FakeEntity { Id = 1, Name = "Alpha" });
+        var sut = CreateLookupSut(repository);
+
+        var result = await sut.GetAllForLookupAsync("NoSuchProperty", e => e.Id == 1);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Source.Should().Be(nameof(EntityQueryService<,,>.GetAllForLookupAsync));
+        result.Errors[0].Target.Should().Be(nameof(FakeEntity));
+
+        repository.Verify(
+            x => x.GetAllForLookupAsync(
+                It.IsAny<string>(),
+                It.IsAny<Expression<Func<FakeEntity, bool>>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/ChangePasswordHandlerBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/ChangePasswordHandlerBaseTests.cs
@@ -1,0 +1,124 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Users.UseCases.ChangePassword;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the shared password-change workflow (ADR-032): verify-before-write ordering, the
+/// no-save-on-invariant-failure rule, and the error payload the app handlers reported before the hoist.
+/// </summary>
+public sealed class ChangePasswordHandlerBaseTests
+{
+    private static readonly byte[] NewHash = [7, 7, 7];
+    private static readonly byte[] NewSalt = [8, 8, 8];
+
+    [Fact]
+    public async Task HandleAsync_WhenUserMissing_ReturnsNotFoundWithHandlerSourceAndEntityTarget()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(404, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestIdentityUser?)null);
+
+        Result result = await sut.HandleAsync(new TestChangePasswordCommand(404, new ChangePasswordRequest("old", "new")));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Type == ErrorType.NotFound
+            && e.Source == nameof(TestChangePasswordHandler)
+            && e.Target == nameof(TestIdentityUser));
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCurrentPasswordWrong_ReturnsUnauthorizedWithoutHashingOrSaving()
+    {
+        var (sut, mocks) = CreateSut();
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+        mocks.PasswordHasher
+            .Setup(x => x.VerifyPassword(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<byte[]>()))
+            .Returns(false);
+
+        Result result = await sut.HandleAsync(new TestChangePasswordCommand(1, new ChangePasswordRequest("wrong", "new")));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Code == "Auth.InvalidCurrentPassword" && e.Type == ErrorType.Unauthorized);
+        mocks.PasswordHasher.Verify(x => x.HashPassword(It.IsAny<string>()), Times.Never);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCurrentPasswordCorrect_WritesNewMaterialAndSaves()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestIdentityUser { Id = 1 };
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestChangePasswordCommand(1, new ChangePasswordRequest("old", "new")));
+
+        result.IsSuccess.Should().BeTrue();
+        user.PasswordHash.Should().BeEquivalentTo(NewHash);
+        user.PasswordSalt.Should().BeEquivalentTo(NewSalt);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAggregateRejectsChange_ReturnsFailureWithoutSaving()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestIdentityUser
+        {
+            Id = 1,
+            ForcedFailure = Error.Invariant("User.PasswordReused", "New password must differ."),
+        };
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestChangePasswordCommand(1, new ChangePasswordRequest("old", "new")));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "User.PasswordReused");
+        mocks.UnitOfWork.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an invariant failure must not persist");
+    }
+
+    private static void ArrangeUser(HandlerMocks mocks, TestIdentityUser user) =>
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+    private sealed record HandlerMocks(
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IRepository<TestIdentityUser, UserIdentifierType>> Repository,
+        Mock<IPasswordHasher> PasswordHasher);
+
+    private static (TestChangePasswordHandler Sut, HandlerMocks Mocks) CreateSut()
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<TestIdentityUser, UserIdentifierType>>();
+        var passwordHasher = new Mock<IPasswordHasher>();
+
+        unitOfWork.Setup(x => x.GetRepository<TestIdentityUser, UserIdentifierType>()).Returns(repository.Object);
+        unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        passwordHasher
+            .Setup(x => x.VerifyPassword(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<byte[]>()))
+            .Returns(true);
+        passwordHasher.Setup(x => x.HashPassword(It.IsAny<string>())).Returns((NewHash, NewSalt));
+
+        var sut = new TestChangePasswordHandler(unitOfWork.Object, passwordHasher.Object);
+        return (sut, new HandlerMocks(unitOfWork, repository, passwordHasher));
+    }
+}
+
+/// <summary>Concrete subclass standing in for an app's <c>ChangePasswordHandler</c>.</summary>
+public sealed class TestChangePasswordHandler(IUnitOfWork unitOfWork, IPasswordHasher passwordHasher)
+    : ChangePasswordHandlerBase<TestIdentityUser, TestChangePasswordCommand>(
+        unitOfWork, passwordHasher, NullLogger.Instance);

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/ChangePreferencesHandlerBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/ChangePreferencesHandlerBaseTests.cs
@@ -1,0 +1,109 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Users.UseCases.ChangePreferences;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the shared preference-write workflow (ADR-027 / ADR-028), above all the partial-update
+/// rule: a null field falls back to the stored value, so the culture switcher and the theme toggle
+/// never clobber each other.
+/// </summary>
+public sealed class ChangePreferencesHandlerBaseTests
+{
+    [Fact]
+    public async Task HandleAsync_WhenUserMissing_ReturnsNotFoundWithoutSaving()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(404, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestIdentityUser?)null);
+
+        Result result = await sut.HandleAsync(new TestChangePreferencesCommand(404, new ChangePreferencesRequest("es", null)));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Type == ErrorType.NotFound
+            && e.Source == nameof(TestChangePreferencesHandler)
+            && e.Target == nameof(TestIdentityUser));
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOnlyCultureSupplied_KeepsStoredTheme()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestIdentityUser { Id = 1 };
+        user.SeedPreferences("en", "dark");
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestChangePreferencesCommand(1, new ChangePreferencesRequest("es", null)));
+
+        result.IsSuccess.Should().BeTrue();
+        user.PreferredCulture.Should().Be("es");
+        user.PreferredTheme.Should().Be("dark", "a null request field leaves that preference unchanged");
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOnlyThemeSupplied_KeepsStoredCulture()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestIdentityUser { Id = 1 };
+        user.SeedPreferences("es", "light");
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestChangePreferencesCommand(1, new ChangePreferencesRequest(null, "dark")));
+
+        result.IsSuccess.Should().BeTrue();
+        user.PreferredCulture.Should().Be("es");
+        user.PreferredTheme.Should().Be("dark");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAggregateRejectsUpdate_ReturnsFailureWithoutSaving()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestIdentityUser
+        {
+            Id = 1,
+            ForcedFailure = Error.Invariant("User.PreferredCulture.Invalid", "Culture is not supported."),
+        };
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestChangePreferencesCommand(1, new ChangePreferencesRequest("zz", null)));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "User.PreferredCulture.Invalid");
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static void ArrangeUser(HandlerMocks mocks, TestIdentityUser user) =>
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+    private sealed record HandlerMocks(
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IRepository<TestIdentityUser, UserIdentifierType>> Repository);
+
+    private static (TestChangePreferencesHandler Sut, HandlerMocks Mocks) CreateSut()
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<TestIdentityUser, UserIdentifierType>>();
+
+        unitOfWork.Setup(x => x.GetRepository<TestIdentityUser, UserIdentifierType>()).Returns(repository.Object);
+        unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var sut = new TestChangePreferencesHandler(unitOfWork.Object);
+        return (sut, new HandlerMocks(unitOfWork, repository));
+    }
+}
+
+/// <summary>Concrete subclass standing in for an app's <c>ChangePreferencesHandler</c>.</summary>
+public sealed class TestChangePreferencesHandler(IUnitOfWork unitOfWork)
+    : ChangePreferencesHandlerBase<TestIdentityUser, TestChangePreferencesCommand>(unitOfWork, NullLogger.Instance);

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/DeleteUserHandlerBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/DeleteUserHandlerBaseTests.cs
@@ -1,0 +1,234 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Users.UseCases.DeleteUser;
+using MMCA.Common.Shared.Abstractions;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the shared account-erasure workflow: the owner-or-privileged-role gate, the
+/// delete-then-anonymize-then-save ordering, the app tail hook, and the post-commit queue.
+/// </summary>
+public sealed class DeleteUserHandlerBaseTests
+{
+    private const string PrivilegedRole = "Organizer";
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNeitherOwnerNorPrivileged_ReturnsForbiddenWithoutFetching()
+    {
+        var (sut, mocks) = CreateSut();
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 2, "Attendee"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Code == "User.DeleteForbidden"
+            && e.Type == ErrorType.Forbidden
+            && e.Source == nameof(TestDeleteUserHandler)
+            && e.Target == "UserId");
+        mocks.Repository.Verify(
+            x => x.GetByIdAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerHoldsPrivilegedRole_ErasesAnotherAccount()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 2, PrivilegedRole));
+
+        result.IsSuccess.Should().BeTrue();
+        user.IsDeleted.Should().BeTrue();
+        user.AnonymizeCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserMissing_ReturnsNotFoundWithoutSaving()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(404, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestHidingDeleteUser?)null);
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 404, CurrentUserId: 404, null));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Type == ErrorType.NotFound && e.Target == nameof(TestHidingDeleteUser));
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_CallsTheAggregatesOwnDeleteEvenWhenItHidesTheBaseMethod()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        user.UpdateRefreshToken("outstanding", DateTime.UtcNow.AddDays(1));
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsSuccess.Should().BeTrue();
+        user.HidingDeleteCalled.Should().BeTrue(
+            "IErasableUser re-maps the interface onto the aggregate's own hiding Delete()");
+        user.RevokeCalled.Should().BeTrue("the app couples refresh-token revocation to deletion");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAlreadyDeleted_ReturnsAlreadyDeletedBeforeRunningTheAppTail()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        user.Delete();
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsFailure.Should().BeTrue();
+        sut.TailInvocations.Should().Be(0, "an already-deleted account fails on its own error, not a cascaded one");
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAppTailFails_AbortsBeforeAnonymizingOrSaving()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        ArrangeUser(mocks, user);
+        sut.TailResult = Result.Failure(Error.Invariant("Customer.AlreadyDeleted", "Linked profile already deleted."));
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "Customer.AlreadyDeleted");
+        user.AnonymizeCalled.Should().BeFalse();
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RunsTheAppTailBeforeAnonymizeSoItStillSeesPersonalData()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        ArrangeUser(mocks, user);
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsSuccess.Should().BeTrue();
+        sut.TailSawAnonymizedUser.Should().BeFalse();
+        sut.TailSawDeletedUser.Should().BeTrue("the tail runs after the soft-delete and before the erasure");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAnonymizeFails_DoesNotSave()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        ArrangeUser(mocks, user);
+        sut.OnTail = () => user.ForcedFailure = Error.Invariant("User.Anonymize.Invalid", "Placeholder email invalid.");
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "User.Anonymize.Invalid");
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_RunsPostCommitActionsInOrderOnlyAfterTheSave()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestHidingDeleteUser { Id = 1 };
+        ArrangeUser(mocks, user);
+
+        var trace = new List<string>();
+        mocks.UnitOfWork
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1)
+            .Callback(() => trace.Add("save"));
+        sut.PostCommitActions =
+        [
+            _ => TraceAsync(trace, "marker"),
+            _ => TraceAsync(trace, "blob"),
+        ];
+
+        Result result = await sut.HandleAsync(new TestDeleteUserCommand(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsSuccess.Should().BeTrue();
+        trace.Should().Equal("save", "marker", "blob");
+    }
+
+    private static Task TraceAsync(List<string> trace, string entry)
+    {
+        trace.Add(entry);
+        return Task.CompletedTask;
+    }
+
+    private static void ArrangeUser(HandlerMocks mocks, TestHidingDeleteUser user) =>
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+    private sealed record HandlerMocks(
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IRepository<TestHidingDeleteUser, UserIdentifierType>> Repository);
+
+    private static (TestDeleteUserHandler Sut, HandlerMocks Mocks) CreateSut()
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<TestHidingDeleteUser, UserIdentifierType>>();
+
+        unitOfWork.Setup(x => x.GetRepository<TestHidingDeleteUser, UserIdentifierType>()).Returns(repository.Object);
+        unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        var sut = new TestDeleteUserHandler(unitOfWork.Object);
+        return (sut, new HandlerMocks(unitOfWork, repository));
+    }
+}
+
+/// <summary>Concrete subclass standing in for an app's <c>DeleteUserHandler</c> plus its erasure tail.</summary>
+public sealed class TestDeleteUserHandler(IUnitOfWork unitOfWork)
+    : DeleteUserHandlerBase<TestHidingDeleteUser, TestDeleteUserCommand>(unitOfWork, NullLogger.Instance)
+{
+    public int TailInvocations { get; private set; }
+
+    public bool TailSawDeletedUser { get; private set; }
+
+    public bool TailSawAnonymizedUser { get; private set; }
+
+    public Result TailResult { get; set; } = Result.Success();
+
+    public Action? OnTail { get; set; }
+
+    public IReadOnlyList<Func<CancellationToken, Task>> PostCommitActions { get; set; } = [];
+
+    protected override bool HasDeletePrivilege(string? currentUserRole) =>
+        string.Equals(currentUserRole, "Organizer", StringComparison.OrdinalIgnoreCase);
+
+    protected override Task<Result> OnAfterSoftDeleteAsync(
+        TestHidingDeleteUser user,
+        TestDeleteUserCommand command,
+        ICollection<Func<CancellationToken, Task>> afterCommit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(afterCommit);
+
+        TailInvocations++;
+        TailSawDeletedUser = user.IsDeleted;
+        TailSawAnonymizedUser = user.AnonymizeCalled;
+        OnTail?.Invoke();
+
+        foreach (var action in PostCommitActions)
+        {
+            afterCommit.Add(action);
+        }
+
+        return Task.FromResult(TailResult);
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/GetUserPreferencesHandlerBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/GetUserPreferencesHandlerBaseTests.cs
@@ -1,0 +1,88 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Users.UseCases.GetPreferences;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the shared preference-read workflow (ADR-027 / ADR-028), including the read-path choice:
+/// the query resolves the READ repository, never the write repository.
+/// </summary>
+public sealed class GetUserPreferencesHandlerBaseTests
+{
+    [Fact]
+    public async Task HandleAsync_WhenUserMissing_ReturnsNotFoundWithHandlerSourceAndEntityTarget()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.ReadRepository
+            .Setup(x => x.GetByIdAsync(404, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestIdentityUser?)null);
+
+        Result<UserPreferencesResponse> result = await sut.HandleAsync(new GetUserPreferencesQuery(404));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Type == ErrorType.NotFound
+            && e.Source == nameof(TestGetUserPreferencesHandler)
+            && e.Target == nameof(TestIdentityUser));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserExists_ProjectsStoredPreferences()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = new TestIdentityUser { Id = 1 };
+        user.SeedPreferences("es", "dark");
+        mocks.ReadRepository
+            .Setup(x => x.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        Result<UserPreferencesResponse> result = await sut.HandleAsync(new GetUserPreferencesQuery(1));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Culture.Should().Be("es");
+        result.Value.Theme.Should().Be("dark");
+    }
+
+    [Fact]
+    public async Task HandleAsync_UsesReadRepositoryNotWriteRepository()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.ReadRepository
+            .Setup(x => x.GetByIdAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestIdentityUser { Id = 1 });
+
+        await sut.HandleAsync(new GetUserPreferencesQuery(1));
+
+        mocks.UnitOfWork.Verify(
+            x => x.GetReadRepository<TestIdentityUser, UserIdentifierType>(),
+            Times.Once,
+            "a query handler never saves, so it takes the read path");
+        mocks.UnitOfWork.Verify(
+            x => x.GetRepository<TestIdentityUser, UserIdentifierType>(),
+            Times.Never);
+    }
+
+    private sealed record HandlerMocks(
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IReadRepository<TestIdentityUser, UserIdentifierType>> ReadRepository);
+
+    private static (TestGetUserPreferencesHandler Sut, HandlerMocks Mocks) CreateSut()
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var readRepository = new Mock<IReadRepository<TestIdentityUser, UserIdentifierType>>();
+
+        unitOfWork.Setup(x => x.GetReadRepository<TestIdentityUser, UserIdentifierType>()).Returns(readRepository.Object);
+
+        var sut = new TestGetUserPreferencesHandler(unitOfWork.Object);
+        return (sut, new HandlerMocks(unitOfWork, readRepository));
+    }
+}
+
+/// <summary>Concrete subclass standing in for an app's <c>GetUserPreferencesHandler</c>.</summary>
+public sealed class TestGetUserPreferencesHandler(IUnitOfWork unitOfWork)
+    : GetUserPreferencesHandlerBase<TestIdentityUser>(unitOfWork);

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/SoftDeletedUserValidatorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/SoftDeletedUserValidatorTests.cs
@@ -1,0 +1,85 @@
+using System.Linq.Expressions;
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Users;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the generic soft-deleted user check (BR-133): one query, filters bypassed, matching only
+/// rows that exist AND are soft-deleted.
+/// </summary>
+public sealed class SoftDeletedUserValidatorTests
+{
+    [Fact]
+    public async Task IsUserSoftDeletedAsync_QueriesOnceWithQueryFiltersIgnored()
+    {
+        var (sut, repository) = CreateSut(exists: true);
+
+        var isDeleted = await sut.IsUserSoftDeletedAsync(42);
+
+        isDeleted.Should().BeTrue();
+        repository.Verify(
+            x => x.ExistsAsync(
+                It.IsAny<Expression<Func<TestIdentityUser, bool>>>(),
+                true,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the soft-delete global query filter has to be bypassed to see the deleted row");
+    }
+
+    [Fact]
+    public async Task IsUserSoftDeletedAsync_WhenNoMatchingRow_ReturnsFalse()
+    {
+        var (sut, _) = CreateSut(exists: false);
+
+        var isDeleted = await sut.IsUserSoftDeletedAsync(42);
+
+        isDeleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsUserSoftDeletedAsync_PredicateMatchesOnlyTheDeletedTargetRow()
+    {
+        Expression<Func<TestIdentityUser, bool>>? captured = null;
+        var (sut, repository) = CreateSut(exists: true);
+        repository
+            .Setup(x => x.ExistsAsync(
+                It.IsAny<Expression<Func<TestIdentityUser, bool>>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((Expression<Func<TestIdentityUser, bool>> where, bool _, CancellationToken _) => captured = where)
+            .ReturnsAsync(true);
+
+        await sut.IsUserSoftDeletedAsync(42);
+
+        captured.Should().NotBeNull();
+        var predicate = captured!.Compile();
+        var deletedTarget = new TestIdentityUser { Id = 42 };
+        deletedTarget.Delete();
+        predicate(deletedTarget).Should().BeTrue();
+        predicate(new TestIdentityUser { Id = 42 }).Should().BeFalse("a live account is not soft-deleted");
+
+        var otherDeleted = new TestIdentityUser { Id = 43 };
+        otherDeleted.Delete();
+        predicate(otherDeleted).Should().BeFalse("another user's deleted row must not match");
+    }
+
+    private static (SoftDeletedUserValidator<TestIdentityUser> Sut, Mock<IRepository<TestIdentityUser, UserIdentifierType>> Repository)
+        CreateSut(bool exists)
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<TestIdentityUser, UserIdentifierType>>();
+
+        unitOfWork.Setup(x => x.GetRepository<TestIdentityUser, UserIdentifierType>()).Returns(repository.Object);
+        repository
+            .Setup(x => x.ExistsAsync(
+                It.IsAny<Expression<Func<TestIdentityUser, bool>>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(exists);
+
+        return (new SoftDeletedUserValidator<TestIdentityUser>(unitOfWork.Object), repository);
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/UserOwnershipRuleTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/UserOwnershipRuleTests.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Users;
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the shared self-service authorization rule the account-deletion and data-export use
+/// cases both apply (it was written out four times across the two apps before the hoist).
+/// </summary>
+public sealed class UserOwnershipRuleTests
+{
+    [Fact]
+    public void CheckOwnership_WhenCallerIsOwner_Allows()
+    {
+        var error = Check(userId: 7, currentUserId: 7, callerHasPrivilegedRole: false);
+
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public void CheckOwnership_WhenCallerIsPrivileged_Allows()
+    {
+        var error = Check(userId: 7, currentUserId: 9, callerHasPrivilegedRole: true);
+
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public void CheckOwnership_WhenCallerIsNeither_ReturnsForbiddenWithSuppliedPayload()
+    {
+        var error = Check(userId: 7, currentUserId: 9, callerHasPrivilegedRole: false);
+
+        error.Should().NotBeNull();
+        error!.Type.Should().Be(ErrorType.Forbidden);
+        error.Code.Should().Be("User.ExportForbidden");
+        error.Message.Should().Be("You can only export your own account data.");
+        error.Source.Should().Be("ExportUserDataHandler");
+        error.Target.Should().Be("UserId");
+    }
+
+    [Fact]
+    public void CheckOwnership_WhenRequestIsNull_Throws()
+    {
+        var act = () => UserOwnershipRule.CheckOwnership(null!, false, "c", "m", "s");
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static Error? Check(
+        UserIdentifierType userId,
+        UserIdentifierType currentUserId,
+        bool callerHasPrivilegedRole) =>
+        UserOwnershipRule.CheckOwnership(
+            new TestDeleteUserCommand(userId, currentUserId, "Attendee"),
+            callerHasPrivilegedRole,
+            code: "User.ExportForbidden",
+            message: "You can only export your own account data.",
+            source: "ExportUserDataHandler");
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/UserUseCaseTestDoubles.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/UserUseCaseTestDoubles.cs
@@ -1,0 +1,120 @@
+using MMCA.Common.Application.Users;
+using MMCA.Common.Domain.Auth;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Minimal <c>User</c> aggregate standing in for an app's Identity user across the shared Users
+/// use-case base tests. Public (not nested) because Moq must proxy <c>IRepository</c> closed over it.
+/// </summary>
+public class TestIdentityUser : AuditableAggregateRootEntity<UserIdentifierType>,
+    IPasswordChangeableUser, IUserPreferences, IErasableUser
+{
+    public byte[] PasswordHash { get; private set; } = [1, 2, 3];
+
+    public byte[] PasswordSalt { get; private set; } = [4, 5, 6];
+
+    public string? RefreshToken { get; private set; }
+
+    public DateTime? RefreshTokenExpiry { get; private set; }
+
+    public string? PreferredCulture { get; private set; }
+
+    public string? PreferredTheme { get; private set; }
+
+    public bool AnonymizeCalled { get; private set; }
+
+    public bool RevokeCalled { get; private set; }
+
+    /// <summary>Forces the next <c>ChangePassword</c>/<c>UpdatePreferences</c>/<c>Anonymize</c> to fail.</summary>
+    public Error? ForcedFailure { get; set; }
+
+    public void SeedPreferences(string? culture, string? theme)
+    {
+        PreferredCulture = culture;
+        PreferredTheme = theme;
+    }
+
+    public Result ChangePassword(byte[] newPasswordHash, byte[] newPasswordSalt)
+    {
+        if (ForcedFailure is { } error)
+        {
+            return Result.Failure(error);
+        }
+
+        PasswordHash = newPasswordHash;
+        PasswordSalt = newPasswordSalt;
+        return Result.Success();
+    }
+
+    public Result UpdatePreferences(string? preferredCulture, string? preferredTheme)
+    {
+        if (ForcedFailure is { } error)
+        {
+            return Result.Failure(error);
+        }
+
+        PreferredCulture = preferredCulture;
+        PreferredTheme = preferredTheme;
+        return Result.Success();
+    }
+
+    public Result Anonymize()
+    {
+        if (ForcedFailure is { } error)
+        {
+            return Result.Failure(error);
+        }
+
+        AnonymizeCalled = true;
+        return Result.Success();
+    }
+
+    public void UpdateRefreshToken(string refreshToken, DateTime expiry)
+    {
+        RefreshToken = refreshToken;
+        RefreshTokenExpiry = expiry;
+    }
+
+    public void RevokeRefreshToken()
+    {
+        RevokeCalled = true;
+        RefreshToken = null;
+        RefreshTokenExpiry = null;
+    }
+}
+
+/// <summary>
+/// A <c>User</c> that <b>hides</b> the base soft-delete with <c>public new Result Delete()</c>, the way
+/// ADC's aggregate does to revoke the refresh token. Declaring <see cref="IErasableUser"/> here is what
+/// re-maps the interface onto the hiding member, which is the property the shared erasure workflow
+/// depends on.
+/// </summary>
+public sealed class TestHidingDeleteUser : TestIdentityUser, IErasableUser
+{
+    public bool HidingDeleteCalled { get; private set; }
+
+    public new Result Delete()
+    {
+        HidingDeleteCalled = true;
+        RevokeRefreshToken();
+        return base.Delete();
+    }
+}
+
+/// <summary>App-side change-password command shape (<c>UserId</c> plus the shared request payload).</summary>
+public sealed record TestChangePasswordCommand(UserIdentifierType UserId, ChangePasswordRequest Request)
+    : IUserScopedCommand<ChangePasswordRequest>;
+
+/// <summary>App-side change-preferences command shape.</summary>
+public sealed record TestChangePreferencesCommand(UserIdentifierType UserId, ChangePreferencesRequest Request)
+    : IUserScopedCommand<ChangePreferencesRequest>;
+
+/// <summary>App-side delete-user command shape (target plus authenticated caller).</summary>
+public sealed record TestDeleteUserCommand(
+    UserIdentifierType UserId,
+    UserIdentifierType CurrentUserId,
+    string? CurrentUserRole) : IUserOwnedRequest;

--- a/Tests/Core/MMCA.Common.Domain.Tests/Invariants/CommonInvariantsTests.cs
+++ b/Tests/Core/MMCA.Common.Domain.Tests/Invariants/CommonInvariantsTests.cs
@@ -1,6 +1,8 @@
 using AwesomeAssertions;
 using MMCA.Common.Domain.Invariants;
 using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Globalization;
+using MMCA.Common.Shared.ValueObjects;
 
 namespace MMCA.Common.Domain.Tests.Invariants;
 
@@ -135,5 +137,181 @@ public sealed class CommonInvariantsTests
             null!, "Test.Null", "Data is required.", "Upload", "File");
 
         result.IsFailure.Should().BeTrue();
+    }
+
+    // ── EnsureIntIsPositive ──
+    [Fact]
+    public void EnsureIntIsPositive_WithPositiveValue_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureIntIsPositive(
+            1, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void EnsureIntIsPositive_WithZeroOrNegative_ReturnsFailure(int value)
+    {
+        Result result = CommonInvariants.EnsureIntIsPositive(
+            value, "Test.Quantity.NotPositive", "Quantity must be positive.", "Create", "Quantity");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Test.Quantity.NotPositive");
+        result.Errors[0].Message.Should().Be("Quantity must be positive.");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    // ── EnsureMoneyIsNotNegative ──
+    [Fact]
+    public void EnsureMoneyIsNotNegative_WithPositiveAmount_ReturnsSuccess()
+    {
+        Money money = Money.Create(10.50m, Currency.Usd).Value!;
+
+        Result result = CommonInvariants.EnsureMoneyIsNotNegative(
+            money, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureMoneyIsNotNegative_WithZeroAmount_ReturnsSuccess()
+    {
+        var money = Money.Zero(Currency.Usd);
+
+        Result result = CommonInvariants.EnsureMoneyIsNotNegative(
+            money, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureMoneyIsNotNegative_WithNegativeAmount_ReturnsFailure()
+    {
+        Money money = Money.Create(-0.01m, Currency.Eur).Value!;
+
+        Result result = CommonInvariants.EnsureMoneyIsNotNegative(
+            money, "Test.Price.Negative", "Price cannot be negative.", "Create", "Price");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Test.Price.Negative");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    [Fact]
+    public void EnsureMoneyIsNotNegative_WithNull_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureMoneyIsNotNegative(
+            null!, "Test.Price.Missing", "Price is required.", "Create", "Price");
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    // ── EnsureCollectionIsNotEmpty ──
+    [Fact]
+    public void EnsureCollectionIsNotEmpty_WithItems_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureCollectionIsNotEmpty<string>(
+            ["line"], "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureCollectionIsNotEmpty_WithEmptyCollection_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureCollectionIsNotEmpty<string>(
+            [], "Test.Lines.Empty", "Order must not be empty.", "Create", "OrderLines");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Test.Lines.Empty");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    [Fact]
+    public void EnsureCollectionIsNotEmpty_WithNull_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureCollectionIsNotEmpty<string>(
+            null!, "Test.Lines.Null", "Order must not be empty.", "Create", "OrderLines");
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    // ── EnsurePreferredCultureIsValid ──
+    [Fact]
+    public void EnsurePreferredCultureIsValid_WithNull_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsurePreferredCultureIsValid(
+            null, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsurePreferredCultureIsValid_WithSupportedCulture_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsurePreferredCultureIsValid(
+            SupportedCultures.Default, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("xx-YY")]
+    public void EnsurePreferredCultureIsValid_WithUnsupportedCulture_ReturnsFailure(string culture)
+    {
+        Result result = CommonInvariants.EnsurePreferredCultureIsValid(
+            culture, "Test.Culture.Invalid", "Culture is not supported.", "SetPreferences", "Culture");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Test.Culture.Invalid");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    // ── EnsurePreferredThemeIsValid ──
+    [Fact]
+    public void EnsurePreferredThemeIsValid_WithNull_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsurePreferredThemeIsValid(
+            null, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("light")]
+    [InlineData("dark")]
+    [InlineData("LIGHT")]
+    [InlineData("Dark")]
+    public void EnsurePreferredThemeIsValid_WithKnownTheme_ReturnsSuccess(string theme)
+    {
+        Result result = CommonInvariants.EnsurePreferredThemeIsValid(
+            theme, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("neon")]
+    public void EnsurePreferredThemeIsValid_WithUnknownTheme_ReturnsFailure(string theme)
+    {
+        Result result = CommonInvariants.EnsurePreferredThemeIsValid(
+            theme, "Test.Theme.Invalid", "Theme is not valid.", "SetPreferences", "Theme");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Test.Theme.Invalid");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    [Fact]
+    public void ThemeConstants_MatchTheAcceptedValues()
+    {
+        CommonInvariants.LightTheme.Should().Be("light");
+        CommonInvariants.DarkTheme.Should().Be("dark");
     }
 }

--- a/Tests/Core/MMCA.Common.Domain.Tests/Specifications/OwnedByUserSpecificationTests.cs
+++ b/Tests/Core/MMCA.Common.Domain.Tests/Specifications/OwnedByUserSpecificationTests.cs
@@ -1,0 +1,101 @@
+using System.Linq.Expressions;
+using AwesomeAssertions;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Specifications;
+
+namespace MMCA.Common.Domain.Tests.Specifications;
+
+public sealed class OwnedByUserSpecificationTests
+{
+    // CreatedBy is stamped by the infrastructure layer through EF's change tracker, so the
+    // fake overrides the virtual getter to make the audit field settable from a test.
+    private sealed class FakeAnswer : AuditableBaseEntity<int>
+    {
+        private UserIdentifierType _createdBy;
+
+        public override UserIdentifierType CreatedBy => _createdBy;
+
+        public void StampCreatedBy(UserIdentifierType userId) => _createdBy = userId;
+    }
+
+    private static FakeAnswer CreateAnswer(int id, UserIdentifierType createdBy)
+    {
+        var answer = new FakeAnswer { Id = id };
+        answer.StampCreatedBy(createdBy);
+        return answer;
+    }
+
+    // ── IsSatisfiedBy ──
+    [Fact]
+    public void IsSatisfiedBy_OwnedByTheSameUser_ReturnsTrue()
+    {
+        var spec = new OwnedByUserSpecification<FakeAnswer, int>(7);
+
+        spec.IsSatisfiedBy(CreateAnswer(1, 7)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSatisfiedBy_OwnedByAnotherUser_ReturnsFalse()
+    {
+        var spec = new OwnedByUserSpecification<FakeAnswer, int>(7);
+
+        spec.IsSatisfiedBy(CreateAnswer(1, 8)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UserId_ExposesTheConstructorArgument()
+    {
+        var spec = new OwnedByUserSpecification<FakeAnswer, int>(42);
+
+        spec.UserId.Should().Be(42);
+    }
+
+    // ── Criteria stays an EF-translatable expression over the mapped audit column ──
+    [Fact]
+    public void Criteria_ComparesTheCreatedByPropertyDeclaredOnTheEntity()
+    {
+        var spec = new OwnedByUserSpecification<FakeAnswer, int>(7);
+
+        Expression<Func<FakeAnswer, bool>> criteria = spec.Criteria;
+
+        var comparison = criteria.Body.Should().BeAssignableTo<BinaryExpression>().Subject;
+        comparison.NodeType.Should().Be(ExpressionType.Equal);
+
+        var member = comparison.Left.Should().BeAssignableTo<MemberExpression>().Subject;
+        member.Member.Name.Should().Be(nameof(FakeAnswer.CreatedBy));
+        member.Expression.Should().BeAssignableTo<ParameterExpression>();
+        typeof(FakeAnswer).Should().BeAssignableTo(member.Member.DeclaringType!);
+    }
+
+    // ── Composition with the existing operators ──
+    [Fact]
+    public void Composition_WithNotSpecification_InvertsOwnership()
+    {
+        var ownSpec = new OwnedByUserSpecification<FakeAnswer, int>(7);
+        var notOwnSpec = new NotSpecification<FakeAnswer, int>(ownSpec);
+
+        notOwnSpec.IsSatisfiedBy(CreateAnswer(1, 7)).Should().BeFalse();
+        notOwnSpec.IsSatisfiedBy(CreateAnswer(2, 8)).Should().BeTrue();
+    }
+
+    // ── LINQ filtering, the same shape EF Core translates to SQL ──
+    [Fact]
+    public void Criteria_FiltersAQueryableToTheOwningUsersRows()
+    {
+        var spec = new OwnedByUserSpecification<FakeAnswer, int>(7);
+
+        FakeAnswer[] answers =
+        [
+            CreateAnswer(1, 7),
+            CreateAnswer(2, 8),
+            CreateAnswer(3, 7)
+        ];
+
+        var owned = answers.AsQueryable().Where(spec.Criteria).ToList();
+
+        owned.Should().HaveCount(2);
+        owned.Should().OnlyContain(a => a.CreatedBy == 7);
+        owned.Should().Contain(a => a.Id == 1);
+        owned.Should().Contain(a => a.Id == 3);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/IndexBuilderExtensionsTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/IndexBuilderExtensionsTests.cs
@@ -1,0 +1,139 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.Configuration;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Configuration;
+
+/// <summary>
+/// Tests for <c>IndexBuilderExtensions.HasSoftDeleteFilter</c>: the opt-in replacement for the
+/// literal <c>HasFilter("[IsDeleted] = 0")</c> on hand-authored NON-unique indexes (the unique ones
+/// are already covered automatically by <c>SoftDeleteUniqueIndexConvention</c>). It must produce the
+/// same SQL the literal produced, and it must derive quoting from the engine using the very same
+/// predicate builder the convention uses.
+/// </summary>
+public sealed class IndexBuilderExtensionsTests : IDisposable
+{
+    private readonly FilteredIndexTestDbContext _dbContext = FilteredIndexTestDbContext.Create();
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public void HasSoftDeleteFilter_DefaultsToSqlServerBracketQuoting()
+        => Filter<SqlServerIndexedEntity>(nameof(SqlServerIndexedEntity.Name))
+            .Should().Be("[IsDeleted] = 0", "this is the literal the 17 hand-authored call sites carry today");
+
+    [Fact]
+    public void HasSoftDeleteFilter_OnSqlite_UsesDoubleQuoteQuoting()
+        => Filter<SqliteIndexedEntity>(nameof(SqliteIndexedEntity.Name))
+            .Should().Be("\"IsDeleted\" = 0", "same branch SoftDeleteUniqueIndexConvention takes for SQLite");
+
+    [Fact]
+    public void HasSoftDeleteFilter_OnCosmos_LeavesTheIndexUnfiltered()
+        => Filter<CosmosIndexedEntity>(nameof(CosmosIndexedEntity.Name))
+            .Should().BeNull("Cosmos has no filtered indexes, exactly as the convention skips it");
+
+    [Fact]
+    public void HasSoftDeleteFilter_WithAnAdditionalFilter_CombinesInTheHandAuthoredOrder()
+        => Filter<SqlServerIndexedEntity>(nameof(SqlServerIndexedEntity.Sku))
+            .Should().Be(
+                "[Sku] IS NOT NULL AND [IsDeleted] = 0",
+                "the combined literal it replaces reads predicate first, soft-delete second");
+
+    [Fact]
+    public void HasSoftDeleteFilter_StaysChainable()
+    {
+        var index = _dbContext.Model.FindEntityType(typeof(SqlServerIndexedEntity))!
+            .GetIndexes()
+            .Single(i => i.Properties.Count == 1 && i.Properties[0].Name == nameof(SqlServerIndexedEntity.Code));
+
+        index.GetDatabaseName().Should().Be("IX_Chained");
+        index.GetFilter().Should().Be("[IsDeleted] = 0");
+    }
+
+    [Fact]
+    public void HasSoftDeleteFilter_FollowsARenamedIsDeletedColumn()
+        => Filter<RenamedFlagEntity>(nameof(RenamedFlagEntity.Name))
+            .Should().Be("[Deleted] = 0", "the column name comes from the model, not from a string literal");
+
+    private string? Filter<TEntity>(string propertyName)
+        => _dbContext.Model.FindEntityType(typeof(TEntity))!
+            .GetIndexes()
+            .Single(i => i.Properties.Count == 1 && i.Properties[0].Name == propertyName)
+            .GetFilter();
+
+    // ── Test doubles ──
+    public sealed class SqlServerIndexedEntity : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public string Code { get; set; } = string.Empty;
+
+        public string? Sku { get; set; }
+    }
+
+    public sealed class SqliteIndexedEntity : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class CosmosIndexedEntity : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class RenamedFlagEntity : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public sealed class FilteredIndexTestDbContext : DbContext
+    {
+        private FilteredIndexTestDbContext(DbContextOptions<FilteredIndexTestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public static FilteredIndexTestDbContext Create()
+        {
+            var options = new DbContextOptionsBuilder<FilteredIndexTestDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            return new FilteredIndexTestDbContext(options);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SqlServerIndexedEntity>(builder =>
+            {
+                builder.HasKey(p => p.Id);
+                builder.HasIndex(p => p.Name).HasSoftDeleteFilter();
+                builder.HasIndex(p => p.Sku).HasSoftDeleteFilter(additionalFilter: "[Sku] IS NOT NULL");
+                builder.HasIndex(p => p.Code).HasSoftDeleteFilter().HasDatabaseName("IX_Chained");
+            });
+
+            modelBuilder.Entity<SqliteIndexedEntity>(builder =>
+            {
+                builder.HasKey(p => p.Id);
+                builder.HasIndex(p => p.Name).HasSoftDeleteFilter(DataSource.Sqlite);
+            });
+
+            modelBuilder.Entity<CosmosIndexedEntity>(builder =>
+            {
+                builder.HasKey(p => p.Id);
+                builder.HasIndex(p => p.Name).HasSoftDeleteFilter(DataSource.CosmosDB);
+            });
+
+            modelBuilder.Entity<RenamedFlagEntity>(builder =>
+            {
+                builder.HasKey(p => p.Id);
+
+                // The column name is read when the extension is called, so the rename has to precede it.
+                builder.Property(p => p.IsDeleted).HasColumnName("Deleted");
+                builder.HasIndex(p => p.Name).HasSoftDeleteFilter();
+            });
+        }
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/OwnsMoneyTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/OwnsMoneyTests.cs
@@ -1,0 +1,283 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MMCA.Common.Infrastructure.Persistence.Configuration;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Configuration;
+
+/// <summary>
+/// Tests for <c>EntityTypeBuilderExtensions.OwnsMoney</c>. The helper replaces a block that was
+/// triplicated across Store's Order, OrderLine and ProductVariant configurations, so the load-bearing
+/// assertion is <b>zero schema drift</b>: every relational facet it produces must equal what the
+/// hand-rolled block produces, compared against a control entity configured with that block verbatim.
+/// The currency round-trip fallback is exercised too: a zero <see cref="Money"/> persists an empty
+/// currency code, which <see cref="Currency.FromCode"/> rejects, and without the sentinel fallback it
+/// would materialize a null Currency inside <see cref="Money"/>.
+/// </summary>
+public sealed class OwnsMoneyTests : IDisposable
+{
+    private readonly MoneyTestDbContext _dbContext = MoneyTestDbContext.Create();
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Theory]
+    [InlineData(nameof(HelperOwner.Total), "TotalAmount", "TotalCurrency")]
+    [InlineData(nameof(HelperOwner.UnitPrice), "UnitPriceAmount", "UnitPriceCurrency")]
+    [InlineData(nameof(HelperOwner.Price), "PriceAmount", "PriceCurrency")]
+    public void OwnsMoney_ProducesTheColumnNamesItWasGiven(
+        string navigationName,
+        string amountColumnName,
+        string currencyColumnName)
+    {
+        var owned = OwnedType<HelperOwner>(navigationName);
+
+        owned.FindProperty(nameof(Money.Amount))!.GetColumnName().Should().Be(amountColumnName);
+        owned.FindProperty(nameof(Money.Currency))!.GetColumnName().Should().Be(currencyColumnName);
+    }
+
+    [Theory]
+    [InlineData(nameof(HelperOwner.Total))]
+    [InlineData(nameof(HelperOwner.UnitPrice))]
+    [InlineData(nameof(HelperOwner.Price))]
+    public void OwnsMoney_MatchesTheHandRolledBlock_FacetForFacet(string navigationName)
+    {
+        var helper = OwnedType<HelperOwner>(navigationName);
+        var handRolled = OwnedType<HandRolledOwner>(navigationName);
+
+        Facets(helper, nameof(Money.Amount)).Should().Be(Facets(handRolled, nameof(Money.Amount)));
+        Facets(helper, nameof(Money.Currency)).Should().Be(Facets(handRolled, nameof(Money.Currency)));
+    }
+
+    [Theory]
+    [InlineData(nameof(HelperOwner.Total))]
+    [InlineData(nameof(HelperOwner.UnitPrice))]
+    [InlineData(nameof(HelperOwner.Price))]
+    public void OwnsMoney_MatchesTheHandRolledBlock_OnNavigationRequiredness(string navigationName)
+    {
+        bool helper = Navigation<HelperOwner>(navigationName).ForeignKey.IsRequiredDependent;
+        bool handRolled = Navigation<HandRolledOwner>(navigationName).ForeignKey.IsRequiredDependent;
+
+        helper.Should().Be(handRolled);
+    }
+
+    [Fact]
+    public void OwnsMoney_RequiredFlag_DrivesTheNavigationRequiredness()
+    {
+        // Total is the Order case (required: false); UnitPrice and Price are the OrderLine and
+        // ProductVariant cases (required: true). That flag is the only facet the three sites differ on.
+        Navigation<HelperOwner>(nameof(HelperOwner.Total)).ForeignKey.IsRequiredDependent.Should().BeFalse();
+        Navigation<HelperOwner>(nameof(HelperOwner.UnitPrice)).ForeignKey.IsRequiredDependent.Should().BeTrue();
+        Navigation<HelperOwner>(nameof(HelperOwner.Price)).ForeignKey.IsRequiredDependent.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OwnsMoney_MapsTheCurrencyColumnAsAThreeCharacterNonUnicodeCode()
+    {
+        var owned = OwnedType<HelperOwner>(nameof(HelperOwner.Price));
+        var currency = owned.FindProperty(nameof(Money.Currency))!;
+
+        currency.GetMaxLength().Should().Be(3);
+        currency.IsUnicode().Should().BeFalse();
+        currency.GetValueConverter()!.ProviderClrType.Should().Be<string>();
+    }
+
+    [Fact]
+    public async Task OwnsMoney_RoundTripsARealCurrency()
+    {
+        // Distinct instances per navigation: EF tracks owned entities by reference, so sharing one
+        // Money object across three owned navigations is an identity conflict, not a mapping problem.
+        _dbContext.HelperOwners.Add(new HelperOwner
+        {
+            Price = Money.Create(19.99m, Currency.Usd).Value!,
+            UnitPrice = Money.Create(19.99m, Currency.Usd).Value!,
+            Total = Money.Create(19.99m, Currency.Usd).Value!,
+        });
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var read = await _dbContext.HelperOwners.AsNoTracking().SingleAsync();
+
+        read.Price.Amount.Should().Be(19.99m);
+        read.Price.Currency.Code.Should().Be("USD");
+    }
+
+    [Fact]
+    public async Task OwnsMoney_ReadsBackAZeroMoney_WithoutANullCurrency()
+    {
+        // Money.Zero() carries the "no currency" sentinel, whose Code is the empty string: a code
+        // Currency.FromCode rejects. A bare .Value! would materialize a null Currency here, which is
+        // a NullReferenceException at materialization time on the very next read.
+        _dbContext.HelperOwners.Add(new HelperOwner { Total = Money.Zero() });
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var read = await _dbContext.HelperOwners.AsNoTracking().SingleAsync();
+
+        read.Total.Should().NotBeNull();
+        read.Total.Currency.Should().NotBeNull();
+        read.Total.Currency.Code.Should().BeEmpty();
+        read.Total.Currency.Should().BeSameAs(Money.Zero().Currency, "the read leg falls back to the sentinel");
+    }
+
+    private static PropertyFacets Facets(IReadOnlyEntityType owned, string propertyName)
+    {
+        var property = owned.FindProperty(propertyName)!;
+
+        return new PropertyFacets(
+            property.GetColumnName(),
+            property.GetColumnType(),
+            property.IsNullable,
+            property.GetMaxLength(),
+            property.IsUnicode(),
+            property.GetValueConverter()?.ProviderClrType);
+    }
+
+    private IReadOnlyEntityType OwnedType<TOwner>(string navigationName)
+        where TOwner : class
+        => Navigation<TOwner>(navigationName).TargetEntityType;
+
+    private IReadOnlyNavigation Navigation<TOwner>(string navigationName)
+        where TOwner : class
+        => _dbContext.Model.FindEntityType(typeof(TOwner))!.FindNavigation(navigationName)!;
+
+    private sealed record PropertyFacets(
+        string? ColumnName,
+        string? ColumnType,
+        bool IsNullable,
+        int? MaxLength,
+        bool? IsUnicode,
+        Type? ProviderClrType);
+
+    // ── Test doubles ──
+
+    /// <summary>Owner mapped through the shared <c>OwnsMoney</c> helper.</summary>
+    public sealed class HelperOwner
+    {
+        public int Id { get; set; }
+
+        public Money Total { get; set; } = Money.Zero();
+
+        public Money UnitPrice { get; set; } = Money.Zero();
+
+        public Money Price { get; set; } = Money.Zero();
+    }
+
+    /// <summary>Control owner mapped with the hand-rolled block the helper replaces.</summary>
+    public sealed class HandRolledOwner
+    {
+        public int Id { get; set; }
+
+        public Money Total { get; set; } = Money.Zero();
+
+        public Money UnitPrice { get; set; } = Money.Zero();
+
+        public Money Price { get; set; } = Money.Zero();
+    }
+
+    public sealed class MoneyTestDbContext : DbContext
+    {
+        /// <summary>
+        /// Read-leg fallback for the Currency value converter, copied verbatim from the consumer
+        /// configurations so the control entity below really is the code being replaced.
+        /// </summary>
+        private static readonly Currency NoCurrency = Money.Zero().Currency;
+
+        private MoneyTestDbContext(DbContextOptions<MoneyTestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<HelperOwner> HelperOwners => Set<HelperOwner>();
+
+        public DbSet<HandRolledOwner> HandRolledOwners => Set<HandRolledOwner>();
+
+        public static MoneyTestDbContext Create()
+        {
+            var options = new DbContextOptionsBuilder<MoneyTestDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            var context = new MoneyTestDbContext(options);
+            context.Database.OpenConnection();
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<HelperOwner>(builder =>
+            {
+                builder.HasKey(p => p.Id);
+                builder.OwnsMoney(p => p.Total, "TotalAmount", "TotalCurrency", required: false);
+                builder.OwnsMoney(p => p.UnitPrice, "UnitPriceAmount", "UnitPriceCurrency");
+                builder.OwnsMoney(p => p.Price, "PriceAmount", "PriceCurrency");
+            });
+
+            modelBuilder.Entity<HandRolledOwner>(builder =>
+            {
+                builder.HasKey(p => p.Id);
+
+                // Verbatim copy of MMCA.Store Sales OrderConfiguration (Total, optional navigation).
+                builder.OwnsOne(p => p.Total, moneyBuilder =>
+                {
+                    moneyBuilder.Property(m => m.Amount)
+                        .HasColumnName("TotalAmount")
+                        .IsRequired();
+
+                    moneyBuilder.Property(m => m.Currency)
+                        .HasConversion(
+                            currency => currency.Code,
+                            code => Currency.FromCode(code).Value ?? NoCurrency)
+                        .HasMaxLength(3)
+                        .IsUnicode(false)
+                        .HasColumnName("TotalCurrency")
+                        .IsRequired();
+                });
+
+                builder.Navigation(p => p.Total)
+                    .IsRequired(false);
+
+                // Verbatim copy of MMCA.Store Sales OrderLineConfiguration (UnitPrice, required).
+                builder.OwnsOne(p => p.UnitPrice, moneyBuilder =>
+                {
+                    moneyBuilder.Property(m => m.Amount)
+                        .HasColumnName("UnitPriceAmount")
+                        .IsRequired();
+
+                    moneyBuilder.Property(m => m.Currency)
+                        .HasConversion(
+                            currency => currency.Code,
+                            code => Currency.FromCode(code).Value ?? NoCurrency)
+                        .HasMaxLength(3)
+                        .IsUnicode(false)
+                        .HasColumnName("UnitPriceCurrency")
+                        .IsRequired();
+                });
+
+                builder.Navigation(p => p.UnitPrice)
+                    .IsRequired();
+
+                // Verbatim copy of MMCA.Store Catalog ProductVariantConfiguration (Price, required).
+                builder.OwnsOne(p => p.Price, moneyBuilder =>
+                {
+                    moneyBuilder.Property(m => m.Amount)
+                        .HasColumnName("PriceAmount")
+                        .IsRequired();
+
+                    moneyBuilder.Property(m => m.Currency)
+                        .HasConversion(
+                            currency => currency.Code,
+                            code => Currency.FromCode(code).Value ?? NoCurrency)
+                        .HasMaxLength(3)
+                        .IsUnicode(false)
+                        .HasColumnName("PriceCurrency")
+                        .IsRequired();
+                });
+
+                builder.Navigation(p => p.Price)
+                    .IsRequired();
+            });
+        }
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Conversions/EmailValueConverterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Conversions/EmailValueConverterTests.cs
@@ -1,0 +1,83 @@
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Persistence.Conversions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Conversions;
+
+/// <summary>
+/// Tests for <see cref="EmailValueConverter"/> and <see cref="NullableEmailValueConverter"/>: the
+/// packaged replacements for the <c>e =&gt; e.Value, v =&gt; Email.Create(v).Value!</c> lambda pair
+/// that every consumer entity configuration used to hand-roll.
+/// </summary>
+public sealed class EmailValueConverterTests
+{
+    // ── Non-nullable converter ──
+    [Fact]
+    public void Converter_RoundTrips_EmailThroughItsStringValue()
+    {
+        var converter = new EmailValueConverter();
+        var email = Email.Create("Person@Example.COM").Value!;
+
+        string stored = converter.ConvertToProviderExpression.Compile()(email);
+        var read = converter.ConvertFromProviderExpression.Compile()(stored);
+
+        stored.Should().Be("person@example.com", "Email normalizes to lowercase at creation time");
+        read.Should().Be(email);
+    }
+
+    [Fact]
+    public void Converter_MapsToAndFromString_SoTheColumnStaysAPlainStringColumn()
+    {
+        var converter = new EmailValueConverter();
+
+        converter.ModelClrType.Should().Be<Email>();
+        converter.ProviderClrType.Should().Be<string>();
+    }
+
+    [Fact]
+    public void Converter_WriteLeg_MatchesTheHandRolledLambdaItReplaces()
+    {
+        var converter = new EmailValueConverter();
+        var email = Email.Create("a@b.com").Value!;
+
+        converter.ConvertToProviderExpression.Compile()(email).Should().Be(HandRolled(email));
+
+        static string HandRolled(Email e) => e.Value;
+    }
+
+    // ── Nullable converter ──
+    [Fact]
+    public void NullableConverter_RoundTripsAValue()
+    {
+        var converter = new NullableEmailValueConverter();
+        var email = Email.Create("person@example.com").Value!;
+
+        string? stored = converter.ConvertToProviderExpression.Compile()(email);
+        var read = converter.ConvertFromProviderExpression.Compile()(stored);
+
+        stored.Should().Be("person@example.com");
+        read.Should().Be(email);
+    }
+
+    [Fact]
+    public void NullableConverter_PassesNullThroughBothLegs()
+    {
+        var converter = new NullableEmailValueConverter();
+
+        converter.ConvertToProviderExpression.Compile()(null).Should().BeNull();
+        converter.ConvertFromProviderExpression.Compile()(null).Should().BeNull(
+            "an absent email must stay a NULL column value, not an empty string or a failed Create");
+    }
+
+    [Fact]
+    public void NullableConverter_ReadLeg_MatchesTheHandRolledLambdaItReplaces()
+    {
+        var converter = new NullableEmailValueConverter();
+        var read = converter.ConvertFromProviderExpression.Compile();
+
+        read("person@example.com").Should().Be(HandRolled("person@example.com"));
+        read(null).Should().Be(HandRolled(null));
+
+        static Email? HandRolled(string? v) => v == null ? null : Email.Create(v).Value;
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Conversions/PhoneNumberValueConverterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Conversions/PhoneNumberValueConverterTests.cs
@@ -1,0 +1,61 @@
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Persistence.Conversions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Conversions;
+
+/// <summary>
+/// Tests for <see cref="PhoneNumberValueConverter"/> and
+/// <see cref="NullablePhoneNumberValueConverter"/>.
+/// </summary>
+public sealed class PhoneNumberValueConverterTests
+{
+    private const string Sample = "+1 404 555 0134";
+
+    // ── Non-nullable converter ──
+    [Fact]
+    public void Converter_RoundTrips_PhoneNumberThroughItsStringValue()
+    {
+        var converter = new PhoneNumberValueConverter();
+        var phoneNumber = PhoneNumber.Create($"  {Sample}  ").Value!;
+
+        string stored = converter.ConvertToProviderExpression.Compile()(phoneNumber);
+        var read = converter.ConvertFromProviderExpression.Compile()(stored);
+
+        stored.Should().Be(Sample, "PhoneNumber trims at creation time");
+        read.Should().Be(phoneNumber);
+    }
+
+    [Fact]
+    public void Converter_MapsToAndFromString_SoTheColumnStaysAPlainStringColumn()
+    {
+        var converter = new PhoneNumberValueConverter();
+
+        converter.ModelClrType.Should().Be<PhoneNumber>();
+        converter.ProviderClrType.Should().Be<string>();
+    }
+
+    // ── Nullable converter ──
+    [Fact]
+    public void NullableConverter_RoundTripsAValue()
+    {
+        var converter = new NullablePhoneNumberValueConverter();
+        var phoneNumber = PhoneNumber.Create(Sample).Value!;
+
+        string? stored = converter.ConvertToProviderExpression.Compile()(phoneNumber);
+        var read = converter.ConvertFromProviderExpression.Compile()(stored);
+
+        stored.Should().Be(Sample);
+        read.Should().Be(phoneNumber);
+    }
+
+    [Fact]
+    public void NullableConverter_PassesNullThroughBothLegs()
+    {
+        var converter = new NullablePhoneNumberValueConverter();
+
+        converter.ConvertToProviderExpression.Compile()(null).Should().BeNull();
+        converter.ConvertFromProviderExpression.Compile()(null).Should().BeNull(
+            "an absent phone number must stay a NULL column value, not an empty string or a failed Create");
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/IdentityModuleDbSeederBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/IdentityModuleDbSeederBaseTests.cs
@@ -1,0 +1,189 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Seeding;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.ValueObjects;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Exercises the shared Identity seeding loop: the opt-in gate, the per-account
+/// exists-then-hash-then-create-then-save idiom, the per-account save boundary, and the delegation of
+/// aggregate construction to the app (the two apps' <c>User.Create</c> factories take their arguments
+/// in different orders).
+/// </summary>
+public sealed class IdentityModuleDbSeederBaseTests
+{
+    private static readonly SeedAccount[] TwoAccounts =
+    [
+        new("admin@example.com", "Admin123!", "Admin", "Admin", "User"),
+        new("customer@example.com", "Password", "Customer", "Ivan", "Ball"),
+    ];
+
+    [Fact]
+    public async Task SeedAsync_WhenGateIsClosed_SeedsNothing()
+    {
+        var (sut, mocks) = CreateSut(TwoAccounts, shouldSeed: false);
+
+        await sut.SeedAsync(CancellationToken.None);
+
+        sut.CreateUserCalls.Should().Be(0);
+        mocks.Repository.Verify(
+            x => x.AddAsync(It.IsAny<TestSeedUser>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenGateIsOpen_AddsAndSavesEachAccountIndividually()
+    {
+        var (sut, mocks) = CreateSut(TwoAccounts);
+
+        await sut.SeedAsync(CancellationToken.None);
+
+        sut.CreateUserCalls.Should().Be(2);
+        mocks.Repository.Verify(
+            x => x.AddAsync(It.IsAny<TestSeedUser>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        mocks.UnitOfWork.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "each account is saved on its own so one bad account cannot roll back the others");
+    }
+
+    [Fact]
+    public async Task SeedAsync_NormalizesTheEmailBeforeTheExistenceCheck()
+    {
+        var (sut, _) = CreateSut([TwoAccounts[0]]);
+
+        await sut.SeedAsync(CancellationToken.None);
+
+        sut.CheckedEmails.Should().ContainSingle();
+        sut.CheckedEmails[0]!.Value.Should().Be("admin@example.com");
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenAccountAlreadyExists_SkipsItWithoutHashingOrSaving()
+    {
+        var (sut, mocks) = CreateSut(TwoAccounts);
+        sut.ExistingEmails.Add("admin@example.com");
+
+        await sut.SeedAsync(CancellationToken.None);
+
+        sut.CreateUserCalls.Should().Be(1);
+        mocks.PasswordHasher.Verify(x => x.HashPassword("Admin123!"), Times.Never);
+        mocks.PasswordHasher.Verify(x => x.HashPassword("Password"), Times.Once);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenTheFactoryRejectsAnAccount_SkipsItAndContinues()
+    {
+        var (sut, mocks) = CreateSut(TwoAccounts);
+        sut.RejectedEmails.Add("admin@example.com");
+
+        await sut.SeedAsync(CancellationToken.None);
+
+        mocks.Repository.Verify(
+            x => x.AddAsync(It.IsAny<TestSeedUser>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SeedAsync_HandsTheHashedCredentialToTheAppFactory()
+    {
+        var (sut, _) = CreateSut([TwoAccounts[0]]);
+
+        await sut.SeedAsync(CancellationToken.None);
+
+        sut.CreatedUsers.Should().ContainSingle();
+        sut.CreatedUsers[0].PasswordHash.Should().BeEquivalentTo(new byte[] { 1, 1, 1 });
+        sut.CreatedUsers[0].PasswordSalt.Should().BeEquivalentTo(new byte[] { 2, 2, 2 });
+        sut.CreatedUsers[0].Role.Should().Be("Admin");
+    }
+
+    private sealed record SeederMocks(
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IRepository<TestSeedUser, UserIdentifierType>> Repository,
+        Mock<IPasswordHasher> PasswordHasher);
+
+    private static (TestIdentityModuleDbSeeder Sut, SeederMocks Mocks) CreateSut(
+        IReadOnlyList<SeedAccount> accounts,
+        bool shouldSeed = true)
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<TestSeedUser, UserIdentifierType>>();
+        var passwordHasher = new Mock<IPasswordHasher>();
+
+        unitOfWork.Setup(x => x.GetRepository<TestSeedUser, UserIdentifierType>()).Returns(repository.Object);
+        unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        passwordHasher.Setup(x => x.HashPassword(It.IsAny<string>())).Returns((new byte[] { 1, 1, 1 }, new byte[] { 2, 2, 2 }));
+
+        var sut = new TestIdentityModuleDbSeeder(unitOfWork.Object, passwordHasher.Object, accounts, shouldSeed);
+        return (sut, new SeederMocks(unitOfWork, repository, passwordHasher));
+    }
+}
+
+/// <summary>Minimal <c>User</c> aggregate for the seeding tests (public so Moq can proxy the repository).</summary>
+public sealed class TestSeedUser : AuditableAggregateRootEntity<UserIdentifierType>
+{
+    public required string Role { get; init; }
+
+#pragma warning disable CA1819 // Properties should not return arrays: mirrors IAuthUser's byte[] credential material.
+    public required byte[] PasswordHash { get; init; }
+
+    public required byte[] PasswordSalt { get; init; }
+#pragma warning restore CA1819
+}
+
+/// <summary>Concrete subclass standing in for an app's <c>IdentityModuleDbSeeder</c>.</summary>
+public sealed class TestIdentityModuleDbSeeder(
+    IUnitOfWork unitOfWork,
+    IPasswordHasher passwordHasher,
+    IReadOnlyList<SeedAccount> accounts,
+    bool shouldSeed) : IdentityModuleDbSeederBase<TestSeedUser>(unitOfWork, passwordHasher)
+{
+    public HashSet<string> ExistingEmails { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public HashSet<string> RejectedEmails { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public List<Email?> CheckedEmails { get; } = [];
+
+    public List<TestSeedUser> CreatedUsers { get; } = [];
+
+    public int CreateUserCalls { get; private set; }
+
+    protected override IReadOnlyList<SeedAccount> Accounts => accounts;
+
+    protected override bool ShouldSeed => shouldSeed;
+
+    protected override Task<bool> EmailExistsAsync(Email? email, CancellationToken cancellationToken)
+    {
+        CheckedEmails.Add(email);
+        return Task.FromResult(email is not null && ExistingEmails.Contains(email.Value));
+    }
+
+    protected override Result<TestSeedUser> CreateUser(SeedAccount account, byte[] passwordHash, byte[] passwordSalt)
+    {
+        ArgumentNullException.ThrowIfNull(account);
+
+        CreateUserCalls++;
+        if (RejectedEmails.Contains(account.Email))
+        {
+            return Result.Failure<TestSeedUser>(Error.Invariant("User.Invalid", "Seed account rejected."));
+        }
+
+        var user = new TestSeedUser
+        {
+            Id = CreateUserCalls,
+            Role = account.Role,
+            PasswordHash = passwordHash,
+            PasswordSalt = passwordSalt,
+        };
+        CreatedUsers.Add(user);
+        return Result.Success(user);
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Kestrel/KestrelEndpointExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Kestrel/KestrelEndpointExtensionsTests.cs
@@ -1,0 +1,127 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using MMCA.Common.Aspire.Kestrel;
+
+namespace MMCA.Common.Aspire.Tests.Kestrel;
+
+/// <summary>
+/// The shared Kestrel endpoint profile: endpoint defaults on one protocol set, plus a dedicated
+/// Http1-only listener for the platform health probes when <c>HealthProbe:Port</c> is configured.
+/// The listener plan is what decides whether a deployed revision answers its probes at all, so it is
+/// asserted directly rather than through a bound server.
+/// </summary>
+public sealed class KestrelEndpointExtensionsTests
+{
+    private static IConfiguration Config(string? probePort)
+    {
+        var values = new Dictionary<string, string?>();
+        if (probePort is not null)
+        {
+            values["HealthProbe:Port"] = probePort;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void NoProbePortConfigured_DeclaresNoExplicitListener()
+    {
+        var plan = KestrelEndpointExtensions.BuildListenerPlan(
+            Config(null),
+            HttpProtocols.Http2,
+            redeclareCleartextEndpoint: true,
+            KestrelEndpointExtensions.DefaultCleartextPort);
+
+        plan.Should().BeEmpty(
+            "locally there is no probe port, and an explicit Listen call would override the dynamic ports Aspire assigns");
+    }
+
+    [Fact]
+    public void BlankProbePort_IsTreatedAsAbsent()
+    {
+        var plan = KestrelEndpointExtensions.BuildListenerPlan(
+            Config(string.Empty),
+            HttpProtocols.Http2,
+            redeclareCleartextEndpoint: true,
+            KestrelEndpointExtensions.DefaultCleartextPort);
+
+        plan.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UnparseableProbePort_FailsFast()
+    {
+        var act = () => KestrelEndpointExtensions.BuildListenerPlan(
+            Config("eighty-eighty-two"),
+            HttpProtocols.Http2,
+            redeclareCleartextEndpoint: true,
+            KestrelEndpointExtensions.DefaultCleartextPort);
+
+        act.Should().Throw<InvalidOperationException>(
+            "a mistyped probe port that silently produced no listener would leave the platform probing a closed port");
+    }
+
+    /// <summary>
+    /// The REST/gRPC profile: h2c everywhere, and because an explicit Listen call replaces the
+    /// container's default binding, the main cleartext endpoint has to be re-declared next to the
+    /// probe listener.
+    /// </summary>
+    [Fact]
+    public void Http2Profile_RedeclaresTheCleartextEndpointAndAddsAnHttp1ProbeListener()
+    {
+        var plan = KestrelEndpointExtensions.BuildListenerPlan(
+            Config("8082"),
+            HttpProtocols.Http2,
+            redeclareCleartextEndpoint: true,
+            KestrelEndpointExtensions.DefaultCleartextPort);
+
+        plan.Should().Equal(
+            new KestrelEndpointExtensions.KestrelListenerSpec(8080, HttpProtocols.Http2),
+            new KestrelEndpointExtensions.KestrelListenerSpec(8082, HttpProtocols.Http1));
+    }
+
+    /// <summary>
+    /// The mixed profile (a SignalR host whose endpoints come from configuration): the probe listener
+    /// is strictly additive, because re-declaring 8080 would collide with the config-declared
+    /// endpoint that already owns it.
+    /// </summary>
+    [Fact]
+    public void MixedProfile_AddsOnlyTheProbeListener()
+    {
+        var plan = KestrelEndpointExtensions.BuildListenerPlan(
+            Config("8082"),
+            HttpProtocols.Http1AndHttp2,
+            redeclareCleartextEndpoint: false,
+            KestrelEndpointExtensions.DefaultCleartextPort);
+
+        plan.Should().Equal(
+            new KestrelEndpointExtensions.KestrelListenerSpec(8082, HttpProtocols.Http1));
+    }
+
+    [Fact]
+    public void ProbeListener_IsAlwaysHttp1_EvenWhenTheDefaultsAreHttp2()
+    {
+        var plan = KestrelEndpointExtensions.BuildListenerPlan(
+            Config("9090"),
+            HttpProtocols.Http2,
+            redeclareCleartextEndpoint: true,
+            KestrelEndpointExtensions.DefaultCleartextPort);
+
+        plan[^1].Protocols.Should().Be(
+            HttpProtocols.Http1,
+            "the platform httpGet probes speak HTTP/1.1, which an Http2-only endpoint rejects with GOAWAY HTTP_1_1_REQUIRED");
+    }
+
+    [Fact]
+    public void CleartextPort_IsHonoured_WhenTheHostDoesNotUseTheContainerDefault()
+    {
+        var plan = KestrelEndpointExtensions.BuildListenerPlan(
+            Config("8082"),
+            HttpProtocols.Http2,
+            redeclareCleartextEndpoint: true,
+            cleartextPort: 5000);
+
+        plan[0].Port.Should().Be(5000);
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Warmup/SelfHttpWarmupTaskBaseTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Warmup/SelfHttpWarmupTaskBaseTests.cs
@@ -1,0 +1,453 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Aspire.Warmup;
+
+namespace MMCA.Common.Aspire.Tests.Warmup;
+
+/// <summary>
+/// The shared self-HTTP warm-up base (ADR-025): once the server is listening, replay a service's hot
+/// read paths against its own endpoint. The behaviors asserted here are the ones the per-service
+/// copies each had to get right on their own: port resolution under dynamic ports, the Testing
+/// short-circuit, the h2c version pin, per-service success semantics, and the non-fatal wrapper that
+/// keeps a failed warm-up from taking the replica down with it.
+/// </summary>
+public sealed class SelfHttpWarmupTaskBaseTests
+{
+    private static IConfiguration Config(string? aspnetcoreUrls = null)
+    {
+        var values = new Dictionary<string, string?>();
+        if (aspnetcoreUrls is not null)
+        {
+            values["ASPNETCORE_URLS"] = aspnetcoreUrls;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private static FakeServer ServerWith(params string[] addresses)
+    {
+        var addressFeature = new ServerAddressesFeature();
+        foreach (var address in addresses)
+        {
+            addressFeature.Addresses.Add(address);
+        }
+
+        var features = new FeatureCollection();
+        features.Set<IServerAddressesFeature>(addressFeature);
+        return new FakeServer(features);
+    }
+
+    private static FakeServer ServerWithoutAddressesFeature() => new(new FeatureCollection());
+
+    /// <summary>A port nothing is listening on: bound then released, so a connect is refused at once.</summary>
+    private static int ClosedPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    // ---------------------------------------------------------------- port resolution
+    [Fact]
+    public void ResolveWarmupPort_PrefersTheServersBoundCleartextAddress()
+    {
+        var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(
+            ServerWith("http://localhost:51234"),
+            Config("http://+:8080"));
+
+        port.Should().Be(51234, "the bound address is the only correct answer under Aspire's dynamic ports");
+    }
+
+    [Fact]
+    public void ResolveWarmupPort_SkipsHttpsAddresses()
+    {
+        var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(
+            ServerWith("https://localhost:7001", "http://localhost:51234"),
+            Config());
+
+        port.Should().Be(51234, "the warm-up self-requests over cleartext");
+    }
+
+    [Fact]
+    public void ResolveWarmupPort_FallsBackToAspnetcoreUrls_WhenTheServerHasNoCleartextAddress()
+    {
+        var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(
+            ServerWith("https://localhost:7001"),
+            Config("http://+:8080"));
+
+        port.Should().Be(8080);
+    }
+
+    [Fact]
+    public void ResolveWarmupPort_FallsBackToAspnetcoreUrls_WhenThereIsNoAddressesFeature()
+    {
+        var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(
+            ServerWithoutAddressesFeature(),
+            Config("http://+:5005"));
+
+        port.Should().Be(5005);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("http://+:not-a-port")]
+    [InlineData("http://localhost:8080/")]
+    public void ResolveWarmupPort_FallsBackToTheContainerDefault_WhenNothingParses(string? aspnetcoreUrls)
+    {
+        var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(ServerWith(), Config(aspnetcoreUrls));
+
+        port.Should().Be(SelfHttpWarmupTaskBase.DefaultPort);
+    }
+
+    // ---------------------------------------------------------------- execution semantics
+    [Fact]
+    public async Task TestingEnvironment_SkipsTheWarmupWithoutWaitingForTheServer()
+    {
+        using var lifetime = new FakeLifetime();
+        var logger = new CapturingLogger();
+        var task = new ConfigurableWarmupTask(
+            ServerWith("http://localhost:8080"),
+            Config(),
+            new FakeEnvironment("Testing"),
+            lifetime,
+            logger,
+            ["anything"]);
+
+        // The lifetime never signals ApplicationStarted, so completing at all proves the
+        // short-circuit ran ahead of the wait: an in-memory TestServer opens no port to warm.
+        await task.ExecuteAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CancellationDuringTheServerWait_IsRethrown()
+    {
+        using var lifetime = new FakeLifetime();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var task = new ConfigurableWarmupTask(
+            ServerWith("http://localhost:8080"),
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            new CapturingLogger(),
+            ["anything"]);
+
+        var act = () => task.ExecuteAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "shutdown is not a warm-up failure and must propagate to the runner");
+    }
+
+    [Fact]
+    public async Task UnreachableEndpoint_IsLoggedAndNonFatal()
+    {
+        using var lifetime = new FakeLifetime();
+        lifetime.SignalStarted();
+        var logger = new CapturingLogger();
+        var task = new ConfigurableWarmupTask(
+            ServerWith($"http://localhost:{ClosedPort().ToString(CultureInfo.InvariantCulture)}"),
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            logger,
+            ["anything"]);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        logger.Entries.Should().ContainSingle()
+            .Which.Level.Should().Be(
+                LogLevel.Warning,
+                "a warm-up that cannot reach its own endpoint falls back to lazy warm-up, it does not crash the host");
+    }
+
+    // ---------------------------------------------------------------- against a real h2c listener
+    [Fact]
+    public async Task ReplaysEveryPathInOrder_OverH2cPriorKnowledge()
+    {
+        await using var server = await TestServerHost.StartAsync(HttpProtocols.Http2, _ => StatusCodes.Status200OK);
+        using var lifetime = new FakeLifetime();
+        lifetime.SignalStarted();
+        var logger = new CapturingLogger();
+
+        var task = new ConfigurableWarmupTask(
+            server.Server,
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            logger,
+            ["Products/paged?pageNumber=1&pageSize=12", "Categories/lookup?nameProperty=Name"]);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        server.RequestedPaths.Should().Equal(
+            "/Products/paged?pageNumber=1&pageSize=12",
+            "/Categories/lookup?nameProperty=Name");
+        logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Information);
+    }
+
+    /// <summary>
+    /// The protected-endpoint profile: a 401 is the expected outcome of an unauthenticated
+    /// self-request and still traverses everything the warm-up exists to JIT, so it must not end the
+    /// run or log a failure.
+    /// </summary>
+    [Fact]
+    public async Task NonSuccessStatus_IsIgnored_WhenSuccessIsNotRequired()
+    {
+        await using var server = await TestServerHost.StartAsync(HttpProtocols.Http2, _ => StatusCodes.Status401Unauthorized);
+        using var lifetime = new FakeLifetime();
+        lifetime.SignalStarted();
+        var logger = new CapturingLogger();
+
+        var task = new ConfigurableWarmupTask(
+            server.Server,
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            logger,
+            ["bookmarks?pageNumber=1&pageSize=10", "users?pageNumber=1&pageSize=10"],
+            requireSuccessStatusCode: false);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        server.RequestedPaths.Should().HaveCount(2, "every path still runs after a by-design refusal");
+        logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Information);
+    }
+
+    /// <summary>
+    /// The output-cache profile: an anonymous read that answers non-2xx warmed nothing, so it is a
+    /// real failure and the remaining paths are abandoned with it.
+    /// </summary>
+    [Fact]
+    public async Task NonSuccessStatus_EndsTheRun_WhenSuccessIsRequired()
+    {
+        await using var server = await TestServerHost.StartAsync(HttpProtocols.Http2, _ => StatusCodes.Status500InternalServerError);
+        using var lifetime = new FakeLifetime();
+        lifetime.SignalStarted();
+        var logger = new CapturingLogger();
+
+        var task = new ConfigurableWarmupTask(
+            server.Server,
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            logger,
+            ["Events/paged?pageNumber=1", "Events?includeFKs=False"]);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        server.RequestedPaths.Should().ContainSingle();
+        logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Warning);
+    }
+
+    /// <summary>
+    /// The Http1AndHttp2 profile (a service with no inbound gRPC server): overriding the version knob
+    /// is what makes the same base talk to an HTTP/1.1-only listener.
+    /// </summary>
+    [Fact]
+    public async Task Http11Override_WarmsAnHttp1OnlyListener()
+    {
+        await using var server = await TestServerHost.StartAsync(HttpProtocols.Http1, _ => StatusCodes.Status200OK);
+        using var lifetime = new FakeLifetime();
+        lifetime.SignalStarted();
+        var logger = new CapturingLogger();
+
+        var task = new ConfigurableWarmupTask(
+            server.Server,
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            logger,
+            ["Orders/paged?pageNumber=1&pageSize=10"],
+            requestVersion: HttpVersion.Version11,
+            requestVersionPolicy: HttpVersionPolicy.RequestVersionOrLower);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        server.RequestedPaths.Should().ContainSingle();
+        logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Information);
+    }
+
+    /// <summary>
+    /// The default h2c pin is not cosmetic: an Http2-only host needs it, and against an
+    /// HTTP/1.1-only listener the exact pin fails rather than silently downgrading.
+    /// </summary>
+    [Fact]
+    public async Task DefaultHttp2Pin_DoesNotDowngrade_AgainstAnHttp1OnlyListener()
+    {
+        await using var server = await TestServerHost.StartAsync(HttpProtocols.Http1, _ => StatusCodes.Status200OK);
+        using var lifetime = new FakeLifetime();
+        lifetime.SignalStarted();
+        var logger = new CapturingLogger();
+
+        var task = new ConfigurableWarmupTask(
+            server.Server,
+            Config(),
+            new FakeEnvironment("Production"),
+            lifetime,
+            logger,
+            ["Products/paged?pageNumber=1"]);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        logger.Entries.Should().ContainSingle().Which.Level.Should().Be(LogLevel.Warning);
+    }
+
+    // ---------------------------------------------------------------- doubles
+    private sealed class ConfigurableWarmupTask(
+        IServer server,
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        IHostApplicationLifetime lifetime,
+        ILogger logger,
+        string[] paths,
+        bool requireSuccessStatusCode = true,
+        Version? requestVersion = null,
+        HttpVersionPolicy requestVersionPolicy = HttpVersionPolicy.RequestVersionExact)
+        : SelfHttpWarmupTaskBase(server, configuration, environment, lifetime, logger)
+    {
+        public override string Name => "TestWarmup";
+
+        protected override IReadOnlyList<string> WarmupPaths => paths;
+
+        protected override bool RequireSuccessStatusCode => requireSuccessStatusCode;
+
+        protected override Version RequestVersion => requestVersion ?? HttpVersion.Version20;
+
+        protected override HttpVersionPolicy RequestVersionPolicy => requestVersionPolicy;
+    }
+
+    private sealed class FakeServer(IFeatureCollection features) : IServer
+    {
+        public IFeatureCollection Features { get; } = features;
+
+        public void Dispose()
+        {
+            // Nothing to release: the feature collection is inert.
+        }
+
+        public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
+            where TContext : notnull => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class FakeEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+
+        public string ApplicationName { get; set; } = "MMCA.Common.Aspire.Tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class FakeLifetime : IHostApplicationLifetime, IDisposable
+    {
+        private readonly CancellationTokenSource _started = new();
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly CancellationTokenSource _stopped = new();
+
+        public CancellationToken ApplicationStarted => _started.Token;
+
+        public CancellationToken ApplicationStopping => _stopping.Token;
+
+        public CancellationToken ApplicationStopped => _stopped.Token;
+
+        public void SignalStarted() => _started.Cancel();
+
+        public void StopApplication() => _stopping.Cancel();
+
+        public void Dispose()
+        {
+            _started.Dispose();
+            _stopping.Dispose();
+            _stopped.Dispose();
+        }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+
+    /// <summary>
+    /// A throwaway Kestrel listener on a dynamic loopback port that records what was requested. Real
+    /// enough to prove the h2c prior-knowledge pin and the status-code semantics; it holds no
+    /// application pipeline beyond a single terminal delegate.
+    /// </summary>
+    private sealed class TestServerHost(WebApplication app, List<string> requestedPaths) : IAsyncDisposable
+    {
+        public IServer Server => app.Services.GetRequiredService<IServer>();
+
+        public IReadOnlyList<string> RequestedPaths => requestedPaths;
+
+        public static async Task<TestServerHost> StartAsync(HttpProtocols protocols, Func<string, int> statusFor)
+        {
+            var requestedPaths = new List<string>();
+
+            var builder = WebApplication.CreateSlimBuilder();
+            builder.Logging.ClearProviders();
+            // Loopback + dynamic port: Kestrel refuses dynamic binding on the "localhost" alias, and a
+            // fixed port would make parallel test runs collide.
+            builder.WebHost.ConfigureKestrel(kestrel =>
+                kestrel.Listen(IPAddress.Loopback, 0, endpoint => endpoint.Protocols = protocols));
+
+            var app = builder.Build();
+            app.Run(async context =>
+            {
+                lock (requestedPaths)
+                {
+                    requestedPaths.Add(context.Request.Path + context.Request.QueryString);
+                }
+
+                context.Response.StatusCode = statusFor(context.Request.Path);
+                await context.Response.WriteAsync("warm");
+            });
+
+            await app.StartAsync();
+            return new TestServerHost(app, requestedPaths);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await app.StopAsync();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/CrossServiceFixtureBaseTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/CrossServiceFixtureBaseTests.cs
@@ -1,0 +1,127 @@
+using AwesomeAssertions;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Covers the container-free logic of <see cref="CrossServiceFixtureBase"/>: connection-string composition
+/// and the first-write-wins environment snapshot. The container lifecycle itself needs a Docker daemon and
+/// is exercised by the consumers' nightly cross-service tiers; everything asserted here would otherwise only
+/// be verified there.
+/// </summary>
+public class CrossServiceFixtureBaseTests
+{
+    private const string BaseConnectionString = "Server=127.0.0.1,1433;User Id=sa;Password=Test1234!;Database=master";
+
+    [Fact]
+    public void ComposeConnectionString_PointsAtTheRequestedCatalog()
+    {
+        var composed = CrossServiceFixtureBase.ComposeConnectionString(BaseConnectionString, "ADC_Conference");
+
+        var builder = new SqlConnectionStringBuilder(composed);
+        builder.InitialCatalog.Should().Be("ADC_Conference");
+        builder.TrustServerCertificate.Should().BeTrue();
+        builder.DataSource.Should().Be("127.0.0.1,1433");
+    }
+
+    [Fact]
+    public void ComposeConnectionString_WithoutAnApplicationName_StaysOrdinallyEqualToTheTopLevelString()
+    {
+        var first = CrossServiceFixtureBase.ComposeConnectionString(BaseConnectionString, "ADC_Conference");
+        var second = CrossServiceFixtureBase.ComposeConnectionString(BaseConnectionString, "ADC_Conference");
+
+        first.Should().Be(second);
+        new SqlConnectionStringBuilder(first).ApplicationName
+            .Should().Be(new SqlConnectionStringBuilder().ApplicationName);
+    }
+
+    [Fact]
+    public void ComposeConnectionString_WithAnApplicationName_DiffersOrdinallyFromThePlainOne()
+    {
+        // The whole named-data-source trick depends on this difference: an ordinally identical connection
+        // string collapses the named source onto Default and the hosts then share one EF model cache entry.
+        var plain = CrossServiceFixtureBase.ComposeConnectionString(BaseConnectionString, "ADC_Conference");
+        var named = CrossServiceFixtureBase.ComposeConnectionString(BaseConnectionString, "ADC_Conference", "MMCA-Conference");
+
+        named.Should().NotBe(plain);
+        new SqlConnectionStringBuilder(named).ApplicationName.Should().Be("MMCA-Conference");
+        new SqlConnectionStringBuilder(named).InitialCatalog.Should().Be("ADC_Conference");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RestoresTheFirstOriginalValue_OfEveryPushedKey()
+    {
+        const string key = "MMCA_TEST_CROSSSERVICE_RESTORE";
+        const string absentKey = "MMCA_TEST_CROSSSERVICE_ABSENT";
+        Environment.SetEnvironmentVariable(key, "original");
+
+        try
+        {
+            var fixture = new FakeCrossServiceFixture();
+            fixture.Push(key, "first");
+            fixture.Push(key, "second");
+            fixture.Push(absentKey, "pushed");
+
+            Environment.GetEnvironmentVariable(key).Should().Be("second");
+            Environment.GetEnvironmentVariable(absentKey).Should().Be("pushed");
+
+            await fixture.DisposeAsync();
+
+            Environment.GetEnvironmentVariable(key).Should().Be("original");
+            Environment.GetEnvironmentVariable(absentKey).Should().BeNull();
+            fixture.HostsDisposed.Should().BeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, null);
+            Environment.SetEnvironmentVariable(absentKey, null);
+        }
+    }
+
+    [Fact]
+    public async Task SetHostConnectionString_PushesTheSharedTopLevelKey()
+    {
+        const string key = "ConnectionStrings__SQLServerConnectionString";
+        var original = Environment.GetEnvironmentVariable(key);
+
+        var fixture = new FakeCrossServiceFixture();
+        try
+        {
+            fixture.PushHostConnectionString("Server=.;Database=Store_Sales;");
+
+            Environment.GetEnvironmentVariable(key).Should().Be("Server=.;Database=Store_Sales;");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            Environment.GetEnvironmentVariable(key).Should().Be(original);
+        }
+    }
+
+    /// <summary>
+    /// A subclass that never starts a container, so the environment and connection-string logic can be
+    /// driven directly on a machine with no Docker daemon.
+    /// </summary>
+    private sealed class FakeCrossServiceFixture : CrossServiceFixtureBase
+    {
+        public bool HostsDisposed { get; private set; }
+
+        protected override IReadOnlyList<CrossServiceDataSource> DataSources =>
+            [new CrossServiceDataSource("Catalog", "Store_Catalog")];
+
+        protected override string MigrationsAssemblyPrefix => "MMCA.Store.Migrations.SqlServer";
+
+        public void Push(string key, string? value) => SetEnvironmentVariable(key, value);
+
+        public void PushHostConnectionString(string connectionString) => SetHostConnectionString(connectionString);
+
+        protected override ValueTask BootHostsAsync() => ValueTask.CompletedTask;
+
+        protected override ValueTask DisposeHostsAsync()
+        {
+            HostsDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/DependencyInjectionAssertTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/DependencyInjectionAssertTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Covers <see cref="DependencyInjectionAssert.ReturnsSameCollection"/>: it must pass for a genuinely
+/// fluent registration and fail for one that hands back a different collection (the failure mode that
+/// silently drops everything chained after it).
+/// </summary>
+public class DependencyInjectionAssertTests
+{
+    [Fact]
+    public void ReturnsSameCollection_Passes_ForAFluentRegistration()
+    {
+        var assert = () => DependencyInjectionAssert.ReturnsSameCollection(
+            services => services.AddSingleton<ISampleService, SampleService>());
+
+        assert.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReturnsSameCollection_Fails_WhenADifferentCollectionIsReturned()
+    {
+        var assert = () => DependencyInjectionAssert.ReturnsSameCollection(
+            services =>
+            {
+                services.AddSingleton<ISampleService, SampleService>();
+                return new ServiceCollection();
+            });
+
+        assert.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void ReturnsSameCollection_RejectsANullRegistration()
+    {
+        var assert = () => DependencyInjectionAssert.ReturnsSameCollection(null!);
+
+        assert.Should().Throw<ArgumentNullException>();
+    }
+
+    private interface ISampleService;
+
+    private sealed class SampleService : ISampleService;
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/JwtTokenGeneratorTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/JwtTokenGeneratorTests.cs
@@ -1,0 +1,98 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Covers <see cref="JwtTokenGenerator.ConfigureInProcessTokenValidation"/>: the shared replacement for the
+/// per-repo <c>InProcessJwtBearer</c> helpers. The behaviour that matters is that JWKS/OIDC discovery is
+/// switched off and the static committed key takes over, because a test host that still tries to discover
+/// fails at the first authenticated request with a network error rather than an auth error.
+/// </summary>
+public class JwtTokenGeneratorTests
+{
+    private const string Audience = "TestAudience";
+
+    private static JwtBearerOptions ConfiguredOptions(string audience = Audience)
+    {
+        var options = new JwtBearerOptions
+        {
+            Authority = "https://identity.example.com",
+            RequireHttpsMetadata = true,
+            ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "https://identity.example.com/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever()),
+        };
+
+        JwtTokenGenerator.ConfigureInProcessTokenValidation(options, audience);
+        return options;
+    }
+
+    [Fact]
+    public void ConfigureInProcessTokenValidation_StopsJwksDiscovery()
+    {
+        var options = ConfiguredOptions();
+
+        options.Authority.Should().BeNull();
+        options.ConfigurationManager.Should().BeNull();
+        options.RequireHttpsMetadata.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConfigureInProcessTokenValidation_ValidatesAgainstTheCommittedTestKey()
+    {
+        var options = ConfiguredOptions();
+
+        options.TokenValidationParameters.ValidateIssuerSigningKey.Should().BeTrue();
+        options.TokenValidationParameters.IssuerSigningKey.Should().BeOfType<RsaSecurityKey>()
+            .Which.KeyId.Should().Be(JwtTokenGenerator.DefaultKeyId);
+        options.TokenValidationParameters.ValidateIssuer.Should().BeTrue();
+        options.TokenValidationParameters.ValidIssuer.Should().Be(JwtTokenGenerator.DefaultIssuer);
+    }
+
+    [Fact]
+    public void ConfigureInProcessTokenValidation_TakesTheAudienceFromTheCaller()
+    {
+        var options = ConfiguredOptions("SomeOtherApi");
+
+        options.TokenValidationParameters.ValidateAudience.Should().BeTrue();
+        options.TokenValidationParameters.ValidAudience.Should().Be("SomeOtherApi");
+    }
+
+    [Fact]
+    public void ConfigureInProcessTokenValidation_AcceptsATokenFromGenerateToken()
+    {
+        var options = ConfiguredOptions();
+        var token = JwtTokenGenerator.GenerateToken(Audience, userId: 42, role: "Admin");
+
+        var principal = new JwtSecurityTokenHandler().ValidateToken(token, options.TokenValidationParameters, out _);
+
+        principal.FindFirst(ClaimTypes.Role)?.Value.Should().Be("Admin");
+        principal.FindFirst("user_id")?.Value.Should().Be("42");
+    }
+
+    [Fact]
+    public void ConfigureInProcessTokenValidation_RejectsATokenForAnotherAudience()
+    {
+        var options = ConfiguredOptions();
+        var token = JwtTokenGenerator.GenerateToken("AnotherApi", userId: 42, role: "Admin");
+
+        var validate = () => new JwtSecurityTokenHandler().ValidateToken(token, options.TokenValidationParameters, out _);
+
+        validate.Should().Throw<SecurityTokenInvalidAudienceException>();
+    }
+
+    [Fact]
+    public void ConfigureInProcessTokenValidation_RejectsANullOptionsArgument()
+    {
+        var configure = () => JwtTokenGenerator.ConfigureInProcessTokenValidation(null!, Audience);
+
+        configure.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/TestPollingTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/TestPollingTests.cs
@@ -1,0 +1,68 @@
+using AwesomeAssertions;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Covers <see cref="TestPolling.PollUntilAsync"/>: the helper every cross-service assertion goes through
+/// instead of a fixed sleep. It must stop at the first satisfying probe, and on timeout it must return the
+/// last probed value (so the caller's own assertion produces the failure message, not a bare timeout).
+/// </summary>
+public class TestPollingTests
+{
+    [Fact]
+    public async Task PollUntilAsync_ReturnsImmediately_WhenTheFirstProbeSatisfies()
+    {
+        var probes = 0;
+
+        var result = await TestPolling.PollUntilAsync(
+            () =>
+            {
+                probes++;
+                return Task.FromResult(7);
+            },
+            value => value == 7,
+            timeout: TimeSpan.FromSeconds(5),
+            interval: TimeSpan.FromMilliseconds(1));
+
+        result.Should().Be(7);
+        probes.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PollUntilAsync_KeepsProbing_UntilTheConditionHolds()
+    {
+        var probes = 0;
+
+        var result = await TestPolling.PollUntilAsync(
+            () => Task.FromResult(++probes),
+            value => value >= 3,
+            timeout: TimeSpan.FromSeconds(5),
+            interval: TimeSpan.FromMilliseconds(1));
+
+        result.Should().Be(3);
+        probes.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task PollUntilAsync_ReturnsTheLastProbedValue_OnTimeout()
+    {
+        var result = await TestPolling.PollUntilAsync(
+            () => Task.FromResult("pending"),
+            value => string.Equals(value, "done", StringComparison.Ordinal),
+            timeout: TimeSpan.FromMilliseconds(20),
+            interval: TimeSpan.FromMilliseconds(1));
+
+        result.Should().Be("pending");
+    }
+
+    [Fact]
+    public async Task PollUntilAsync_RejectsNullArguments()
+    {
+        var nullProbe = async () => await TestPolling.PollUntilAsync<int>(null!, _ => true);
+        var nullCondition = async () => await TestPolling.PollUntilAsync(() => Task.FromResult(1), null!);
+
+        await nullProbe.Should().ThrowAsync<ArgumentNullException>();
+        await nullCondition.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
@@ -75,12 +75,33 @@
           "System.Memory.Data": "8.0.1"
         }
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.4.0",
+        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
         "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
         "dependencies": {
           "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.129.0",
+        "contentHash": "+mTwpvdnCs0366AfuofuBhUFGHuGraWX+4am+NX93sL1tmLTCX6idDS8stDA6JG/5SYdx+UFn7BNu8H5Fjhj9g==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.129.0",
+        "contentHash": "UxMlIB7XX9jZKWUGk/hosD1VGlnb9BTcMzBkhba9ZvN3PZn/bLlhLSDLLFa29Wh/WUfsngpSfz+zuyfChr7Dqw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.129.0"
         }
       },
       "FluentValidation": {
@@ -443,19 +464,19 @@
       },
       "Microsoft.IdentityModel.Protocols": {
         "type": "Transitive",
-        "resolved": "7.7.1",
-        "contentHash": "h+fHHBGokepmCX+QZXJk4Ij8OApCb2n2ktoDkNX5CXteXsOxTHMNgjPGpAwdJMFvAL7TtGarUnk3o97NmBq2QQ==",
+        "resolved": "8.19.2",
+        "contentHash": "sGxSsSrZXNmca6D+jHH2rVRyo2nNRd/g4H9CFbPmLLq0xgoH1U0orLWE5minfijw7+zq49tBs7txenbfAErRoQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "7.7.1"
+          "Microsoft.IdentityModel.Tokens": "8.19.2"
         }
       },
       "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
         "type": "Transitive",
-        "resolved": "7.7.1",
-        "contentHash": "yT2Hdj8LpPbcT9C9KlLVxXl09C8zjFaVSaApdOwuecMuoV4s6Sof/mnTDz/+F/lILPIBvrWugR9CC7iRVZgbfQ==",
+        "resolved": "8.19.2",
+        "contentHash": "1XOcyY36cVymzE3qKdzKaUEZ4Pzt7ZpSa14JZoPPK1NLFUkQDs85TCqpV6XDo0YjFXj6nVK00AfOHppjghjhtw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols": "7.7.1",
-          "System.IdentityModel.Tokens.Jwt": "7.7.1"
+          "Microsoft.IdentityModel.Protocols": "8.19.2",
+          "System.IdentityModel.Tokens.Jwt": "8.19.2"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
@@ -524,6 +545,19 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0"
         }
       },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2024.2.0",
+        "contentHash": "9r+4UF2P51lTztpd+H7SJywk7WgmlWB//Cm2o96c6uGVZU5r58ys2/cD9pCgTk0zCdSkfflWL1WtqQ9I4IVO9Q==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.4.0"
+        }
+      },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
         "resolved": "1.2.0.556",
@@ -566,6 +600,18 @@
         "type": "Transitive",
         "resolved": "9.0.4",
         "contentHash": "o94k2RKuAce3GeDMlUvIXlhVa1kWpJw95E6C9LwW0KlG0nj5+SgCiIxJ2Eroqb9sLtG1mEMbFttZIBZ13EJPvQ=="
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.8.0",
+        "contentHash": "P84aPfFCIxyc+yxwj8J1AjDyv+tnhDYosD3kouXdgxHTV2UPeRvck09l1WLqeVa170wyp6t319x9shzAx5wwvQ==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.129.0",
+          "Docker.DotNet.Enhanced.X509": "3.129.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2024.2.0",
+          "SharpZipLib": "1.4.2"
+        }
       },
       "xunit.analyzers": {
         "type": "Transitive",
@@ -651,12 +697,15 @@
         "dependencies": {
           "AwesomeAssertions": "[9.5.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.10, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, )",
           "Microsoft.Data.SqlClient": "[6.1.1, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "Moq": "[4.20.72, )",
           "Respawn": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.21.0, )",
+          "Testcontainers.MsSql": "[4.8.0, )",
+          "Testcontainers.RabbitMq": "[4.8.0, )",
           "xunit.v3.extensibility.core": "[3.2.2, )"
         }
       },
@@ -679,6 +728,15 @@
         "dependencies": {
           "FluentValidation": "12.1.1",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "VAcqS42zb9WJd9DjPdkVTS5YrQENmNzPNJuRu8VAW7x3TEWUipc4d4hHzVJdFB0h/KLdr4XcXZzRHcUOKVanMQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.19.2"
         }
       },
       "Microsoft.AspNetCore.Mvc.Testing": {
@@ -784,6 +842,24 @@
         "requested": "[1.7.3, )",
         "resolved": "1.7.3",
         "contentHash": "0m52+B4Jce/9AXLXPZnnFW7NeLotHBuYvbsVF3D/DTvvbCGJZdskPn5xjr5sjnnFI3XekNdPqG2djyJE3UU7SA=="
+      },
+      "Testcontainers.MsSql": {
+        "type": "CentralTransitive",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "NOPbOViWvaEXiuh+fg9KoPUYsxt3hOAra1volUPSeWlLFCuS+3HLavaYaocybNOVBtNr0IeTIcQk96OqcMfAwQ==",
+        "dependencies": {
+          "Testcontainers": "4.8.0"
+        }
+      },
+      "Testcontainers.RabbitMq": {
+        "type": "CentralTransitive",
+        "requested": "[4.8.0, )",
+        "resolved": "4.8.0",
+        "contentHash": "RwaylDN7aeud+eYAPb9TfBnC21W5Tb/jg7+w4oBr/PfkbDjQF8Y2pUGvPfcriHcKjc65FxXnZNvd880K+QePuA==",
+        "dependencies": {
+          "Testcontainers": "4.8.0"
+        }
       },
       "xunit.v3.extensibility.core": {
         "type": "CentralTransitive",

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/UserAccountAuthControllerBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/UserAccountAuthControllerBaseTests.cs
@@ -1,0 +1,272 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MMCA.Common.API.Controllers;
+using MMCA.Common.Application.Auth;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Application.Users;
+using MMCA.Common.Application.Users.UseCases.GetPreferences;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+using Moq;
+
+namespace MMCA.Common.API.Tests.Controllers;
+
+public sealed class UserAccountAuthControllerBaseTests
+{
+    private const int UserId = 42;
+
+    private readonly Mock<IAuthenticationService> _authServiceMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+    private readonly Mock<ICommandHandler<TestChangePasswordCommand, Result>> _changePasswordHandlerMock = new();
+    private readonly Mock<ICommandHandler<TestChangePreferencesCommand, Result>> _changePreferencesHandlerMock = new();
+    private readonly Mock<IQueryHandler<GetUserPreferencesQuery, Result<UserPreferencesResponse>>> _getPreferencesHandlerMock = new();
+
+    private TestUserAccountAuthController CreateController() =>
+        new(
+            _authServiceMock.Object,
+            _currentUserServiceMock.Object,
+            _changePasswordHandlerMock.Object,
+            _changePreferencesHandlerMock.Object,
+            _getPreferencesHandlerMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+    // ── ChangePasswordAsync ──
+    [Fact]
+    public async Task ChangePasswordAsync_WhenUserIdNull_ReturnsUnauthorized()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns((int?)null);
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.ChangePasswordAsync(
+            new ChangePasswordRequest("old", "New-Password1!"),
+            CancellationToken.None);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+        _changePasswordHandlerMock.Verify(
+            x => x.HandleAsync(It.IsAny<TestChangePasswordCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_Success_ReturnsNoContentAndDispatchesAppCommand()
+    {
+        var request = new ChangePasswordRequest("old", "New-Password1!");
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _changePasswordHandlerMock
+            .Setup(x => x.HandleAsync(It.IsAny<TestChangePasswordCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.ChangePasswordAsync(request, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        _changePasswordHandlerMock.Verify(
+            x => x.HandleAsync(
+                It.Is<TestChangePasswordCommand>(c => c.UserId == UserId && c.Request == request),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_Failure_ReturnsHandleFailure()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _changePasswordHandlerMock
+            .Setup(x => x.HandleAsync(It.IsAny<TestChangePasswordCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(
+                Error.Unauthorized("Auth.InvalidCurrentPassword", "Current password is incorrect.")));
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.ChangePasswordAsync(
+            new ChangePasswordRequest("wrong", "New-Password1!"),
+            CancellationToken.None);
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        objectResult.Value.Should().BeOfType<ProblemDetails>();
+    }
+
+    // ── ChangePreferencesAsync ──
+    [Fact]
+    public async Task ChangePreferencesAsync_WhenUserIdNull_ReturnsUnauthorized()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns((int?)null);
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.ChangePreferencesAsync(
+            new ChangePreferencesRequest("es", null),
+            CancellationToken.None);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+        _changePreferencesHandlerMock.Verify(
+            x => x.HandleAsync(It.IsAny<TestChangePreferencesCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePreferencesAsync_Success_ReturnsNoContentAndDispatchesAppCommand()
+    {
+        var request = new ChangePreferencesRequest("es", "dark");
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _changePreferencesHandlerMock
+            .Setup(x => x.HandleAsync(It.IsAny<TestChangePreferencesCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.ChangePreferencesAsync(request, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        _changePreferencesHandlerMock.Verify(
+            x => x.HandleAsync(
+                It.Is<TestChangePreferencesCommand>(c => c.UserId == UserId && c.Request == request),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangePreferencesAsync_Failure_ReturnsHandleFailure()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _changePreferencesHandlerMock
+            .Setup(x => x.HandleAsync(It.IsAny<TestChangePreferencesCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(
+                Error.Validation("User.InvalidCulture", "Culture is not supported.")));
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.ChangePreferencesAsync(
+            new ChangePreferencesRequest("zz", null),
+            CancellationToken.None);
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        objectResult.Value.Should().BeOfType<ProblemDetails>();
+    }
+
+    // ── GetPreferencesAsync ──
+    [Fact]
+    public async Task GetPreferencesAsync_WhenUserIdNull_ReturnsUnauthorized()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns((int?)null);
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult<UserPreferencesResponse> result = await sut.GetPreferencesAsync(CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedResult>();
+        _getPreferencesHandlerMock.Verify(
+            x => x.HandleAsync(It.IsAny<GetUserPreferencesQuery>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPreferencesAsync_Success_ReturnsOkWithPreferences()
+    {
+        var preferences = new UserPreferencesResponse("es", "dark");
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _getPreferencesHandlerMock
+            .Setup(x => x.HandleAsync(
+                It.Is<GetUserPreferencesQuery>(q => q.UserId == UserId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(preferences));
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult<UserPreferencesResponse> result = await sut.GetPreferencesAsync(CancellationToken.None);
+
+        var okResult = result.Result as OkObjectResult;
+        okResult.Should().NotBeNull();
+        okResult!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        okResult.Value.Should().Be(preferences);
+    }
+
+    [Fact]
+    public async Task GetPreferencesAsync_Failure_ReturnsHandleFailure()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _getPreferencesHandlerMock
+            .Setup(x => x.HandleAsync(It.IsAny<GetUserPreferencesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<UserPreferencesResponse>(
+                Error.NotFoundError("User.NotFound", "User not found")));
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult<UserPreferencesResponse> result = await sut.GetPreferencesAsync(CancellationToken.None);
+
+        var objectResult = result.Result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        objectResult.Value.Should().BeOfType<ProblemDetails>();
+    }
+
+    // ── inherited AuthControllerBase behavior stays intact ──
+    [Fact]
+    public async Task InheritedLoginAsync_Success_StillReturnsOk()
+    {
+        var authResponse = new AuthenticationResponse("access-token", "refresh-token", DateTime.UtcNow.AddHours(1));
+        var request = new LoginRequest("test@example.com", "Password123!");
+        _authServiceMock.Setup(x => x.LoginAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(authResponse));
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult<AuthenticationResponse> result = await sut.LoginAsync(request, CancellationToken.None);
+
+        var okResult = result.Result as OkObjectResult;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().Be(authResponse);
+    }
+
+    [Fact]
+    public async Task InheritedRevokeAsync_Success_StillReturnsNoContent()
+    {
+        _currentUserServiceMock.Setup(x => x.UserId).Returns(UserId);
+        _authServiceMock.Setup(x => x.RevokeTokenAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        TestUserAccountAuthController sut = CreateController();
+
+        ActionResult result = await sut.RevokeAsync(CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+    }
+}
+
+/// <summary>
+/// Stand-in for an app change-password command (the real ones stay app-side). Public because Moq
+/// proxies <c>ICommandHandler&lt;TestChangePasswordCommand, Result&gt;</c> over it.
+/// </summary>
+public sealed record TestChangePasswordCommand(UserIdentifierType UserId, ChangePasswordRequest Request)
+    : IUserScopedCommand<ChangePasswordRequest>;
+
+/// <summary>
+/// Stand-in for an app change-preferences command (the real ones stay app-side). Public because Moq
+/// proxies <c>ICommandHandler&lt;TestChangePreferencesCommand, Result&gt;</c> over it.
+/// </summary>
+public sealed record TestChangePreferencesCommand(UserIdentifierType UserId, ChangePreferencesRequest Request)
+    : IUserScopedCommand<ChangePreferencesRequest>;
+
+internal sealed class TestUserAccountAuthController(
+    IAuthenticationService authenticationService,
+    ICurrentUserService currentUserService,
+    ICommandHandler<TestChangePasswordCommand, Result> changePasswordHandler,
+    ICommandHandler<TestChangePreferencesCommand, Result> changePreferencesHandler,
+    IQueryHandler<GetUserPreferencesQuery, Result<UserPreferencesResponse>> getUserPreferencesHandler)
+    : UserAccountAuthControllerBase<TestChangePasswordCommand, TestChangePreferencesCommand>(
+        authenticationService,
+        currentUserService,
+        changePasswordHandler,
+        changePreferencesHandler,
+        getUserPreferencesHandler)
+{
+    protected override TestChangePasswordCommand CreateChangePasswordCommand(
+        UserIdentifierType userId,
+        ChangePasswordRequest request) => new(userId, request);
+
+    protected override TestChangePreferencesCommand CreateChangePreferencesCommand(
+        UserIdentifierType userId,
+        ChangePreferencesRequest request) => new(userId, request);
+}

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/WebVitalsBudgetTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/WebVitalsBudgetTests.cs
@@ -1,0 +1,74 @@
+using MMCA.Common.Testing.E2E.Infrastructure;
+using Xunit;
+
+namespace MMCA.Common.UI.E2E.Tests;
+
+/// <summary>
+/// Pure unit coverage for the shared budget mechanics in <see cref="WebVitalsBudget"/> (no browser is
+/// started). It is the one place the behaviours that only ever fire on a REGRESSION can be exercised: that
+/// each metric actually fails when it exceeds its ceiling, and that a 0 INP (no interaction cleared the
+/// 16 ms event threshold) is skipped rather than read as a pass or a failure.
+/// </summary>
+public sealed class WebVitalsBudgetTests
+{
+    private static WebVitalsSample Good() => new() { Lcp = 600, Fcp = 400, Ttfb = 30, Cls = 0.005, Inp = 32 };
+
+    [Fact]
+    public void Defaults_AreTheCoreWebVitalsGoodBand()
+    {
+        var budget = new WebVitalsBudget();
+
+        Assert.Equal(2500, budget.Lcp);
+        Assert.Equal(1800, budget.Fcp);
+        Assert.Equal(800, budget.Ttfb);
+        Assert.Equal(0.1, budget.Cls);
+        Assert.Equal(500, budget.Inp);
+    }
+
+    [Fact]
+    public void AssertWithinBudget_Passes_ForASampleInsideEveryCeiling() =>
+        new WebVitalsBudget().AssertWithinBudget(Good(), "unit", "/");
+
+    [Fact]
+    public void AssertWithinBudget_WritesTheSampleLine()
+    {
+        var lines = new List<string>();
+
+        new WebVitalsBudget().AssertWithinBudget(Good(), "sessions", "/conference/sessions", lines.Add);
+
+        var line = Assert.Single(lines);
+        Assert.Equal(
+            "[web-vitals:sessions] path=/conference/sessions LCP=600ms FCP=400ms CLS=0.005 TTFB=30ms INP-sample=32ms",
+            line);
+    }
+
+    [Theory]
+    [InlineData(3000, 400, 30, 0.005, 32)] // LCP over
+    [InlineData(600, 2000, 30, 0.005, 32)] // FCP over
+    [InlineData(600, 400, 900, 0.005, 32)] // TTFB over
+    [InlineData(600, 400, 30, 0.2, 32)] // CLS over
+    [InlineData(600, 400, 30, 0.005, 700)] // INP sample over
+    public void AssertWithinBudget_Fails_WhenAnyMetricExceedsItsCeiling(double lcp, double fcp, double ttfb, double cls, double inp)
+    {
+        var sample = new WebVitalsSample { Lcp = lcp, Fcp = fcp, Ttfb = ttfb, Cls = cls, Inp = inp };
+
+        Assert.ThrowsAny<Exception>(() => new WebVitalsBudget().AssertWithinBudget(sample, "unit", "/"));
+    }
+
+    [Fact]
+    public void AssertWithinBudget_SkipsInp_WhenNoInteractionSampleWasRecorded()
+    {
+        var sample = Good() with { Inp = 0 };
+
+        new WebVitalsBudget(Inp: 1).AssertWithinBudget(sample, "unit", "/");
+    }
+
+    [Fact]
+    public void AssertWithinBudget_HonoursACallerSuppliedBudget()
+    {
+        var sample = Good() with { Lcp = 5000 };
+
+        new WebVitalsBudget(Lcp: 8000).AssertWithinBudget(sample, "unit", "/");
+        Assert.ThrowsAny<Exception>(() => new WebVitalsBudget(Lcp: 4000).AssertWithinBudget(sample, "unit", "/"));
+    }
+}


### PR DESCRIPTION
## Summary

Wave 5 of the move-to-Common extraction plan (workspace `Docs/Planning/CommonExtraction-plan.md`), sourced from the 2026-08-03 six-agent layer scan with adversarial verification. All items are **additive**: no existing public member changed, no EF schema change, no consumer break.

### New surface by package
- **Aspire**: `ConfigureEndpointsWithHealthProbe` (collapses 5 identical KestrelConfiguration copies + Notification's variant); `SelfHttpWarmupTaskBase` (approved E13 revisit: 6 near-identical warm-up tasks keep only Name/paths/HTTP-version overrides)
- **Aspire.Hosting**: `WithE2eRegistrationThrottleLift`
- **Infrastructure**: `EmailValueConverter`/`PhoneNumberValueConverter` (+nullable variants); `OwnsMoney` (proved facet-for-facet identical mapping to the 3 hand-rolled Store blocks: no migration); `HasSoftDeleteFilter`; `IdentityModuleDbSeederBase` (Wave 3.4)
- **Domain**: 5 new `CommonInvariants` helpers; `OwnedByUserSpecification`; `IPasswordChangeableUser`/`IUserPreferences`/`IErasableUser` (the last defends against ADC's method-hiding `new Delete()`, regression-tested)
- **Application**: Users handler bases (Wave 3.2); `UserOwnershipRule`; `SoftDeletedUserValidator<TUser>` (Wave 3.3 validator half; Mapperly half verified non-viable); **bug fix**: `GetAllForLookupAsync` now forwards its `where` predicate
- **Shared**: `ChangePreferencesRequest`/`UserPreferencesResponse`
- **API**: `UserAccountAuthControllerBase` (subclass of unchanged `AuthControllerBase`)
- **Testing**: `ConfigureInProcessTokenValidation` (adds JwtBearer dep, approved); `CrossServiceFixtureBase` + `TestPolling` (adds Testcontainers MsSql/RabbitMq deps, test-tier only); `DependencyInjectionAssert`; `ModuleConformanceTestsBase` (Testing.Architecture); `WebVitalsBudget` (Testing.E2E)
- **UI / UI.Maui**: `AddUIModule<TModule>`; hardened `MauiTokenStorageService`; `NativeThemeSync`; `MainPageBase` (XAML subclassing verified Debug+Release); UI.Maui csproj moves to `Microsoft.NET.Sdk.Razor`

FACTS regenerated: 100 fitness methods / 32 bases (Common executes 78).

## Test plan
- Full Release suite: **2898 passed / 0 failed** locally
- UI.Maui windows TFM builds clean Debug+Release (other TFMs are CI's windows job)
- Consumer adoption (ADC/Store/Helpdesk) follows in the release sweep per ADR-016; consumer-source-build canary covers Helpdesk against this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX