### PR TITLE
feat!: remove the never-honored orderBy parameter from GetAllForLookupAsync

### DIFF
--- a/Source/Core/MMCA.Common.Application/Interfaces/IEntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/IEntityQueryService.cs
@@ -75,14 +75,18 @@ public interface IEntityQueryService<TEntity, TEntityDTO, TIdentifierType>
     /// </summary>
     /// <param name="nameProperty">The entity property to use as the display name.</param>
     /// <param name="where">Optional filter expression.</param>
-    /// <param name="orderBy">Optional ordering expression.</param>
     /// <param name="asTracking">Whether to track entities in the EF change tracker.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A collection of id/name lookup pairs.</returns>
+    /// <returns>A collection of id/name lookup pairs, ordered by display name.</returns>
+    /// <remarks>
+    /// Results are always ordered by the projected display name (the repository orders after the
+    /// id/name projection). An <c>orderBy</c> parameter existed here through v1.138.0 but was never
+    /// honored (the repository contract has no ordering hook), so it was removed rather than widened;
+    /// see the extraction plan if entity-level lookup ordering ever becomes a real requirement.
+    /// </remarks>
     Task<Result<IReadOnlyCollection<BaseLookup<TIdentifierType>>>> GetAllForLookupAsync(
         string nameProperty,
         Expression<Func<TEntity, bool>>? where = null,
-        Expression<Func<TEntity, string>>? orderBy = null,
         bool asTracking = false,
         CancellationToken cancellationToken = default);
 

--- a/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EntityQueryService.cs
@@ -278,7 +278,6 @@ public class EntityQueryService<TEntity, TEntityDTO, TIdentifierType>(
     public virtual async Task<Result<IReadOnlyCollection<BaseLookup<TIdentifierType>>>> GetAllForLookupAsync(
         string nameProperty,
         Expression<Func<TEntity, bool>>? where = null,
-        Expression<Func<TEntity, string>>? orderBy = null,
         bool asTracking = false,
         CancellationToken cancellationToken = default)
     {

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/EntityControllerBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/EntityControllerBaseTests.cs
@@ -199,7 +199,6 @@ public sealed class EntityControllerBaseTests
             .Setup(q => q.GetAllForLookupAsync(
                 "Name",
                 null,
-                null,
                 false,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(lookups));
@@ -222,7 +221,6 @@ public sealed class EntityControllerBaseTests
         _queryServiceMock
             .Setup(q => q.GetAllForLookupAsync(
                 "Name",
-                null,
                 null,
                 false,
                 It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Deletes the decorative orderBy parameter from IEntityQueryService.GetAllForLookupAsync (accepted-and-dropped since introduction; the repository contract has no ordering hook and lookups are always name-ordered). No consumer passes it; consumer-side impact is mock-arity only and rides the v1.139.0 sweep. Full suite 2898/2898 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX