### PR TITLE
fix: close bug-hunt items H19, H20 and M50-M56

### DIFF
--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/GetHistory/GetNotificationHistoryHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/GetHistory/GetNotificationHistoryHandler.cs
@@ -40,7 +40,10 @@ public sealed class GetNotificationHistoryHandler(
             cancellationToken).ConfigureAwait(false);
 
         IReadOnlyCollection<PushNotificationDTO> dtos = dtoMapper.MapToDTOs(paged);
-        var metadata = new PaginationMetadata(totalCount, take, query.PageNumber);
+
+        // The floor mirrors what PagingMath.Clamp already applied for the read, so the metadata
+        // reports the page actually served instead of throwing on a sub-1 page number.
+        var metadata = new PaginationMetadata(totalCount, take, Math.Max(query.PageNumber, 1));
 
         return Result.Success(new PagedCollectionResult<PushNotificationDTO>(dtos, metadata));
     }

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsHandler.cs
@@ -54,7 +54,9 @@ public sealed class GetMyNotificationsHandler(
             joined.Skip(skip).Take(take),
             cancellationToken).ConfigureAwait(false);
 
-        var metadata = new PaginationMetadata(totalCount, take, query.PageNumber);
+        // The floor mirrors what PagingMath.Clamp already applied for the read, so the metadata
+        // reports the page actually served instead of throwing on a sub-1 page number.
+        var metadata = new PaginationMetadata(totalCount, take, Math.Max(query.PageNumber, 1));
         return Result.Success(new PagedCollectionResult<UserNotificationDTO>(paged, metadata));
     }
 }

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/FilterValueParser.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/FilterValueParser.cs
@@ -42,8 +42,8 @@ internal static class FilterValueParser
     /// <summary>
     /// Whether a value-type strategy can apply <paramref name="value"/> under <paramref name="op"/>,
     /// following the shape every built-in strategy shares: presence checks ignore the value, IN needs
-    /// at least one parseable item, BETWEEN needs exactly two bounds, and every other operator needs
-    /// the single scalar to parse.
+    /// at least one parseable item, BETWEEN needs exactly two segments that both parse, and every
+    /// other operator needs the single scalar to parse.
     /// </summary>
     /// <typeparam name="T">The value type each item parses to.</typeparam>
     /// <param name="op">The operator, already uppercased by the caller.</param>
@@ -59,8 +59,28 @@ internal static class FilterValueParser
         {
             "IS EMPTY" or "IS NOT EMPTY" => true,
             "IN" => ParseList(value, parse).Count > 0,
-            "BETWEEN" => ParseList(value, parse).Count == 2,
+            "BETWEEN" => HasExactlyTwoBounds(value, parse),
             _ => parse(value) is not null,
         };
+    }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is exactly two comma-separated segments that both parse.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not use <see cref="StringSplitOptions.RemoveEmptyEntries"/> and does not go
+    /// through <see cref="ParseList{T}(string, Func{string, T?})"/>: dropping unparseable and empty
+    /// segments let "5,abc,10" and "5,,10" validate as a two-bound range, and the strategies then
+    /// applied the surviving pair as the bounds the caller never asked for.
+    /// </remarks>
+    private static bool HasExactlyTwoBounds<T>(string value, Func<string, T?> parse)
+        where T : struct
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var parts = value.Split(Separator, StringSplitOptions.TrimEntries);
+
+        return parts.Length == 2 && parse(parts[0]) is not null && parse(parts[1]) is not null;
     }
 }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingCommandDecorator.cs
@@ -7,7 +7,8 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// <summary>
 /// Decorator that invalidates cached data after a command succeeds, when the command
 /// implements the <see cref="ICacheInvalidating"/> marker interface. Cache entries
-/// matching the command's <see cref="ICacheInvalidating.CachePrefix"/> are evicted.
+/// matching the command's <see cref="ICacheInvalidating.CachePrefix"/> are evicted; an empty or
+/// whitespace prefix is the opt-out and evicts nothing.
 /// <para>
 /// Invalidation is intentionally skipped on failure results to avoid evicting valid
 /// cache entries when the mutation did not actually persist any changes.
@@ -48,8 +49,12 @@ public sealed partial class CachingCommandDecorator<TCommand, TResult>(
     {
         var result = await inner.HandleAsync(command, cancellationToken).ConfigureAwait(false);
 
-        // Only invalidate cache on success — failed commands should not evict valid cache entries
-        if (command is ICacheInvalidating cacheInvalidating && !IsFailure(result))
+        // Only invalidate cache on success — failed commands should not evict valid cache entries.
+        // An empty prefix is the opt-out for commands that carry a defaulted prefix, and the guard
+        // is load-bearing either way: RemoveByPrefixAsync("") would evict the entire cache.
+        if (command is ICacheInvalidating cacheInvalidating
+            && !string.IsNullOrWhiteSpace(cacheInvalidating.CachePrefix)
+            && !IsFailure(result))
         {
             try
             {

--- a/Source/Core/MMCA.Common.Application/UseCases/DeleteEntityCommand.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/DeleteEntityCommand.cs
@@ -2,13 +2,20 @@ namespace MMCA.Common.Application.UseCases;
 
 /// <summary>
 /// Generic delete command for any aggregate root entity. The <typeparamref name="TEntity"/>
-/// type parameter is not used at runtime but is required so that DI can distinguish between
-/// delete handlers for different entity types that share the same identifier type.
+/// type parameter distinguishes delete handlers for different entity types that share the same
+/// identifier type, and supplies the default cache prefix evicted after a successful delete.
 /// </summary>
-/// <typeparam name="TEntity">The entity type to delete (used for DI type discrimination).</typeparam>
+/// <typeparam name="TEntity">The entity type to delete.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
 /// <param name="Id">The primary key of the entity to delete.</param>
-#pragma warning disable S2326 // TEntity is used for DI type discrimination between modules with same TIdentifierType
-public sealed record DeleteEntityCommand<TEntity, TIdentifierType>(TIdentifierType Id)
-    where TIdentifierType : notnull;
-#pragma warning restore S2326
+public sealed record DeleteEntityCommand<TEntity, TIdentifierType>(TIdentifierType Id) : ICacheInvalidating
+    where TIdentifierType : notnull
+{
+    /// <summary>
+    /// Gets the cache key prefix evicted after a successful delete. Defaults to the
+    /// aggregate-prefix convention every consumer already keys its cached reads under
+    /// (<c>{entity full name}:</c>), because the generic controller constructs this command
+    /// itself and cannot supply one. Set it to an empty string to opt out of invalidation.
+    /// </summary>
+    public string CachePrefix { get; init; } = typeof(TEntity).FullName + ":";
+}

--- a/Source/Core/MMCA.Common.Shared/Abstractions/PaginationMetadata.cs
+++ b/Source/Core/MMCA.Common.Shared/Abstractions/PaginationMetadata.cs
@@ -30,17 +30,45 @@ public sealed record PaginationMetadata
         CurrentPage = currentPage;
     }
 
+    // The init accessors re-validate because object initializers, record "with" expressions and
+    // System.Text.Json (which builds this type through the parameterless constructor plus the init
+    // setters) all bypass the constructor guards above.
+
     /// <summary>Gets the total number of items across all pages.</summary>
     [DataMember(Order = 1)]
-    public int TotalItemCount { get; init; }
+    public int TotalItemCount
+    {
+        get;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            field = value;
+        }
+    }
 
     /// <summary>Gets the number of items per page.</summary>
     [DataMember(Order = 2)]
-    public int PageSize { get; init; }
+    public int PageSize
+    {
+        get;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            field = value;
+        }
+    }
 
     /// <summary>Gets the 1-based current page number.</summary>
     [DataMember(Order = 3)]
-    public int CurrentPage { get; init; }
+    public int CurrentPage
+    {
+        get;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            field = value;
+        }
+    }
 
     /// <summary>Gets the total number of pages (ceiling division of total items by page size).</summary>
     [IgnoreDataMember]

--- a/Source/Presentation/MMCA.Common.API/SessionCookies/CookieSessionRefresher.cs
+++ b/Source/Presentation/MMCA.Common.API/SessionCookies/CookieSessionRefresher.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using MMCA.Common.Shared.Auth;
+using MMCA.Common.Shared.Concurrency;
 
 namespace MMCA.Common.API.SessionCookies;
 
@@ -34,23 +35,28 @@ public interface ICookieSessionRefresher
 }
 
 /// <summary>
-/// Singleton refresher. A process-wide lock plus a short rotation-grace cache collapse concurrent
+/// Singleton refresher. A per-token lock plus a short rotation-grace cache collapse concurrent
 /// refreshes (single-flight): the first request rotates and caches the result keyed by the OLD refresh
 /// token; queued/slightly-late siblings carrying the same expired pair return the cached result instead
-/// of rotating again — preventing double rotation under a thundering herd. Refreshes are infrequent
-/// (only on access-token expiry during a cold navigation) and each holds the lock for one short HTTP call.
+/// of rotating again — preventing double rotation under a thundering herd.
+/// <para>
+/// The lock is striped by refresh token rather than process-wide: it is held across an outbound HTTP
+/// call, so a single semaphore serialized every unrelated user's cold navigation behind whichever
+/// refresh was in flight. Two unrelated tokens can still share a stripe, which is harmless because the
+/// rotation-grace cache is re-checked per token after acquiring.
+/// </para>
 /// </summary>
 internal sealed class CookieSessionRefresher(
     IHttpClientFactory httpClientFactory,
     IMemoryCache cache,
-    IWebHostEnvironment environment) : ICookieSessionRefresher, IDisposable
+    IWebHostEnvironment environment) : ICookieSessionRefresher
 {
     internal const string RefreshClientName = "SessionCookieRefreshClient";
 
     private static readonly TimeSpan ClockSkew = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan RotationGrace = TimeSpan.FromSeconds(10);
 
-    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private readonly KeyedSemaphoreStripe _refreshLocks = new();
 
     public async Task<SessionTokenResult?> GetOrRefreshAsync(HttpContext context, CancellationToken cancellationToken = default)
     {
@@ -90,21 +96,15 @@ internal sealed class CookieSessionRefresher(
             return cached;
         }
 
-        await _refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            // Double-check: a request we were queued behind may have just rotated this same token.
-            if (cache.TryGetValue(CacheKey(refreshToken), out cached))
-            {
-                return cached;
-            }
+        using var releaser = await _refreshLocks.AcquireAsync(CacheKey(refreshToken), cancellationToken).ConfigureAwait(false);
 
-            return await CallRefreshAsync(accessToken, refreshToken).ConfigureAwait(false);
-        }
-        finally
+        // Double-check: a request we were queued behind may have just rotated this same token.
+        if (cache.TryGetValue(CacheKey(refreshToken), out cached))
         {
-            _refreshLock.Release();
+            return cached;
         }
+
+        return await CallRefreshAsync(accessToken, refreshToken).ConfigureAwait(false);
     }
 
     private async Task<AuthenticationResponse?> CallRefreshAsync(string accessToken, string refreshToken)
@@ -165,7 +165,9 @@ internal sealed class CookieSessionRefresher(
         }
     }
 
-    private static string CacheKey(string refreshToken) => $"mmca:session-refresh:{refreshToken}";
-
-    public void Dispose() => _refreshLock.Dispose();
+    /// <summary>
+    /// The rotation-grace cache key, which is also the striping key. Internal rather than private so a
+    /// concurrency test can pick two refresh tokens that do not land on the same stripe.
+    /// </summary>
+    internal static string CacheKey(string refreshToken) => $"mmca:session-refresh:{refreshToken}";
 }

--- a/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
@@ -31,8 +31,22 @@ public sealed class MauiTokenStorageService : ITokenStorageService
     /// <inheritdoc />
     public async Task SetTokensAsync(string accessToken, string refreshToken)
     {
-        await SetAsync(AccessTokenKey, accessToken);
+        // Refresh first: if it fails the old pair stays coherent. If the access write then fails,
+        // drop both so storage is a clean signed-out state instead of a mismatched pair holding a
+        // new access token against a stale refresh token whose refresh path is already dead.
         await SetAsync(RefreshTokenKey, refreshToken);
+        try
+        {
+            await SetAsync(AccessTokenKey, accessToken);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; rethrown after the cleanup
+        catch
+#pragma warning restore CA1031
+        {
+            TryRemove(AccessTokenKey);
+            TryRemove(RefreshTokenKey);
+            throw;
+        }
     }
 
     /// <inheritdoc />

--- a/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.138, )",
+        "resolved": "3.0.138",
+        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -70,9 +70,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.31.0.145097, )",
+        "resolved": "10.31.0.145097",
+        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -571,33 +571,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
+        "resolved": "8.22.0",
+        "contentHash": "LU3V3owsu4vGpCg2kyL7SsQEuHwcoJ8FSNBqzLADzCf3/PcKUTcx5Plsd51DoTJMfK/WigXV/03UhaN5JXE6uQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
+        "resolved": "8.22.0",
+        "contentHash": "kv6peMLjALZLDAy2H3F77KjVRdwiscn2p/g3ui2chcbuEcAX2MpAbyDcYnJ7Vyh8jZ1aJWrniUMCDWoOgnu4NQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
+        "resolved": "8.22.0",
+        "contentHash": "G9Tl0yXSlr2pkXv4EpXjO16M4q6oo9N/od+gNyOusZ8yM8LZg1H3f/QOMFuOJiV6znzY5MkAREU97JRRnqpEQw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.21.0"
+          "Microsoft.IdentityModel.Abstractions": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
+        "resolved": "8.22.0",
+        "contentHash": "i4lywKKUuVmheCUA+w/q8QNPReNI0qanHI9hhz48AFqD1ljyb8sxPL2RbXOGiPV13XdJ4kxieL9ukS7tD43LxA==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.21.0"
+          "Microsoft.IdentityModel.Logging": "8.22.0"
         }
       },
       "Microsoft.JSInterop": {
@@ -1750,7 +1750,7 @@
           "MudBlazor": "[9.7.0, )",
           "Polly": "[8.7.0, )",
           "Scrutor": "[7.0.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[8.21.0, )"
+          "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
       },
       "Microsoft.AspNetCore.Components.Authorization": {
@@ -1908,12 +1908,12 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
-        "resolved": "8.21.0",
-        "contentHash": "dKsTkmlpUf/I6g1Aw9joWaZAahXvC0gWGQvkXW1IjZLSefC/4LhQI0tL0VIs64/NZQbl4XnQvLQyu6c7z1pMxg==",
+        "requested": "[8.22.0, )",
+        "resolved": "8.22.0",
+        "contentHash": "CpXGfNhLl6EgYaOC9XYsc1p7Ci9HtAy0soHJDSBNGse647al4tTq9RDr+LQsrF4Ls79Dx7VfzN34km0W4DWPow==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.22.0",
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       }
     },
@@ -1930,9 +1930,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.138, )",
+        "resolved": "3.0.138",
+        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -1992,9 +1992,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.31.0.145097, )",
+        "resolved": "10.31.0.145097",
+        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -2470,33 +2470,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
+        "resolved": "8.22.0",
+        "contentHash": "LU3V3owsu4vGpCg2kyL7SsQEuHwcoJ8FSNBqzLADzCf3/PcKUTcx5Plsd51DoTJMfK/WigXV/03UhaN5JXE6uQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
+        "resolved": "8.22.0",
+        "contentHash": "kv6peMLjALZLDAy2H3F77KjVRdwiscn2p/g3ui2chcbuEcAX2MpAbyDcYnJ7Vyh8jZ1aJWrniUMCDWoOgnu4NQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
+        "resolved": "8.22.0",
+        "contentHash": "G9Tl0yXSlr2pkXv4EpXjO16M4q6oo9N/od+gNyOusZ8yM8LZg1H3f/QOMFuOJiV6znzY5MkAREU97JRRnqpEQw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.21.0"
+          "Microsoft.IdentityModel.Abstractions": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
+        "resolved": "8.22.0",
+        "contentHash": "i4lywKKUuVmheCUA+w/q8QNPReNI0qanHI9hhz48AFqD1ljyb8sxPL2RbXOGiPV13XdJ4kxieL9ukS7tD43LxA==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.21.0"
+          "Microsoft.IdentityModel.Logging": "8.22.0"
         }
       },
       "Microsoft.JSInterop": {
@@ -2609,7 +2609,7 @@
           "MudBlazor": "[9.7.0, )",
           "Polly": "[8.7.0, )",
           "Scrutor": "[7.0.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[8.21.0, )"
+          "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
       },
       "Microsoft.AspNetCore.Components.Authorization": {
@@ -2767,12 +2767,12 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
-        "resolved": "8.21.0",
-        "contentHash": "dKsTkmlpUf/I6g1Aw9joWaZAahXvC0gWGQvkXW1IjZLSefC/4LhQI0tL0VIs64/NZQbl4XnQvLQyu6c7z1pMxg==",
+        "requested": "[8.22.0, )",
+        "resolved": "8.22.0",
+        "contentHash": "CpXGfNhLl6EgYaOC9XYsc1p7Ci9HtAy0soHJDSBNGse647al4tTq9RDr+LQsrF4Ls79Dx7VfzN34km0W4DWPow==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.22.0",
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       }
     },
@@ -2789,9 +2789,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.138, )",
+        "resolved": "3.0.138",
+        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -2851,9 +2851,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.31.0.145097, )",
+        "resolved": "10.31.0.145097",
+        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -3329,33 +3329,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
+        "resolved": "8.22.0",
+        "contentHash": "LU3V3owsu4vGpCg2kyL7SsQEuHwcoJ8FSNBqzLADzCf3/PcKUTcx5Plsd51DoTJMfK/WigXV/03UhaN5JXE6uQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
+        "resolved": "8.22.0",
+        "contentHash": "kv6peMLjALZLDAy2H3F77KjVRdwiscn2p/g3ui2chcbuEcAX2MpAbyDcYnJ7Vyh8jZ1aJWrniUMCDWoOgnu4NQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
+        "resolved": "8.22.0",
+        "contentHash": "G9Tl0yXSlr2pkXv4EpXjO16M4q6oo9N/od+gNyOusZ8yM8LZg1H3f/QOMFuOJiV6znzY5MkAREU97JRRnqpEQw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.21.0"
+          "Microsoft.IdentityModel.Abstractions": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
+        "resolved": "8.22.0",
+        "contentHash": "i4lywKKUuVmheCUA+w/q8QNPReNI0qanHI9hhz48AFqD1ljyb8sxPL2RbXOGiPV13XdJ4kxieL9ukS7tD43LxA==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.21.0"
+          "Microsoft.IdentityModel.Logging": "8.22.0"
         }
       },
       "Microsoft.JSInterop": {
@@ -3468,7 +3468,7 @@
           "MudBlazor": "[9.7.0, )",
           "Polly": "[8.7.0, )",
           "Scrutor": "[7.0.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[8.21.0, )"
+          "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
       },
       "Microsoft.AspNetCore.Components.Authorization": {
@@ -3626,12 +3626,12 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
-        "resolved": "8.21.0",
-        "contentHash": "dKsTkmlpUf/I6g1Aw9joWaZAahXvC0gWGQvkXW1IjZLSefC/4LhQI0tL0VIs64/NZQbl4XnQvLQyu6c7z1pMxg==",
+        "requested": "[8.22.0, )",
+        "resolved": "8.22.0",
+        "contentHash": "CpXGfNhLl6EgYaOC9XYsc1p7Ci9HtAy0soHJDSBNGse647al4tTq9RDr+LQsrF4Ls79Dx7VfzN34km0W4DWPow==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.22.0",
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       }
     },
@@ -3648,9 +3648,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.138, )",
+        "resolved": "3.0.138",
+        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -3705,9 +3705,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.31.0.145097, )",
+        "resolved": "10.31.0.145097",
+        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -4193,33 +4193,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
+        "resolved": "8.22.0",
+        "contentHash": "LU3V3owsu4vGpCg2kyL7SsQEuHwcoJ8FSNBqzLADzCf3/PcKUTcx5Plsd51DoTJMfK/WigXV/03UhaN5JXE6uQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
+        "resolved": "8.22.0",
+        "contentHash": "kv6peMLjALZLDAy2H3F77KjVRdwiscn2p/g3ui2chcbuEcAX2MpAbyDcYnJ7Vyh8jZ1aJWrniUMCDWoOgnu4NQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
+        "resolved": "8.22.0",
+        "contentHash": "G9Tl0yXSlr2pkXv4EpXjO16M4q6oo9N/od+gNyOusZ8yM8LZg1H3f/QOMFuOJiV6znzY5MkAREU97JRRnqpEQw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.21.0"
+          "Microsoft.IdentityModel.Abstractions": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
+        "resolved": "8.22.0",
+        "contentHash": "i4lywKKUuVmheCUA+w/q8QNPReNI0qanHI9hhz48AFqD1ljyb8sxPL2RbXOGiPV13XdJ4kxieL9ukS7tD43LxA==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.21.0"
+          "Microsoft.IdentityModel.Logging": "8.22.0"
         }
       },
       "Microsoft.IO.RecyclableMemoryStream": {
@@ -4488,7 +4488,7 @@
           "MudBlazor": "[9.7.0, )",
           "Polly": "[8.7.0, )",
           "Scrutor": "[7.0.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[8.21.0, )"
+          "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
       },
       "Microsoft.AspNetCore.Components.Authorization": {
@@ -4646,12 +4646,12 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
-        "resolved": "8.21.0",
-        "contentHash": "dKsTkmlpUf/I6g1Aw9joWaZAahXvC0gWGQvkXW1IjZLSefC/4LhQI0tL0VIs64/NZQbl4XnQvLQyu6c7z1pMxg==",
+        "requested": "[8.22.0, )",
+        "resolved": "8.22.0",
+        "contentHash": "CpXGfNhLl6EgYaOC9XYsc1p7Ci9HtAy0soHJDSBNGse647al4tTq9RDr+LQsrF4Ls79Dx7VfzN34km0W4DWPow==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.22.0",
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       }
     }

--- a/Source/Presentation/MMCA.Common.UI.Web/Services/ServerTokenStorageService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Web/Services/ServerTokenStorageService.cs
@@ -22,6 +22,8 @@ public sealed class ServerTokenStorageService(
 {
     private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(30);
 
+    private readonly Lock _hydrateSync = new();
+
     private string? _accessToken;
     private Task<string?>? _hydrateInFlight;
 
@@ -40,15 +42,32 @@ public sealed class ServerTokenStorageService(
             return _accessToken;
         }
 
-        // Single-flight: concurrent callers (delegating handler, auth-state, SignalR) share one acquisition.
-        var inFlight = _hydrateInFlight ??= HydrateAsync();
+        // Single-flight: concurrent callers (delegating handler, auth-state, SignalR) share one
+        // acquisition. The circuit is genuinely multi-threaded, so an unguarded "??=" lets two
+        // callers each start a hydrate and the later one to finish overwrite the other's token.
+        // HydrateAsync reaches its first await immediately, so nothing slow runs under the lock.
+        Task<string?> inFlight;
+        lock (_hydrateSync)
+        {
+            _hydrateInFlight ??= HydrateAsync();
+            inFlight = _hydrateInFlight;
+        }
+
         try
         {
             return await inFlight.ConfigureAwait(false);
         }
         finally
         {
-            _hydrateInFlight = null;
+            // Only clear our own task: an unguarded clear can drop a NEWER hydrate started after
+            // this one completed, splitting the next set of callers again.
+            lock (_hydrateSync)
+            {
+                if (ReferenceEquals(_hydrateInFlight, inFlight))
+                {
+                    _hydrateInFlight = null;
+                }
+            }
         }
     }
 

--- a/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationListener.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationListener.razor
@@ -38,26 +38,37 @@
     {
         HubService.NotificationCallback = async (title, body) =>
         {
-            await InvokeAsync(() =>
+            try
             {
-                // Optimistic: increment immediately so the badge updates without waiting for an API round-trip
-                NotificationState.IncrementUnreadCount();
-                // Ask NotificationBell to also fetch the authoritative count from the API
-                NotificationState.RequestRefresh();
-                Snackbar.Add(builder =>
+                await InvokeAsync(() =>
                 {
-                    builder.OpenElement(0, "strong");
-                    builder.AddContent(1, title);
-                    builder.CloseElement();
-                    builder.OpenElement(2, "br");
-                    builder.CloseElement();
-                    builder.AddContent(3, body);
-                }, Severity.Info, options =>
-                {
-                    options.RequireInteraction = true;
-                    options.SnackbarVariant = Variant.Filled;
+                    // Optimistic: increment immediately so the badge updates without waiting for an API round-trip
+                    NotificationState.IncrementUnreadCount();
+                    // Ask NotificationBell to also fetch the authoritative count from the API
+                    NotificationState.RequestRefresh();
+                    Snackbar.Add(builder =>
+                    {
+                        builder.OpenElement(0, "strong");
+                        builder.AddContent(1, title);
+                        builder.CloseElement();
+                        builder.OpenElement(2, "br");
+                        builder.CloseElement();
+                        builder.AddContent(3, body);
+                    }, Severity.Info, options =>
+                    {
+                        options.RequireInteraction = true;
+                        options.SnackbarVariant = Variant.Filled;
+                    });
                 });
-            });
+            }
+            catch (ObjectDisposedException)
+            {
+                // Component was disposed between the hub event and the render dispatch.
+            }
+            catch (InvalidOperationException)
+            {
+                // Same race, surfaced by the renderer as a disposed/unavailable dispatcher.
+            }
         };
 
         await HubService.StartAsync();

--- a/Source/Presentation/MMCA.Common.UI/Services/Auth/WasmTokenStorageService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Auth/WasmTokenStorageService.cs
@@ -14,6 +14,8 @@ public sealed class WasmTokenStorageService(
 {
     private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(30);
 
+    private readonly Lock _hydrateSync = new();
+
     private string? _accessToken;
     private Task<string?>? _hydrateInFlight;
 
@@ -24,15 +26,32 @@ public sealed class WasmTokenStorageService(
             return _accessToken;
         }
 
-        // Single-flight: concurrent callers (delegating handler, auth-state, SignalR) share one acquisition.
-        var inFlight = _hydrateInFlight ??= HydrateAsync();
+        // Single-flight: concurrent callers (delegating handler, auth-state, SignalR) share one
+        // acquisition. The lock is what makes it single: an unguarded "??=" lets two callers each
+        // start a hydrate, and the later one to finish overwrites the other's token. HydrateAsync
+        // reaches its first await immediately, so nothing slow runs under the lock.
+        Task<string?> inFlight;
+        lock (_hydrateSync)
+        {
+            _hydrateInFlight ??= HydrateAsync();
+            inFlight = _hydrateInFlight;
+        }
+
         try
         {
             return await inFlight.ConfigureAwait(false);
         }
         finally
         {
-            _hydrateInFlight = null;
+            // Only clear our own task: an unguarded clear can drop a NEWER hydrate started after
+            // this one completed, splitting the next set of callers again.
+            lock (_hydrateSync)
+            {
+                if (ReferenceEquals(_hydrateInFlight, inFlight))
+                {
+                    _hydrateInFlight = null;
+                }
+            }
         }
     }
 

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationHubService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationHubService.cs
@@ -30,8 +30,6 @@ public sealed partial class NotificationHubService : IAsyncDisposable
     private const string ReceiveChannelEventMethodName = "ReceiveChannelEvent";
     private const string JoinChannelMethodName = "JoinChannel";
     private const string LeaveChannelMethodName = "LeaveChannel";
-    private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(2);
-
     private readonly ITokenStorageService _tokenStorageService;
     private readonly string _hubUrl;
     private readonly ILogger<NotificationHubService> _logger;
@@ -60,6 +58,12 @@ public sealed partial class NotificationHubService : IAsyncDisposable
 
     /// <summary>Gets a value indicating whether the hub connection is active.</summary>
     public bool IsConnected => _hubConnection?.State == HubConnectionState.Connected;
+
+    /// <summary>
+    /// Backoff before the first connection retry, doubling on each subsequent attempt. Settable so a
+    /// test can exercise the terminal-failure path without waiting out the real multi-second backoff.
+    /// </summary>
+    internal TimeSpan InitialRetryDelay { get; set; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Starts the SignalR connection if not already connected. Called after user login.
@@ -96,6 +100,7 @@ public sealed partial class NotificationHubService : IAsyncDisposable
         {
             if (_disposed)
             {
+                await DiscardUnstartedConnectionAsync().ConfigureAwait(false);
                 return;
             }
 
@@ -113,6 +118,11 @@ public sealed partial class NotificationHubService : IAsyncDisposable
                 if (attempt == MaxRetries)
                 {
                     LogConnectionFailed(ex, _hubUrl);
+
+                    // A connection that never started must not satisfy the null guard above, or every
+                    // later StartAsync (including one reached through JoinChannelAsync) no-ops
+                    // forever; automatic reconnect only covers drops after a successful start.
+                    await DiscardUnstartedConnectionAsync().ConfigureAwait(false);
                     return;
                 }
 
@@ -232,6 +242,22 @@ public sealed partial class NotificationHubService : IAsyncDisposable
     {
         _disposed = true;
         await StopAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Clears and disposes the connection built for a start attempt that never succeeded, leaving the
+    /// field null so the next <see cref="StartAsync"/> builds a fresh one. Tolerates
+    /// <see cref="StopAsync"/> having already cleared the field.
+    /// </summary>
+    private async Task DiscardUnstartedConnectionAsync()
+    {
+        HubConnection? failed = _hubConnection;
+        _hubConnection = null;
+
+        if (failed is not null)
+        {
+            await failed.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private async Task DispatchChannelEventAsync(string channelKey, string eventName, string payloadJson)

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingCommandDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingCommandDecoratorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.UseCases;
 using MMCA.Common.Application.UseCases.Decorators;
+using MMCA.Common.Domain.Entities;
 using MMCA.Common.Shared.Abstractions;
 using Moq;
 
@@ -124,6 +125,71 @@ public sealed class CachingCommandDecoratorTests
             x => x.RemoveByPrefixAsync("test-prefix", CancellationToken.None),
             Times.Once);
     }
+
+    // ── An empty prefix opts out; without the guard it would evict the whole cache (M50) ──
+    [Fact]
+    public async Task HandleAsync_WithEmptyCachePrefix_SkipsEviction()
+    {
+        var inner = new Mock<ICommandHandler<OptedOutCacheInvalidatingTestCommand, Result>>();
+        var cacheService = new Mock<ICacheService>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<OptedOutCacheInvalidatingTestCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var sut = new CachingCommandDecorator<OptedOutCacheInvalidatingTestCommand, Result>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingCommandDecorator<OptedOutCacheInvalidatingTestCommand, Result>>.Instance);
+
+        var result = await sut.HandleAsync(new OptedOutCacheInvalidatingTestCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        cacheService.Verify(
+            x => x.RemoveByPrefixAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── The generic delete command now evicts its aggregate's prefix (M50) ──
+    [Fact]
+    public async Task HandleAsync_DeleteEntityCommand_EvictsEntityPrefixOnSuccess()
+    {
+        var inner = new Mock<ICommandHandler<DeleteEntityCommand<CachingTestEntity, int>, Result>>();
+        var cacheService = new Mock<ICacheService>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<DeleteEntityCommand<CachingTestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var sut = new CachingCommandDecorator<DeleteEntityCommand<CachingTestEntity, int>, Result>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingCommandDecorator<DeleteEntityCommand<CachingTestEntity, int>, Result>>.Instance);
+
+        var result = await sut.HandleAsync(new DeleteEntityCommand<CachingTestEntity, int>(1));
+
+        result.IsSuccess.Should().BeTrue();
+        cacheService.Verify(
+            x => x.RemoveByPrefixAsync(typeof(CachingTestEntity).FullName + ":", CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DeleteEntityCommandFailure_DoesNotEvict()
+    {
+        var inner = new Mock<ICommandHandler<DeleteEntityCommand<CachingTestEntity, int>, Result>>();
+        var cacheService = new Mock<ICacheService>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<DeleteEntityCommand<CachingTestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(Error.Failure("test", "missing")));
+
+        var sut = new CachingCommandDecorator<DeleteEntityCommand<CachingTestEntity, int>, Result>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingCommandDecorator<DeleteEntityCommand<CachingTestEntity, int>, Result>>.Instance);
+
+        var result = await sut.HandleAsync(new DeleteEntityCommand<CachingTestEntity, int>(1));
+
+        result.IsFailure.Should().BeTrue();
+        cacheService.Verify(
+            x => x.RemoveByPrefixAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }
 
 // ── Test types (must be public for Moq DynamicProxy) ──
@@ -133,3 +199,10 @@ public sealed record CacheInvalidatingTestCommand : ICacheInvalidating
 {
     public string CachePrefix => "test-prefix";
 }
+
+public sealed record OptedOutCacheInvalidatingTestCommand : ICacheInvalidating
+{
+    public string CachePrefix => string.Empty;
+}
+
+public sealed class CachingTestEntity : AuditableAggregateRootEntity<int>;

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetMyNotificationsHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetMyNotificationsHandlerTests.cs
@@ -53,6 +53,22 @@ public sealed class GetMyNotificationsHandlerTests
         result.Value!.PaginationMetadata.PageSize.Should().Be(500);
     }
 
+    // ── Sub-1 page numbers ──
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public async Task HandleAsync_WithNegativePageNumber_ReportsPageOneWithoutThrowing(int pageNumber)
+    {
+        var (sut, _) = CreateSut(totalCount: 5, pageItems: 5);
+
+        var query = new GetMyNotificationsQuery(UserId: 1, pageNumber, PageSize: 20);
+        Result<PagedCollectionResult<UserNotificationDTO>> result = await sut.HandleAsync(query);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PaginationMetadata.CurrentPage.Should().Be(1);
+        result.Value.PaginationMetadata.PageSize.Should().Be(20);
+    }
+
     // ── Helpers ──
     private static (GetMyNotificationsHandler Sut, Mock<IUnitOfWork> UnitOfWork) CreateSut(
         int totalCount, int pageItems)

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetNotificationHistoryHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetNotificationHistoryHandlerTests.cs
@@ -53,6 +53,22 @@ public sealed class GetNotificationHistoryHandlerTests
         result.Value!.PaginationMetadata.PageSize.Should().Be(500);
     }
 
+    // ── Sub-1 page numbers ──
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public async Task HandleAsync_WithNegativePageNumber_ReportsPageOneWithoutThrowing(int pageNumber)
+    {
+        var (sut, _) = CreateSut(totalCount: 25, pageItems: 10);
+
+        var query = new GetNotificationHistoryQuery(pageNumber, PageSize: 10);
+        Result<PagedCollectionResult<PushNotificationDTO>> result = await sut.HandleAsync(query);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PaginationMetadata.CurrentPage.Should().Be(1);
+        result.Value.PaginationMetadata.PageSize.Should().Be(10);
+    }
+
     // ── Helpers ──
     private static (GetNotificationHistoryHandler Sut, Mock<IUnitOfWork> UnitOfWork) CreateSut(
         int totalCount, int pageItems)

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceValidateTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/QueryFilterServiceValidateTests.cs
@@ -10,6 +10,7 @@ public sealed class QueryFilterServiceValidateTests
     {
         public string Name { get; set; } = string.Empty;
         public int Price { get; set; }
+        public long Quantity { get; set; }
         public decimal Amount { get; set; }
         public bool IsActive { get; set; }
         public DateTime CreatedOn { get; set; }
@@ -241,6 +242,46 @@ public sealed class QueryFilterServiceValidateTests
     {
         // Presence checks never read the value, so an arbitrary one must not be rejected.
         var filters = new Dictionary<string, (string, string)> { ["Price"] = (op, "ignored") };
+
+        var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // ── BETWEEN needs exactly two segments that both parse ──
+    // Dropping unparseable and empty segments let a three-segment value validate as a two-bound
+    // range, and the strategy then applied bounds the caller never asked for.
+    [Theory]
+    [InlineData("Price", "5,abc,10")]
+    [InlineData("Price", "5,,10")]
+    [InlineData("Price", "5,10,")]
+    [InlineData("Price", ",5,10")]
+    [InlineData("Quantity", "5,abc,10")]
+    [InlineData("Quantity", "5,,10")]
+    [InlineData("Amount", "5.5,abc,10.5")]
+    [InlineData("Amount", "5.5,,10.5")]
+    [InlineData("CreatedOn", "2026-01-01,nope,2026-12-31")]
+    [InlineData("CreatedOn", "2026-01-01,,2026-12-31")]
+    public void ValidateFilters_Between_WithAnythingButTwoParseableSegments_ReturnsFailure(
+        string property, string value)
+    {
+        var filters = new Dictionary<string, (string, string)> { [property] = ("BETWEEN", value) };
+
+        var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "Filter.Value.Invalid");
+    }
+
+    [Theory]
+    [InlineData("Price", "5,10")]
+    [InlineData("Price", " 5 , 10 ")]
+    [InlineData("Quantity", "5,10")]
+    [InlineData("Amount", "5.5,10.5")]
+    [InlineData("CreatedOn", "2026-01-01,2026-12-31")]
+    public void ValidateFilters_Between_WithTwoValidBounds_ReturnsSuccess(string property, string value)
+    {
+        var filters = new Dictionary<string, (string, string)> { [property] = ("BETWEEN", value) };
 
         var result = QueryFilterService.ValidateFilters<Product>(filters, EmptyMap);
 

--- a/Tests/Core/MMCA.Common.Application.Tests/UseCases/DeleteEntityHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/UseCases/DeleteEntityHandlerTests.cs
@@ -77,6 +77,19 @@ public sealed class DeleteEntityHandlerTests
 
         _repository.Verify(r => r.GetByIdAsync(1, token), Times.Once);
     }
+
+    // ── Cache invalidation contract (M50) ──
+    // The generic controller constructs this command itself, so the default prefix is the only
+    // thing that makes a delete evict the aggregate's cached reads.
+    [Fact]
+    public void CachePrefix_DefaultsToEntityFullNameConvention() =>
+        new DeleteEntityCommand<TestAggregateEntity, int>(1).CachePrefix
+            .Should().Be(typeof(TestAggregateEntity).FullName + ":");
+
+    [Fact]
+    public void CachePrefix_CanBeOverriddenToOptOut() =>
+        (new DeleteEntityCommand<TestAggregateEntity, int>(1) with { CachePrefix = string.Empty })
+            .CachePrefix.Should().BeEmpty();
 }
 
 // ── Test aggregate entity (must be public for Moq DynamicProxy) ──

--- a/Tests/Core/MMCA.Common.Shared.Tests/Abstractions/PaginationMetadataTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Abstractions/PaginationMetadataTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using AwesomeAssertions;
 using MMCA.Common.Shared.Abstractions;
 
@@ -102,5 +103,50 @@ public class PaginationMetadataTests
     [Fact]
     public void Constructor_WithNegativeCurrentPage_Throws() =>
         FluentActions.Invoking(() => new PaginationMetadata(10, 10, -1))
+            .Should().Throw<ArgumentOutOfRangeException>();
+
+    // ── Object-initializer validation (bypasses the constructor guards) ──
+    [Fact]
+    public void ObjectInitializer_WithNegativeTotalItemCount_Throws() =>
+        FluentActions.Invoking(() => new PaginationMetadata { TotalItemCount = -1 })
+            .Should().Throw<ArgumentOutOfRangeException>();
+
+    [Fact]
+    public void ObjectInitializer_WithNegativePageSize_Throws() =>
+        FluentActions.Invoking(() => new PaginationMetadata { PageSize = -1 })
+            .Should().Throw<ArgumentOutOfRangeException>();
+
+    [Fact]
+    public void ObjectInitializer_WithNegativeCurrentPage_Throws() =>
+        FluentActions.Invoking(() => new PaginationMetadata { CurrentPage = -1 })
+            .Should().Throw<ArgumentOutOfRangeException>();
+
+    [Fact]
+    public void WithExpression_WithNegativeValue_Throws() =>
+        FluentActions.Invoking(() => new PaginationMetadata(100, 10, 1) with { PageSize = -1 })
+            .Should().Throw<ArgumentOutOfRangeException>();
+
+    // ── JSON round-trip ──
+    // Pins the deserialization path the init accessors depend on: with two public constructors and
+    // no [JsonConstructor], System.Text.Json builds through the parameterless one and the setters.
+    [Fact]
+    public void JsonRoundTrip_PreservesCoreValues()
+    {
+        var original = new PaginationMetadata(101, 10, 2);
+
+        string json = JsonSerializer.Serialize(original);
+        PaginationMetadata? restored = JsonSerializer.Deserialize<PaginationMetadata>(json);
+
+        restored.Should().NotBeNull();
+        restored!.TotalItemCount.Should().Be(101);
+        restored.PageSize.Should().Be(10);
+        restored.CurrentPage.Should().Be(2);
+        restored.TotalPageCount.Should().Be(11);
+    }
+
+    [Fact]
+    public void JsonDeserialize_WithNegativeValue_Throws() =>
+        FluentActions.Invoking(() => JsonSerializer.Deserialize<PaginationMetadata>(
+                """{"TotalItemCount":-1,"PageSize":10,"CurrentPage":1}"""))
             .Should().Throw<ArgumentOutOfRangeException>();
 }

--- a/Tests/Presentation/MMCA.Common.API.Tests/SessionCookies/CookieSessionRefresherTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/SessionCookies/CookieSessionRefresherTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Json;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Hosting;
 using MMCA.Common.API.SessionCookies;
 using MMCA.Common.Shared.Auth;
+using MMCA.Common.Shared.Concurrency;
 using Moq;
 
 namespace MMCA.Common.API.Tests.SessionCookies;
@@ -157,7 +159,86 @@ public sealed class CookieSessionRefresherTests
             "new-access", "the sibling still gets cookies and the stashed token for its own SSR pass");
     }
 
+    // ── Per-token single flight (M52) ──
+    // The lock is held across the outbound refresh call, so a process-wide one made every unrelated
+    // user's cold navigation queue behind whichever refresh happened to be in flight.
+    [Fact]
+    public async Task GetOrRefreshAsync_ConcurrentDifferentTokens_RefreshInParallel()
+    {
+        string expired = CreateJwt(DateTime.UtcNow.AddMinutes(-5));
+        using var harness = CreateSut(RespondWithTokens("new-access", "new-refresh", DateTime.UtcNow.AddMinutes(15)));
+        const string tokenA = "refresh-a";
+        string tokenB = TokenOnAnotherStripeThan(tokenA);
+
+        harness.Handler.BlockWhenBodyContains = tokenA;
+        Task<SessionTokenResult?> blocked = harness.Sut.GetOrRefreshAsync(
+            CreateContext(accessToken: expired, refreshToken: tokenA));
+        await harness.Handler.Entered.Task.WaitAsync(WaitTimeout);
+
+        SessionTokenResult? unrelated = await harness.Sut
+            .GetOrRefreshAsync(CreateContext(accessToken: expired, refreshToken: tokenB))
+            .WaitAsync(WaitTimeout);
+
+        unrelated.Should().NotBeNull("an unrelated token must not queue behind an in-flight refresh");
+        blocked.IsCompleted.Should().BeFalse();
+
+        harness.Handler.Gate.SetResult();
+        (await blocked.WaitAsync(WaitTimeout)).Should().NotBeNull();
+        harness.Handler.CallCount.Should().Be(2, "two distinct tokens each rotate once");
+    }
+
+    [Fact]
+    public async Task GetOrRefreshAsync_ConcurrentSameToken_SecondReusesRotationWithoutSecondCall()
+    {
+        string expired = CreateJwt(DateTime.UtcNow.AddMinutes(-5));
+        using var harness = CreateSut(RespondWithTokens("new-access", "new-refresh", DateTime.UtcNow.AddMinutes(15)));
+
+        harness.Handler.BlockWhenBodyContains = "old-refresh";
+        Task<SessionTokenResult?> first = harness.Sut.GetOrRefreshAsync(
+            CreateContext(accessToken: expired, refreshToken: "old-refresh"));
+        await harness.Handler.Entered.Task.WaitAsync(WaitTimeout);
+
+        Task<SessionTokenResult?> second = harness.Sut.GetOrRefreshAsync(
+            CreateContext(accessToken: expired, refreshToken: "old-refresh"));
+
+        second.IsCompleted.Should().BeFalse("the same token must still serialize on one stripe");
+
+        harness.Handler.Gate.SetResult();
+        SessionTokenResult?[] results = await Task.WhenAll(first, second).WaitAsync(WaitTimeout);
+
+        harness.Handler.CallCount.Should().Be(1, "the queued sibling reuses the rotation-grace entry");
+        results[0]!.Value.AccessToken.Should().Be("new-access");
+        results[1]!.Value.AccessToken.Should().Be("new-access");
+    }
+
     // ── Helpers ──
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Finds a refresh token whose stripe differs from <paramref name="token"/>'s, so the parallel
+    /// test cannot flake on the one-in-<see cref="KeyedSemaphoreStripe.DefaultWidth"/> collision that
+    /// striping accepts by design. Mirrors the stripe's ordinal-hash fold over the real cache key,
+    /// which is also the striping key.
+    /// </summary>
+    private static string TokenOnAnotherStripeThan(string token)
+    {
+        uint target = StripeOf(token);
+        for (int i = 0; i < 1000; i++)
+        {
+            string candidate = string.Create(CultureInfo.InvariantCulture, $"refresh-b-{i}");
+            if (StripeOf(candidate) != target)
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException("No candidate refresh token landed on a different stripe.");
+    }
+
+    private static uint StripeOf(string refreshToken) =>
+        (uint)string.GetHashCode(CookieSessionRefresher.CacheKey(refreshToken), StringComparison.Ordinal)
+        % KeyedSemaphoreStripe.DefaultWidth;
+
     private static string CreateJwt(DateTime expires) =>
         new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
             notBefore: expires.AddMinutes(-30),
@@ -219,7 +300,7 @@ public sealed class CookieSessionRefresherTests
 
         public void Dispose()
         {
-            Sut.Dispose();
+            // The sut is not disposable: its striped locks are held for the process lifetime by design.
             Handler.Dispose();
             _cache.Dispose();
         }
@@ -234,21 +315,43 @@ public sealed class CookieSessionRefresherTests
     private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
         : HttpMessageHandler
     {
-        public int CallCount { get; private set; }
+        private int _callCount;
+
+        // Counted with Interlocked because the concurrency tests drive this handler from two
+        // requests at once.
+        public int CallCount => Volatile.Read(ref _callCount);
 
         public Uri? LastRequestUri { get; private set; }
 
         public string? LastRequestBody { get; private set; }
 
+        /// <summary>Completed once a blocking call has entered the handler and is waiting on <see cref="Gate"/>.</summary>
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Released by the test to let the blocked call finish.</summary>
+        public TaskCompletionSource Gate { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>When set, a call whose body carries this token parks on <see cref="Gate"/>.</summary>
+        public string? BlockWhenBodyContains { get; set; }
+
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            CallCount++;
+            Interlocked.Increment(ref _callCount);
             LastRequestUri = request.RequestUri;
-            LastRequestBody = request.Content is null
+            string? body = request.Content is null
                 ? null
                 : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            LastRequestBody = body;
+
+            if (BlockWhenBodyContains is { } marker
+                && body?.Contains(marker, StringComparison.Ordinal) == true)
+            {
+                Entered.TrySetResult();
+                await Gate.Task.ConfigureAwait(false);
+            }
+
             return responder(request);
         }
     }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationListenerTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationListenerTests.cs
@@ -1,0 +1,110 @@
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Common.Settings;
+using MMCA.Common.UI.Components.Notifications;
+using MMCA.Common.UI.Services.Auth;
+using MMCA.Common.UI.Services.Notifications;
+using Moq;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers <see cref="NotificationListener"/>, the invisible component that turns hub notifications
+/// into badge state and a snackbar. The regression these lock down (M54): the callback dispatched a
+/// render without guarding the disposed-component race, so an event arriving after the page had
+/// navigated away threw back into the hub service's own receive handler.
+/// </summary>
+public sealed class NotificationListenerTests : BunitTestBase
+{
+    private readonly NotificationState _state = new();
+    private readonly Mock<ISnackbar> _snackbar = new();
+
+    public NotificationListenerTests()
+    {
+        Services.AddSingleton(_state);
+
+        // Registered after the base class's AddMudServices, so this wins: it is the only way to make
+        // the dispatched body throw the way a torn-down circuit does.
+        Services.AddSingleton(_snackbar.Object);
+        Services.AddSingleton(_ =>
+        {
+            var tokenStorage = new Mock<ITokenStorageService>();
+
+            // The access-token provider runs before the negotiate request, so throwing here makes the
+            // background connect attempt fail immediately instead of waiting on a real socket.
+            tokenStorage
+                .Setup(t => t.GetAccessTokenAsync())
+                .ThrowsAsync(new InvalidOperationException("no session"));
+
+            return new NotificationHubService(
+                tokenStorage.Object,
+                Options.Create(new ApiSettings { ApiEndpoint = "http://127.0.0.1:1" }),
+                NullLogger<NotificationHubService>.Instance)
+            {
+                InitialRetryDelay = TimeSpan.Zero,
+            };
+        });
+    }
+
+    [Fact]
+    public async Task NotificationWhileRendered_IncrementsUnreadAndRequestsRefresh()
+    {
+        bool refreshRequested = false;
+        _state.OnRefreshRequested += (_, _) => refreshRequested = true;
+        Func<string, string, Task> callback = await RenderAndCaptureCallbackAsync();
+
+        await callback("Title", "Body");
+
+        _state.UnreadCount.Should().Be(1, "the badge updates optimistically, before any API round-trip");
+        refreshRequested.Should().BeTrue("NotificationBell still fetches the authoritative count");
+    }
+
+    // bUnit's dispatcher keeps working after the components are disposed, so the disposed-renderer
+    // race cannot be staged by disposal alone: the exception it raises is injected at the dispatched
+    // body instead. Both types the guard names are exercised.
+    [Fact]
+    public Task NotificationDispatchThrowingObjectDisposed_DoesNotThrowBackAtTheHub() =>
+        AssertDispatchExceptionIsSwallowedAsync(new ObjectDisposedException("Renderer"));
+
+    [Fact]
+    public Task NotificationDispatchThrowingInvalidOperation_DoesNotThrowBackAtTheHub() =>
+        AssertDispatchExceptionIsSwallowedAsync(new InvalidOperationException("The renderer has been disposed."));
+
+    private async Task AssertDispatchExceptionIsSwallowedAsync(Exception raised)
+    {
+        _snackbar
+            .Setup(s => s.Add(
+                It.IsAny<RenderFragment>(),
+                It.IsAny<Severity>(),
+                It.IsAny<Action<SnackbarOptions>>(),
+                It.IsAny<string>()))
+            .Throws(raised);
+        Func<string, string, Task> callback = await RenderAndCaptureCallbackAsync();
+
+        await DisposeComponentsAsync();
+
+        Func<Task> raise = () => callback("Title", "Body");
+
+        await raise.Should().NotThrowAsync(
+            "a render dispatched onto a disposed component must not surface inside the hub's receive handler");
+    }
+
+    private async Task<Func<string, string, Task>> RenderAndCaptureCallbackAsync()
+    {
+        IRenderedComponent<NotificationListener> cut = RenderAs<NotificationListener>(
+            TestPrincipal.AuthenticatedUser(), _ => { });
+
+        NotificationHubService hubService = Services.GetRequiredService<NotificationHubService>();
+
+        // The callback is assigned in the component's first-render hook, before the hub connect.
+        await cut.WaitForAssertionAsync(() => hubService.NotificationCallback.Should().NotBeNull());
+
+        return hubService.NotificationCallback!;
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Auth/WasmTokenStorageServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Auth/WasmTokenStorageServiceTests.cs
@@ -111,6 +111,19 @@ public sealed class WasmTokenStorageServiceTests
         refresher.Verify(r => r.AcquireAccessTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task GetAccessTokenAsync_AfterCompletion_SecondStaleCallStartsNewHydrate()
+    {
+        // The single-flight slot must be cleared once its own hydrate finishes, so a later caller
+        // with a still-stale token hydrates again rather than awaiting a completed task forever.
+        var (sut, mocks) = CreateSut(refresherToken: null);
+
+        (await sut.GetAccessTokenAsync()).Should().BeNull();
+        (await sut.GetAccessTokenAsync()).Should().BeNull();
+
+        mocks.Refresher.Verify(r => r.AcquireAccessTokenAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
     // == Refresh token never surfaces in the browser ==
     [Fact]
     public async Task GetRefreshTokenAsync_EvenAfterSet_ReturnsNull()

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationHubServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationHubServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using MMCA.Common.UI.Common.Settings;
@@ -12,11 +13,15 @@ namespace MMCA.Common.UI.Tests.Services.Notifications;
 /// Verifies the testable surface of <see cref="NotificationHubService"/>: constructor endpoint
 /// validation, the idle lifecycle (not connected before start; stop/dispose are safe no-ops), and
 /// the channel API's argument validation, subscription registry, and disconnected no-op paths.
-/// PARTIAL BY DESIGN: <c>StartAsync</c>, the retry/backoff loop, the ReceiveNotification and
+/// The terminal-failure path of the retry loop IS covered, via the internal
+/// <c>InitialRetryDelay</c> override plus an unroutable endpoint: it is the path that regressed
+/// (H20), and a failed start used to leave the connection field populated so every later start
+/// no-opped forever.
+/// PARTIAL BY DESIGN: the successful <c>StartAsync</c>, the ReceiveNotification and
 /// ReceiveChannelEvent wiring, and the join/re-join invocations build a real SignalR
 /// <c>HubConnection</c> internally via <c>HubConnectionBuilder</c> with no injectable extension point, so
-/// exercising them would attempt real network connections with multi-second backoff. Left
-/// uncovered rather than changing Source (covered end to end by the consuming apps' E2E suites).
+/// exercising them would need a live hub. Left uncovered rather than changing Source (covered end
+/// to end by the consuming apps' E2E suites).
 /// The reference-counted channel membership that decides WHETHER those invocations happen is
 /// covered directly in <see cref="ChannelReferenceCounterTests"/>, since the decision is the part
 /// that regressed and it is reachable without a connection.
@@ -170,6 +175,62 @@ public sealed class NotificationHubServiceTests
 
         await act.Should().NotThrowAsync();
         sut.IsConnected.Should().BeFalse();
+    }
+
+    // ── Terminal connection failure must not poison later starts (H20) ──
+    [Fact]
+    public async Task StartAsync_AfterExhaustedRetries_RetriesOnNextCall()
+    {
+        var logger = new CapturingLogger();
+        var tokenStorage = new Mock<ITokenStorageService>();
+
+        // The access-token provider runs before the negotiate request, so throwing here fails every
+        // attempt without any network wait.
+        tokenStorage.Setup(t => t.GetAccessTokenAsync()).ThrowsAsync(new InvalidOperationException("no session"));
+
+        await using var sut = new NotificationHubService(
+            tokenStorage.Object,
+            Options.Create(new ApiSettings { ApiEndpoint = "http://127.0.0.1:1" }),
+            logger)
+        {
+            InitialRetryDelay = TimeSpan.Zero,
+        };
+
+        await sut.StartAsync();
+        await sut.StartAsync();
+
+        logger.FailureCount.Should().Be(
+            2,
+            "a start that never connected must leave no connection behind, or the second call no-ops forever");
+        sut.IsConnected.Should().BeFalse();
+    }
+
+    /// <summary>Counts the terminal "Failed to connect" warning; the retry loop's own messages are ignored.</summary>
+    private sealed class CapturingLogger : ILogger<NotificationHubService>
+    {
+        private int _failureCount;
+
+        public int FailureCount => Volatile.Read(ref _failureCount);
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            if (formatter(state, exception).Contains("Failed to connect", StringComparison.Ordinal))
+            {
+                Interlocked.Increment(ref _failureCount);
+            }
+        }
     }
 }
 

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/Services/ServerTokenStorageServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/Services/ServerTokenStorageServiceTests.cs
@@ -170,6 +170,19 @@ public sealed class ServerTokenStorageServiceTests
         refresher.Verify(r => r.AcquireAccessTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task GetAccessTokenAsync_OnCircuit_AfterCompletionSecondStaleCallStartsNewHydrate()
+    {
+        // The single-flight slot must be cleared once its own hydrate finishes, so a later caller
+        // with a still-stale token hydrates again rather than awaiting a completed task forever.
+        var (sut, mocks) = CreateSut(httpContext: null, refresherToken: null);
+
+        (await sut.GetAccessTokenAsync()).Should().BeNull();
+        (await sut.GetAccessTokenAsync()).Should().BeNull();
+
+        mocks.Refresher.Verify(r => r.AcquireAccessTokenAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
     // == Refresh token exposure ==
     [Fact]
     public async Task GetRefreshTokenAsync_DuringSsr_ReadsRefreshCookie()


### PR DESCRIPTION
Closes nine verified bug-hunt items across Shared, Application, API, UI and MAUI. Each was reproduced against source before the fix; the mechanism behind every fix was re-verified at implementation time rather than taken from the plan.

## Items

| Item | Defect | Fix |
|---|---|---|
| **H19** | Both notification handlers passed the raw `PageNumber` into `PaginationMetadata`, which throws on a negative, though `PagingMath` had already floored the page to 1 for the read. A sub-1 page returned 500 instead of page 1. | Floor the metadata page the same way, mirroring `EntityQueryService`. |
| **H20** | `NotificationHubService` left the connection field populated after a terminal connect failure, so every later `StartAsync` no-opped forever at the null guard. Automatic reconnect only covers drops after a successful start, so live notifications never recovered. | Clear and dispose a connection that never started. |
| **M50** | `DeleteEntityCommand` implemented no cache contract, so deleting an aggregate left every cached read of it stale. | Implement `ICacheInvalidating` defaulting to the aggregate-prefix convention consumers already key under; empty prefix opts out. |
| **M51** | `BETWEEN` validated through `ParseList`, which drops unparseable and empty segments, so `5,abc,10` and `5,,10` passed as a two-bound range and the strategy applied bounds the caller never asked for. | Require exactly two segments that both parse. |
| **M52** | `CookieSessionRefresher` held one process-wide semaphore across an outbound refresh call, so every unrelated user's cold navigation queued behind whichever refresh was in flight. | Stripe the lock by refresh token via `KeyedSemaphoreStripe`. |
| **M53** | Both token storage services used an unguarded `??=` for single-flight hydration. On a genuinely multi-threaded Blazor Server circuit two callers each started a hydrate and the later one to finish overwrote the other's token. | Take the slot under a `Lock`; clear only your own task. |
| **M54** | The `NotificationListener` hub callback dispatched a render unguarded, so an event arriving after disposal threw back into the hub service's receive handler. | Same `ObjectDisposedException` / `InvalidOperationException` guard the sibling components use. |
| **M55** | `MauiTokenStorageService` wrote access before refresh with no rollback, so a failed refresh write left a new access token against a stale refresh token whose refresh path was already dead. | Write refresh first; a failed access write drops both. H14 semantics unchanged. |
| **M56** | `PaginationMetadata` validated only in its ctor, so object initializers, `with` expressions and STJ could all build a negative instance. | Semi-auto properties validating in `init`. |

## Design constraint worth flagging

**M56 keeps its `init` accessors deliberately.** The record has two explicit constructors and no `[JsonConstructor]`, so System.Text.Json builds it through the parameterless ctor plus the init setters. Removing them would silently produce all-zero metadata in every UI client reading a paged response. A round-trip test pins that path.

## Deviations from the original plan

- **M51** is tested through the public `ValidateFilters` gate: the filter strategies are `internal` and `MMCA.Common.Application` has no `InternalsVisibleTo`, so `CanParseValue` is unreachable from tests. Coverage spans int, long, decimal and DateTime.
- **M52** widens `CacheKey` from `private` to `internal`. `string.GetHashCode` is randomized per process, so a hardcoded token pair would collide onto one stripe in roughly 1 run in 256 and deadlock the parallel test; the test now picks a token off a known-different stripe.
- **M54** injects the exception at the dispatched body rather than relying on disposal. bUnit's dispatcher keeps working after `DisposeComponentsAsync` and after full context disposal, so the originally planned disposal-only test passed with the guard removed. Re-verified: 2 of 3 fail without the guard, 3 of 3 pass with it.
- **H20**'s test drives failure through a throwing access-token provider instead of an unroutable endpoint, which cut that test class from 16.5s to 372ms.

## Verification

- `dotnet build MMCA.Common.slnx -c Release` - 0 warnings, 0 errors
- `dotnet test --solution MMCA.Common.slnx -c Release` - **2936 passed, 0 failed, 0 skipped**
- `dotnet build MMCA.Common.UI.Maui.csproj -c Release -f net10.0-windows10.0.19041.0` - 0/0
- `dotnet build MMCA.Common.UI.Maui.csproj -c Release -f net10.0-android` - 0/0
- ios and maccatalyst are not compilable on the authoring machine; M55 has no test project (outside the slnx per ADR-042) so it is compile-verified only.
- FACTS drift gate: up to date.

Also carries a separate commit regenerating the `MMCA.Common.UI.Maui` lock file, which had drifted behind `Directory.Packages.props` because that project sits outside the slnx and nothing restores it with `--locked-mode`. Regenerated only; no pin changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX
