### PR TITLE
fix: include IsDeleted in PushNotification DedupKey index filter (BugHunt M58)

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
@@ -52,8 +52,14 @@ internal sealed class PushNotificationConfiguration
         // "[DedupKey] IS NOT NULL" is SQL Server filter syntax and matches this configuration's
         // engine base class (EntityTypeConfigurationSQLServer); the Cosmos context strips
         // relational indexes, so no other engine sees it.
+        //
+        // The IsDeleted clause follows the same precedent SoftDeleteUniqueIndexConvention applies
+        // to every other unique index on a soft-deletable entity: without it a soft-deleted row
+        // keeps occupying its dedup slot forever and blocks a resend under the same key (BugHunt
+        // M58). The convention leaves a hand-authored filter alone, so this index has to opt in,
+        // which HasSoftDeleteFilter does while reading the column name and quoting from the model.
         builder.HasIndex(p => p.DedupKey)
             .IsUnique()
-            .HasFilter("[DedupKey] IS NOT NULL");
+            .HasSoftDeleteFilter(additionalFilter: "[DedupKey] IS NOT NULL");
     }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/PushNotificationConfigurationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/PushNotificationConfigurationTests.cs
@@ -1,0 +1,61 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Domain.Notifications.PushNotifications;
+using MMCA.Common.Infrastructure.Persistence.Configuration.EntityTypeConfiguration.Notifications;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Configuration;
+
+/// <summary>
+/// Tests for <c>PushNotificationConfiguration</c>'s deduplication index. The index is unique and
+/// hand-filtered, and <c>SoftDeleteUniqueIndexConvention</c> deliberately leaves a hand-authored
+/// filter alone, so this configuration has to opt into the soft-delete predicate itself. Without it
+/// a soft-deleted notification keeps occupying its dedup slot and blocks every later send under the
+/// same key (BugHunt M58).
+/// </summary>
+public sealed class PushNotificationConfigurationTests : IDisposable
+{
+    private readonly PushNotificationTestDbContext _dbContext = PushNotificationTestDbContext.Create();
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public void DedupKeyIndex_IsUnique()
+        => DedupKeyIndex().IsUnique.Should().BeTrue("the database is what arbitrates a retried send");
+
+    [Fact]
+    public void DedupKeyIndex_FiltersOutSoftDeletedRows()
+        => DedupKeyIndex().GetFilter().Should().Be(
+            "[DedupKey] IS NOT NULL AND [IsDeleted] = 0",
+            "a soft-deleted notification must not keep occupying its dedup slot");
+
+    private Microsoft.EntityFrameworkCore.Metadata.IIndex DedupKeyIndex()
+        => _dbContext.Model.FindEntityType(typeof(PushNotification))!
+            .GetIndexes()
+            .Single(i => i.Properties.Count == 1 && i.Properties[0].Name == nameof(PushNotification.DedupKey));
+
+    public sealed class PushNotificationTestDbContext : DbContext
+    {
+        private PushNotificationTestDbContext(DbContextOptions<PushNotificationTestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public static PushNotificationTestDbContext Create()
+        {
+            var options = new DbContextOptionsBuilder<PushNotificationTestDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .Options;
+
+            return new PushNotificationTestDbContext(options);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(modelBuilder);
+
+            // The real configuration, applied directly: the assertions below pin what it declares,
+            // not what a rewritten test double declares.
+            modelBuilder.ApplyConfiguration(new PushNotificationConfiguration());
+        }
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/CultureSwitcherTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/CultureSwitcherTests.cs
@@ -32,12 +32,12 @@ public sealed class CultureSwitcherTests : BunitTestBase
     }
 
     [Fact]
-    public void SelectingACulture_DelegatesToTheApplier_WithTheCurrentPathAsReturnPath()
+    public async Task SelectingACulture_DelegatesToTheApplier_WithTheCurrentPathAsReturnPath()
     {
         var navigation = Services.GetRequiredService<Bunit.TestDoubles.BunitNavigationManager>();
         navigation.NavigateTo("/sessions?page=2");
 
-        SpanishItem().Click();
+        await SpanishItem().ClickAsync();
 
         _applier.Culture.Should().Be("es");
         _applier.ReturnPath.Should().Be("/sessions?page=2");
@@ -46,16 +46,19 @@ public sealed class CultureSwitcherTests : BunitTestBase
     // The switcher must not reintroduce a navigation of its own: the applier owns landing the user back
     // on the page, and on a hybrid head that is a WebView reload, not a server redirect.
     [Fact]
-    public void SelectingACulture_DoesNotNavigateOnItsOwn()
+    public async Task SelectingACulture_DoesNotNavigateOnItsOwn()
     {
         var navigation = Services.GetRequiredService<Bunit.TestDoubles.BunitNavigationManager>();
 
-        SpanishItem().Click();
+        await SpanishItem().ClickAsync();
 
         _applier.Culture.Should().Be("es", "the applier ran, so an empty history is not a no-op test");
         navigation.History.Should().BeEmpty();
     }
 
+    // Selecting a culture must be awaited via ClickAsync: MudMenuItem's OnClick is an async
+    // EventCallback, so the synchronous Click() returns once the handler is dispatched rather than
+    // once it has run, and asserting on the applier straight after it loses the race under CI load.
     private IElement SpanishItem()
     {
         var items = OpenMenu();


### PR DESCRIPTION
## The defect

`PushNotificationConfiguration` declares the deduplication index as unique with a hand-authored filter, `"[DedupKey] IS NOT NULL"`. `SoftDeleteUniqueIndexConvention` deliberately leaves a hand-authored filter alone ("hand-authored filters win"), so this index is the one unique index on a soft-deletable entity that never received the `IsDeleted = 0` predicate.

The consequence is the exact scenario the convention exists to prevent: a soft-deleted notification keeps occupying its dedup slot forever, so every later send under the same key is rejected by the unique index even though the row is invisible to the application.

## The fix

The index now opts in through `HasSoftDeleteFilter(additionalFilter: "[DedupKey] IS NOT NULL")`, which is the shared predicate builder (`SoftDeleteFilterSql`) the convention itself uses. It produces exactly `"[DedupKey] IS NOT NULL AND [IsDeleted] = 0"` while reading the column name from the model and the identifier quoting from the engine, instead of a SQL-Server-shaped string literal. The doc comment states the precedent.

Adds `PushNotificationConfigurationTests`, which applies the real configuration to a model and pins both the uniqueness and the composed filter. Revert-proven: the filter test fails against the pre-fix configuration.

## Consumer migration ships later, not here

This changes the generated index, so consumers need a migration (ADC `Migrations.SqlServer.Notification`, and Store if it maps the entity). That migration ships with the next release and pin-bump sweep, not in this PR: consumers are still pinned to 1.140.0 and cannot see this change until then.

## Verification

- `dotnet build MMCA.Common.slnx`: 0 warnings, 0 errors
- `dotnet test --solution MMCA.Common.slnx`: 2900 total, 2900 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX
