### PR TITLE
fix: BugHunt Low sweep L2-L17 (Common wave)

### DIFF
--- a/Source/Core/MMCA.Common.Application/MMCA.Common.Application.csproj
+++ b/Source/Core/MMCA.Common.Application/MMCA.Common.Application.csproj
@@ -4,6 +4,9 @@
     <Description>MMCA framework: CQRS handlers, decorators, module system, query service</Description>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="MMCA.Common.Application.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.FeatureManagement" />
 

--- a/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
+++ b/Source/Core/MMCA.Common.Application/Services/Filtering/IntFilterStrategy.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Globalization;
 using System.Linq.Dynamic.Core;
 
 namespace MMCA.Common.Application.Services.Filtering;
@@ -6,8 +7,10 @@ namespace MMCA.Common.Application.Services.Filtering;
 /// <summary>
 /// Filter strategy for <see cref="int"/> and <see cref="Nullable{Int32}"/> properties.
 /// Supports equality and numeric comparison operators, the comma-separated IN set, an inclusive
-/// BETWEEN range, and the IS EMPTY / IS NOT EMPTY null checks. Silently returns the unfiltered
-/// query if the value cannot be parsed as an integer.
+/// BETWEEN range, and the IS EMPTY / IS NOT EMPTY null checks. Uses
+/// <see cref="CultureInfo.InvariantCulture"/> for parsing, matching the decimal, long and date
+/// strategies, so the filter DSL means the same thing under every request culture. Silently returns
+/// the unfiltered query if the value cannot be parsed as an integer.
 /// </summary>
 internal sealed class IntFilterStrategy : IFilterStrategy
 {
@@ -25,17 +28,20 @@ internal sealed class IntFilterStrategy : IFilterStrategy
     public IQueryable<T> Apply<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
         {
-            "EQUALS" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", v),
-            "NOT EQUALS" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", v),
-            "GREATER THAN" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} > @0", v),
-            "LESS THAN" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} < @0", v),
-            "GREATER THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0", v),
-            "LESS THAN OR EQUAL" when int.TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} <= @0", v),
+            "EQUALS" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} == @0", v),
+            "NOT EQUALS" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} != @0", v),
+            "GREATER THAN" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} > @0", v),
+            "LESS THAN" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} < @0", v),
+            "GREATER THAN OR EQUAL" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} >= @0", v),
+            "LESS THAN OR EQUAL" when TryParse(value, out var v) => query.Where(DynamicQueryConfig.Parameterized, $"{property} <= @0", v),
             "IS EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} == null"),
             "IS NOT EMPTY" => query.Where(DynamicQueryConfig.Parameterized, $"{property} != null"),
             // IN/BETWEEN parse a list rather than a single scalar; handle them out of the main switch.
             _ => ApplyInOrRange(query, property, op, value)
         };
+
+    private static bool TryParse(string value, out int result) =>
+        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
 
     private static IQueryable<T> ApplyInOrRange<T>(IQueryable<T> query, string property, string op, string value)
         => op switch
@@ -60,5 +66,6 @@ internal sealed class IntFilterStrategy : IFilterStrategy
             : query;
     }
 
-    private static int? ParseInt(string s) => int.TryParse(s, out var v) ? v : null;
+    private static int? ParseInt(string s) =>
+        int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null;
 }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingCommandDecorator.cs
@@ -44,6 +44,20 @@ public sealed partial class CachingCommandDecorator<TCommand, TResult>(
     {
     }
 
+    /// <summary>
+    /// Gets or sets the delay before the second, best-effort eviction. A query that missed the cache
+    /// and started executing before this command committed can finish afterwards and re-populate the
+    /// entry with pre-write state; the delayed re-eviction removes that repopulated entry. Settable so
+    /// a test does not have to wait out the production delay.
+    /// </summary>
+    internal TimeSpan ReInvalidationDelay { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets the most recent delayed re-invalidation. Exposed so the fire-and-forget task is observed
+    /// rather than dropped, and so a test can await it deterministically.
+    /// </summary>
+    internal Task InvalidationFollowUp { get; private set; } = Task.CompletedTask;
+
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TCommand command, CancellationToken cancellationToken = default)
     {
@@ -62,6 +76,13 @@ public sealed partial class CachingCommandDecorator<TCommand, TResult>(
                 // cleanup must outlive a caller that has already walked away.
                 await cacheService.RemoveByPrefixAsync(cacheInvalidating.CachePrefix, CancellationToken.None)
                     .ConfigureAwait(false);
+
+                // A read that missed the cache before this command committed can still be running its
+                // handler against pre-write state and populate the entry after the eviction above.
+                // A second, delayed eviction removes that repopulated entry. Best-effort like the
+                // first one: ICacheService is a singleton, so the follow-up outlives the request scope
+                // safely, and anything it cannot evict expires on its own TTL.
+                InvalidationFollowUp = ReInvalidateAfterDelayAsync(cacheInvalidating.CachePrefix);
             }
 #pragma warning disable CA1031 // Do not catch general exception types: invalidation is best-effort and must never fail a committed command
             catch (Exception ex)
@@ -72,6 +93,25 @@ public sealed partial class CachingCommandDecorator<TCommand, TResult>(
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Waits <see cref="ReInvalidationDelay"/> and evicts the prefix a second time, swallowing every
+    /// failure exactly like the first eviction does.
+    /// </summary>
+    private async Task ReInvalidateAfterDelayAsync(string cachePrefix)
+    {
+        try
+        {
+            await Task.Delay(ReInvalidationDelay, CancellationToken.None).ConfigureAwait(false);
+            await cacheService.RemoveByPrefixAsync(cachePrefix, CancellationToken.None).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types: re-invalidation is best-effort and runs detached from the request
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            LogCacheInvalidationFailed(logger, cachePrefix, typeof(TCommand).Name, ex);
+        }
     }
 
     [LoggerMessage(

--- a/Source/Core/MMCA.Common.Infrastructure/Auth/RsaJwksProvider.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Auth/RsaJwksProvider.cs
@@ -14,7 +14,13 @@ namespace MMCA.Common.Infrastructure.Auth;
 /// <param name="options">The bound <see cref="JwksSettings"/> options.</param>
 public sealed class RsaJwksProvider(IOptions<JwksSettings> options) : IJwksProvider
 {
-    private readonly Lazy<JsonWebKeySet> _cachedKeySet = new(() => BuildKeySet(options.Value));
+    // PublicationOnly, not the default ExecutionAndPublication: the default caches a factory
+    // exception forever, so one transient IO failure reading the PEM would brick
+    // /.well-known/jwks.json (and with it cross-service auth) until the process restarts.
+    // PublicationOnly caches only a successful result and lets a later call retry. Concurrent
+    // factory runs are harmless: BuildKeySet is pure and disposes its own RSA instance.
+    private readonly Lazy<JsonWebKeySet> _cachedKeySet =
+        new(() => BuildKeySet(options.Value), LazyThreadSafetyMode.PublicationOnly);
 
     /// <inheritdoc />
     public JsonWebKeySet GetJsonWebKeySet() => _cachedKeySet.Value;
@@ -58,8 +64,9 @@ public sealed class RsaJwksProvider(IOptions<JwksSettings> options) : IJwksProvi
 
         if (!string.IsNullOrWhiteSpace(settings.RsaPublicKeyPath))
         {
-            // File.ReadAllText is acceptable here — the provider runs once at startup
-            // (the result is cached in _cachedKeySet) so we don't need an async read path.
+            // File.ReadAllText is acceptable here: the provider runs on the first request and the
+            // result is cached in _cachedKeySet on success, so we don't need an async read path.
+            // A failure is not cached, so the next call reads the file again.
             return File.ReadAllText(settings.RsaPublicKeyPath);
         }
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Inbox/EfInboxStore.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Inbox/EfInboxStore.cs
@@ -35,7 +35,7 @@ public sealed partial class EfInboxStore(
     {
         var context = ResolveContext();
 #pragma warning disable VSTHRD103 // EF DbSet.Add is intentionally synchronous (in-memory); AddAsync is only for special value generators (EF guidance).
-        context.Set<InboxMessage>().Add(new InboxMessage
+        var entry = context.Set<InboxMessage>().Add(new InboxMessage
         {
             MessageId = messageId,
             EventType = eventType,
@@ -51,6 +51,12 @@ public sealed partial class EfInboxStore(
         {
             // A concurrent duplicate delivery already inserted this MessageId (unique index).
             // Idempotent — treat as processed.
+            // The context is cached per data source for the whole scope, so the rejected row must be
+            // detached: left Added, every later SaveChangesAsync on this scope would re-attempt the
+            // duplicate insert and fail. Same idiom as DomainEventSaveChangesInterceptor uses when it
+            // discards an abandoned capture.
+            entry.State = EntityState.Detached;
+
             LogConcurrentDuplicate(logger, messageId);
         }
     }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
@@ -157,7 +157,12 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
     {
         ArgumentNullException.ThrowIfNull(id);
 
-        return await Entities.FindAsync([id], cancellationToken).ConfigureAwait(false);
+        // A filtered query, not FindAsync: FindAsync serves a tracked instance straight from the
+        // identity map without evaluating the global soft-delete filter, so an entity soft-deleted
+        // earlier in the same scope came back as if it were live. Table (tracked) is deliberate:
+        // EFRepository inherits this member and the generic delete/update handlers load through it,
+        // mutate, and save, so a no-tracking query would turn those into silent no-ops.
+        return await Table.FirstOrDefaultAsync(e => e.Id.Equals(id), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/Source/Core/MMCA.Common.Infrastructure/Services/CurrentUserService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/CurrentUserService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using MMCA.Common.Application.Interfaces.Infrastructure;
@@ -17,7 +18,9 @@ public sealed class CurrentUserService(IHttpContextAccessor httpContextAccessor)
     private readonly Lazy<UserIdentifierType?> _userId = new(() =>
     {
         var claim = httpContextAccessor.HttpContext?.User?.FindFirst(UserIdClaimType)?.Value;
-        return int.TryParse(claim, out var id) ? id : null;
+        // Invariant, matching the writer: TokenService formats these claims with
+        // CultureInfo.InvariantCulture, so reading them under the request culture is a mismatch.
+        return int.TryParse(claim, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id) ? id : null;
     });
 
     private readonly Lazy<string?> _role = new(() =>
@@ -37,6 +40,8 @@ public sealed class CurrentUserService(IHttpContextAccessor httpContextAccessor)
         where T : struct, IParsable<T>
     {
         var claim = httpContextAccessor.HttpContext?.User?.FindFirst(claimType)?.Value;
-        return claim is not null && T.TryParse(claim, null, out var value) ? value : null;
+        // Claims are machine-written in the invariant culture; parsing them under the ambient
+        // request culture misreads separators for decimal, double and DateTime claim types.
+        return claim is not null && T.TryParse(claim, CultureInfo.InvariantCulture, out var value) ? value : null;
     }
 }

--- a/Source/Core/MMCA.Common.Shared/Serialization/ResultJsonConverterFactory.cs
+++ b/Source/Core/MMCA.Common.Shared/Serialization/ResultJsonConverterFactory.cs
@@ -34,6 +34,9 @@ public sealed class ResultJsonConverterFactory : JsonConverterFactory
 
     private sealed class ResultConverter : JsonConverter<Result>
     {
+        // Note: the non-generic Result carries no value, so Write emits a bare "{}" for a success.
+        // An empty object is therefore the legitimate wire form here and must stay a success, unlike
+        // in ResultConverter<T> where it means a corrupt payload.
         public override Result Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             List<Error>? errors = null;
@@ -63,16 +66,36 @@ public sealed class ResultJsonConverterFactory : JsonConverterFactory
         {
             T? value = default;
             List<Error>? errors = null;
+            var sawValue = false;
+            var sawErrors = false;
 
             ReadObject(ref reader, options, (ref r, propertyName) =>
             {
                 if (string.Equals(propertyName, ValuePropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    sawValue = true;
                     value = JsonSerializer.Deserialize<T>(ref r, options);
+                }
                 else if (string.Equals(propertyName, ErrorsPropertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    sawErrors = true;
                     errors = JsonSerializer.Deserialize<List<Error>>(ref r, options);
+                }
                 else
+                {
                     r.Skip();
+                }
             });
+
+            // Write always emits one of the two properties for Result<T>, so an object carrying
+            // neither is a corrupt payload (a truncated or partially overwritten cache entry).
+            // Returning Result.Success(default!) there would hand the caller a fake success wrapping
+            // null. A success whose value genuinely is null still writes "value": null, which sets
+            // sawValue and stays a success.
+            if (!sawValue && !sawErrors)
+            {
+                throw new JsonException("Result<T> payload contained neither 'value' nor 'errors'.");
+            }
 
             return errors is { Count: > 0 } ? Result.Failure<T>(errors) : Result.Success(value!);
         }

--- a/Source/Hosting/MMCA.Common.Aspire/Warmup/SelfHttpWarmupTaskBase.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Warmup/SelfHttpWarmupTaskBase.cs
@@ -158,11 +158,32 @@ public abstract partial class SelfHttpWarmupTaskBase(
     {
         var address = server.Features.Get<IServerAddressesFeature>()?.Addresses
             .FirstOrDefault(a => a.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
-            ?? configuration["ASPNETCORE_URLS"];
+            ?? SelectCleartextUrl(configuration["ASPNETCORE_URLS"]);
 
-        return int.TryParse(address?.Split(':')[^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var port)
+        return int.TryParse(address?.TrimEnd('/').Split(':')[^1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var port)
             ? port
             : DefaultPort;
+    }
+
+    /// <summary>
+    /// Picks the cleartext entry out of an <c>ASPNETCORE_URLS</c> value. The variable may hold a
+    /// semicolon-separated list (for example <c>https://+:443;http://+:8080/</c>), and entries
+    /// commonly carry a trailing slash, which the caller trims before reading the port. Wildcard
+    /// hosts such as <c>+</c> and <c>*</c> are why this stays string handling: Uri rejects them.
+    /// </summary>
+    /// <param name="configuredUrls">The raw configuration value, possibly null.</param>
+    /// <returns>The chosen url, or null when nothing was configured.</returns>
+    private static string? SelectCleartextUrl(string? configuredUrls)
+    {
+        if (string.IsNullOrWhiteSpace(configuredUrls))
+        {
+            return null;
+        }
+
+        var entries = configuredUrls.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return Array.Find(entries, e => e.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            ?? (entries.Length > 0 ? entries[0] : null);
     }
 
     // The warm-up runner is a hosted service that starts BEFORE Kestrel begins listening (the web

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiMediaPickerService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiMediaPickerService.cs
@@ -35,8 +35,13 @@ public sealed class MauiMediaPickerService : IMediaPickerService
                 return null;
             }
 
-            var stream = await file.OpenReadAsync().ConfigureAwait(false);
+            // Checked before the stream is opened, not after: throwing between OpenReadAsync and the
+            // PickedMedia that owns the stream would leak the file handle, since nothing downstream
+            // has anything to dispose yet. A cancellation that lands during OpenReadAsync simply
+            // returns the picked media, which the caller disposes as usual.
             cancellationToken.ThrowIfCancellationRequested();
+
+            var stream = await file.OpenReadAsync().ConfigureAwait(false);
             return new PickedMedia(stream, file.FileName, file.ContentType ?? "application/octet-stream");
         }
         catch (OperationCanceledException)

--- a/Source/Presentation/MMCA.Common.UI/Extensions/MoneyExtensions.cs
+++ b/Source/Presentation/MMCA.Common.UI/Extensions/MoneyExtensions.cs
@@ -15,16 +15,19 @@ public static class MoneyExtensions
 {
     extension(Money price)
     {
-        /// <summary>Formats a single price as <c>$12.50 USD</c>.</summary>
+        /// <summary>Formats a single price as <c>$12.50 USD</c>, using the symbol of its own currency.</summary>
         public string ToDisplayString() =>
-            $"${price.Amount.ToString("N2", CultureInfo.InvariantCulture)} {price.Currency.Code}";
+            FormatGroup(price.Amount, price.Amount, price.Currency.Code);
     }
 
     extension(IReadOnlyCollection<Money> prices)
     {
         /// <summary>
-        /// Formats a collection of prices as a range (e.g., <c>$10.00 -- $25.00 USD</c>).
+        /// Formats a collection of prices as a range (e.g., <c>$10.00 - $25.00 USD</c>).
         /// When all prices are equal, a single price is displayed instead of a range.
+        /// Prices are grouped by currency, so a mixed collection renders one range per currency,
+        /// each with its own symbol, instead of collapsing unrelated amounts under whichever
+        /// currency happened to appear first.
         /// </summary>
         public string ToDisplayRange()
         {
@@ -33,13 +36,39 @@ public static class MoneyExtensions
                 return string.Empty;
             }
 
-            var min = prices.Min(p => p.Amount);
-            var max = prices.Max(p => p.Amount);
-            var currency = prices.First().Currency.Code;
+            // GroupBy preserves first-appearance order, so a single-currency collection (every
+            // collection in practice today) renders exactly one group and is unchanged.
+            var groups = prices
+                .GroupBy(p => p.Currency.Code, StringComparer.Ordinal)
+                .Select(g => FormatGroup(g.Min(p => p.Amount), g.Max(p => p.Amount), g.Key));
 
-            return min == max
-                ? $"${min.ToString("N2", CultureInfo.InvariantCulture)} {currency}"
-                : $"${min.ToString("N2", CultureInfo.InvariantCulture)} — ${max.ToString("N2", CultureInfo.InvariantCulture)} {currency}";
+            return string.Join(", ", groups);
         }
+    }
+
+    /// <summary>
+    /// Resolves the display symbol for a currency code. Unknown codes and the empty code of the
+    /// <c>Currency.None</c> sentinel behind <c>Money.Zero()</c> render without a symbol rather than
+    /// falsely claiming dollars.
+    /// </summary>
+    private static string Symbol(string code) => code switch
+    {
+        "USD" => "$",
+        "EUR" => "\u20AC", // euro sign, escaped to keep this source file ASCII-only
+        _ => string.Empty,
+    };
+
+    /// <summary>
+    /// Formats one currency's amounts, as a single price when the bounds are equal and as a range
+    /// otherwise. The trailing code is omitted for the empty sentinel code.
+    /// </summary>
+    private static string FormatGroup(decimal min, decimal max, string code)
+    {
+        var symbol = Symbol(code);
+        var body = min == max
+            ? $"{symbol}{min.ToString("N2", CultureInfo.InvariantCulture)}"
+            : $"{symbol}{min.ToString("N2", CultureInfo.InvariantCulture)} - {symbol}{max.ToString("N2", CultureInfo.InvariantCulture)}";
+
+        return string.IsNullOrEmpty(code) ? body : $"{body} {code}";
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationHubService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationHubService.cs
@@ -34,6 +34,11 @@ public sealed partial class NotificationHubService : IAsyncDisposable
     private readonly string _hubUrl;
     private readonly ILogger<NotificationHubService> _logger;
     private readonly Lock _channelSync = new();
+
+    // Serializes StartAsync. A SemaphoreSlim rather than _channelSync because the guarded body
+    // awaits, and a System.Threading.Lock cannot be held across an await.
+    private readonly SemaphoreSlim _startSync = new(1, 1);
+
     private readonly ChannelReferenceCounter _channelRefs = new();
     private readonly Dictionary<string, List<ChannelSubscription>> _channelSubscriptions = [];
     private HubConnection? _hubConnection;
@@ -68,8 +73,50 @@ public sealed partial class NotificationHubService : IAsyncDisposable
     /// <summary>
     /// Starts the SignalR connection if not already connected. Called after user login.
     /// Retries with exponential backoff if the initial attempt fails.
+    /// <para>
+    /// Serialized: without it, two concurrent callers (two components calling
+    /// <see cref="JoinChannelAsync"/> at once on Blazor Server, which has no single
+    /// synchronization context) could both see a null connection, both build one, and leak the
+    /// loser socket with duplicate server registrations. A second caller now waits for the first
+    /// attempt to finish; if that attempt fails terminally the connection is discarded, so the
+    /// second caller runs its own attempt exactly as a sequential caller would.
+    /// </para>
     /// </summary>
     public async Task StartAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            await _startSync.WaitAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed while this caller was waiting: there is nothing left to start.
+            return;
+        }
+
+        try
+        {
+            await StartCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            try
+            {
+                _startSync.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The service was disposed while this start was running. Nothing to release.
+            }
+        }
+    }
+
+    private async Task StartCoreAsync()
     {
         if (_hubConnection is not null)
         {
@@ -240,8 +287,19 @@ public sealed partial class NotificationHubService : IAsyncDisposable
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _disposed = true;
         await StopAsync().ConfigureAwait(false);
+
+        // Disposal deliberately does not wait for a start already in flight: that start can be
+        // sitting in a multi-second retry backoff, and blocking a Blazor circuit teardown on it
+        // would be worse than the alternative. The _disposed flag makes the retry loop bail at its
+        // next iteration, and StartAsync tolerates the semaphore disappearing underneath it.
+        _startSync.Dispose();
     }
 
     /// <summary>

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingCommandDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingCommandDecoratorTests.cs
@@ -190,6 +190,62 @@ public sealed class CachingCommandDecoratorTests
             x => x.RemoveByPrefixAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    // ── Delayed re-invalidation closes the read-repopulate race (L2) ──
+    [Fact]
+    public async Task HandleAsync_SuccessfulCacheInvalidatingCommand_EvictsPrefixASecondTimeAfterTheDelay()
+    {
+        var inner = new Mock<ICommandHandler<CacheInvalidatingTestCommand, Result>>();
+        var cacheService = new Mock<ICacheService>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheInvalidatingTestCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var sut = new CachingCommandDecorator<CacheInvalidatingTestCommand, Result>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingCommandDecorator<CacheInvalidatingTestCommand, Result>>.Instance)
+        {
+            // A real short delay, not a fake clock: the in-process xUnit v3 runner cannot drive
+            // FakeTimeProvider through a fire-and-forget continuation.
+            ReInvalidationDelay = TimeSpan.FromMilliseconds(50),
+        };
+
+        await sut.HandleAsync(new CacheInvalidatingTestCommand());
+        await sut.InvalidationFollowUp;
+
+        // A query that missed the cache before the command committed can re-populate the entry with
+        // pre-write state right after the first eviction, so a second one has to follow.
+        cacheService.Verify(
+            x => x.RemoveByPrefixAsync("test-prefix", It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task HandleAsync_DelayedReInvalidationFails_IsSwallowed()
+    {
+        var inner = new Mock<ICommandHandler<CacheInvalidatingTestCommand, Result>>();
+        var cacheService = new Mock<ICacheService>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheInvalidatingTestCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        cacheService
+            .SetupSequence(x => x.RemoveByPrefixAsync("test-prefix", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .ThrowsAsync(new InvalidOperationException("cache went away"));
+
+        var sut = new CachingCommandDecorator<CacheInvalidatingTestCommand, Result>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingCommandDecorator<CacheInvalidatingTestCommand, Result>>.Instance)
+        {
+            ReInvalidationDelay = TimeSpan.FromMilliseconds(50),
+        };
+
+        var result = await sut.HandleAsync(new CacheInvalidatingTestCommand());
+
+        result.IsSuccess.Should().BeTrue();
+        var followUp = async () => await sut.InvalidationFollowUp;
+        await followUp.Should().NotThrowAsync("re-invalidation is best-effort, exactly like the first eviction");
+    }
 }
 
 // ── Test types (must be public for Moq DynamicProxy) ──

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/IntFilterStrategyTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/Filtering/IntFilterStrategyTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AwesomeAssertions;
 using MMCA.Common.Application.Services.Filtering;
 
@@ -121,4 +122,58 @@ public sealed class IntFilterStrategyTests
     [Fact]
     public void IsNotEmpty_ReturnsNonNullScores() =>
         FilterScore("IS NOT EMPTY", string.Empty).Should().HaveCount(2);
+
+    // ── Culture independence: the filter DSL is a wire format, not user input (L10) ──
+    private static IQueryable<Item> SignedItems() =>
+        new List<Item>
+        {
+            new() { Count = -5, Score = -5 },
+            new() { Count = 5, Score = 5 },
+        }.AsQueryable();
+
+    private static IQueryable<Item> FilterSigned(string op, string value) =>
+        QueryFilterService.ApplyFilters(
+            SignedItems(),
+            new Dictionary<string, (string, string)> { ["Count"] = (op, value) },
+            EmptyMap);
+
+    /// <summary>
+    /// Runs <paramref name="assert"/> under a culture whose negative sign is not "-". API hosts call
+    /// UseRequestLocalization, so a culture-sensitive parse made the int strategy track the request
+    /// culture while the decimal, long and date strategies stayed invariant. A failed parse falls
+    /// through to the UNFILTERED query, which silently widens the result set.
+    /// </summary>
+    private static void UnderACultureWithACustomNegativeSign(Action assert)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            var culture = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
+            culture.NumberFormat.NegativeSign = "~";
+            CultureInfo.CurrentCulture = culture;
+            assert();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // NOTE: these assert the exact row COUNT, not just that a matching row is present. A failed
+    // parse falls through to the UNFILTERED query, which still contains the expected row, so
+    // ContainSingle(predicate) would pass against the very bug these tests exist to catch.
+    [Fact]
+    public void Equals_UnderAForeignNegativeSign_StillParsesTheInvariantValue() =>
+        UnderACultureWithACustomNegativeSign(() =>
+            FilterSigned("EQUALS", "-5").Should().ContainSingle().Which.Count.Should().Be(-5));
+
+    [Fact]
+    public void In_UnderAForeignNegativeSign_StillParsesEveryInvariantValue() =>
+        UnderACultureWithACustomNegativeSign(() =>
+            FilterSigned("IN", "-5,5").Should().HaveCount(2));
+
+    [Fact]
+    public void Between_UnderAForeignNegativeSign_StillParsesBothBounds() =>
+        UnderACultureWithACustomNegativeSign(() =>
+            FilterSigned("BETWEEN", "-5,0").Should().ContainSingle().Which.Count.Should().Be(-5));
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Auth/RsaJwksProviderTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Auth/RsaJwksProviderTests.cs
@@ -84,4 +84,39 @@ public sealed class RsaJwksProviderTests
         // Assert: provider caches via Lazy<T>; same instance both times.
         ReferenceEquals(first, second).Should().BeTrue();
     }
+
+    [Fact]
+    public void GetJsonWebKeySet_TransientKeyFileFailure_IsNotCached_AndALaterCallSucceeds()
+    {
+        // A transient IO failure reading the PEM used to be cached forever by the default
+        // Lazy mode, bricking /.well-known/jwks.json (and cross-service auth) until a restart.
+        var path = Path.Combine(Path.GetTempPath(), $"mmca-jwks-{Guid.NewGuid():N}.pem");
+        var settings = new JwksSettings
+        {
+            Enabled = true,
+            KeyId = "transient-key",
+            RsaPublicKeyPath = path,
+        };
+        var sut = new RsaJwksProvider(Options.Create(settings));
+
+        try
+        {
+            // Act 1: the key file is not there yet.
+            var firstCall = () => sut.GetJsonWebKeySet();
+            firstCall.Should().Throw<FileNotFoundException>();
+
+            // Act 2: the file appears (the transient condition clears).
+            using var rsa = RSA.Create(2048);
+            File.WriteAllText(path, rsa.ExportSubjectPublicKeyInfoPem());
+
+            // Assert: the failure was not cached, so the retry builds the key set.
+            var keySet = sut.GetJsonWebKeySet();
+            keySet.Keys.Should().ContainSingle();
+            keySet.Keys[0].Kid.Should().Be("transient-key");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFReadRepositoryGetByIdFilterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFReadRepositoryGetByIdFilterTests.cs
@@ -1,0 +1,112 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.Repositories;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Pins the id-only <c>GetByIdAsync</c> overload against a real database with a global soft-delete
+/// filter. It used to call <c>FindAsync</c>, which serves a tracked instance straight from the
+/// identity map without evaluating query filters, so an entity soft-deleted earlier in the same
+/// scope came back as if it were live. The replacement is a filtered query that must stay TRACKED:
+/// the write repository inherits this member and the generic delete/update handlers load through
+/// it, mutate, and save.
+/// </summary>
+public sealed class EFReadRepositoryGetByIdFilterTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly SoftDeleteTestDbContext _context;
+    private readonly EFReadRepository<SoftDeletableTestEntity, int> _sut;
+
+    public EFReadRepositoryGetByIdFilterTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<SoftDeleteTestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new SoftDeleteTestDbContext(options);
+        _context.Database.EnsureCreated();
+        _sut = new EFReadRepository<SoftDeletableTestEntity, int>(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_EntitySoftDeletedInTheSameScope_ReturnsNull()
+    {
+        var entity = new SoftDeletableTestEntity { Id = 1, Name = "Doomed" };
+        _context.Add(entity);
+        await _context.SaveChangesAsync();
+
+        entity.Delete().IsSuccess.Should().BeTrue();
+        await _context.SaveChangesAsync();
+
+        // The entity is still tracked, so FindAsync handed it back from the identity map and the
+        // caller saw a live entity that the very same scope had just soft-deleted.
+        var found = await _sut.GetByIdAsync(1);
+
+        found.Should().BeNull("the global soft-delete filter must apply to the id-only overload too");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_LiveEntity_IsReturnedAndStaysTracked()
+    {
+        _context.Add(new SoftDeletableTestEntity { Id = 2, Name = "Live" });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var found = await _sut.GetByIdAsync(2);
+
+        found.Should().NotBeNull();
+        found!.Name.Should().Be("Live");
+
+        // Load-bearing: the write repository inherits this overload, and the generic delete/update
+        // handlers load through it, mutate, and save. A no-tracking query would make them no-ops.
+        _context.Entry(found).State.Should().Be(EntityState.Unchanged);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_CalledTwice_ReturnsTheSameTrackedInstance()
+    {
+        _context.Add(new SoftDeletableTestEntity { Id = 3, Name = "Shared" });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var first = await _sut.GetByIdAsync(3);
+        var second = await _sut.GetByIdAsync(3);
+
+        first.Should().NotBeNull();
+        ReferenceEquals(first, second).Should().BeTrue(
+            "a tracked query resolves through the change tracker, so identity-map continuity survives");
+    }
+
+    /// <summary>An entity with the production soft-delete flag, mapped with the matching filter.</summary>
+    public sealed class SoftDeletableTestEntity : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class SoftDeleteTestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<SoftDeletableTestEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.Property(e => e.Name);
+                b.Ignore(e => e.RowVersion);
+
+                // The convention-applied global filter every soft-deletable entity gets in production.
+                b.HasQueryFilter(e => !e.IsDeleted);
+            });
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Inbox/EfInboxStoreTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Inbox/EfInboxStoreTests.cs
@@ -104,6 +104,30 @@ public sealed class EfInboxStoreTests : IDisposable
         rows.Should().Be(1, "the unique index guarantees exactly one inbox row per message id");
     }
 
+    [Fact]
+    public async Task AfterAbsorbedDuplicate_TheSameScopeCanStillRecordAnotherMessage()
+    {
+        // The context is cached per data source for the whole scope, so the rejected row has to be
+        // detached. Left Added, it poisoned the scope: every later save re-attempted the duplicate
+        // insert and threw, taking an unrelated message down with it.
+        var storeA = CreateStore(_contextA);
+        var storeB = CreateStore(_contextB);
+        var duplicated = Guid.NewGuid();
+        var unrelated = Guid.NewGuid();
+
+        await storeA.MarkProcessedAsync(duplicated, "UserRegistered", CancellationToken.None);
+        await storeB.MarkProcessedAsync(duplicated, "UserRegistered", CancellationToken.None);
+
+        // Same store, same (poisoned) context, a different message id.
+        var next = async () => await storeB.MarkProcessedAsync(unrelated, "OrderPlaced", CancellationToken.None);
+        await next.Should().NotThrowAsync("the rejected duplicate must not poison the scope's context");
+
+        (await storeA.AlreadyProcessedAsync(duplicated, CancellationToken.None)).Should().BeTrue();
+        (await storeA.AlreadyProcessedAsync(unrelated, CancellationToken.None)).Should().BeTrue(
+            "the unrelated message must actually have been persisted");
+        (await _contextA.Set<InboxMessage>().CountAsync(m => m.MessageId == duplicated)).Should().Be(1);
+    }
+
     private static EfInboxStore CreateStore(ApplicationDbContext context)
     {
         var factory = new Mock<IDbContextFactory>();

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/CurrentUserServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/CurrentUserServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
@@ -31,6 +32,47 @@ public sealed class CurrentUserServiceTests
         var sut = CreateSut(principal);
 
         sut.UserId.Should().Be(42);
+    }
+
+    [Fact]
+    public void GetClaimValue_UnderANonInvariantCulture_StillParsesTheInvariantClaimValue()
+    {
+        // TokenService writes claims with CultureInfo.InvariantCulture, and API hosts run
+        // UseRequestLocalization, so reading them under the ambient culture is a mismatch. Under
+        // de-DE the dot is a group separator, so "1.5" used to come back as 15.
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var principal = CreatePrincipal(new Claim("balance", "1.5"));
+            var sut = CreateSut(principal);
+
+            sut.GetClaimValue<decimal>("balance").Should().Be(1.5m);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void UserId_UnderANonInvariantCulture_StillParsesTheInvariantClaimValue()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var principal = CreatePrincipal(new Claim("user_id", "42"));
+            var sut = CreateSut(principal);
+
+            sut.UserId.Should().Be(42);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     [Fact]

--- a/Tests/Core/MMCA.Common.Shared.Tests/Serialization/ResultJsonConverterFactoryTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Serialization/ResultJsonConverterFactoryTests.cs
@@ -115,4 +115,52 @@ public class ResultJsonConverterFactoryTests
         roundTripped.IsSuccess.Should().BeTrue();
         roundTripped.Value.Should().Be(new TestDTO(7, "X"));
     }
+
+    // ── A corrupt Result<T> payload must not deserialize as a fake success (L17) ──
+    [Fact]
+    public void GenericResult_WithNeitherValueNorErrors_Throws()
+    {
+        // Write always emits one of the two for Result<T>, so an empty object is a corrupt payload
+        // (a truncated or partially overwritten cache entry). It used to become
+        // Result.Success(default!): a success carrying null that the caller could not tell apart.
+        var act = () => JsonSerializer.Deserialize<Result<int>>("{}", WebOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void GenericResult_WithOnlyUnknownProperties_Throws()
+    {
+        var act = () => JsonSerializer.Deserialize<Result<TestDTO>>("""{"stale":true}""", WebOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void GenericResult_WithExplicitNullValue_IsStillASuccess()
+    {
+        // "value": null is what Write emits for a success whose value genuinely is null, so it must
+        // stay a success: the marker is the property's presence, not its content.
+        var roundTripped = JsonSerializer.Deserialize<Result<string>>("""{"value":null}""", WebOptions);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped.IsSuccess.Should().BeTrue();
+        roundTripped.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void NonGenericResult_EmptyObject_IsStillASuccess()
+    {
+        // Scope guard: the non-generic Result carries no value, so Write emits a bare "{}" for a
+        // success. An empty object is the legitimate wire form there and must NOT throw.
+        const string json = "{}";
+
+        var roundTripped = JsonSerializer.Deserialize<Result>(json, WebOptions);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped.IsSuccess.Should().BeTrue();
+
+        // And that really is what Write produces.
+        JsonSerializer.Serialize(Result.Success(), WebOptions).Should().Be(json);
+    }
 }

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Warmup/SelfHttpWarmupTaskBaseTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Warmup/SelfHttpWarmupTaskBaseTests.cs
@@ -107,12 +107,27 @@ public sealed class SelfHttpWarmupTaskBaseTests
     [Theory]
     [InlineData(null)]
     [InlineData("http://+:not-a-port")]
-    [InlineData("http://localhost:8080/")]
+    [InlineData("http://localhost/")]
     public void ResolveWarmupPort_FallsBackToTheContainerDefault_WhenNothingParses(string? aspnetcoreUrls)
     {
         var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(ServerWith(), Config(aspnetcoreUrls));
 
         port.Should().Be(SelfHttpWarmupTaskBase.DefaultPort);
+    }
+
+    [Theory]
+    // A trailing slash is the normal shape of ASPNETCORE_URLS; splitting on ':' used to leave
+    // "9090/", which does not parse, so the warm-up silently self-requested DefaultPort instead.
+    [InlineData("http://+:9090/", 9090)]
+    [InlineData("http://localhost:9090/", 9090)]
+    // ASPNETCORE_URLS may also hold a semicolon-separated list; the cleartext entry is the one to use.
+    [InlineData("https://+:443;http://+:9090/", 9090)]
+    [InlineData("https://+:443;http://+:9090", 9090)]
+    public void ResolveWarmupPort_HandlesTrailingSlashesAndUrlLists(string aspnetcoreUrls, int expected)
+    {
+        var port = SelfHttpWarmupTaskBase.ResolveWarmupPort(ServerWith(), Config(aspnetcoreUrls));
+
+        port.Should().Be(expected);
     }
 
     // ---------------------------------------------------------------- execution semantics

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Extensions/MoneyExtensionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Extensions/MoneyExtensionsTests.cs
@@ -35,11 +35,17 @@ public class MoneyExtensionsTests
     }
 
     [Fact]
-    public void ToDisplayString_EurCurrency_ShowsEurCode()
+    public void ToDisplayString_EurCurrency_ShowsEuroSymbolNotDollar()
     {
         var money = CreateEur(9.99m);
-        money.ToDisplayString().Should().Be("$9.99 EUR");
+        money.ToDisplayString().Should().Be("\u20AC9.99 EUR");
     }
+
+    [Fact]
+    // Money.Zero() carries the internal Currency.None sentinel (empty code). Rendering it as a
+    // dollar amount was wrong, and the empty code used to leave a trailing space.
+    public void ToDisplayString_ZeroSentinel_RendersWithoutSymbolOrDanglingCode() =>
+        Money.Zero().ToDisplayString().Should().Be("0.00");
 
     // ── ToDisplayRange ──
     [Fact]
@@ -67,6 +73,22 @@ public class MoneyExtensionsTests
     public void ToDisplayRange_DifferentPrices_ShowsMinMaxRange()
     {
         List<Money> prices = [CreateMoney(10.00m), CreateMoney(25.00m), CreateMoney(15.00m)];
-        prices.ToDisplayRange().Should().Be("$10.00 — $25.00 USD");
+        prices.ToDisplayRange().Should().Be("$10.00 - $25.00 USD");
+    }
+
+    [Fact]
+    public void ToDisplayRange_MixedCurrencies_GroupsPerCurrencyInsteadOfMixingThem()
+    {
+        // Before the fix min/max spanned every entry while the code came from the first one, so
+        // this rendered "$8.00 - $25.00 USD": a range that never existed, in the wrong currency.
+        List<Money> prices = [CreateMoney(10.00m), CreateMoney(25.00m), CreateEur(8.00m)];
+        prices.ToDisplayRange().Should().Be("$10.00 - $25.00 USD, \u20AC8.00 EUR");
+    }
+
+    [Fact]
+    public void ToDisplayRange_MixedCurrencies_PreservesFirstAppearanceOrder()
+    {
+        List<Money> prices = [CreateEur(8.00m), CreateMoney(10.00m), CreateEur(12.00m)];
+        prices.ToDisplayRange().Should().Be("\u20AC8.00 - \u20AC12.00 EUR, $10.00 USD");
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationHubServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationHubServiceTests.cs
@@ -205,6 +205,83 @@ public sealed class NotificationHubServiceTests
         sut.IsConnected.Should().BeFalse();
     }
 
+    // ── Concurrent starts must not each build a connection (L11) ──
+    [Fact]
+    public async Task StartAsync_CalledConcurrently_NeverRunsTwoStartsAtOnce()
+    {
+        // Two components calling JoinChannelAsync at the same time both used to see a null
+        // connection field, both build one, and start both: the loser's socket leaked with
+        // duplicate server registrations. Blazor Server has no single synchronization context,
+        // so nothing else serialized them.
+        var tokenStorage = new ConcurrencyTrackingTokenStorage();
+
+        await using var sut = new NotificationHubService(
+            tokenStorage,
+            Options.Create(new ApiSettings { ApiEndpoint = "http://127.0.0.1:1" }),
+            NullLogger<NotificationHubService>.Instance)
+        {
+            InitialRetryDelay = TimeSpan.FromMilliseconds(1),
+        };
+
+        await Task.WhenAll(
+            Task.Run(async () => await sut.StartAsync()),
+            Task.Run(async () => await sut.StartAsync()));
+
+        // The access-token provider runs inside the guarded body, so overlapping entries there mean
+        // overlapping starts. Reverting the fix lets both callers in, and this reads 2.
+        tokenStorage.MaxConcurrentCalls.Should().Be(1, "StartAsync must be serialized");
+    }
+
+    /// <summary>
+    /// A token provider that records how many callers are inside it at once and then fails the
+    /// attempt fast (the provider runs before the negotiate request, so no network wait). The short
+    /// hold widens the overlap window: without it a revert could slip through unobserved. The
+    /// flakiness is one-sided, so a false pass is only ever possible on the reverted code.
+    /// </summary>
+    private sealed class ConcurrencyTrackingTokenStorage : ITokenStorageService
+    {
+        private int _current;
+        private int _max;
+
+        public int MaxConcurrentCalls => Volatile.Read(ref _max);
+
+        public async Task<string?> GetAccessTokenAsync()
+        {
+            var inside = Interlocked.Increment(ref _current);
+            RecordMax(inside);
+            try
+            {
+                await Task.Delay(50).ConfigureAwait(false);
+                throw new InvalidOperationException("no session");
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _current);
+            }
+        }
+
+        public Task<string?> GetRefreshTokenAsync() => Task.FromResult<string?>(null);
+
+        public Task SetTokensAsync(string accessToken, string refreshToken) => Task.CompletedTask;
+
+        public Task ClearTokensAsync() => Task.CompletedTask;
+
+        private void RecordMax(int inside)
+        {
+            int observed = Volatile.Read(ref _max);
+            while (inside > observed)
+            {
+                int previous = Interlocked.CompareExchange(ref _max, inside, observed);
+                if (previous == observed)
+                {
+                    return;
+                }
+
+                observed = previous;
+            }
+        }
+    }
+
     /// <summary>Counts the terminal "Failed to connect" warning; the retry loop's own messages are ignored.</summary>
     private sealed class CapturingLogger : ILogger<NotificationHubService>
     {


### PR DESCRIPTION
Twelve low-severity findings from the bug-hunt ledger (L2, L3, L4, L5, L8, L9, L10, L11, L14, L15, L16, L17). Each item was re-verified against current source before implementing, and each fix was **revert-proved**: the fix was temporarily reverted and the matching test confirmed to fail, then restored.

## What changed

| Item | File | Fix |
|---|---|---|
| L2 | `CachingCommandDecorator` | Delayed second eviction closes the read-repopulate race |
| L3 | `RsaJwksProvider` | `LazyThreadSafetyMode.PublicationOnly`: a transient PEM read failure is no longer cached forever |
| L4 | `EFReadRepository.GetByIdAsync` (id-only) | Filtered, still-tracked query instead of `FindAsync` |
| L5 | `MoneyExtensions.ToDisplayString` | Symbol follows the currency instead of a hardcoded `$` |
| L8 | `EfInboxStore` | Detach the rejected row so an absorbed duplicate stops poisoning the scope |
| L9 | `CurrentUserService` | Invariant claim parsing, matching `TokenService` |
| L10 | `IntFilterStrategy` | Invariant parsing, matching the decimal/long/date strategies |
| L11 | `NotificationHubService.StartAsync` | Serialized behind a `SemaphoreSlim` |
| L14 | `MoneyExtensions.ToDisplayRange` | Group by currency instead of mixing them under the first code |
| L15 | `SelfHttpWarmupTaskBase.ResolveWarmupPort` | Trailing slash and semicolon-list handling |
| L16 | `MauiMediaPickerService` | Check cancellation before opening the stream, not after |
| L17 | `ResultJsonConverterFactory` | A `Result<T>` payload with neither `value` nor `errors` throws instead of faking a success |

## Notable details

**L4 keeps tracking on purpose.** `EFRepository` (the write repository) inherits this overload, and `DeleteEntityHandler` plus many consumer update handlers load through it, mutate, and save. A no-tracking swap would have turned every generic delete/update into a silent no-op. A test pins `EntityState.Unchanged` so that cannot regress.

**L17 deliberately does NOT touch the non-generic converter.** `ResultConverter.Write` serializes a success `Result` as exactly `{}`, so an empty object is the legitimate wire form there. A test pins that scope boundary.

**L11 disposal.** `CA2213` requires the new `SemaphoreSlim` to be disposed. Disposal deliberately does not wait for a start already in flight (that start can be sitting in a multi-second retry backoff, and blocking a Blazor circuit teardown on it would be worse); the `_disposed` flag makes the retry loop bail and `StartAsync` tolerates the semaphore disappearing underneath it. `DisposeAsync` is now idempotent, which an existing test required.

**L16 has no test.** `MediaPicker.Default` is static and `MMCA.Common.UI.Maui` has no test project (it is out of the slnx). Verified by building the package for the `net10.0-windows10.0.19041.0` and `net10.0-android` TFMs plus review. Stated honestly rather than papered over.

**One deviation from the plan.** The plan assumed the L2 test could reach `internal` members of `MMCA.Common.Application`, but that project had no `InternalsVisibleTo`. Added one for `MMCA.Common.Application.Tests`, matching the Infrastructure, UI, API and Aspire projects. (`IntFilterStrategyTests` works because it goes through the public `QueryFilterService`, not the internal strategy.)

**Two pre-existing tests were strengthened, not just added to.**
- `ResolveWarmupPort_FallsBackToTheContainerDefault_WhenNothingParses` pinned `"http://localhost:8080/"` to `DefaultPort`. Since `DefaultPort` is 8080, it passed either way and could never have caught L15. Replaced with `"http://localhost/"` (genuinely no port) and added revert-proof cases on port 9090.
- The new L10 culture tests originally used `ContainSingle(predicate)`, which asserts one *matching* element, not a filtered collection. Since a failed parse falls through to the UNFILTERED query (which still contains the expected row), they passed against the very bug they existed to catch. Tightened to assert the exact row count.

## Consumer-visible behavior changes (for the release notes at sweep time)

- **L4**: `GetByIdAsync(id)` no longer returns a tracked soft-deleted entity, nor an Added-but-unsaved one, and costs one DB round trip by primary key instead of an identity-map hit.
- **L17**: corrupt `Result` payloads now throw `JsonException` out of `ICacheService.GetAsync`. The only production path that does this, `CachingQueryDecorator.TryReadAsync`, already catches and treats it as a cache miss, so it degrades to an uncached query.
- **L2**: every invalidating command now issues a second, delayed eviction (extra cache traffic only).
- **L5/L14**: price strings change format (EUR symbol, `Money.Zero()` rendering, `" - "` range separator). All Store data is USD today.
- **L15**: hosts that silently warmed the wrong port now warm the right one.
- **L3**: a jwks build failure is retried instead of cached.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors
- `dotnet test --solution MMCA.Common.slnx -c Release`: **2962 passed, 0 failed, 0 skipped**
- `MMCA.Common.UI.Maui` builds for the windows and android TFMs (out-of-slnx package)
- FACTS drift gate clean; no out-of-slnx lock file drift
- No package version bumps, no ADR changes, no EF migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX
