### PR TITLE
docs: OutboxSettings backoff XML doc mentions the retry jitter

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/OutboxSettings.cs
@@ -83,8 +83,9 @@ public sealed class OutboxSettings
 
     /// <summary>
     /// Gets the base, in seconds, of the exponential backoff applied to a FAILED message before it
-    /// is retried (attempt <c>n</c> waits <c>RetryBackoffBaseSeconds * 2^(n-1)</c>, capped at
-    /// <see cref="LeaseSeconds"/>). Defaults to <c>10</c>.
+    /// is retried (attempt <c>n</c> waits <c>RetryBackoffBaseSeconds * 2^(n-1)</c>, multiplied by a
+    /// random jitter factor in [0.8, 1.2] so rows that failed together do not retry in lockstep,
+    /// then capped at <see cref="LeaseSeconds"/>). Defaults to <c>10</c>.
     /// </summary>
     /// <remarks>
     /// A failed message keeps its claim until this backoff elapses. Before this setting existed the


### PR DESCRIPTION
One XML-doc fix found by the 2026-08-07 ADR audit: `RetryBackoffBaseSeconds` still described a deterministic `base * 2^(n-1)` curve capped at `LeaseSeconds`, but `ComputeRetryBackoffSeconds` (OutboxProcessor.cs) has multiplied that by a random jitter factor in [0.8, 1.2] before the cap since 2026-08-03, precisely so rows that failed together do not retry in lockstep. The summary now says so. Comment-only; no behavior change.

ADR-003 (Website) was updated with the same fact in its 2026-08-07 revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CktxohyvX7D4ok3xkertX