### PR TITLE
fix: guard OpenAPI generation against unbound route tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 > ADR-016. An audit that reports the consumers as "several versions behind" for that window is
 > reading history, not a gap.
 
+### Fixed
+
+- **URL-segment-versioned routes no longer fail OpenAPI document generation.** A route such as
+  `[Route("api/v{version:apiVersion}/orders")]` turned `GET /openapi/{documentName}.json` into a
+  500: MVC leaves `ApiParameterDescription.ParameterDescriptor` null for a route token with no
+  matching action parameter, and `Asp.Versioning.OpenApi` 10.2.1 dereferences it without a null
+  check inside `XmlCommentsTransformer`. `AddCommonApiVersioning()` and `AddCommonOpenApi()` now
+  register `ApiParameterDescriptorBackfillProvider`, an `IApiDescriptionProvider` that runs last and
+  fills a placeholder descriptor wherever one is missing. This closes the 1.144.0 known issue below.
+  The guard is deliberately general: an unbound `{tenant}` or `{region}` token fails identically,
+  because it is the token being unbound, not the versioning, that produces the null. Existing
+  descriptors are never replaced, so the guard goes inert once the upstream null check lands and can
+  then be removed without a behavior change. No consumer action is required, and header-versioned
+  hosts (the entire current consumer surface) are unaffected either way.
+
 ## [1.144.0] - 2026-08-11
 
 A dependency-refresh release driven by the August Dependabot sweep, plus the framework changes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ capability to the UI packages, plus a security pin lifting a vulnerable transiti
   ([GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284), high severity,
   ScpClient recursive-download path traversal). CPM does not pin transitives, hence the direct
   reference; no MMCA code uses SSH.NET.
->>>>>>> origin/main
 
 ## [1.144.0] - 2026-08-11
 

--- a/Source/Presentation/MMCA.Common.API/OpenApi/ApiParameterDescriptorBackfillProvider.cs
+++ b/Source/Presentation/MMCA.Common.API/OpenApi/ApiParameterDescriptorBackfillProvider.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace MMCA.Common.API.OpenApi;
+
+/// <summary>
+/// Backfills a placeholder <see cref="ParameterDescriptor"/> onto every
+/// <see cref="ApiParameterDescription"/> the API explorer leaves with a
+/// <see langword="null"/> one, so downstream OpenAPI transformers that assume the property is
+/// always populated cannot fail the document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// MVC's <c>DefaultApiDescriptionProvider</c> creates an <see cref="ApiParameterDescription"/> for
+/// every route-template token. When a token has no matching action parameter there is no
+/// descriptor to attach, so <see cref="ApiParameterDescription.ParameterDescriptor"/> stays
+/// <see langword="null"/>. That is normal, documented MVC behaviour for a route such as
+/// <c>[Route("api/v{version:apiVersion}/orders")]</c> or <c>[Route("api/{tenant}/orders")]</c>.
+/// </para>
+/// <para>
+/// <c>Asp.Versioning.OpenApi</c> 10.2.1 does not account for it:
+/// <c>XmlCommentsTransformer.TransformAsync(OpenApiOperation, ...)</c> reads
+/// <c>arg.ParameterDescriptor.Name</c> without a null check, so the first URL-segment-versioned
+/// route turns <c>GET /openapi/{documentName}.json</c> into a <c>500</c> with a
+/// <see cref="NullReferenceException"/>. Because <c>AddCommonApiVersioning</c> enables
+/// <c>SubstituteApiVersionInUrl</c>, any consumer that adopts segment versioning would hit this.
+/// </para>
+/// <para>
+/// The guard is deliberately general rather than special-casing the API version token: the null is
+/// a property of unbound route tokens, not of versioning, so a <c>{tenant}</c> or <c>{region}</c>
+/// segment fails the same way. Filling the gap here fixes it once for every consumer of the API
+/// explorer instead of only for the one transformer that happens to dereference it today.
+/// </para>
+/// <para>
+/// It runs with <see cref="Order"/> at <see cref="int.MinValue"/>. Providers execute
+/// <c>OnProvidersExecuted</c> in DESCENDING order, so the lowest order runs last and observes
+/// every parameter any other provider contributed, including the ones
+/// <c>VersionedApiDescriptionProvider</c> adds. Existing descriptors are never replaced, so the
+/// guard is inert on a fixed upstream package and can be deleted without a behaviour change once
+/// the upstream null check lands.
+/// </para>
+/// </remarks>
+internal sealed class ApiParameterDescriptorBackfillProvider : IApiDescriptionProvider
+{
+    /// <inheritdoc />
+    public int Order => int.MinValue;
+
+    /// <inheritdoc />
+    public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+    {
+        // Nothing to do before the descriptions are built: the parameters this guard repairs do
+        // not exist yet.
+    }
+
+    /// <inheritdoc />
+    public void OnProvidersExecuted(ApiDescriptionProviderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var parameter in context.Results.SelectMany(description => description.ParameterDescriptions))
+        {
+            // Only fill the gap. A descriptor supplied by MVC or by API versioning is richer than
+            // anything reconstructable here (ControllerParameterDescriptor carries the
+            // ParameterInfo that XML-comment lookups prefer), so it always wins.
+            parameter.ParameterDescriptor ??= new ParameterDescriptor
+            {
+                Name = parameter.Name ?? string.Empty,
+                ParameterType = parameter.Type
+                    ?? parameter.ModelMetadata?.ModelType
+                    ?? typeof(string),
+            };
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/WebApplicationBuilderExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/WebApplicationBuilderExtensions.cs
@@ -6,12 +6,15 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
 using MMCA.Common.API.Authorization;
+using MMCA.Common.API.OpenApi;
 using MMCA.Common.Infrastructure.Settings;
 
 namespace MMCA.Common.API.Startup;
@@ -106,6 +109,8 @@ public static class WebApplicationBuilderExtensions
     {
         /// <summary>
         /// Registers header-based API versioning (v1.0 default) with MVC and API explorer support.
+        /// Also installs <see cref="ApiParameterDescriptorBackfillProvider"/>, which keeps
+        /// URL-segment-versioned routes from failing OpenAPI document generation.
         /// </summary>
         public IServiceCollection AddCommonApiVersioning()
         {
@@ -123,6 +128,8 @@ public static class WebApplicationBuilderExtensions
                 options.GroupNameFormat = "'v'VVV";
                 options.SubstituteApiVersionInUrl = true;
             });
+
+            services.AddApiParameterDescriptorBackfill();
 
             return services;
         }
@@ -223,13 +230,27 @@ public static class WebApplicationBuilderExtensions
         /// <c>MapCommonOpenApi()</c> so each service serves <c>/openapi/v1.json</c> the same way.
         /// The parameterless <c>AddApiVersioning()</c> call only returns the builder; the options
         /// configured by <c>AddCommonApiVersioning</c> accumulate independently of call order.
+        /// Also installs <see cref="ApiParameterDescriptorBackfillProvider"/>, so a host that opts
+        /// into OpenAPI without calling <c>AddCommonApiVersioning</c> is guarded too.
         /// </summary>
         public IServiceCollection AddCommonOpenApi()
         {
             services.AddApiVersioning().AddOpenApi();
+            services.AddApiParameterDescriptorBackfill();
 
             return services;
         }
+
+        /// <summary>
+        /// Registers the <see cref="ApiParameterDescriptorBackfillProvider"/> guard exactly once,
+        /// however many of the registration helpers above a host calls.
+        /// <see cref="ServiceCollectionDescriptorExtensions.TryAddEnumerable(IServiceCollection, ServiceDescriptor)"/>
+        /// de-duplicates on the implementation type, so the repeated call is a no-op rather than a
+        /// second pass over every API description.
+        /// </summary>
+        private void AddApiParameterDescriptorBackfill() =>
+            services.TryAddEnumerable(
+                ServiceDescriptor.Transient<IApiDescriptionProvider, ApiParameterDescriptorBackfillProvider>());
 
         /// <summary>
         /// Registers JWT Bearer authentication that trusts an external Identity service's JWKS

--- a/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/ApiParameterDescriptorBackfillProviderTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/ApiParameterDescriptorBackfillProviderTests.cs
@@ -1,0 +1,220 @@
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using Asp.Versioning;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.API.OpenApi;
+using MMCA.Common.API.Startup;
+
+namespace MMCA.Common.API.Tests.OpenApi;
+
+/// <summary>
+/// Covers <see cref="ApiParameterDescriptorBackfillProvider"/>, the guard that keeps an unbound
+/// route token (most importantly the <c>v{version:apiVersion}</c> segment that
+/// <c>AddCommonApiVersioning</c> enables through <c>SubstituteApiVersionInUrl</c>) from failing
+/// OpenAPI document generation.
+/// <para>
+/// The headline test is end to end on purpose. <c>Asp.Versioning.OpenApi</c> 10.2.1 dereferences
+/// <c>ApiParameterDescription.ParameterDescriptor</c> without a null check inside
+/// <c>XmlCommentsTransformer</c>, and that transformer is only attached when an XML documentation
+/// file is found, so a mocked pipeline would assert nothing about the real failure. Booting a
+/// TestServer over the real MVC + API versioning + OpenAPI stack and fetching the document is the
+/// only assertion that actually reproduces the <c>500</c> when the guard is removed.
+/// </para>
+/// </summary>
+public sealed class ApiParameterDescriptorBackfillProviderTests
+{
+    /// <summary>Route tokens declared by the probe controllers with no matching action parameter.</summary>
+    private static readonly HashSet<string> UnboundTokenNames =
+        new(StringComparer.Ordinal) { "version", "tenant" };
+
+    // ── The regression: a URL-segment-versioned route must not fail the document ──
+    [Fact]
+    public async Task GetOpenApiDocument_WithUrlSegmentVersionedRoute_ReturnsTheDocument()
+    {
+        await using WebApplication app = await CreateHostAsync();
+        using HttpClient client = app.GetTestClient();
+
+        using var response = await client.GetAsync(new Uri("/openapi/v1.json", UriKind.Relative));
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "Asp.Versioning.OpenApi 10.2.1 throws a NullReferenceException on the null ParameterDescriptor "
+            + "of an unbound route token, which surfaces as a 500 on the document endpoint");
+
+        string body = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(body);
+        var paths = document.RootElement.GetProperty("paths");
+
+        paths.TryGetProperty("/api/v{version}/backfill-probe/{id}", out _).Should().BeTrue(
+            "the segment-versioned route must still be described, not merely tolerated");
+        paths.TryGetProperty("/api/backfill-probe/{tenant}/items", out _).Should().BeTrue(
+            "an unbound route token that is not the API version fails identically and is guarded too");
+    }
+
+    // ── The invariant the upstream transformer relies on, asserted against the real pipeline ──
+    [Fact]
+    public async Task ApiDescriptions_ForUnboundRouteTokens_AlwaysCarryAParameterDescriptor()
+    {
+        await using WebApplication app = await CreateHostAsync();
+
+        var descriptions = app.Services
+            .GetRequiredService<IApiDescriptionGroupCollectionProvider>()
+            .ApiDescriptionGroups.Items
+            .SelectMany(group => group.Items)
+            .ToList();
+
+        descriptions.Should().NotBeEmpty("the probe controllers must have been discovered");
+
+        var unbound = descriptions
+            .SelectMany(description => description.ParameterDescriptions)
+            .Where(parameter => UnboundTokenNames.Contains(parameter.Name))
+            .ToList();
+
+        unbound.Should().NotBeEmpty("both probe routes declare a token with no matching action parameter");
+        unbound.Should().AllSatisfy(parameter => parameter.ParameterDescriptor.Should().NotBeNull());
+    }
+
+    // ── Only the gaps are filled; a real descriptor is never overwritten ──
+    [Fact]
+    public void OnProvidersExecuted_FillsOnlyTheMissingDescriptors()
+    {
+        var existing = new ParameterDescriptor { Name = "kept", ParameterType = typeof(Guid) };
+        var context = new ApiDescriptionProviderContext([]);
+        var description = new ApiDescription();
+        description.ParameterDescriptions.Add(new ApiParameterDescription
+        {
+            Name = "version",
+            Type = typeof(string),
+            Source = BindingSource.Path,
+        });
+        description.ParameterDescriptions.Add(new ApiParameterDescription
+        {
+            Name = "kept",
+            Type = typeof(Guid),
+            Source = BindingSource.Path,
+            ParameterDescriptor = existing,
+        });
+        context.Results.Add(description);
+
+        new ApiParameterDescriptorBackfillProvider().OnProvidersExecuted(context);
+
+        var filled = description.ParameterDescriptions[0].ParameterDescriptor;
+        filled.Should().NotBeNull();
+        filled!.Name.Should().Be("version");
+        filled.ParameterType.Should().Be<string>();
+
+        description.ParameterDescriptions[1].ParameterDescriptor.Should().BeSameAs(
+            existing,
+            "a descriptor MVC or API versioning already supplied is richer than any reconstruction");
+    }
+
+    // ── Runs last so it observes every parameter other providers contributed ──
+    // OnProvidersExecuted runs in DESCENDING order, so the lowest order executes last.
+    [Fact]
+    public void Order_IsLowest_SoTheGuardRunsAfterEveryOtherProvider() =>
+        new ApiParameterDescriptorBackfillProvider().Order.Should().Be(int.MinValue);
+
+    // ── Registered once even when a host calls both helpers ──
+    [Fact]
+    public void BothRegistrationHelpers_RegisterTheGuardExactlyOnce()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddCommonApiVersioning();
+        services.AddCommonOpenApi();
+
+        services.Count(descriptor =>
+                descriptor.ServiceType == typeof(IApiDescriptionProvider)
+                && descriptor.ImplementationType == typeof(ApiParameterDescriptorBackfillProvider))
+            .Should().Be(1, "TryAddEnumerable de-duplicates on the implementation type");
+    }
+
+    // ── Helpers ──
+    private static async Task<WebApplication> CreateHostAsync()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        // Restrict discovery to this file's probe controllers so the assertions cannot be
+        // perturbed by controllers belonging to other tests or to MMCA.Common.API itself.
+        builder.Services.AddControllers().ConfigureApplicationPartManager(manager =>
+        {
+            for (int i = manager.FeatureProviders.Count - 1; i >= 0; i--)
+            {
+                if (manager.FeatureProviders[i] is IApplicationFeatureProvider<ControllerFeature>)
+                {
+                    manager.FeatureProviders.RemoveAt(i);
+                }
+            }
+
+            manager.FeatureProviders.Add(new ProbeControllerFeatureProvider());
+        });
+
+        builder.Services.AddCommonApiVersioning();
+        builder.Services.AddCommonOpenApi();
+
+        WebApplication app = builder.Build();
+        app.MapControllers();
+        app.MapCommonOpenApi();
+        await app.StartAsync();
+
+        return app;
+    }
+
+    private sealed class ProbeControllerFeatureProvider : IApplicationFeatureProvider<ControllerFeature>
+    {
+        public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
+        {
+            feature.Controllers.Add(typeof(SegmentVersionedProbeController).GetTypeInfo());
+            feature.Controllers.Add(typeof(UnboundRouteTokenProbeController).GetTypeInfo());
+        }
+    }
+}
+
+/// <summary>
+/// Probe controller whose route carries the API version as a URL segment. Nothing binds
+/// <c>version</c> to an action parameter, so MVC describes it with a null
+/// <c>ParameterDescriptor</c>: the exact shape that fails document generation unguarded.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/backfill-probe")]
+public sealed class SegmentVersionedProbeController : ControllerBase
+{
+    /// <summary>Echoes the supplied identifier.</summary>
+    /// <param name="id">The identifier to echo.</param>
+    [HttpGet("{id}")]
+    public IActionResult Get(int id) => Ok(id);
+}
+
+/// <summary>
+/// Probe controller with an unbound route token that is NOT the API version, proving the guard
+/// addresses the general MVC condition rather than special-casing API versioning.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/backfill-probe/{tenant}/items")]
+public sealed class UnboundRouteTokenProbeController : ControllerBase
+{
+    /// <summary>Returns a constant payload.</summary>
+    [HttpGet]
+    public IActionResult Get() => Ok("ok");
+}


### PR DESCRIPTION
Closes the v1.144.0 known issue: Asp.Versioning.OpenApi 10.2.1 NREs (500 from the OpenAPI document endpoint) on any route with an unbound token, which includes every URL-segment-versioned route. The fix is a general, public-surface IApiDescriptionProvider (ApiParameterDescriptorBackfillProvider) registered by AddCommonApiVersioning()/AddCommonOpenApi() that runs last and backfills a placeholder ParameterDescriptor only where the API explorer left null; richer descriptors always win, so the guard is inert once upstream fixes the null check.

Verification (real pipeline, TestServer + actual GET /openapi/v1.json against the real upstream transformer):
- Pre-fix repro confirmed on main (500, NRE in XmlCommentsTransformer)
- Post-fix: segment-versioned route 200, unbound {tenant} token 200, header-versioned route 200, Scalar UI 200
- No-regression proof: header-only document byte-for-byte identical with guard on vs off
- 5 new tests; 3 fail when the guard body is neutralized (load-bearing, not vacuous)
- Full suite: 2967 passed, 0 failed; Release build 0 warnings

Known residual (pre-existing, deliberately NOT in this PR): consumer-host XML comments never reach the document because Asp.Versioning's XmlCommentsFile stops at the calling assembly (the framework), and segment-versioning adopters will also need a UrlSegmentApiVersionReader. Both noted for a future decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXf3gZa1G61GpCYwvSUveZ