### PR TITLE
feat(ui): shared QR component + barcode-scanner capability (+ SSH.NET security pin)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -150,6 +150,14 @@
          RabbitMQ containers for consumer cross-service integration tiers. Test-tier only. -->
     <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.13.0" />
+    <!-- Pinned directly to force transitive resolution to the patched version: every Testcontainers
+         package floors SSH.NET at 2025.1.0, which carries GHSA-q939-rpr3-3284 (high, published
+         2026-08-12: ScpClient recursive download lets a malicious server write arbitrary files via
+         server-controlled SCP filenames); fixed in 2026.0.0. CPM does not pin transitives, so the
+         projects that pull Testcontainers add a direct PackageReference (same pattern as the
+         MessagePack and SQLitePCLRaw pins above), which also carries the fix to consumers of the
+         MMCA.Common.Testing package through the published package graph. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
     <PackageVersion Include="NetArchTest.eNhancedEdition" Version="1.4.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,6 +95,10 @@
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
     <PackageVersion Include="MudBlazor" Version="9.8.0" />
     <PackageVersion Include="Polly" Version="8.7.0" />
+    <!-- QR encoding for the shared QrCodeImage component (MIT). Pure managed encode-to-PNG: no
+         native binary, no network call, no image service, so it renders identically on every head
+         including Blazor WebAssembly. -->
+    <PackageVersion Include="QRCoder" Version="1.8.0" />
     <!-- Common.UI.Maui — must match the Microsoft.Maui.Controls pin the consumer heads use
          (ADC/Store pin 10.0.70); MAUI plugin/toolkit packages bind to the MAUI minor, so
          bump them together, never independently. -->
@@ -113,6 +117,11 @@
     <!-- BlazorWebView host support for UI.Maui (Wave 5: MainPageBase / NativeThemeSync);
          versions on the MAUI train, bump together with Microsoft.Maui.Controls. -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.80" />
+    <!-- Camera barcode/QR scanning for UI.Maui's opt-in IBarcodeScannerService (MIT, by Redth).
+         Ships assets for all four MAUI TFMs of this package (net10.0-android36.0 / -ios26.0 /
+         -maccatalyst26.0 / -windows10.0.19041) and depends on Microsoft.Maui.Controls, so it
+         binds to the MAUI train: bump together with Microsoft.Maui.Controls. -->
+    <PackageVersion Include="ZXing.Net.Maui.Controls" Version="0.10.3" />
     <!-- Analyzers -->
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.141" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />

--- a/Source/Hosting/MMCA.Common.Testing.UI/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing.UI/packages.lock.json
@@ -156,6 +156,11 @@
         "resolved": "10.0.10",
         "contentHash": "FjPAGQWbCP85FWY2Wl9opHSsY+u9nZb8Ui6eTVHEMY/RJateOhW78jEtC4QOQ/6slkS1MKyIAF6ZHIrUR1fX/w=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.7.0",
@@ -165,6 +170,14 @@
         "type": "Transitive",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
       },
       "mmca.common.shared": {
         "type": "Project"
@@ -177,6 +190,7 @@
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -207,6 +221,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {

--- a/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
+++ b/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
@@ -29,6 +29,9 @@
          SqlServerIntegrationTestFixtureBase does not touch these. -->
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Testcontainers.RabbitMq" />
+    <!-- Direct only to lift the vulnerable SSH.NET that Testcontainers floors at 2025.1.0
+         (GHSA-q939-rpr3-3284); no code here uses it. See the pin comment in Directory.Packages.props. -->
+    <PackageReference Include="SSH.NET" />
     <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Hosting/MMCA.Common.Testing/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing/packages.lock.json
@@ -100,6 +100,15 @@
         "resolved": "10.32.0.713",
         "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
+      "SSH.NET": {
+        "type": "Direct",
+        "requested": "[2026.0.0, )",
+        "resolved": "2026.0.0",
+        "contentHash": "Yu9dirPq8l3oaat0+OQ7K0nUf5MmYltpia5UGqsApTG4zTPvBC1cxbNnC3NERij26dUST0A3Ef1QdHSn5ArbWQ==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.7.0"
+        }
+      },
       "StyleCop.Analyzers": {
         "type": "Direct",
         "requested": "[1.2.0-beta.556, )",
@@ -158,8 +167,8 @@
       },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+        "resolved": "2.7.0",
+        "contentHash": "U+12df8UEWHgBi04YVf/Lgi2dy3SItlIYvHjjEVa/BngCQIzDCDRBk50DDByCfDvSbe5pRNFr3b7UrVK2kMcLw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -358,14 +367,6 @@
         "type": "Transitive",
         "resolved": "1.4.2",
         "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
-      },
-      "SSH.NET": {
-        "type": "Transitive",
-        "resolved": "2025.1.0",
-        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
-        "dependencies": {
-          "BouncyCastle.Cryptography": "2.6.2"
-        }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/BarcodeScanPage.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/BarcodeScanPage.cs
@@ -1,0 +1,112 @@
+using ZXing.Net.Maui;
+using ZXing.Net.Maui.Controls;
+
+namespace MMCA.Common.UI.Maui.Capabilities;
+
+/// <summary>
+/// Modal scan surface for <see cref="MauiBarcodeScannerService"/>: a full-bleed ZXing camera
+/// reader with a cancel button underneath. Built in code rather than XAML so the package ships no
+/// compiled resource dictionary and the page stays an implementation detail of the service.
+/// <para>
+/// Every exit path resolves the same completion source exactly once (first decode, cancel button,
+/// platform back gesture, or the page disappearing), so the caller always gets an answer and the
+/// camera is always released.
+/// </para>
+/// <para>
+/// <c>partial</c> is required by CsWinRT1028 on the windows TFM (a ContentPage crosses the WinRT
+/// ABI); the redundancy style rules that object to it on the other TFMs are silenced project-wide
+/// in the csproj, exactly as the comment there describes.
+/// </para>
+/// </summary>
+internal sealed partial class BarcodeScanPage : ContentPage
+{
+    private readonly TaskCompletionSource<string?> _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private readonly CameraBarcodeReaderView _reader;
+
+    internal BarcodeScanPage(string cancelText, string cameraDescription)
+    {
+        _reader = new CameraBarcodeReaderView
+        {
+            Options = new BarcodeReaderOptions
+            {
+                // Two-dimensional only: the affordance is a QR/DataMatrix scan, and admitting the
+                // 1D formats multiplies false positives on a shaky handheld frame.
+                Formats = BarcodeFormats.TwoDimensional,
+                AutoRotate = true,
+                Multiple = false,
+            },
+            IsDetecting = true,
+        };
+        _reader.BarcodesDetected += OnBarcodesDetected;
+        SemanticProperties.SetDescription(_reader, cameraDescription);
+
+        var cancel = new Button
+        {
+            Text = cancelText,
+            Margin = new Thickness(16),
+        };
+        cancel.Clicked += OnCancelClicked;
+        SemanticProperties.SetDescription(cancel, cancelText);
+
+        var layout = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto),
+            },
+        };
+        layout.Add(_reader, 0, 0);
+        layout.Add(cancel, 0, 1);
+
+        Title = cameraDescription;
+        Content = layout;
+    }
+
+    /// <summary>Completes with the first decoded payload, or <see langword="null"/> on any cancel.</summary>
+    internal Task<string?> Completion => _completion.Task;
+
+    /// <summary>Resolves the scan as cancelled. Safe to call repeatedly and from any exit path.</summary>
+    internal void Cancel() => _completion.TrySetResult(null);
+
+    /// <inheritdoc />
+    protected override bool OnBackButtonPressed()
+    {
+        // Consume the gesture: the service owns the single PopModalAsync, so letting the platform
+        // pop the page itself would leave the service popping whatever page came next.
+        Cancel();
+        return true;
+    }
+
+    /// <inheritdoc />
+    protected override void OnDisappearing()
+    {
+        StopDetecting();
+        Cancel();
+        base.OnDisappearing();
+    }
+
+    private void OnCancelClicked(object? sender, EventArgs e) => Cancel();
+
+    private void OnBarcodesDetected(object? sender, BarcodeDetectionEventArgs e)
+    {
+        var value = e.Results?.FirstOrDefault(result => !string.IsNullOrWhiteSpace(result.Value))?.Value;
+        if (value is null)
+        {
+            return;
+        }
+
+        // Stop the camera on the first hit: continued detection would keep raising this event
+        // against an already-completed source while the modal animates away.
+        StopDetecting();
+        _completion.TrySetResult(value);
+    }
+
+    private void StopDetecting()
+    {
+        _reader.BarcodesDetected -= OnBarcodesDetected;
+        _reader.IsDetecting = false;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiBarcodeScannerService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiBarcodeScannerService.cs
@@ -1,0 +1,90 @@
+using MMCA.Common.UI.Services.Capabilities;
+
+namespace MMCA.Common.UI.Maui.Capabilities;
+
+/// <summary>
+/// MAUI camera scanner over ZXing.Net.MAUI (ADR-042). Pushes <see cref="BarcodeScanPage"/> modally
+/// over the current window page, resolves on the first decoded payload, and pops the page again on
+/// every exit path. The camera permission belongs to the platform (Android CAMERA, iOS
+/// NSCameraUsageDescription): a head that has not declared it, or a user who denies it, gets a scan
+/// that simply never decodes and is cancelled out of, which the contract surfaces as
+/// <see langword="null"/> rather than an exception.
+/// <para>
+/// Registered by <c>UseCommonBarcodeScanner()</c> only, so a head that never scans neither ships
+/// the camera handler nor needs the permission.
+/// </para>
+/// </summary>
+/// <param name="cancelText">Label for the scan page's cancel button; pass a localized string.</param>
+/// <param name="cameraDescription">Accessible description and title for the scan surface.</param>
+public sealed class MauiBarcodeScannerService(string cancelText, string cameraDescription) : IBarcodeScannerService
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Android and iOS only. Mac Catalyst and Windows have cameras, but the scan affordance there
+    /// is a desktop paste field in every head that uses this, and the ZXing camera view is not a
+    /// supported surface on those targets.
+    /// </remarks>
+    public bool IsSupported =>
+        DeviceInfo.Current.Platform == DevicePlatform.Android ||
+        DeviceInfo.Current.Platform == DevicePlatform.iOS;
+
+    /// <inheritdoc />
+    public async Task<string?> ScanAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsSupported || cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await MainThread
+                .InvokeOnMainThreadAsync(() => ScanOnMainThreadAsync(cancelText, cameraDescription, cancellationToken))
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - scanning is best-effort; a missing window, a denied camera, and a handler-less platform must all read as "no scan"
+        catch
+#pragma warning restore CA1031
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> ScanOnMainThreadAsync(
+        string cancelText,
+        string cameraDescription,
+        CancellationToken cancellationToken)
+    {
+        var host = CurrentPage;
+        if (host is null)
+        {
+            return null;
+        }
+
+        var scanPage = new BarcodeScanPage(cancelText, cameraDescription);
+
+        // ConfigureAwait(true) throughout: modal navigation and the camera view are main-thread
+        // bound, and this method is already running on it.
+        await host.Navigation.PushModalAsync(scanPage).ConfigureAwait(true);
+        try
+        {
+            await using var registration = cancellationToken.Register(scanPage.Cancel);
+            return await scanPage.Completion.ConfigureAwait(true);
+        }
+        finally
+        {
+            await host.Navigation.PopModalAsync().ConfigureAwait(true);
+        }
+    }
+
+    private static Page? CurrentPage
+    {
+        get
+        {
+            // Application.MainPage is obsolete on the .NET 10 MAUI train; the window's Page is the
+            // supported way to reach the active navigation stack.
+            var windows = Application.Current?.Windows;
+            return windows is { Count: > 0 } ? windows[0].Page : null;
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/HostingDependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/HostingDependencyInjection.cs
@@ -1,6 +1,9 @@
+using MMCA.Common.UI.Maui.Capabilities;
 using MMCA.Common.UI.Maui.Globalization;
 using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Capabilities;
 using Plugin.LocalNotification;
+using ZXing.Net.Maui.Controls;
 
 namespace MMCA.Common.UI.Maui;
 
@@ -35,6 +38,30 @@ public static class HostingDependencyInjection
             // here means no head can be left half-configured. UseMauiCulture() stays separately
             // callable for a head that composes its registrations by hand.
             builder.UseMauiCulture();
+            return builder;
+        }
+
+        /// <summary>
+        /// Opt-in camera barcode/QR scanning (ADR-042): registers the ZXing.Net.MAUI handlers
+        /// (<c>UseBarcodeReader()</c>) and overrides the null <c>IBarcodeScannerService</c> with
+        /// <see cref="MauiBarcodeScannerService"/>. Deliberately NOT folded into
+        /// <see cref="UseMauiDeviceCapabilities"/>: a head that never scans should ship neither the
+        /// camera handler nor a camera permission declaration.
+        /// <para>
+        /// The head still declares the platform permission itself (Android CAMERA, iOS
+        /// NSCameraUsageDescription). Call AFTER <c>AddUIShared</c> so the plain Add overrides the
+        /// TryAdd default (last registration wins).
+        /// </para>
+        /// </summary>
+        /// <param name="cancelText">Label for the scan page's cancel button; pass a localized string.</param>
+        /// <param name="cameraDescription">Accessible description and title for the scan surface; pass a localized string.</param>
+        public MauiAppBuilder UseCommonBarcodeScanner(
+            string cancelText = "Cancel",
+            string cameraDescription = "Scan a code")
+        {
+            builder.UseBarcodeReader();
+            builder.Services.AddSingleton<IBarcodeScannerService>(
+                _ => new MauiBarcodeScannerService(cancelText, cameraDescription));
             return builder;
         }
 

--- a/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
+++ b/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
@@ -48,6 +48,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" ExcludeAssets="build;buildTransitive" />
     <PackageReference Include="Plugin.LocalNotification" />
     <PackageReference Include="CommunityToolkit.Maui" />
+    <!-- Camera barcode/QR scanning behind the opt-in UseCommonBarcodeScanner() builder call.
+         Ships lib assets only (no build/buildTransitive targets), so unlike WebView.Maui above it
+         cannot turn this Razor-SDK project into a static-web-asset producer. -->
+    <PackageReference Include="ZXing.Net.Maui.Controls" />
     <PackageReference Include="MinVer">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build</IncludeAssets>

--- a/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.138, )",
-        "resolved": "3.0.138",
-        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -64,15 +64,15 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.31.0.145097, )",
-        "resolved": "10.31.0.145097",
-        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -96,6 +96,17 @@
           "Xamarin.AndroidX.Fragment": "1.8.8.1",
           "Xamarin.AndroidX.Lifecycle.LiveData.Core": "2.9.2.1",
           "Xamarin.AndroidX.Lifecycle.ViewModel": "2.9.2.1"
+        }
+      },
+      "ZXing.Net.Maui.Controls": {
+        "type": "Direct",
+        "requested": "[0.10.3, )",
+        "resolved": "0.10.3",
+        "contentHash": "hDhT2yvZCZiqwJ/SqwtI1Tdq1LVJIFcy2wMYFZZ6cKuEAigeebNwS8Uh5G067Qv225I1WhGLjbZyLCZ7rGuhEw==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11",
+          "ZXing.Net.Maui": "0.10.3"
         }
       },
       "CommunityToolkit.Maui.Core": {
@@ -689,6 +700,11 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Plugin.LocalNotification.Core": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -703,6 +719,14 @@
         "type": "Transitive",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
       },
       "Xamarin.Android.Glide": {
         "type": "Transitive",
@@ -858,6 +882,86 @@
           "Xamarin.Google.Guava.ListenableFuture": "1.0.0.29"
         }
       },
+      "Xamarin.AndroidX.Camera.Camera2": {
+        "type": "Transitive",
+        "resolved": "1.4.2.3",
+        "contentHash": "gBeLU2IKN0N18LLAWqPpwzvVpfvEitNhoYj2bBEZshfgk5UkUmBh3knWmLtiUlqdowefN5Ve3JgyT24h1cYP2A==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.5",
+          "Xamarin.AndroidX.Camera.Core": "[1.4.2.3, 1.4.3)",
+          "Xamarin.AndroidX.Concurrent.Futures": "1.3.0.1",
+          "Xamarin.AndroidX.Core": "1.16.0.3",
+          "Xamarin.AndroidX.Tracing.Tracing": "1.3.0.1",
+          "Xamarin.Google.AutoValue.Annotations": "1.11.0.8",
+          "Xamarin.Google.Guava.ListenableFuture": "1.0.0.29"
+        }
+      },
+      "Xamarin.AndroidX.Camera.Core": {
+        "type": "Transitive",
+        "resolved": "1.4.2.3",
+        "contentHash": "B0nEc5k2hzo3V83p+LOQGo5GwznFcnSsklRTpPMcYDWCqUPPDPOIA0HCV6tKurOpOA/nVx4m6KRLpauM5GoMIw==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.5",
+          "Xamarin.AndroidX.Annotation.Experimental": "1.5.1.1",
+          "Xamarin.AndroidX.Concurrent.Futures": "1.3.0.1",
+          "Xamarin.AndroidX.Concurrent.Futures.Ktx": "1.3.0.1",
+          "Xamarin.AndroidX.Core": "1.16.0.3",
+          "Xamarin.AndroidX.ExifInterface": "1.4.1.1",
+          "Xamarin.AndroidX.Lifecycle.Common": "2.9.2.1",
+          "Xamarin.AndroidX.Lifecycle.LiveData": "2.9.2.1",
+          "Xamarin.AndroidX.Tracing.Tracing": "1.3.0.1",
+          "Xamarin.Google.AutoValue.Annotations": "1.11.0.8",
+          "Xamarin.Google.Guava.ListenableFuture": "1.0.0.29",
+          "Xamarin.Kotlin.StdLib": "2.2.0.1",
+          "Xamarin.KotlinX.Coroutines.Android": "1.10.2.1"
+        }
+      },
+      "Xamarin.AndroidX.Camera.Lifecycle": {
+        "type": "Transitive",
+        "resolved": "1.4.2.3",
+        "contentHash": "/gPG7P8sH6y0mJkIxzeOf3x8wrtyOJjKNC9WqApuKc7YxLaRU1h9QWcUTIDWXdbBAmregLi4WMy6rAdfH89NjA==",
+        "dependencies": {
+          "Xamarin.AndroidX.Camera.Core": "[1.4.2.3, 1.4.3)",
+          "Xamarin.AndroidX.Concurrent.Futures": "1.3.0.1",
+          "Xamarin.AndroidX.Concurrent.Futures.Ktx": "1.3.0.1",
+          "Xamarin.AndroidX.Core": "1.16.0.3",
+          "Xamarin.AndroidX.Lifecycle.Common": "2.9.2.1",
+          "Xamarin.AndroidX.Tracing.Tracing.Ktx": "1.3.0.1",
+          "Xamarin.Google.AutoValue.Annotations": "1.11.0.8",
+          "Xamarin.Google.Guava.ListenableFuture": "1.0.0.29",
+          "Xamarin.KotlinX.Coroutines.Android": "1.10.2.1"
+        }
+      },
+      "Xamarin.AndroidX.Camera.Video": {
+        "type": "Transitive",
+        "resolved": "1.4.2.3",
+        "contentHash": "JHK9l53p7ksmGbI9znjs/EZs12WvDMlwc4VgRLfV+bGW+Zn5taKXQ3zhKQg/6aa5wP2iQvPKqXUf0m7t4lP92g==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.5",
+          "Xamarin.AndroidX.Camera.Core": "[1.4.2.3, 1.4.3)",
+          "Xamarin.AndroidX.Concurrent.Futures": "1.3.0.1",
+          "Xamarin.AndroidX.Core": "1.16.0.3",
+          "Xamarin.Google.AutoValue.Annotations": "1.11.0.8"
+        }
+      },
+      "Xamarin.AndroidX.Camera.View": {
+        "type": "Transitive",
+        "resolved": "1.4.2.3",
+        "contentHash": "UntAHlxWk0fIw+S0DwA/KLLJPQWZUA8uHRgJ8ybEAVJO+lhrJE5ZY2hJGcgWjWSTI/e9nDvBTAHMNrJTA193Zw==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.5",
+          "Xamarin.AndroidX.Annotation.Experimental": "1.5.1.1",
+          "Xamarin.AndroidX.AppCompat": "1.7.1.1",
+          "Xamarin.AndroidX.Camera.Core": "[1.4.2.3, 1.4.3)",
+          "Xamarin.AndroidX.Camera.Lifecycle": "[1.4.2.3, 1.4.3)",
+          "Xamarin.AndroidX.Camera.Video": "[1.4.2.3, 1.4.3)",
+          "Xamarin.AndroidX.Concurrent.Futures": "1.3.0.1",
+          "Xamarin.AndroidX.Core": "1.16.0.3",
+          "Xamarin.AndroidX.Lifecycle.Common": "2.9.2.1",
+          "Xamarin.Google.AutoValue.Annotations": "1.11.0.8",
+          "Xamarin.Google.Guava.ListenableFuture": "1.0.0.29"
+        }
+      },
       "Xamarin.AndroidX.CardView": {
         "type": "Transitive",
         "resolved": "1.0.0.36",
@@ -901,6 +1005,16 @@
           "Xamarin.AndroidX.Annotation": "1.9.1.5",
           "Xamarin.Google.Guava.ListenableFuture": "1.0.0.29",
           "Xamarin.JSpecify": "1.0.0.4"
+        }
+      },
+      "Xamarin.AndroidX.Concurrent.Futures.Ktx": {
+        "type": "Transitive",
+        "resolved": "1.3.0.1",
+        "contentHash": "pcynHUJiZsjXCNx99vN2H9YQyZdh9JB1tbPMvM3UflL26DNwbE3uNzf77HoQLeiyF/etMD0cNRhMWDVGKEgAwA==",
+        "dependencies": {
+          "Xamarin.AndroidX.Concurrent.Futures": "[1.3.0.1, 1.3.1)",
+          "Xamarin.Kotlin.StdLib": "2.2.0.1",
+          "Xamarin.KotlinX.Coroutines.Core": "1.10.2.1"
         }
       },
       "Xamarin.AndroidX.ConstraintLayout": {
@@ -1042,8 +1156,8 @@
       },
       "Xamarin.AndroidX.ExifInterface": {
         "type": "Transitive",
-        "resolved": "1.4.1.1",
-        "contentHash": "V6c8eS61dM+/7kHuG3wT956EjxwKOSfCiAY8faNmUY76BNt5VFNaimQZJT9ROSctf3Svv/GAGTl91Rcxzuf/9g==",
+        "resolved": "1.4.2",
+        "contentHash": "XJBHwk//4yX33eVXFZVI+DlzBDAIsoKVFOn/9c6AAdu3rdQFf3SmYXinbWK3RILqXNkliG06u4JfcttTQnRtNg==",
         "dependencies": {
           "Xamarin.AndroidX.Annotation": "1.9.1.5",
           "Xamarin.JSpecify": "1.0.0.4"
@@ -1519,6 +1633,14 @@
           "Xamarin.Kotlin.StdLib": "2.2.0.1"
         }
       },
+      "Xamarin.AndroidX.Tracing.Tracing.Ktx": {
+        "type": "Transitive",
+        "resolved": "1.3.0.1",
+        "contentHash": "KCatDCV43OnTqkLG/b2jc8ichEvHYH5n8Sj3C12hmAl1gcgkKSK12qtac3F+aO299NajwCbFTRRA2qKNnNYhkg==",
+        "dependencies": {
+          "Xamarin.AndroidX.Tracing.Tracing": "[1.3.0.1, 1.3.1)"
+        }
+      },
       "Xamarin.AndroidX.Transition": {
         "type": "Transitive",
         "resolved": "1.6.0.1",
@@ -1645,6 +1767,11 @@
           "Xamarin.Google.ErrorProne.Annotations": "2.41.0.1"
         }
       },
+      "Xamarin.Google.AutoValue.Annotations": {
+        "type": "Transitive",
+        "resolved": "1.11.0.8",
+        "contentHash": "walriZJAiKAfsMhFAAvKS9KSqbbk7HVBxQgDlE7Sc+pKr9JsUPMnGQ0Aaa7TVIhmVrzXJSVend7ARV5f3HB4dQ=="
+      },
       "Xamarin.Google.Code.FindBugs.JSR305": {
         "type": "Transitive",
         "resolved": "3.0.2.21",
@@ -1731,6 +1858,24 @@
           "Xamarin.Kotlin.StdLib": "2.2.0.1"
         }
       },
+      "ZXing.Net": {
+        "type": "Transitive",
+        "resolved": "0.16.11",
+        "contentHash": "OZfAVu88hl87BffQ+rlWCj/vLvAhhCK4QnFaoveeF/MY8SjHNSYBQ3qyUEWlPKNgBQGh1syXhCDg10vUnCsqkg=="
+      },
+      "ZXing.Net.Maui": {
+        "type": "Transitive",
+        "resolved": "0.10.3",
+        "contentHash": "58aDIeLeQaC+SDMYiBc7H7CsJUgbs1VIvTqfGowisQW+GCFv7S9u/bkd55QqqfoRdUqLjRD9jI69GHH4YUXVoA==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "Xamarin.AndroidX.Camera.Camera2": "1.4.2.3",
+          "Xamarin.AndroidX.Camera.Lifecycle": "1.4.2.3",
+          "Xamarin.AndroidX.Camera.View": "1.4.2.3",
+          "Xamarin.AndroidX.ExifInterface": "1.4.2",
+          "ZXing.Net": "0.16.11"
+        }
+      },
       "mmca.common.shared": {
         "type": "Project"
       },
@@ -1747,8 +1892,9 @@
           "Microsoft.Extensions.Localization": "[10.0.10, )",
           "Microsoft.Extensions.Options.DataAnnotations": "[10.0.10, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
-          "MudBlazor": "[9.7.0, )",
+          "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -1878,9 +2024,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[9.7.0, )",
-        "resolved": "9.7.0",
-        "contentHash": "uWOgNn9B556J/TL8KFoSqpA3YD2heqOpK5etcofwlj1RiEX1IDy0NmwYE9urlTUQ8zProEK5GqwTBnoObFPN3g==",
+        "requested": "[9.8.0, )",
+        "resolved": "9.8.0",
+        "contentHash": "JLJ81j6cn5RUTbgpYAtjRfB3bTNweX0q8lkMS6B9v1oGzZsjVTxDDnWahD+rOtzJWPU6D9svsymiETe4G8bSLw==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.1",
           "Microsoft.AspNetCore.Components.Web": "10.0.1",
@@ -1894,6 +2040,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {
@@ -1930,9 +2085,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.138, )",
-        "resolved": "3.0.138",
-        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -1986,15 +2141,15 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.31.0.145097, )",
-        "resolved": "10.31.0.145097",
-        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -2003,6 +2158,17 @@
         "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
         "dependencies": {
           "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "ZXing.Net.Maui.Controls": {
+        "type": "Direct",
+        "requested": "[0.10.3, )",
+        "resolved": "0.10.3",
+        "contentHash": "hDhT2yvZCZiqwJ/SqwtI1Tdq1LVJIFcy2wMYFZZ6cKuEAigeebNwS8Uh5G067Qv225I1WhGLjbZyLCZ7rGuhEw==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11",
+          "ZXing.Net.Maui": "0.10.3"
         }
       },
       "CommunityToolkit.Maui.Core": {
@@ -2575,6 +2741,11 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Plugin.LocalNotification.Core": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -2589,6 +2760,28 @@
         "type": "Transitive",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
+      "ZXing.Net": {
+        "type": "Transitive",
+        "resolved": "0.16.11",
+        "contentHash": "OZfAVu88hl87BffQ+rlWCj/vLvAhhCK4QnFaoveeF/MY8SjHNSYBQ3qyUEWlPKNgBQGh1syXhCDg10vUnCsqkg=="
+      },
+      "ZXing.Net.Maui": {
+        "type": "Transitive",
+        "resolved": "0.10.3",
+        "contentHash": "58aDIeLeQaC+SDMYiBc7H7CsJUgbs1VIvTqfGowisQW+GCFv7S9u/bkd55QqqfoRdUqLjRD9jI69GHH4YUXVoA==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11"
+        }
       },
       "mmca.common.shared": {
         "type": "Project"
@@ -2606,8 +2799,9 @@
           "Microsoft.Extensions.Localization": "[10.0.10, )",
           "Microsoft.Extensions.Options.DataAnnotations": "[10.0.10, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
-          "MudBlazor": "[9.7.0, )",
+          "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -2737,9 +2931,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[9.7.0, )",
-        "resolved": "9.7.0",
-        "contentHash": "uWOgNn9B556J/TL8KFoSqpA3YD2heqOpK5etcofwlj1RiEX1IDy0NmwYE9urlTUQ8zProEK5GqwTBnoObFPN3g==",
+        "requested": "[9.8.0, )",
+        "resolved": "9.8.0",
+        "contentHash": "JLJ81j6cn5RUTbgpYAtjRfB3bTNweX0q8lkMS6B9v1oGzZsjVTxDDnWahD+rOtzJWPU6D9svsymiETe4G8bSLw==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.1",
           "Microsoft.AspNetCore.Components.Web": "10.0.1",
@@ -2753,6 +2947,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {
@@ -2789,9 +2992,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.138, )",
-        "resolved": "3.0.138",
-        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -2845,15 +3048,15 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.31.0.145097, )",
-        "resolved": "10.31.0.145097",
-        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -2862,6 +3065,17 @@
         "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
         "dependencies": {
           "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "ZXing.Net.Maui.Controls": {
+        "type": "Direct",
+        "requested": "[0.10.3, )",
+        "resolved": "0.10.3",
+        "contentHash": "hDhT2yvZCZiqwJ/SqwtI1Tdq1LVJIFcy2wMYFZZ6cKuEAigeebNwS8Uh5G067Qv225I1WhGLjbZyLCZ7rGuhEw==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11",
+          "ZXing.Net.Maui": "0.10.3"
         }
       },
       "CommunityToolkit.Maui.Core": {
@@ -3434,6 +3648,11 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Plugin.LocalNotification.Core": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -3448,6 +3667,28 @@
         "type": "Transitive",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
+      "ZXing.Net": {
+        "type": "Transitive",
+        "resolved": "0.16.11",
+        "contentHash": "OZfAVu88hl87BffQ+rlWCj/vLvAhhCK4QnFaoveeF/MY8SjHNSYBQ3qyUEWlPKNgBQGh1syXhCDg10vUnCsqkg=="
+      },
+      "ZXing.Net.Maui": {
+        "type": "Transitive",
+        "resolved": "0.10.3",
+        "contentHash": "58aDIeLeQaC+SDMYiBc7H7CsJUgbs1VIvTqfGowisQW+GCFv7S9u/bkd55QqqfoRdUqLjRD9jI69GHH4YUXVoA==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11"
+        }
       },
       "mmca.common.shared": {
         "type": "Project"
@@ -3465,8 +3706,9 @@
           "Microsoft.Extensions.Localization": "[10.0.10, )",
           "Microsoft.Extensions.Options.DataAnnotations": "[10.0.10, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
-          "MudBlazor": "[9.7.0, )",
+          "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -3596,9 +3838,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[9.7.0, )",
-        "resolved": "9.7.0",
-        "contentHash": "uWOgNn9B556J/TL8KFoSqpA3YD2heqOpK5etcofwlj1RiEX1IDy0NmwYE9urlTUQ8zProEK5GqwTBnoObFPN3g==",
+        "requested": "[9.8.0, )",
+        "resolved": "9.8.0",
+        "contentHash": "JLJ81j6cn5RUTbgpYAtjRfB3bTNweX0q8lkMS6B9v1oGzZsjVTxDDnWahD+rOtzJWPU6D9svsymiETe4G8bSLw==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.1",
           "Microsoft.AspNetCore.Components.Web": "10.0.1",
@@ -3612,6 +3854,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {
@@ -3648,9 +3899,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.138, )",
-        "resolved": "3.0.138",
-        "contentHash": "o97FZRHWIpMeg/Mzb5Whhcqe1/95SxZLn1bkG+P8T4ijiAY6eoe9BYTYyINBVzkyl5zehQ7NB6bz1DnEgqVZmQ=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.AspNetCore.Components.WebView.Maui": {
         "type": "Direct",
@@ -3699,15 +3950,15 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.31.0.145097, )",
-        "resolved": "10.31.0.145097",
-        "contentHash": "Kz/B+7NsmSaRgHWdd9exXHLFNAS9Dt1LmLqwiAdUHybV/z/stcOFlaGSzflekLMu7hVog0aUek2ihTiFlu06Zw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -3716,6 +3967,17 @@
         "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
         "dependencies": {
           "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "ZXing.Net.Maui.Controls": {
+        "type": "Direct",
+        "requested": "[0.10.3, )",
+        "resolved": "0.10.3",
+        "contentHash": "hDhT2yvZCZiqwJ/SqwtI1Tdq1LVJIFcy2wMYFZZ6cKuEAigeebNwS8Uh5G067Qv225I1WhGLjbZyLCZ7rGuhEw==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11",
+          "ZXing.Net.Maui": "0.10.3"
         }
       },
       "CommunityToolkit.Maui.Core": {
@@ -4330,6 +4592,11 @@
         "resolved": "1.0.3719.77",
         "contentHash": "t+ucyKw5NTwMjsUrDF6R9Lk40lpcKQD1/HgyGFxl49tdA4h9dKlsj6FYGEmDRpFNfnTpENuTypMcdbrlkqBdDA=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Microsoft.Windows.AI.MachineLearning": {
         "type": "Transitive",
         "resolved": "2.1.70",
@@ -4459,6 +4726,14 @@
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
       },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
       "System.Numerics.Tensors": {
         "type": "Transitive",
         "resolved": "9.0.0",
@@ -4468,6 +4743,20 @@
         "type": "Transitive",
         "resolved": "10.0.1",
         "contentHash": "Sra5Gv7qcZzLuQW4alVglQpnDgJiqeGmbwz8WLZa1QdqmTo4bi7FYQP5CJAzlwLDcmHrBS2L7+W6HqFT14HBTA=="
+      },
+      "ZXing.Net": {
+        "type": "Transitive",
+        "resolved": "0.16.11",
+        "contentHash": "OZfAVu88hl87BffQ+rlWCj/vLvAhhCK4QnFaoveeF/MY8SjHNSYBQ3qyUEWlPKNgBQGh1syXhCDg10vUnCsqkg=="
+      },
+      "ZXing.Net.Maui": {
+        "type": "Transitive",
+        "resolved": "0.10.3",
+        "contentHash": "58aDIeLeQaC+SDMYiBc7H7CsJUgbs1VIvTqfGowisQW+GCFv7S9u/bkd55QqqfoRdUqLjRD9jI69GHH4YUXVoA==",
+        "dependencies": {
+          "Microsoft.Maui.Controls": "10.0.0",
+          "ZXing.Net": "0.16.11"
+        }
       },
       "mmca.common.shared": {
         "type": "Project"
@@ -4485,8 +4774,9 @@
           "Microsoft.Extensions.Localization": "[10.0.10, )",
           "Microsoft.Extensions.Options.DataAnnotations": "[10.0.10, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
-          "MudBlazor": "[9.7.0, )",
+          "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -4616,9 +4906,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[9.7.0, )",
-        "resolved": "9.7.0",
-        "contentHash": "uWOgNn9B556J/TL8KFoSqpA3YD2heqOpK5etcofwlj1RiEX1IDy0NmwYE9urlTUQ8zProEK5GqwTBnoObFPN3g==",
+        "requested": "[9.8.0, )",
+        "resolved": "9.8.0",
+        "contentHash": "JLJ81j6cn5RUTbgpYAtjRfB3bTNweX0q8lkMS6B9v1oGzZsjVTxDDnWahD+rOtzJWPU6D9svsymiETe4G8bSLw==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.1",
           "Microsoft.AspNetCore.Components.Web": "10.0.1",
@@ -4632,6 +4922,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -365,6 +365,11 @@
         "resolved": "1.0.0",
         "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "MiniProfiler.AspNetCore": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -490,6 +495,14 @@
           "System.Security.Cryptography.ProtectedData": "9.0.4"
         }
       },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
       "System.IO.Hashing": {
         "type": "Transitive",
         "resolved": "10.0.3",
@@ -598,6 +611,7 @@
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -994,6 +1008,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scalar.AspNetCore": {

--- a/Source/Presentation/MMCA.Common.UI/Components/QrCodeImage.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/QrCodeImage.razor
@@ -1,0 +1,84 @@
+@using QRCoder
+
+@* Shared QR rendering primitive. Encodes the payload locally with QRCoder (MIT) and emits it as a
+   base64 PNG data URI, so there is no network round trip and no third-party image service in the
+   path. The component only renders: callers own what goes in. When the code is meant to be scanned
+   by another device's OS camera, encode an absolute PUBLIC url, never a WebView-internal origin. *@
+
+@if (_dataUri is not null)
+{
+    <img src="@_dataUri" alt="@AltText" class="@Class" />
+}
+
+@code {
+    /// <summary>Text encoded into the code, typically an absolute public url. Blank renders nothing.</summary>
+    [Parameter]
+    [EditorRequired]
+    public string Payload { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Alternative text for the image. Required: a QR code carries no accessible information of
+    /// its own, so the alt text must say where the code leads (screen readers cannot scan it).
+    /// </summary>
+    [Parameter]
+    [EditorRequired]
+    public string AltText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Rendered pixels per QR module. Defaults to 10, which puts a typical short url at roughly
+    /// 300 CSS pixels. Values below 1 are clamped to 1.
+    /// </summary>
+    [Parameter]
+    public int PixelsPerModule { get; set; } = 10;
+
+    /// <summary>Error-correction strength. Defaults to <see cref="QrErrorCorrectionLevel.Medium"/>.</summary>
+    [Parameter]
+    public QrErrorCorrectionLevel ErrorCorrection { get; set; } = QrErrorCorrectionLevel.Medium;
+
+    /// <summary>CSS classes applied to the rendered image (sizing, borders, print rules).</summary>
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string? _dataUri;
+    private string? _encodedPayload;
+    private int _encodedPixelsPerModule;
+    private QrErrorCorrectionLevel _encodedLevel;
+
+    protected override void OnParametersSet()
+    {
+        // Encoding is CPU work, so it runs only when an input that affects the bitmap actually
+        // changed; an unrelated parent re-render must not re-encode the same code.
+        if (string.Equals(_encodedPayload, Payload, StringComparison.Ordinal)
+            && _encodedPixelsPerModule == PixelsPerModule
+            && _encodedLevel == ErrorCorrection)
+        {
+            return;
+        }
+
+        _encodedPayload = Payload;
+        _encodedPixelsPerModule = PixelsPerModule;
+        _encodedLevel = ErrorCorrection;
+        _dataUri = Encode(Payload, PixelsPerModule, ErrorCorrection);
+    }
+
+    private static string? Encode(string payload, int pixelsPerModule, QrErrorCorrectionLevel level)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return null;
+        }
+
+        using var generator = new QRCodeGenerator();
+        using var data = generator.CreateQrCode(payload, ToEccLevel(level));
+        using var png = new PngByteQRCode(data);
+        return "data:image/png;base64," + Convert.ToBase64String(png.GetGraphic(Math.Max(1, pixelsPerModule)));
+    }
+
+    private static QRCodeGenerator.ECCLevel ToEccLevel(QrErrorCorrectionLevel level) => level switch
+    {
+        QrErrorCorrectionLevel.Low => QRCodeGenerator.ECCLevel.L,
+        QrErrorCorrectionLevel.Quartile => QRCodeGenerator.ECCLevel.Q,
+        QrErrorCorrectionLevel.High => QRCodeGenerator.ECCLevel.H,
+        _ => QRCodeGenerator.ECCLevel.M,
+    };
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/QrErrorCorrectionLevel.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/QrErrorCorrectionLevel.cs
@@ -1,0 +1,22 @@
+namespace MMCA.Common.UI.Components;
+
+/// <summary>
+/// Error-correction strength for <c>QrCodeImage</c>. Higher levels survive more damage or
+/// occlusion but pack fewer characters into the same module count, so the code grows denser.
+/// Declared as a framework enum rather than exposing QRCoder's own <c>ECCLevel</c>, so the
+/// component's public API does not pin consumers to the encoder package.
+/// </summary>
+public enum QrErrorCorrectionLevel
+{
+    /// <summary>About 7% recovery. Densest code; use only for short payloads on clean screens.</summary>
+    Low = 0,
+
+    /// <summary>About 15% recovery. The default: the usual screen and print trade-off.</summary>
+    Medium = 1,
+
+    /// <summary>About 25% recovery. Worth it for printed sheets that may get scuffed.</summary>
+    Quartile = 2,
+
+    /// <summary>About 30% recovery. For codes overlaid with a logo or scanned in poor light.</summary>
+    High = 3,
+}

--- a/Source/Presentation/MMCA.Common.UI/MMCA.Common.UI.csproj
+++ b/Source/Presentation/MMCA.Common.UI/MMCA.Common.UI.csproj
@@ -31,6 +31,8 @@
     </PackageReference>
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="Polly" />
+    <!-- QrCodeImage encodes locally; managed-only, so it stays WebAssembly-safe. -->
+    <PackageReference Include="QRCoder" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="Scrutor" />
   </ItemGroup>

--- a/Source/Presentation/MMCA.Common.UI/Services/Capabilities/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Capabilities/DependencyInjection.cs
@@ -51,6 +51,11 @@ public static class DependencyInjection
             // Media picking (ADR-045): web heads render InputFile instead (IsSupported false).
             services.TryAddSingleton<IMediaPickerService, NullMediaPickerService>();
 
+            // Camera barcode/QR scanning (ADR-042): no browser primitive, so web heads hide the
+            // affordance. The native override is opt-in (UseCommonBarcodeScanner in UI.Maui), so
+            // even a MAUI head keeps this default until it asks for the camera.
+            services.TryAddSingleton<IBarcodeScannerService, NullBarcodeScannerService>();
+
             // Scoped so the Blazor Server fallback holds per-circuit (per-user) state,
             // never cross-user state.
             services.TryAddScoped<IDevicePreferences, InMemoryDevicePreferences>();

--- a/Source/Presentation/MMCA.Common.UI/Services/Capabilities/Fallbacks/NullBarcodeScannerService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Capabilities/Fallbacks/NullBarcodeScannerService.cs
@@ -1,0 +1,17 @@
+namespace MMCA.Common.UI.Services.Capabilities.Fallbacks;
+
+/// <summary>
+/// No-op barcode scanner (ADR-042). Browsers have no shared camera-scanning primitive the
+/// framework can rely on, so web heads keep this default and simply hide the scan button
+/// (<see cref="IsSupported"/> is false); the native override ships in
+/// <c>MMCA.Common.UI.Maui</c> and is opt-in.
+/// </summary>
+public sealed class NullBarcodeScannerService : IBarcodeScannerService
+{
+    /// <inheritdoc />
+    public bool IsSupported => false;
+
+    /// <inheritdoc />
+    public Task<string?> ScanAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult<string?>(null);
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Capabilities/IBarcodeScannerService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Capabilities/IBarcodeScannerService.cs
@@ -1,0 +1,21 @@
+namespace MMCA.Common.UI.Services.Capabilities;
+
+/// <summary>
+/// Scans a QR code or barcode with the device camera (ADR-042). Implementations own the camera
+/// permission flow and never throw; a denied permission, a cancelled scan, an unsupported head,
+/// or a cancelled token all surface as <see langword="null"/>. Web heads keep the null default
+/// and hide the scan affordance (<see cref="IsSupported"/> is false) instead of opening a camera
+/// surface the browser cannot back - the affordance switch, not a degraded path. The scanned
+/// payload is untrusted input: validate it before acting on it.
+/// </summary>
+public interface IBarcodeScannerService
+{
+    /// <summary>Whether camera scanning is available on this head.</summary>
+    bool IsSupported { get; }
+
+    /// <summary>
+    /// Opens the camera scanner and returns the first decoded payload. Returns
+    /// <see langword="null"/> when cancelled, denied, or unavailable.
+    /// </summary>
+    Task<string?> ScanAsync(CancellationToken cancellationToken = default);
+}

--- a/Source/Presentation/MMCA.Common.UI/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI/packages.lock.json
@@ -151,6 +151,15 @@
           "Polly.Core": "8.7.0"
         }
       },
+      "QRCoder": {
+        "type": "Direct",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
+        }
+      },
       "Roslynator.Analyzers": {
         "type": "Direct",
         "requested": "[4.16.0, )",
@@ -633,6 +642,11 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.7.0",
@@ -642,6 +656,14 @@
         "type": "Transitive",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
       },
       "mmca.common.shared": {
         "type": "Project"

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
@@ -921,6 +921,11 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "MiniProfiler.AspNetCore": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -1039,6 +1044,14 @@
         "type": "Transitive",
         "resolved": "9.0.4",
         "contentHash": "getRQEXD8idlpb1KW56XuxImMy0FKp2WJPDf3Qr0kI/QKxxJSftqfDFVo0DZ3HCJRLU73qHSruv5q2l5O47jQQ=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
       },
       "System.IO.Hashing": {
         "type": "Transitive",
@@ -1217,6 +1230,7 @@
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -1662,6 +1676,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scalar.AspNetCore": {

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/MMCA.Common.Infrastructure.Redis.Tests.csproj
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/MMCA.Common.Infrastructure.Redis.Tests.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Testcontainers.Redis" />
+    <!-- Direct only to lift the vulnerable SSH.NET that Testcontainers floors at 2025.1.0
+         (GHSA-q939-rpr3-3284). This project has no path to MMCA.Common.Testing, so it cannot
+         inherit that pin and needs its own. See the comment in Directory.Packages.props. -->
+    <PackageReference Include="SSH.NET" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.Extensions.Caching.StackExchangeRedis": {
         "type": "Direct",
@@ -40,15 +40,25 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
+      },
+      "SSH.NET": {
+        "type": "Direct",
+        "requested": "[2026.0.0, )",
+        "resolved": "2026.0.0",
+        "contentHash": "Yu9dirPq8l3oaat0+OQ7K0nUf5MmYltpia5UGqsApTG4zTPvBC1cxbNnC3NERij26dUST0A3Ef1QdHSn5ArbWQ==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.7.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -121,8 +131,8 @@
       },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
-        "resolved": "2.4.0",
-        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
+        "resolved": "2.7.0",
+        "contentHash": "U+12df8UEWHgBi04YVf/Lgi2dy3SItlIYvHjjEVa/BngCQIzDCDRBk50DDByCfDvSbe5pRNFr3b7UrVK2kMcLw=="
       },
       "Docker.DotNet.Enhanced": {
         "type": "Transitive",
@@ -147,8 +157,8 @@
       },
       "MassTransit.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.5.5",
-        "contentHash": "0mn2Ay17dD6z5tgSLjbVRlldSbL9iowzFEfVgVfBXVG5ttz9dSWeR4TrdD6pqH93GWXp4CvSmF8i1HqxLX7DZw=="
+        "resolved": "8.5.10",
+        "contentHash": "nZnm2YNH+NcVwY6yC114sJy8J9LtKdFjfKUm/A5HfmzOlZ8ksjgHaPBg5XCG1VAqKDRDFnaudIcesVultKJD7g=="
       },
       "MessagePack.Annotations": {
         "type": "Transitive",
@@ -367,19 +377,19 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "cxsK9/Dx7Ka9sfiA1nY8XlSzIaWff5FNRw0+ls8yR+aGzmnah5JGKsTHgQrehjMwGAVud/pjiUZ9MWizfUSkTQ==",
+        "resolved": "10.0.0",
+        "contentHash": "4x6y2Uy+g9Ou93eBCVkG/3JCwnc2AMKhrE1iuEhXT/MzNN7co/Zt6yL+q1Srt0CnOe3iLX+sVqpJI4ZGlOPfug==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Options": "9.0.0"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "H1IbHm/MnUgEV0N07WrkPBIIoX7isP6IPaqUdZ3CwbMcUVDGIu+okamW28kyDRfIiZqbTbyHuNIkr4ZSHPyvDw=="
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
@@ -670,8 +680,8 @@
       },
       "RabbitMQ.Client": {
         "type": "Transitive",
-        "resolved": "7.1.2",
-        "contentHash": "y3c6ulgULScWthHw5PLM1ShHRLhxg0vCtzX/hh61gRgNecL3ZC3WoBW2HYHoXOVRqTl99Br9E7CZEytGZEsCyQ==",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
         "dependencies": {
           "System.Threading.RateLimiting": "8.0.0"
         }
@@ -705,14 +715,6 @@
         "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
         "dependencies": {
           "SQLitePCLRaw.core": "3.0.5"
-        }
-      },
-      "SSH.NET": {
-        "type": "Transitive",
-        "resolved": "2024.2.0",
-        "contentHash": "9r+4UF2P51lTztpd+H7SJywk7WgmlWB//Cm2o96c6uGVZU5r58ys2/cD9pCgTk0zCdSkfflWL1WtqQ9I4IVO9Q==",
-        "dependencies": {
-          "BouncyCastle.Cryptography": "2.4.0"
         }
       },
       "StyleCop.Analyzers.Unstable": {
@@ -864,9 +866,9 @@
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
           "MMCA.Common.Application": "[1.0.0, )",
-          "MassTransit": "[8.5.5, )",
-          "MassTransit.Azure.ServiceBus.Core": "[8.5.5, )",
-          "MassTransit.RabbitMQ": "[8.5.5, )",
+          "MassTransit": "[8.5.10, )",
+          "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
+          "MassTransit.RabbitMQ": "[8.5.10, )",
           "MessagePack": "[2.5.302, )",
           "Microsoft.AspNetCore.SignalR.StackExchangeRedis": "[10.0.10, )",
           "Microsoft.Azure.NotificationHubs": "[4.2.0, )",
@@ -914,37 +916,37 @@
       },
       "MassTransit": {
         "type": "CentralTransitive",
-        "requested": "[8.5.5, )",
-        "resolved": "8.5.5",
-        "contentHash": "bSg8k5q+rP1s+dIGXLLbctqDGdIkfDjdxwNWtCUH7xNCN9ZuM7mqSPQPIFgaYIi34e81m4FqAqo4CAHuWPkhRA==",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "TGi34UA8RftBIpYCHEdoIP5uSu2/pLWZRen4RUcg4CV1nr8MmCZMuFYjzvXXUyFcj0ZuRQxZZNhG7fB5/raSOg==",
         "dependencies": {
-          "MassTransit.Abstractions": "8.5.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "9.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Options": "9.0.0"
+          "MassTransit.Abstractions": "8.5.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
         }
       },
       "MassTransit.Azure.ServiceBus.Core": {
         "type": "CentralTransitive",
-        "requested": "[8.5.5, )",
-        "resolved": "8.5.5",
-        "contentHash": "/9wmsURLh0CtRpDnI9WLE0NNYHqst7O1t5B7OyF0iUiy5zNy+mq1x9UrsWTz8j63yU4aD23HmMWHLdC+08kaow==",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "pXA+Vk/VB+s/0PeL4iht3q3VzxirbLNuSWnDDvEIFBfQdZpY28ZD/l2+6PTcVj6KvJH9nkqzlI7mnMw2pEYKPQ==",
         "dependencies": {
-          "Azure.Identity": "1.16.0",
+          "Azure.Identity": "1.21.0",
           "Azure.Messaging.ServiceBus": "7.20.1",
-          "MassTransit": "8.5.5"
+          "MassTransit": "8.5.10"
         }
       },
       "MassTransit.RabbitMQ": {
         "type": "CentralTransitive",
-        "requested": "[8.5.5, )",
-        "resolved": "8.5.5",
-        "contentHash": "UxWn4o90YVMF9PBkJeoskOFPneh6YtnI1fLJHtvZiSAG0eoiRrWPGa+6FQCvjkQ/ljCKfjzok2eGZc/vmNZ01A==",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "5aQGpJpeqRhRv+htkXfi6MfWu0dj/4Lcf1c6h2J3tYZClupGklqB1ixlP3IRdZExrH9BI/60uYoxR+7pg3s1oQ==",
         "dependencies": {
-          "MassTransit": "8.5.5",
-          "RabbitMQ.Client": "7.1.2"
+          "MassTransit": "8.5.10",
+          "RabbitMQ.Client": "7.2.1"
         }
       },
       "MessagePack": {
@@ -980,7 +982,7 @@
       },
       "Microsoft.Data.SqlClient": {
         "type": "CentralTransitive",
-        "requested": "[6.1.1, )",
+        "requested": "[6.1.6, )",
         "resolved": "6.1.1",
         "contentHash": "syGQmIUPAYYHAHyTD8FCkTNThpQWvoA7crnIQRMfp8dyB5A2cWU3fQexlRTFkVmV7S0TjVmthi0LJEFVjHo8AQ==",
         "dependencies": {
@@ -1142,7 +1144,7 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
+        "requested": "[8.22.0, )",
         "resolved": "7.7.1",
         "contentHash": "rQkO1YbAjLwnDJSMpRhRtrc6XwIcEOcUvoEcge+evurpzSZM3UNK+MZfD3sKyTlYsvknZ6eJjSBfnmXqwOsT9Q==",
         "dependencies": {

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
-        "resolved": "2.6.2",
-        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+        "resolved": "2.7.0",
+        "contentHash": "U+12df8UEWHgBi04YVf/Lgi2dy3SItlIYvHjjEVa/BngCQIzDCDRBk50DDByCfDvSbe5pRNFr3b7UrVK2kMcLw=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -609,15 +609,6 @@
         "resolved": "1.4.2",
         "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
       },
-      "SSH.NET": {
-        "type": "Transitive",
-        "resolved": "2025.1.0",
-        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
-        "dependencies": {
-          "BouncyCastle.Cryptography": "2.6.2",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
-        }
-      },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
         "resolved": "1.2.0.556",
@@ -763,6 +754,7 @@
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "Moq": "[4.20.72, )",
           "Respawn": "[7.0.0, )",
+          "SSH.NET": "[2026.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )",
           "Testcontainers.MsSql": "[4.13.0, )",
           "Testcontainers.RabbitMq": "[4.13.0, )",
@@ -887,6 +879,16 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "Microsoft.Extensions.DependencyModel": "10.0.0"
+        }
+      },
+      "SSH.NET": {
+        "type": "CentralTransitive",
+        "requested": "[2026.0.0, )",
+        "resolved": "2026.0.0",
+        "contentHash": "Yu9dirPq8l3oaat0+OQ7K0nUf5MmYltpia5UGqsApTG4zTPvBC1cxbNnC3NERij26dUST0A3Ef1QdHSn5ArbWQ==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.7.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.Playwright": {
         "type": "Direct",
@@ -38,15 +38,15 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -475,33 +475,33 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
+        "resolved": "8.22.0",
+        "contentHash": "LU3V3owsu4vGpCg2kyL7SsQEuHwcoJ8FSNBqzLADzCf3/PcKUTcx5Plsd51DoTJMfK/WigXV/03UhaN5JXE6uQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
+        "resolved": "8.22.0",
+        "contentHash": "kv6peMLjALZLDAy2H3F77KjVRdwiscn2p/g3ui2chcbuEcAX2MpAbyDcYnJ7Vyh8jZ1aJWrniUMCDWoOgnu4NQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
+        "resolved": "8.22.0",
+        "contentHash": "G9Tl0yXSlr2pkXv4EpXjO16M4q6oo9N/od+gNyOusZ8yM8LZg1H3f/QOMFuOJiV6znzY5MkAREU97JRRnqpEQw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.21.0"
+          "Microsoft.IdentityModel.Abstractions": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
+        "resolved": "8.22.0",
+        "contentHash": "i4lywKKUuVmheCUA+w/q8QNPReNI0qanHI9hhz48AFqD1ljyb8sxPL2RbXOGiPV13XdJ4kxieL9ukS7tD43LxA==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.IdentityModel.Logging": "8.21.0"
+          "Microsoft.IdentityModel.Logging": "8.22.0"
         }
       },
       "Microsoft.JSInterop": {
@@ -552,6 +552,11 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.1",
@@ -571,6 +576,14 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "dMkqfy2el8A8/I76n2Hi1oBFEbG1SfxD2l5nhwXV3XjlnOmwxJlQbYpJH4W51odnU9sARCSAgv7S3CyAFMkpYg=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
       },
       "System.IO.Abstractions": {
         "type": "Transitive",
@@ -662,10 +675,11 @@
           "Microsoft.Extensions.Localization": "[10.0.10, )",
           "Microsoft.Extensions.Options.DataAnnotations": "[10.0.10, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
-          "MudBlazor": "[9.7.0, )",
+          "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[8.21.0, )"
+          "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
       },
       "mmca.common.ui.gallery": {
@@ -807,9 +821,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[9.7.0, )",
-        "resolved": "9.7.0",
-        "contentHash": "uWOgNn9B556J/TL8KFoSqpA3YD2heqOpK5etcofwlj1RiEX1IDy0NmwYE9urlTUQ8zProEK5GqwTBnoObFPN3g==",
+        "requested": "[9.8.0, )",
+        "resolved": "9.8.0",
+        "contentHash": "JLJ81j6cn5RUTbgpYAtjRfB3bTNweX0q8lkMS6B9v1oGzZsjVTxDDnWahD+rOtzJWPU6D9svsymiETe4G8bSLw==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "10.0.1",
           "Microsoft.AspNetCore.Components.Web": "10.0.1",
@@ -825,6 +839,15 @@
           "Polly.Core": "8.7.0"
         }
       },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
+        }
+      },
       "Scrutor": {
         "type": "CentralTransitive",
         "requested": "[7.0.0, )",
@@ -837,12 +860,12 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
-        "resolved": "8.21.0",
-        "contentHash": "dKsTkmlpUf/I6g1Aw9joWaZAahXvC0gWGQvkXW1IjZLSefC/4LhQI0tL0VIs64/NZQbl4XnQvLQyu6c7z1pMxg==",
+        "requested": "[8.22.0, )",
+        "resolved": "8.22.0",
+        "contentHash": "CpXGfNhLl6EgYaOC9XYsc1p7Ci9HtAy0soHJDSBNGse647al4tTq9RDr+LQsrF4Ls79Dx7VfzN34km0W4DWPow==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.22.0",
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "xunit.v3.extensibility.core": {

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[3.0.133, )",
-        "resolved": "3.0.133",
-        "contentHash": "pwJq1q4BGRKATlX41YTGRBpxp0XQIxRqpxPyMzB0eaY2aGj0v7u8qg6lIJnqbM7NHBN8sk2IjsanV2Fu8GGS7w=="
+        "requested": "[3.0.141, )",
+        "resolved": "3.0.141",
+        "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
       "Microsoft.AspNetCore.App.Internal.Assets": {
         "type": "Direct",
@@ -22,15 +22,15 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.15.0, )",
-        "resolved": "4.15.0",
-        "contentHash": "E8fu71Y+vzhniJKy1K13Rzwm8Vjcj7CDFBpflqncKUZfc3SzuF0kMBiyMmgXNPkjWTdE3Z+30HlGgYjHONZY/Q=="
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "/EZ1HVILd9jPdXquT03vBawvAuGNotmf+r/GBiVfPj9BdUyn/olOdjF9BqqjIK5Cyq3pdBDL/qMuJEGtBLMaZA=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.30.0.144632, )",
-        "resolved": "10.30.0.144632",
-        "contentHash": "e4n1kWNoFAuXcYR4uEGyMi4I5vKHcjAVmIw6k6y57UWJA1o6cxkeHmcE45xfCphM4k4G0Yo8yMhOT637AmofJw=="
+        "requested": "[10.32.0.713, )",
+        "resolved": "10.32.0.713",
+        "contentHash": "7GiMslvghy0n0t7r2oEAVbBeKTnYTXUOQPtZCwuN5FvtM+9vxf4BR4FVrq5o4KYUziHF/5NLR5SHQ3guBqYPow=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -68,33 +68,38 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "XYgEmYpUvng0oYIagDJ+uebboQSnWtCV7q9zMyXlBw6ZqLLCHcmGUb7TpXvQ3HWY4OzbOCUQm2Ac0saPSnwqSw=="
+        "resolved": "8.22.0",
+        "contentHash": "LU3V3owsu4vGpCg2kyL7SsQEuHwcoJ8FSNBqzLADzCf3/PcKUTcx5Plsd51DoTJMfK/WigXV/03UhaN5JXE6uQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "iiA5uimwlRe4Drd8YKOaB8IQkgGOjxGjO6mu5zCGFjaEBpB6yNOluZ33zJFXiW5MQYRC6ypMnOXsiR5SPrO+tw==",
+        "resolved": "8.22.0",
+        "contentHash": "kv6peMLjALZLDAy2H3F77KjVRdwiscn2p/g3ui2chcbuEcAX2MpAbyDcYnJ7Vyh8jZ1aJWrniUMCDWoOgnu4NQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "LgIWUUX386xCbvjq2ex8iXGIu2raDWrrIQ4OyYZKaNWMhzvN8YOTbAYMFJC+iHmKnkNBM8g7mLak9KQodldH3g==",
+        "resolved": "8.22.0",
+        "contentHash": "G9Tl0yXSlr2pkXv4EpXjO16M4q6oo9N/od+gNyOusZ8yM8LZg1H3f/QOMFuOJiV6znzY5MkAREU97JRRnqpEQw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.21.0"
+          "Microsoft.IdentityModel.Abstractions": "8.22.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "8.21.0",
-        "contentHash": "xFnFEl4VrhAJEbqtRrpgfAACgkm6NYo7cWYKYROH00N9/M5OYrRwTP0lHsginnLrqPrseLcSqAueQNRCyGNsdw==",
+        "resolved": "8.22.0",
+        "contentHash": "i4lywKKUuVmheCUA+w/q8QNPReNI0qanHI9hhz48AFqD1ljyb8sxPL2RbXOGiPV13XdJ4kxieL9ukS7tD43LxA==",
         "dependencies": {
           "Microsoft.Bcl.Cryptography": "10.0.2",
-          "Microsoft.IdentityModel.Logging": "8.21.0"
+          "Microsoft.IdentityModel.Logging": "8.22.0"
         }
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
       "Polly.Core": {
         "type": "Transitive",
@@ -106,6 +111,14 @@
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
       },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
       "mmca.common.shared": {
         "type": "Project"
       },
@@ -115,10 +128,11 @@
           "MMCA.Common.Shared": "[1.0.0, )",
           "Microsoft.AspNetCore.SignalR.Client": "[10.0.10, )",
           "Microsoft.FeatureManagement": "[4.6.0, )",
-          "MudBlazor": "[9.7.0, )",
+          "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
-          "System.IdentityModel.Tokens.Jwt": "[8.21.0, )"
+          "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
       },
       "Microsoft.AspNetCore.SignalR.Client": {
@@ -142,9 +156,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[9.7.0, )",
-        "resolved": "9.7.0",
-        "contentHash": "uWOgNn9B556J/TL8KFoSqpA3YD2heqOpK5etcofwlj1RiEX1IDy0NmwYE9urlTUQ8zProEK5GqwTBnoObFPN3g=="
+        "requested": "[9.8.0, )",
+        "resolved": "9.8.0",
+        "contentHash": "JLJ81j6cn5RUTbgpYAtjRfB3bTNweX0q8lkMS6B9v1oGzZsjVTxDDnWahD+rOtzJWPU6D9svsymiETe4G8bSLw=="
       },
       "Polly": {
         "type": "CentralTransitive",
@@ -153,6 +167,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {
@@ -166,12 +189,12 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",
-        "requested": "[8.21.0, )",
-        "resolved": "8.21.0",
-        "contentHash": "dKsTkmlpUf/I6g1Aw9joWaZAahXvC0gWGQvkXW1IjZLSefC/4LhQI0tL0VIs64/NZQbl4XnQvLQyu6c7z1pMxg==",
+        "requested": "[8.22.0, )",
+        "resolved": "8.22.0",
+        "contentHash": "CpXGfNhLl6EgYaOC9XYsc1p7Ci9HtAy0soHJDSBNGse647al4tTq9RDr+LQsrF4Ls79Dx7VfzN34km0W4DWPow==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "8.21.0",
-          "Microsoft.IdentityModel.Tokens": "8.21.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.22.0",
+          "Microsoft.IdentityModel.Tokens": "8.22.0"
         }
       }
     }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/QrCodeImageTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/QrCodeImageTests.cs
@@ -1,0 +1,76 @@
+using AwesomeAssertions;
+using Bunit;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers the shared QR primitive: it must encode locally into a PNG data URI (no network, no
+/// image service), always carry alt text, and re-encode when the payload changes.
+/// </summary>
+public sealed class QrCodeImageTests : BunitTestBase
+{
+    [Fact]
+    public void Renders_PngDataUri_WithAltText()
+    {
+        var cut = RenderUnderTest<QrCodeImage>(p => p
+            .Add(c => c.Payload, "https://example.com/conference/sessions/42")
+            .Add(c => c.AltText, "QR code opening session 42"));
+
+        var img = cut.Find("img");
+
+        img.GetAttribute("src").Should().StartWith("data:image/png;base64,");
+        img.GetAttribute("alt").Should().Be("QR code opening session 42");
+    }
+
+    [Fact]
+    public void Renders_Nothing_WhenPayloadIsBlank()
+    {
+        var cut = RenderUnderTest<QrCodeImage>(p => p
+            .Add(c => c.Payload, "   ")
+            .Add(c => c.AltText, "unused"));
+
+        cut.FindAll("img").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReEncodes_WhenPayloadChanges()
+    {
+        var cut = RenderUnderTest<QrCodeImage>(p => p
+            .Add(c => c.Payload, "https://example.com/a")
+            .Add(c => c.AltText, "code"));
+        var first = cut.Find("img").GetAttribute("src");
+
+        cut.Render(p => p.Add(c => c.Payload, "https://example.com/b"));
+
+        cut.Find("img").GetAttribute("src").Should().StartWith("data:image/png;base64,").And.NotBe(first);
+    }
+
+    [Fact]
+    public void HigherErrorCorrection_ProducesADifferentCode()
+    {
+        var medium = RenderUnderTest<QrCodeImage>(p => p
+            .Add(c => c.Payload, "https://example.com/a")
+            .Add(c => c.AltText, "code"))
+            .Find("img").GetAttribute("src");
+
+        var high = RenderUnderTest<QrCodeImage>(p => p
+            .Add(c => c.Payload, "https://example.com/a")
+            .Add(c => c.AltText, "code")
+            .Add(c => c.ErrorCorrection, QrErrorCorrectionLevel.High))
+            .Find("img").GetAttribute("src");
+
+        high.Should().NotBe(medium);
+    }
+
+    [Fact]
+    public void Passes_CssClassThrough()
+    {
+        var cut = RenderUnderTest<QrCodeImage>(p => p
+            .Add(c => c.Payload, "https://example.com/a")
+            .Add(c => c.AltText, "code")
+            .Add(c => c.Class, "mmca-qr d-print-block"));
+
+        cut.Find("img").GetAttribute("class").Should().Be("mmca-qr d-print-block");
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Capabilities/CapabilityFallbackTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Capabilities/CapabilityFallbackTests.cs
@@ -121,6 +121,22 @@ public sealed class CapabilityFallbackTests
     }
 
     [Fact]
+    public async Task NullBarcodeScannerService_ReportsUnsupportedAndReturnsNull()
+    {
+        var sut = new NullBarcodeScannerService();
+
+        sut.IsSupported.Should().BeFalse();
+        (await sut.ScanAsync()).Should().BeNull();
+
+        // Even a pre-cancelled token must come back as a plain null, never an OperationCanceledException:
+        // the contract is that the scan affordance is simply absent on heads without a camera.
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+        var act = async () => (await sut.ScanAsync(cancelled.Token)).Should().BeNull();
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task RemainingNullFallbacks_DegradeSilently()
     {
         (await new NullMapNavigationService().OpenAddressAsync("100 Main St", "Venue")).Should().BeFalse();

--- a/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
@@ -658,6 +658,11 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.7.0",
@@ -672,6 +677,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
       },
       "xunit.analyzers": {
         "type": "Transitive",
@@ -759,6 +772,7 @@
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -904,6 +918,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scrutor": {

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -434,6 +434,11 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
+      },
       "MiniProfiler.AspNetCore": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -557,6 +562,14 @@
         "contentHash": "dvjqKp+2LpGid6phzrdrS/2mmEPxFl3jE1+L7614q4ZChKbLJCpHXg6sBILlCCED1t//EE+un/UdAetzIMpqnw==",
         "dependencies": {
           "System.Security.Cryptography.ProtectedData": "9.0.4"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       },
       "System.IO.Hashing": {
@@ -726,6 +739,7 @@
           "Microsoft.FeatureManagement": "[4.6.0, )",
           "MudBlazor": "[9.8.0, )",
           "Polly": "[8.7.0, )",
+          "QRCoder": "[1.8.0, )",
           "Scrutor": "[7.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )"
         }
@@ -1130,6 +1144,15 @@
         "contentHash": "0qR4f0OR8FeCAfLWcfwzAM7w6EmpUgwa22PgxKjcL25dEAto7sKpQQXbtxp38vVvK+V3RFkh/TeI7g/iUdoYIQ==",
         "dependencies": {
           "Polly.Core": "8.7.0"
+        }
+      },
+      "QRCoder": {
+        "type": "CentralTransitive",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "RuvX3PEXU6pbY/I5ItAk800jm62r+YnoPLgyS2WTgwxkOnGkOfU9ORiipHUF0LkLyqM8rlroUCA319JjRYfRFQ==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
         }
       },
       "Scalar.AspNetCore": {


### PR DESCRIPTION
## What

Two reusable UI pieces move into the framework so consumers stop hand-rolling them, plus a security pin folded in (see the last section for why it rides here).

### `MMCA.Common.UI`

- **`Components/QrCodeImage.razor`** - generalizes the QRCoder usage MMCA.ADC had inlined in its Conference `QrCodeButton`. Encodes the payload locally into a base64 PNG data URI (`PngByteQRCode`), so no network round trip and no third-party image service. Parameters: `Payload` (required), `AltText` (required, a QR code is otherwise an unlabeled image), `PixelsPerModule` (default 10), `ErrorCorrection` (default Medium), `Class` passthrough. Re-encodes only when an input that affects the bitmap changes.
- **`Components/QrErrorCorrectionLevel.cs`** - the ECC level is exposed as a framework enum rather than QRCoder's own `ECCLevel`, so the component's public API does not pin consumers to the encoder package.
- **`Services/Capabilities/IBarcodeScannerService.cs` + `Fallbacks/NullBarcodeScannerService.cs`** - modelled exactly on `IMediaPickerService`: `bool IsSupported`, `Task<string?> ScanAsync(CancellationToken)`, never throws, null on cancel/deny/unsupported. The null fallback is `TryAdd`-registered alongside the other ADR-042 defaults, so web heads simply hide the scan affordance.

### `MMCA.Common.UI.Maui` (out-of-slnx MAUI package, ADR-042)

- **`Capabilities/MauiBarcodeScannerService.cs`** - ZXing.Net.MAUI implementation. `IsSupported` on Android/iOS only. Pushes the modal scan page over the current window's `Page` (`Application.MainPage` is obsolete on the .NET 10 MAUI train), resolves on the first decode, and pops on every exit path.
- **`Capabilities/BarcodeScanPage.cs`** - code-built modal: full-bleed `CameraBarcodeReaderView` (2D formats only) plus a cancel button. Decode, cancel button, platform back gesture, token cancellation and page-disappearing all resolve the same completion source exactly once, so the caller always gets an answer and the camera is always released. Marked `partial` for CsWinRT1028 on the windows TFM.
- **`UseCommonBarcodeScanner(cancelText, cameraDescription)`** builder extension - calls ZXing's `UseBarcodeReader()` and registers the native service over the null one. Deliberately **opt-in** and kept out of `UseMauiDeviceCapabilities()`: a head that never scans should ship neither the camera handler nor a camera permission declaration.

### Packages

| Package | Version | License | Referenced by | Why |
|---|---|---|---|---|
| `QRCoder` | 1.8.0 | MIT | `MMCA.Common.UI` | QR encoding for `QrCodeImage` |
| `ZXing.Net.Maui.Controls` | 0.10.3 | MIT (Redth) | `MMCA.Common.UI.Maui` | camera scanning |
| `SSH.NET` | 2026.0.0 | MIT | `MMCA.Common.Testing`, `MMCA.Common.Infrastructure.Redis.Tests` | security pin, no code uses it |

`ZXing.Net.Maui.Controls` ships assets for all four MAUI TFMs of this package and ships **lib only, no build/buildTransitive targets**, so unlike `WebView.Maui` it cannot turn the Razor-SDK project into a static-web-asset producer. All three pins carry license and rationale comments.

## Folded in: SSH.NET security pin (commit 2)

**GHSA-q939-rpr3-3284** (high, published **2026-08-12 15:19 UTC**): SSH.NET `<= 2025.1.0` lets a malicious server write arbitrary files during a `ScpClient` recursive download via server-controlled SCP filenames. Every Testcontainers package floors SSH.NET at a vulnerable version, and NU1903 is warning-as-error here, so the audit step went red repo-wide on an advisory published *after* this repo's last green run (00:11 UTC the same day). It reds every PR, so it is fixed here rather than queued behind this one.

CPM does not pin transitives, so the two projects that pull Testcontainers take a direct `PackageReference`, exactly like the existing MessagePack / SQLitePCLRaw / System.Security.Cryptography.Xml / OpenTelemetry.Api pins:

- **`MMCA.Common.Testing`** (shipped) - also carries the fix to consumers through the published package graph.
- **`MMCA.Common.Infrastructure.Redis.Tests`** (out of slnx) - has no path to `MMCA.Common.Testing`, so it cannot inherit that pin.

No code references SSH.NET; the references exist purely to raise the floor. Consumer repos are handled by the release sweep, not here.

## Verification

- `dotnet build MMCA.Common.slnx -c Release` - 0 warnings, 0 errors
- `dotnet test --solution MMCA.Common.slnx -c Release` - **2968 passed, 0 failed, 0 skipped**, including the 6 tests this PR adds (5 bUnit tests for `QrCodeImage`, 1 for `NullBarcodeScannerService`). CI's own run reports the same 2968.
- `dotnet build Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj -c Release` - all four TFMs green (only the pre-existing `NativeThemeSync.razor` app-bundle-path warnings on ios/maccatalyst)
- `dotnet list package --vulnerable --include-transitive` - clean on the slnx **and** on the out-of-slnx Redis tier
- `build/facts -- . --check` - up to date; package list/count unchanged at 15 (new content in existing packages, no new package)
- Lock files regenerated with `--force-evaluate`, including every out-of-slnx project: `UI.Maui`, `UI.Gallery`, `UI.E2E.Tests`, `Infrastructure.Redis.Tests`
- **All 13 CI checks green**, including the windows 4-TFM MAUI build, all three ui-e2e browsers, the Helpdesk consumer canary, the package-mode consumer, the Redis Testcontainers tier, the perf gate, and coverage.

## Notes

- QRCoder's `net6.0` asset carries a transitive `System.Drawing.Common` 6.0.0 (used only by its `Bitmap` renderers, not the managed `PngByteQRCode` path this component uses). Not a new risk profile: MMCA.ADC already pins the same QRCoder version and ships it into its Blazor heads today. No advisories on it.
- No ADC/Store/Helpdesk changes: consumers pick all of this up through the next release sweep. ADC's own QRCoder pin becomes redundant then, but that is a cross-repo edit for another PR.
- No ADR authoring (canonical in the Website repo) and no version bumps (MinVer at tag time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a
