### PR TITLE
fix: resolve MAUI scan page text per scan, not at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 > ADR-016. An audit that reports the consumers as "several versions behind" for that window is
 > reading history, not a gap.
 
+### Added
+
+- **`UseCommonBarcodeScanner(Func<string> cancelText, Func<string> cameraDescription)` overload in
+  `MMCA.Common.UI.Maui`**: the localization-correct way to wire the camera scanner. Both delegates
+  are invoked once per scan, when the modal page is built, so the scan surface follows the user's
+  in-app language choice. `MauiBarcodeScannerService` gained the matching
+  `(Func<string>, Func<string>)` constructor.
+
+### Fixed
+
+- **The MAUI scan page no longer ignores the in-app language.** `UseCommonBarcodeScanner` resolved
+  its cancel label and camera description at `MauiAppBuilder` time, which runs before
+  `MauiCultureInitializer` restores the persisted culture (ADR-027), so the modal rendered in the
+  DEVICE language for the life of the process even after the user switched language in the app.
+  Both strings now resolve per scan through the new delegate overload. The existing string overload
+  keeps working unchanged (it wraps the values as `() => value`), so no consumer has to move; its
+  XML doc now states plainly that those values are fixed at startup and points heads with a language
+  switcher at the delegate overload. This removes the limitation recorded in ADR-071.
+
 ## [1.146.0] - 2026-08-12
 
 A single-fix release so the OpenAPI guard ships in the same consumer sweep as 1.145.0 (which was

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiBarcodeScannerService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiBarcodeScannerService.cs
@@ -13,11 +13,50 @@ namespace MMCA.Common.UI.Maui.Capabilities;
 /// Registered by <c>UseCommonBarcodeScanner()</c> only, so a head that never scans neither ships
 /// the camera handler nor needs the permission.
 /// </para>
+/// <para>
+/// The page's two strings are supplied as delegates, not values, and are invoked once per scan, at
+/// the moment the page is built. The service is a singleton created while the app is being built,
+/// which is BEFORE <c>MauiCultureInitializer</c> restores the user's persisted language (ADR-027);
+/// resolving the text at construction would therefore pin it to the device language for the life of
+/// the process, and no later in-app language switch would ever reach it.
+/// </para>
 /// </summary>
-/// <param name="cancelText">Label for the scan page's cancel button; pass a localized string.</param>
-/// <param name="cameraDescription">Accessible description and title for the scan surface.</param>
-public sealed class MauiBarcodeScannerService(string cancelText, string cameraDescription) : IBarcodeScannerService
+public sealed class MauiBarcodeScannerService : IBarcodeScannerService
 {
+    private readonly Func<string> _cancelText;
+    private readonly Func<string> _cameraDescription;
+
+    /// <summary>
+    /// Initializes the service with text resolved lazily, per scan. This is the localization-correct
+    /// overload: pass the resource lookups themselves (for example
+    /// <c>() =&gt; Localizer["Cancel"]</c>) so each scan page is built under the
+    /// <see cref="System.Globalization.CultureInfo.CurrentUICulture"/> in effect at that moment.
+    /// </summary>
+    /// <param name="cancelText">Resolves the label for the scan page's cancel button.</param>
+    /// <param name="cameraDescription">Resolves the accessible description and title for the scan surface.</param>
+    public MauiBarcodeScannerService(Func<string> cancelText, Func<string> cameraDescription)
+    {
+        ArgumentNullException.ThrowIfNull(cancelText);
+        ArgumentNullException.ThrowIfNull(cameraDescription);
+
+        _cancelText = cancelText;
+        _cameraDescription = cameraDescription;
+    }
+
+    /// <summary>
+    /// Initializes the service with fixed text. The values are captured as given and never
+    /// re-resolved, so they stay in whatever language was active when the service was constructed
+    /// (the device language, on a head that persists a different in-app choice). Prefer the
+    /// <see cref="MauiBarcodeScannerService(Func{string}, Func{string})"/> overload on any head that
+    /// offers a language switcher.
+    /// </summary>
+    /// <param name="cancelText">Label for the scan page's cancel button.</param>
+    /// <param name="cameraDescription">Accessible description and title for the scan surface.</param>
+    public MauiBarcodeScannerService(string cancelText, string cameraDescription)
+        : this(() => cancelText, () => cameraDescription)
+    {
+    }
+
     /// <inheritdoc />
     /// <remarks>
     /// Android and iOS only. Mac Catalyst and Windows have cameras, but the scan affordance there
@@ -38,8 +77,10 @@ public sealed class MauiBarcodeScannerService(string cancelText, string cameraDe
 
         try
         {
+            // The delegates are invoked here, once per scan, so the page is built under the culture
+            // that is active NOW rather than the one that was active when the app was built.
             return await MainThread
-                .InvokeOnMainThreadAsync(() => ScanOnMainThreadAsync(cancelText, cameraDescription, cancellationToken))
+                .InvokeOnMainThreadAsync(() => ScanOnMainThreadAsync(_cancelText(), _cameraDescription(), cancellationToken))
                 .ConfigureAwait(false);
         }
 #pragma warning disable CA1031 // Do not catch general exception types - scanning is best-effort; a missing window, a denied camera, and a handler-less platform must all read as "no scan"

--- a/Source/Presentation/MMCA.Common.UI.Maui/HostingDependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/HostingDependencyInjection.cs
@@ -52,13 +52,50 @@ public static class HostingDependencyInjection
         /// NSCameraUsageDescription). Call AFTER <c>AddUIShared</c> so the plain Add overrides the
         /// TryAdd default (last registration wins).
         /// </para>
+        /// <para>
+        /// This overload fixes both strings at startup. Everything here runs while the app is being
+        /// built, which is BEFORE <see cref="Globalization.MauiCultureInitializer"/> restores the
+        /// user's persisted language (ADR-027), so the values are resolved under the DEVICE language
+        /// and never change afterwards, not even when the user switches language in the app. On any
+        /// head with a language switcher, call the
+        /// <c>UseCommonBarcodeScanner(Func&lt;string&gt;, Func&lt;string&gt;)</c> overload below instead
+        /// (a cref cannot name a sibling extension member here).
+        /// </para>
         /// </summary>
-        /// <param name="cancelText">Label for the scan page's cancel button; pass a localized string.</param>
-        /// <param name="cameraDescription">Accessible description and title for the scan surface; pass a localized string.</param>
+        /// <param name="cancelText">Label for the scan page's cancel button; fixed at startup.</param>
+        /// <param name="cameraDescription">Accessible description and title for the scan surface; fixed at startup.</param>
         public MauiAppBuilder UseCommonBarcodeScanner(
             string cancelText = "Cancel",
-            string cameraDescription = "Scan a code")
+            string cameraDescription = "Scan a code") =>
+            builder.UseCommonBarcodeScanner(() => cancelText, () => cameraDescription);
+
+        /// <summary>
+        /// Opt-in camera barcode/QR scanning (ADR-042) with the scan page's text resolved lazily:
+        /// registers the ZXing.Net.MAUI handlers (<c>UseBarcodeReader()</c>) and overrides the null
+        /// <c>IBarcodeScannerService</c> with <see cref="MauiBarcodeScannerService"/>. Deliberately
+        /// NOT folded into <see cref="UseMauiDeviceCapabilities"/>: a head that never scans should
+        /// ship neither the camera handler nor a camera permission declaration.
+        /// <para>
+        /// This is the localization-correct overload. Both delegates are invoked once per scan, when
+        /// the page is built, so the modal follows the user's in-app language choice instead of the
+        /// device language that was active at startup. Pass the resource lookups themselves, for
+        /// example <c>() =&gt; localizer["Cancel"]</c>, and keep them cheap and side-effect free.
+        /// </para>
+        /// <para>
+        /// The head still declares the platform permission itself (Android CAMERA, iOS
+        /// NSCameraUsageDescription). Call AFTER <c>AddUIShared</c> so the plain Add overrides the
+        /// TryAdd default (last registration wins).
+        /// </para>
+        /// </summary>
+        /// <param name="cancelText">Resolves the label for the scan page's cancel button, per scan.</param>
+        /// <param name="cameraDescription">Resolves the accessible description and title for the scan surface, per scan.</param>
+        public MauiAppBuilder UseCommonBarcodeScanner(
+            Func<string> cancelText,
+            Func<string> cameraDescription)
         {
+            ArgumentNullException.ThrowIfNull(cancelText);
+            ArgumentNullException.ThrowIfNull(cameraDescription);
+
             builder.UseBarcodeReader();
             builder.Services.AddSingleton<IBarcodeScannerService>(
                 _ => new MauiBarcodeScannerService(cancelText, cameraDescription));


### PR DESCRIPTION
## Problem

`UseCommonBarcodeScanner(cancelText, cameraDescription)` took plain strings and resolved them at `MauiAppBuilder` time. That runs before `MauiCultureInitializer` restores the user's persisted culture (ADR-027), so the modal scan page (`BarcodeScanPage`) showed its Cancel button, page title and semantic description in the DEVICE language for the life of the process, even after the user switched language in the app. ADR-071 records this as an accepted trade-off; this PR removes it.

## Fix

A new overload resolves both strings lazily, once per scan:

```csharp
public MauiAppBuilder UseCommonBarcodeScanner(Func<string> cancelText, Func<string> cameraDescription)
```

`MauiBarcodeScannerService` gained the matching `(Func<string>, Func<string>)` constructor and invokes both delegates inside `ScanAsync`, immediately before the page is built, so `CultureInfo.CurrentUICulture` at scan time drives the text. Culture on a hybrid head is process state (`DefaultThreadCurrentUICulture`, see `MauiCultureStore`), so the main-thread dispatch does not change what the delegates observe.

A `Func<string>` pair was chosen over an options record to match the package's existing wiring shape: no `UseXxx` call in `HostingDependencyInjection` takes an options object today.

## Backward compatibility

The existing signature is untouched and keeps its defaults; it now delegates as `() => value`:

```csharp
public MauiAppBuilder UseCommonBarcodeScanner(string cancelText = "Cancel", string cameraDescription = "Scan a code")
```

`MauiBarcodeScannerService(string, string)` is likewise preserved (it chains to the delegate constructor), so released consumers compile and run unchanged. No ambiguity is introduced: the delegate overload has no optional parameters, so `UseCommonBarcodeScanner()` still binds to the string overload.

The string overload's XML doc now states plainly that its values are fixed at startup and points heads with a language switcher at the delegate overload, which is documented as the localization-correct one.

## Verification

- `dotnet build Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj -c Release`: green across all four TFMs (android, ios, maccatalyst, windows). The two `NativeThemeSync.razor` bundle-path warnings are pre-existing and unrelated.
- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors.
- `dotnet test --solution MMCA.Common.slnx -c Release`: 2973 passed, 0 failed.
- No package references changed, so no lock files regenerate.

## Tests

None added. `MMCA.Common.UI.Maui` is device-bound and has no test project (it sits outside the slnx and is only compiled by the `build-maui` job); the delegate plumbing lives entirely in a MAUI-TFM assembly that nothing can reference from the unit tier. Existing coverage for this capability is `CapabilityFallbackTests` over `NullBarcodeScannerService` in `MMCA.Common.UI.Tests`, which is unaffected. Coverage here is the four-TFM compile, per the package's existing posture; a device harness was deliberately not invented.

## Follow-up (not in this PR)

ADR-071's "The scan page's strings are resolved at composition, not per call" trade-off is now stale and cites `HostingDependencyInjection.cs:63-64` / `MauiBarcodeScannerService.cs:19`. It needs a Website-repo PR once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a
