### PR TITLE
test: pin rate-limit attribute inheritance on AuthControllerBase overrides

### DIFF
--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/AuthControllerBaseRateLimitTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/AuthControllerBaseRateLimitTests.cs
@@ -1,8 +1,13 @@
 using System.Reflection;
 using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using MMCA.Common.API.Controllers;
 using MMCA.Common.API.Startup;
+using MMCA.Common.Application.Auth;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Shared.Auth;
 
 namespace MMCA.Common.API.Tests.Controllers;
 
@@ -38,7 +43,55 @@ public sealed class AuthControllerBaseRateLimitTests
             .Should().BeNull(
                 because: "refresh is automatic and shares the UI host's IP under Blazor Server, so a per-IP window would throttle legitimate token renewal");
 
+    // The framework's own answer, recorded instead of assumed: [EnableRateLimiting] declares
+    // Inherited, which is the mechanism the override pin below relies on. ADR-019 now cites this
+    // fact, so it is asserted here rather than left standing as an unverified claim about
+    // framework internals.
+    [Fact]
+    public void EnableRateLimitingAttribute_IsDeclaredInherited() =>
+        typeof(EnableRateLimitingAttribute).GetCustomAttribute<AttributeUsageAttribute>()!.Inherited
+            .Should().BeTrue(
+                because: "ADR-019 cites attribute inheritance as the reason a derived override keeps the per-IP policy");
+
+    // A derived controller that overrides RegisterAsync without re-applying the attribute still
+    // resolves the policy through the base method, so an override cannot silently drop the throttle.
+    // Consumers nonetheless apply the attribute explicitly on every override by convention (ADC and
+    // Store both do): this pins the mechanism, it does not bless a bare override.
+    [Fact]
+    public void DerivedOverride_WithoutTheAttribute_StillCarriesTheAuthIpPolicy()
+    {
+        MethodInfo? overriddenAction = typeof(OverridingAuthController).GetMethod(
+            nameof(AuthControllerBase.RegisterAsync),
+            BindingFlags.Public | BindingFlags.Instance);
+
+        overriddenAction.Should().NotBeNull(
+            because: "the test double must really override RegisterAsync for this pin to mean anything");
+        overriddenAction!.DeclaringType.Should().Be<OverridingAuthController>();
+
+        EnableRateLimitingAttribute[] inheritedPolicies = overriddenAction
+            .GetCustomAttributes<EnableRateLimitingAttribute>(inherit: true)
+            .ToArray();
+
+        inheritedPolicies.Should().ContainSingle(
+            because: "the attribute is inherited, so an override that omits it still throttles per client IP");
+        inheritedPolicies[0].PolicyName.Should().Be(WebApplicationBuilderExtensions.RateLimitPolicyAuthIp);
+    }
+
     private static MethodInfo Action(string name) =>
         typeof(AuthControllerBase).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)
         ?? throw new InvalidOperationException($"AuthControllerBase.{name} not found; this guard must follow the base's action names.");
+
+    // Stands in for a consumer controller that overrides the action and leaves the attribute off.
+    // Only its type is read, by reflection, so it is never instantiated and the override body is
+    // deliberately inert.
+    private sealed class OverridingAuthController(
+        IAuthenticationService authenticationService,
+        ICurrentUserService currentUserService) : AuthControllerBase(authenticationService, currentUserService)
+    {
+        public override Task<ActionResult<AuthenticationResponse>> RegisterAsync(
+            RegisterRequest request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<ActionResult<AuthenticationResponse>>(
+                StatusCode(StatusCodes.Status501NotImplemented));
+    }
 }


### PR DESCRIPTION
## What

Two new facts in `AuthControllerBaseRateLimitTests`, test-only (no packaged or production code touched):

1. `EnableRateLimitingAttribute_IsDeclaredInherited` asserts `AttributeUsage.Inherited` is true on `[EnableRateLimiting]`. This records the empirical inheritance answer that ADR-019 now cites, instead of leaving it as an unverified claim about framework internals.
2. `DerivedOverride_WithoutTheAttribute_StillCarriesTheAuthIpPolicy` declares a private test controller that subclasses `AuthControllerBase` and overrides `RegisterAsync` WITHOUT re-applying `[EnableRateLimiting]`, then asserts the attribute is still discoverable on the override's `MethodInfo` via `GetCustomAttributes(inherit: true)` and that its `PolicyName` is `WebApplicationBuilderExtensions.RateLimitPolicyAuthIp`.

## Why

The file already pins the presence (and the deliberate absence) of the per-IP throttle on the base actions, because a dropped attribute fails silently: the endpoint just stops being throttled. The override path was the one hole left open. Consumers still apply the attribute explicitly on every override by convention (ADC and Store both do), so the second fact pins the mechanism rather than blessing a bare override.

## Verification

- `dotnet test --project Tests/Presentation/MMCA.Common.API.Tests/MMCA.Common.API.Tests.csproj -- --filter-class "*AuthControllerBaseRateLimitTests*"` -> 5 passed, 0 failed (was 3).
- `dotnet build MMCA.Common.slnx` and `dotnet build MMCA.Common.slnx -c Release` -> 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a