### PR TITLE
feat: event-scoped notifications (ScopeKey) + palette-aware section styles

### DIFF
--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationHandler.cs
@@ -58,7 +58,8 @@ public sealed partial class SendPushNotificationHandler(
             command.Request.Body,
             command.SentByUserId,
             recipientIds.Count,
-            dedupKey);
+            dedupKey,
+            command.Request.ScopeKey);
         if (createResult.IsFailure)
         {
             return Result.Failure<PushNotificationDTO>(createResult.Errors);

--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationRequestValidator.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationRequestValidator.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using FluentValidation;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.PushNotifications.Invariants;
 using MMCA.Common.Shared.Notifications.PushNotifications;
 
@@ -21,5 +22,10 @@ public sealed class SendPushNotificationRequestValidator : AbstractValidator<Sen
             .NotEmpty().WithMessage("Notification body is required.")
             .MaximumLength(PushNotificationInvariants.BodyMaxLength)
             .WithMessage(string.Create(CultureInfo.InvariantCulture, $"Notification body cannot exceed {PushNotificationInvariants.BodyMaxLength} characters."));
+
+        // The scope key stays optional: a null one is the unscoped send every existing caller makes.
+        RuleFor(x => x.ScopeKey)
+            .MaximumLength(PushNotification.ScopeKeyMaxLength)
+            .WithMessage(string.Create(CultureInfo.InvariantCulture, $"Notification scope key cannot exceed {PushNotification.ScopeKeyMaxLength} characters."));
     }
 }

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsHandler.cs
@@ -33,8 +33,18 @@ public sealed class GetMyNotificationsHandler(
         var userNotificationRepo = unitOfWork.GetRepository<UserNotification, UserNotificationIdentifierType>();
         var pushNotificationRepo = unitOfWork.GetRepository<PushNotification, PushNotificationIdentifierType>();
 
+        // Scope is a view filter, not a security boundary: a read that supplies one sees the
+        // notifications carrying that scope plus the unscoped ones, and a read that supplies none
+        // keeps the legacy query untouched (the join stays over the whole table).
+        IQueryable<PushNotification> pushNotifications = pushNotificationRepo.TableNoTracking;
+        if (!string.IsNullOrWhiteSpace(query.ScopeKey))
+        {
+            string scopeKey = query.ScopeKey;
+            pushNotifications = pushNotifications.Where(pn => pn.ScopeKey == null || pn.ScopeKey == scopeKey);
+        }
+
         var joined = from un in userNotificationRepo.TableNoTracking
-                     join pn in pushNotificationRepo.TableNoTracking on un.PushNotificationId equals pn.Id
+                     join pn in pushNotifications on un.PushNotificationId equals pn.Id
                      where un.UserId == query.UserId
                      orderby pn.CreatedOn descending
                      select new UserNotificationDTO

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsQuery.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetInbox/GetMyNotificationsQuery.cs
@@ -4,7 +4,12 @@ namespace MMCA.Common.Application.Notifications.UserNotifications.UseCases.GetIn
 /// <param name="UserId">The authenticated user's identifier.</param>
 /// <param name="PageNumber">Page number (1-based).</param>
 /// <param name="PageSize">Items per page (max 500).</param>
+/// <param name="ScopeKey">
+/// Optional scope key. Null (the default) is the legacy read: every notification is returned.
+/// A scope narrows the inbox to the notifications carrying that scope plus the unscoped ones.
+/// </param>
 public sealed record GetMyNotificationsQuery(
     UserIdentifierType UserId,
     int PageNumber = 1,
-    int PageSize = 20);
+    int PageSize = 20,
+    string? ScopeKey = null);

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetUnreadCount/GetUnreadNotificationCountHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetUnreadCount/GetUnreadNotificationCountHandler.cs
@@ -1,5 +1,6 @@
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.UserNotifications;
 using MMCA.Common.Shared.Abstractions;
 
@@ -20,9 +21,25 @@ public sealed class GetUnreadNotificationCountHandler(
     {
         var repository = unitOfWork.GetRepository<UserNotification, UserNotificationIdentifierType>();
 
-        int count = await queryableExecutor.CountAsync(
-            repository.TableNoTracking.Where(un => un.UserId == query.UserId && !un.IsRead),
-            cancellationToken).ConfigureAwait(false);
+        IQueryable<UserNotification> unread = repository.TableNoTracking
+            .Where(un => un.UserId == query.UserId && !un.IsRead);
+
+        // The join to PushNotification is introduced ONLY for a scoped count. An unconditional join
+        // would drag PushNotification's soft-delete global query filter into the legacy no-scope
+        // count and change a number that no caller asked to change; a scoped count deliberately
+        // accepts that narrowing, since a scoped reader cannot see a deleted parent anyway.
+        if (!string.IsNullOrWhiteSpace(query.ScopeKey))
+        {
+            string scopeKey = query.ScopeKey;
+            var pushNotificationRepo = unitOfWork.GetRepository<PushNotification, PushNotificationIdentifierType>();
+
+            unread = from un in unread
+                     join pn in pushNotificationRepo.TableNoTracking on un.PushNotificationId equals pn.Id
+                     where pn.ScopeKey == null || pn.ScopeKey == scopeKey
+                     select un;
+        }
+
+        int count = await queryableExecutor.CountAsync(unread, cancellationToken).ConfigureAwait(false);
 
         return Result.Success(count);
     }

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetUnreadCount/GetUnreadNotificationCountQuery.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/GetUnreadCount/GetUnreadNotificationCountQuery.cs
@@ -2,4 +2,10 @@ namespace MMCA.Common.Application.Notifications.UserNotifications.UseCases.GetUn
 
 /// <summary>Query to retrieve the number of unread notifications for a user.</summary>
 /// <param name="UserId">The authenticated user's identifier.</param>
-public sealed record GetUnreadNotificationCountQuery(UserIdentifierType UserId);
+/// <param name="ScopeKey">
+/// Optional scope key. Null (the default) is the legacy count over every notification; a scope
+/// counts only the notifications carrying that scope plus the unscoped ones.
+/// </param>
+public sealed record GetUnreadNotificationCountQuery(
+    UserIdentifierType UserId,
+    string? ScopeKey = null);

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/MarkAllRead/MarkAllNotificationsReadCommand.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/MarkAllRead/MarkAllNotificationsReadCommand.cs
@@ -2,4 +2,11 @@ namespace MMCA.Common.Application.Notifications.UserNotifications.UseCases.MarkA
 
 /// <summary>Command to mark all of a user's notifications as read.</summary>
 /// <param name="UserId">The authenticated user's identifier.</param>
-public sealed record MarkAllNotificationsReadCommand(UserIdentifierType UserId);
+/// <param name="ScopeKey">
+/// Optional scope key. Null (the default) marks every notification read; a scope marks only the
+/// notifications carrying that scope plus the unscoped ones, so a scoped client never silently
+/// clears rows it could not see.
+/// </param>
+public sealed record MarkAllNotificationsReadCommand(
+    UserIdentifierType UserId,
+    string? ScopeKey = null);

--- a/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/MarkAllRead/MarkAllNotificationsReadHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/UserNotifications/UseCases/MarkAllRead/MarkAllNotificationsReadHandler.cs
@@ -1,5 +1,6 @@
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.UserNotifications;
 using MMCA.Common.Shared.Abstractions;
 
@@ -20,8 +21,25 @@ public sealed class MarkAllNotificationsReadHandler(
     {
         var repository = unitOfWork.GetRepository<UserNotification, UserNotificationIdentifierType>();
 
+        IQueryable<UserNotification> unreadQuery = repository.Table
+            .Where(un => un.UserId == command.UserId && !un.IsRead);
+
+        // Same conditional join as the unread count, for two reasons: a scoped client must not mark
+        // rows it cannot see as read, and a no-scope command must keep the legacy query exactly as
+        // it was rather than inherit PushNotification's soft-delete global query filter.
+        if (!string.IsNullOrWhiteSpace(command.ScopeKey))
+        {
+            string scopeKey = command.ScopeKey;
+            var pushNotificationRepo = unitOfWork.GetRepository<PushNotification, PushNotificationIdentifierType>();
+
+            unreadQuery = from un in unreadQuery
+                          join pn in pushNotificationRepo.TableNoTracking on un.PushNotificationId equals pn.Id
+                          where pn.ScopeKey == null || pn.ScopeKey == scopeKey
+                          select un;
+        }
+
         List<UserNotification> unread = await queryableExecutor.ToListAsync(
-            repository.Table.Where(un => un.UserId == command.UserId && !un.IsRead),
+            unreadQuery,
             cancellationToken).ConfigureAwait(false);
 
         var readOnUtc = timeProvider.GetUtcNow().UtcDateTime;

--- a/Source/Core/MMCA.Common.Domain/Notifications/PushNotifications/PushNotification.cs
+++ b/Source/Core/MMCA.Common.Domain/Notifications/PushNotifications/PushNotification.cs
@@ -18,6 +18,9 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
     /// <summary>Maximum allowed length for the deduplication key.</summary>
     public const int DedupKeyMaxLength = 128;
 
+    /// <summary>Maximum allowed length for the scope key.</summary>
+    public const int ScopeKeyMaxLength = 128;
+
     /// <summary>Gets the notification title.</summary>
     public string Title { get; private set; }
 
@@ -41,6 +44,14 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
     /// </summary>
     public string? DedupKey { get; private set; }
 
+    /// <summary>
+    /// Gets the optional scope key stamped by the sending application (for example
+    /// <c>"event:2"</c>). It is an opaque view filter, not a security boundary: a read that
+    /// supplies a scope sees the notifications carrying that scope plus every unscoped one, while
+    /// a read that supplies none still sees everything. Null for every send that carries no scope.
+    /// </summary>
+    public string? ScopeKey { get; private set; }
+
     /// <summary>EF Core parameterless constructor.</summary>
     private PushNotification()
     {
@@ -53,7 +64,8 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
         string body,
         UserIdentifierType sentByUserId,
         int recipientCount,
-        string? dedupKey)
+        string? dedupKey,
+        string? scopeKey)
     {
         Title = title;
         Body = body;
@@ -61,6 +73,7 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
         RecipientCount = recipientCount;
         Status = PushNotificationStatus.Pending;
         DedupKey = string.IsNullOrWhiteSpace(dedupKey) ? null : dedupKey;
+        ScopeKey = string.IsNullOrWhiteSpace(scopeKey) ? null : scopeKey;
     }
 
     /// <summary>
@@ -75,13 +88,18 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
     /// Optional deduplication key (max 128 chars); null (the default) keeps the legacy behaviour
     /// where every send creates a new notification.
     /// </param>
+    /// <param name="scopeKey">
+    /// Optional scope key (max 128 chars); null (the default) keeps the legacy behaviour where the
+    /// notification is visible to every read, scoped or not.
+    /// </param>
     /// <returns>A <see cref="Result{T}"/> containing the created notification, or validation errors.</returns>
     public static Result<PushNotification> Create(
         string title,
         string body,
         UserIdentifierType sentByUserId,
         int recipientCount,
-        string? dedupKey = null)
+        string? dedupKey = null,
+        string? scopeKey = null)
     {
         var result = Result.Combine(
             PushNotificationInvariants.EnsureTitleIsValid(title, nameof(Create)),
@@ -92,13 +110,20 @@ public sealed class PushNotification : AuditableAggregateRootEntity<PushNotifica
                 "PushNotification.DedupKey.TooLong",
                 string.Create(CultureInfo.InvariantCulture, $"Notification dedup key cannot exceed {DedupKeyMaxLength} characters."),
                 nameof(Create),
-                nameof(dedupKey)));
+                nameof(dedupKey)),
+            CommonInvariants.EnsureStringMaxLength(
+                scopeKey,
+                ScopeKeyMaxLength,
+                "PushNotification.ScopeKey.TooLong",
+                string.Create(CultureInfo.InvariantCulture, $"Notification scope key cannot exceed {ScopeKeyMaxLength} characters."),
+                nameof(Create),
+                nameof(scopeKey)));
         if (result.IsFailure)
         {
             return Result.Failure<PushNotification>(result.Errors);
         }
 
-        var notification = new PushNotification(title, body, sentByUserId, recipientCount, dedupKey)
+        var notification = new PushNotification(title, body, sentByUserId, recipientCount, dedupKey, scopeKey)
         {
             Id = default
         };

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Configuration/EntityTypeConfiguration/Notifications/PushNotificationConfiguration.cs
@@ -46,6 +46,12 @@ internal sealed class PushNotificationConfiguration
         builder.Property(p => p.DedupKey)
             .HasMaxLength(PushNotification.DedupKeyMaxLength);
 
+        // Nullable and deliberately unindexed: the scope filter runs after the primary-key join from
+        // UserNotification, over a table that holds one row per send, so an index would cost writes
+        // without buying a read.
+        builder.Property(p => p.ScopeKey)
+            .HasMaxLength(PushNotification.ScopeKeyMaxLength);
+
         // Filtered unique index: at most one notification per deduplication key, while the many
         // sends that carry no key (NULL) coexist freely. This is what makes a retried send safe,
         // the database arbitrates the race that a check-then-act lookup in the handler cannot.

--- a/Source/Core/MMCA.Common.Shared/Notifications/PushNotifications/PushNotificationDTO.cs
+++ b/Source/Core/MMCA.Common.Shared/Notifications/PushNotifications/PushNotificationDTO.cs
@@ -25,6 +25,9 @@ public record class PushNotificationDTO : IBaseDTO<PushNotificationIdentifierTyp
     /// <summary>Gets or inits the delivery status.</summary>
     public required string Status { get; init; }
 
+    /// <summary>Gets or inits the optional scope key the notification was stamped with.</summary>
+    public string? ScopeKey { get; init; }
+
     /// <summary>Gets or inits the creation timestamp.</summary>
     public DateTime CreatedOn { get; init; }
 }

--- a/Source/Core/MMCA.Common.Shared/Notifications/PushNotifications/SendPushNotificationRequest.cs
+++ b/Source/Core/MMCA.Common.Shared/Notifications/PushNotifications/SendPushNotificationRequest.cs
@@ -3,4 +3,12 @@ namespace MMCA.Common.Shared.Notifications.PushNotifications;
 /// <summary>
 /// Request record for sending a push notification to all recipients.
 /// </summary>
-public sealed record SendPushNotificationRequest(string Title, string Body);
+public sealed record SendPushNotificationRequest(string Title, string Body)
+{
+    /// <summary>
+    /// Gets the optional scope key the notification is stamped with (for example <c>"event:2"</c>).
+    /// It is an init property rather than a positional parameter so every existing caller keeps
+    /// compiling. Null (the default) sends an unscoped notification, visible to every read.
+    /// </summary>
+    public string? ScopeKey { get; init; }
+}

--- a/Source/Presentation/MMCA.Common.API/Controllers/Notifications/NotificationInboxController.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/Notifications/NotificationInboxController.cs
@@ -11,6 +11,7 @@ using MMCA.Common.Application.Notifications.UserNotifications.UseCases.GetUnread
 using MMCA.Common.Application.Notifications.UserNotifications.UseCases.MarkAllRead;
 using MMCA.Common.Application.Notifications.UserNotifications.UseCases.MarkRead;
 using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.Notifications;
 using MMCA.Common.Shared.Notifications.UserNotifications;
@@ -33,12 +34,17 @@ public sealed class InboxController(
     ICommandHandler<MarkAllNotificationsReadCommand, Result> markAllReadHandler,
     ICurrentUserService currentUserService) : ApiControllerBase
 {
-    /// <summary>Gets the current user's notification inbox (GET /api/notifications/inbox).</summary>
+    /// <summary>
+    /// Gets the current user's notification inbox (GET /api/notifications/inbox).
+    /// An optional <c>scope</c> narrows the inbox to the notifications carrying that scope plus the
+    /// unscoped ones; omitting it returns everything, exactly as before.
+    /// </summary>
     [HttpGet]
     [ProducesResponseType(typeof(PagedCollectionResult<UserNotificationDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult<PagedCollectionResult<UserNotificationDTO>>> GetInboxAsync(
         [FromQuery, Range(1, int.MaxValue)] int pageNumber = 1,
         [FromQuery, Range(1, int.MaxValue)] int pageSize = 20,
+        [FromQuery, StringLength(PushNotification.ScopeKeyMaxLength)] string? scope = null,
         CancellationToken cancellationToken = default)
     {
         UserIdentifierType? userId = currentUserService.UserId;
@@ -47,18 +53,23 @@ public sealed class InboxController(
             return HandleFailure([Error.Unauthorized("Notification.Unauthorized", "User is not authenticated.")]);
         }
 
-        var query = new GetMyNotificationsQuery(userId.Value, pageNumber, pageSize);
+        var query = new GetMyNotificationsQuery(userId.Value, pageNumber, pageSize, scope);
         Result<PagedCollectionResult<UserNotificationDTO>> result = await inboxHandler
             .HandleAsync(query, cancellationToken).ConfigureAwait(false);
 
         return result.IsFailure ? HandleFailure(result.Errors) : Ok(result.Value);
     }
 
-    /// <summary>Gets the count of unread notifications (GET /api/notifications/inbox/unread-count).</summary>
+    /// <summary>
+    /// Gets the count of unread notifications (GET /api/notifications/inbox/unread-count).
+    /// The optional <c>scope</c> matches the inbox read, so the badge and the list agree.
+    /// </summary>
     [HttpGet("unread-count")]
     [ResponseCache(NoStore = true)]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-    public async Task<ActionResult<int>> GetUnreadCountAsync(CancellationToken cancellationToken = default)
+    public async Task<ActionResult<int>> GetUnreadCountAsync(
+        [FromQuery, StringLength(PushNotification.ScopeKeyMaxLength)] string? scope = null,
+        CancellationToken cancellationToken = default)
     {
         UserIdentifierType? userId = currentUserService.UserId;
         if (!userId.HasValue)
@@ -66,7 +77,7 @@ public sealed class InboxController(
             return HandleFailure([Error.Unauthorized("Notification.Unauthorized", "User is not authenticated.")]);
         }
 
-        var query = new GetUnreadNotificationCountQuery(userId.Value);
+        var query = new GetUnreadNotificationCountQuery(userId.Value, scope);
         Result<int> result = await unreadCountHandler.HandleAsync(query, cancellationToken).ConfigureAwait(false);
 
         return result.IsFailure ? HandleFailure(result.Errors) : Ok(result.Value);
@@ -92,10 +103,16 @@ public sealed class InboxController(
         return result.IsFailure ? HandleFailure(result.Errors) : NoContent();
     }
 
-    /// <summary>Marks all notifications as read (PUT /api/notifications/inbox/read-all).</summary>
+    /// <summary>
+    /// Marks all notifications as read (PUT /api/notifications/inbox/read-all).
+    /// The optional <c>scope</c> keeps the write aligned with what the caller can see: a scoped
+    /// caller never clears notifications its inbox read hid from it.
+    /// </summary>
     [HttpPut("read-all")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<IActionResult> MarkAllReadAsync(CancellationToken cancellationToken = default)
+    public async Task<IActionResult> MarkAllReadAsync(
+        [FromQuery, StringLength(PushNotification.ScopeKeyMaxLength)] string? scope = null,
+        CancellationToken cancellationToken = default)
     {
         UserIdentifierType? userId = currentUserService.UserId;
         if (!userId.HasValue)
@@ -103,7 +120,7 @@ public sealed class InboxController(
             return HandleFailure([Error.Unauthorized("Notification.Unauthorized", "User is not authenticated.")]);
         }
 
-        var command = new MarkAllNotificationsReadCommand(userId.Value);
+        var command = new MarkAllNotificationsReadCommand(userId.Value, scope);
         Result result = await markAllReadHandler.HandleAsync(command, cancellationToken).ConfigureAwait(false);
 
         return result.IsFailure ? HandleFailure(result.Errors) : NoContent();

--- a/Source/Presentation/MMCA.Common.UI/Notifications/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/Notifications/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Services.Notifications;
 
@@ -18,6 +19,10 @@ public static class DependencyInjection
         /// </summary>
         public IServiceCollection AddNotificationUI()
         {
+            // Scope provider consumed by both HTTP services below. TryAdd so an app that registers
+            // its own provider wins whichever order the two registration calls run in.
+            services.TryAddScoped<INotificationScopeProvider, NullNotificationScopeProvider>();
+
             // Push notification API service
             services.AddScoped<IPushNotificationUIService, PushNotificationService>();
 

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/INotificationScopeProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/INotificationScopeProvider.cs
@@ -1,0 +1,22 @@
+namespace MMCA.Common.UI.Services.Notifications;
+
+/// <summary>
+/// Supplies the scope key the notification UI should send and read under. The framework has no idea
+/// what an application's notifications are scoped by (a conference event, a tenant, a season), so an
+/// app implements this and both notification HTTP services consume it, which is what keeps a send
+/// and the reads that follow agreeing on one scope.
+/// </summary>
+/// <remarks>
+/// Implementations must never throw: a scope is a view filter, not a security boundary, and the safe
+/// direction on any failure is null (unscoped), which restores the pre-scope behaviour rather than
+/// breaking the bell or the inbox.
+/// </remarks>
+public interface INotificationScopeProvider
+{
+    /// <summary>
+    /// Gets the scope key currently in force, or null when the application is unscoped.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>The scope key (for example <c>"event:2"</c>), or null for no scoping.</returns>
+    Task<string?> GetCurrentScopeKeyAsync(CancellationToken ct = default);
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationInboxService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationInboxService.cs
@@ -8,10 +8,14 @@ namespace MMCA.Common.UI.Services.Notifications;
 
 /// <summary>
 /// HTTP service for the notification inbox WebAPI resource.
+/// Every read that the API can scope carries the application's current scope key, resolved through
+/// <see cref="INotificationScopeProvider"/>, so the inbox, the badge and a bulk mark-read all agree
+/// on which notifications the user is looking at.
 /// </summary>
 public sealed class NotificationInboxService(
     IHttpClientFactory httpClientFactory,
-    ITokenStorageService tokenStorageService)
+    ITokenStorageService tokenStorageService,
+    INotificationScopeProvider scopeProvider)
     : AuthenticatedServiceBase(httpClientFactory, tokenStorageService), INotificationInboxUIService
 {
     private const string Endpoint = "notifications/inbox";
@@ -22,8 +26,9 @@ public sealed class NotificationInboxService(
         int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
+        string scopeQuery = await ScopeQueryAsync("&", cancellationToken);
         using HttpClient httpClient = await CreateAuthenticatedClientAsync();
-        var url = string.Create(CultureInfo.InvariantCulture, $"{Endpoint}?pageNumber={pageNumber}&pageSize={pageSize}");
+        var url = string.Create(CultureInfo.InvariantCulture, $"{Endpoint}?pageNumber={pageNumber}&pageSize={pageSize}{scopeQuery}");
 
         HttpResponseMessage response = await RetryPolicy
             .ExecuteAsync(() => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken));
@@ -41,8 +46,9 @@ public sealed class NotificationInboxService(
     /// <inheritdoc />
     public async Task<int> GetUnreadCountAsync(CancellationToken cancellationToken = default)
     {
+        string scopeQuery = await ScopeQueryAsync("?", cancellationToken);
         using HttpClient httpClient = await CreateAuthenticatedClientAsync();
-        var url = $"{Endpoint}/unread-count";
+        var url = $"{Endpoint}/unread-count{scopeQuery}";
 
         HttpResponseMessage response = await RetryPolicy
             .ExecuteAsync(() => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken));
@@ -76,8 +82,9 @@ public sealed class NotificationInboxService(
     /// <inheritdoc />
     public async Task MarkAllReadAsync(CancellationToken cancellationToken = default)
     {
+        string scopeQuery = await ScopeQueryAsync("?", cancellationToken);
         using HttpClient httpClient = await CreateAuthenticatedClientAsync();
-        var url = $"{Endpoint}/read-all";
+        var url = $"{Endpoint}/read-all{scopeQuery}";
 
         HttpResponseMessage response = await RetryPolicy
             .ExecuteAsync(() => httpClient.PutAsync(new Uri(url, UriKind.Relative), content: null, cancellationToken));
@@ -87,5 +94,22 @@ public sealed class NotificationInboxService(
             await ServiceExceptionHelper.ThrowIfDomainExceptionAsync(response, cancellationToken);
             response.EnsureSuccessStatusCode();
         }
+    }
+
+    /// <summary>
+    /// Renders the <c>scope</c> query fragment for the application's current scope, or an empty
+    /// string when it is unscoped, which leaves the request byte-identical to the pre-scope one.
+    /// </summary>
+    /// <param name="separator">
+    /// <c>"&amp;"</c> for a URL that already carries query parameters, <c>"?"</c> for one that does not.
+    /// </param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    private async Task<string> ScopeQueryAsync(string separator, CancellationToken cancellationToken)
+    {
+        string? scopeKey = await scopeProvider.GetCurrentScopeKeyAsync(cancellationToken);
+
+        return string.IsNullOrWhiteSpace(scopeKey)
+            ? string.Empty
+            : $"{separator}scope={Uri.EscapeDataString(scopeKey)}";
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NullNotificationScopeProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NullNotificationScopeProvider.cs
@@ -1,0 +1,13 @@
+namespace MMCA.Common.UI.Services.Notifications;
+
+/// <summary>
+/// No-op scope provider: always unscoped. Registered as the default by <c>AddNotificationUI</c>, so
+/// an application that never scopes its notifications keeps exactly the behaviour it had before the
+/// scope key existed. Apps that do scope register their own implementation, which wins over this one.
+/// </summary>
+public sealed class NullNotificationScopeProvider : INotificationScopeProvider
+{
+    /// <inheritdoc />
+    public Task<string?> GetCurrentScopeKeyAsync(CancellationToken ct = default) =>
+        Task.FromResult<string?>(null);
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/PushNotificationService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/PushNotificationService.cs
@@ -8,25 +8,44 @@ namespace MMCA.Common.UI.Services.Notifications;
 
 /// <summary>
 /// HTTP service for the <c>notifications</c> WebAPI resource.
-/// Provides send and paginated history operations.
+/// Provides send and paginated history operations. A send is stamped with the application's current
+/// scope key (<see cref="INotificationScopeProvider"/>), the same provider the inbox service reads
+/// through, so what gets sent and what gets shown always resolve to one scope.
 /// </summary>
 public sealed class PushNotificationService(
     IHttpClientFactory httpClientFactory,
-    ITokenStorageService tokenStorageService)
+    ITokenStorageService tokenStorageService,
+    INotificationScopeProvider scopeProvider)
     : EntityServiceBase<PushNotificationDTO, PushNotificationIdentifierType>(
         "notifications", httpClientFactory, tokenStorageService), IPushNotificationUIService
 {
     /// <inheritdoc />
     public async Task<PushNotificationDTO?> SendAsync(
         SendPushNotificationRequest request,
-        CancellationToken cancellationToken = default) =>
-        await SendRequestAsync<PushNotificationDTO>(
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // A request that already names a scope keeps it: an explicit caller choice outranks the
+        // ambient one. Only an unscoped request picks up whatever the app currently scopes to.
+        SendPushNotificationRequest scopedRequest = request;
+        if (string.IsNullOrWhiteSpace(scopedRequest.ScopeKey))
+        {
+            string? scopeKey = await scopeProvider.GetCurrentScopeKeyAsync(cancellationToken);
+            if (!string.IsNullOrWhiteSpace(scopeKey))
+            {
+                scopedRequest = request with { ScopeKey = scopeKey };
+            }
+        }
+
+        return await SendRequestAsync<PushNotificationDTO>(
             httpClient => httpClient.PostAsJsonAsync(
                 new Uri(Endpoint, UriKind.Relative),
-                request,
+                scopedRequest,
                 cancellationToken),
             cancellationToken,
             throwIfNull: true);
+    }
 
     /// <inheritdoc />
     public async Task<PagedCollectionResult<PushNotificationDTO>?> GetHistoryAsync(

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
@@ -273,7 +273,10 @@ h1:focus {
 
 .mmca-section-heading .mud-icon {
     font-size: 8rem !important;
-    color: rgba(0, 0, 0, 0.04);
+    /* Palette-aware watermark: the ink follows the theme, the opacity keeps it a ghost behind the
+       title. A hardcoded black at 4% disappeared entirely on a dark surface. */
+    color: var(--mud-palette-text-primary);
+    opacity: 0.05;
     position: absolute;
     top: 50%;
     left: 50%;
@@ -282,7 +285,10 @@ h1:focus {
 }
 
 .mmca-section-heading-light .mud-icon {
+    /* Sits on a deliberately dark band in both themes, so it keeps its white and resets the
+       opacity the base rule applies (the alpha is already in the color). */
     color: rgba(255, 255, 255, 0.06);
+    opacity: 1;
 }
 
 .mmca-section-heading .mud-typography {
@@ -306,7 +312,7 @@ h1:focus {
 .mmca-section-description {
     max-width: 700px;
     margin: 0 auto;
-    color: rgba(0, 0, 0, 0.62);
+    color: var(--mud-palette-text-secondary);
     line-height: 1.8;
 }
 

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetMyNotificationsHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetMyNotificationsHandlerTests.cs
@@ -69,7 +69,109 @@ public sealed class GetMyNotificationsHandlerTests
         result.Value.PaginationMetadata.PageSize.Should().Be(20);
     }
 
+    // ── Scope filtering ──
+    [Fact]
+    public async Task HandleAsync_WithoutScope_ReturnsEveryNotificationWhateverItsScope()
+    {
+        GetMyNotificationsHandler sut = CreateFilteringSut();
+
+        var query = new GetMyNotificationsQuery(UserId: 1);
+        Result<PagedCollectionResult<UserNotificationDTO>> result = await sut.HandleAsync(query);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Select(i => i.Title).Should().BeEquivalentTo("Unscoped", "Event one", "Event two");
+        result.Value.PaginationMetadata.TotalItemCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithScope_ReturnsMatchingAndUnscopedOnly()
+    {
+        GetMyNotificationsHandler sut = CreateFilteringSut();
+
+        var query = new GetMyNotificationsQuery(UserId: 1, ScopeKey: "event:2");
+        Result<PagedCollectionResult<UserNotificationDTO>> result = await sut.HandleAsync(query);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Select(i => i.Title).Should().BeEquivalentTo("Unscoped", "Event two");
+        result.Value.PaginationMetadata.TotalItemCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithWhitespaceScope_IsTreatedAsUnscoped()
+    {
+        GetMyNotificationsHandler sut = CreateFilteringSut();
+
+        var query = new GetMyNotificationsQuery(UserId: 1, ScopeKey: "   ");
+        Result<PagedCollectionResult<UserNotificationDTO>> result = await sut.HandleAsync(query);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithScopeMatchingNothing_ReturnsUnscopedOnly()
+    {
+        GetMyNotificationsHandler sut = CreateFilteringSut();
+
+        var query = new GetMyNotificationsQuery(UserId: 1, ScopeKey: "event:99");
+        Result<PagedCollectionResult<UserNotificationDTO>> result = await sut.HandleAsync(query);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Select(i => i.Title).Should().BeEquivalentTo("Unscoped");
+    }
+
     // ── Helpers ──
+
+    /// <summary>
+    /// Builds a handler over three real notifications (unscoped, "event:1", "event:2") in one user's
+    /// inbox, with an executor that actually enumerates the composed query. Unlike
+    /// <see cref="CreateSut"/>, which mocks the results outright, this pins the scope predicate itself.
+    /// </summary>
+    private static GetMyNotificationsHandler CreateFilteringSut()
+    {
+        List<PushNotification> pushNotifications =
+        [
+            Push(id: 1, title: "Unscoped", scopeKey: null),
+            Push(id: 2, title: "Event one", scopeKey: "event:1"),
+            Push(id: 3, title: "Event two", scopeKey: "event:2"),
+        ];
+        List<UserNotification> userNotifications =
+            [.. pushNotifications.Select(pn => UserNotification.Create(userId: 1, pushNotificationId: pn.Id).Value!)];
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var userNotificationRepo = new Mock<IRepository<UserNotification, UserNotificationIdentifierType>>();
+        var pushNotificationRepo = new Mock<IRepository<PushNotification, PushNotificationIdentifierType>>();
+        var queryableExecutor = new Mock<IQueryableExecutor>();
+
+        unitOfWork.Setup(x => x.GetRepository<UserNotification, UserNotificationIdentifierType>())
+            .Returns(userNotificationRepo.Object);
+        unitOfWork.Setup(x => x.GetRepository<PushNotification, PushNotificationIdentifierType>())
+            .Returns(pushNotificationRepo.Object);
+
+        userNotificationRepo.Setup(x => x.TableNoTracking).Returns(userNotifications.AsQueryable());
+        pushNotificationRepo.Setup(x => x.TableNoTracking).Returns(pushNotifications.AsQueryable());
+
+        queryableExecutor.Setup(x => x.CountAsync(It.IsAny<IQueryable<UserNotificationDTO>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IQueryable<UserNotificationDTO> source, CancellationToken _) => source.Count());
+        queryableExecutor.Setup(x => x.ToListAsync(It.IsAny<IQueryable<UserNotificationDTO>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IQueryable<UserNotificationDTO> source, CancellationToken _) => source.ToList());
+
+        return new GetMyNotificationsHandler(unitOfWork.Object, queryableExecutor.Object);
+    }
+
+    /// <summary>
+    /// Builds a notification that looks persisted. <c>Id</c> is <c>required init</c> and the factory
+    /// leaves it at its default, so the identifier the join needs is written back through reflection
+    /// rather than by opening the entity up with a test-only setter.
+    /// </summary>
+    private static PushNotification Push(PushNotificationIdentifierType id, string title, string? scopeKey)
+    {
+        PushNotification notification = PushNotification
+            .Create(title, "Body", sentByUserId: 1, recipientCount: 1, scopeKey: scopeKey).Value!;
+        typeof(PushNotification).GetProperty(nameof(PushNotification.Id))!.SetValue(notification, id);
+        return notification;
+    }
+
     private static (GetMyNotificationsHandler Sut, Mock<IUnitOfWork> UnitOfWork) CreateSut(
         int totalCount, int pageItems)
     {

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetUnreadNotificationCountHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/GetUnreadNotificationCountHandlerTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Notifications.UserNotifications.UseCases.GetUnreadCount;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.UserNotifications;
 using MMCA.Common.Shared.Abstractions;
 using Moq;
@@ -47,7 +48,103 @@ public sealed class GetUnreadNotificationCountHandlerTests
         result.IsSuccess.Should().BeTrue();
     }
 
+    // ── Scope filtering ──
+    [Fact]
+    public async Task HandleAsync_WithoutScope_NeverJoinsPushNotification()
+    {
+        // The legacy count must stay the legacy query: joining PushNotification unconditionally
+        // would pull its soft-delete global filter into a number nobody asked to change.
+        var (sut, mocks) = CreateSut(unreadCount: 7);
+
+        Result<int> result = await sut.HandleAsync(new GetUnreadNotificationCountQuery(UserId: 42));
+
+        result.Value.Should().Be(7);
+        mocks.UnitOfWork.Verify(x => x.GetRepository<PushNotification, PushNotificationIdentifierType>(), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithScope_CountsMatchingAndUnscopedOnly()
+    {
+        GetUnreadNotificationCountHandler sut = CreateFilteringSut();
+
+        Result<int> result = await sut.HandleAsync(new GetUnreadNotificationCountQuery(UserId: 1, ScopeKey: "event:2"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutScope_CountsEveryUnreadNotification()
+    {
+        GetUnreadNotificationCountHandler sut = CreateFilteringSut();
+
+        Result<int> result = await sut.HandleAsync(new GetUnreadNotificationCountQuery(UserId: 1));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithScopeMatchingNothing_CountsUnscopedOnly()
+    {
+        GetUnreadNotificationCountHandler sut = CreateFilteringSut();
+
+        Result<int> result = await sut.HandleAsync(new GetUnreadNotificationCountQuery(UserId: 1, ScopeKey: "event:99"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(1);
+    }
+
     // ── Helpers ──
+
+    /// <summary>
+    /// Builds a handler over three real unread notifications (unscoped, "event:1", "event:2") with an
+    /// executor that actually enumerates the composed query, so these tests pin the scope predicate
+    /// rather than a mocked count.
+    /// </summary>
+    private static GetUnreadNotificationCountHandler CreateFilteringSut()
+    {
+        List<PushNotification> pushNotifications =
+        [
+            Push(id: 1, scopeKey: null),
+            Push(id: 2, scopeKey: "event:1"),
+            Push(id: 3, scopeKey: "event:2"),
+        ];
+        List<UserNotification> userNotifications =
+            [.. pushNotifications.Select(pn => UserNotification.Create(userId: 1, pushNotificationId: pn.Id).Value!)];
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<UserNotification, UserNotificationIdentifierType>>();
+        var pushNotificationRepo = new Mock<IRepository<PushNotification, PushNotificationIdentifierType>>();
+        var queryableExecutor = new Mock<IQueryableExecutor>();
+
+        unitOfWork.Setup(x => x.GetRepository<UserNotification, UserNotificationIdentifierType>())
+            .Returns(repository.Object);
+        unitOfWork.Setup(x => x.GetRepository<PushNotification, PushNotificationIdentifierType>())
+            .Returns(pushNotificationRepo.Object);
+
+        repository.Setup(x => x.TableNoTracking).Returns(userNotifications.AsQueryable());
+        pushNotificationRepo.Setup(x => x.TableNoTracking).Returns(pushNotifications.AsQueryable());
+
+        queryableExecutor.Setup(x => x.CountAsync(It.IsAny<IQueryable<UserNotification>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IQueryable<UserNotification> source, CancellationToken _) => source.Count());
+
+        return new GetUnreadNotificationCountHandler(unitOfWork.Object, queryableExecutor.Object);
+    }
+
+    /// <summary>
+    /// Builds a notification that looks persisted. <c>Id</c> is <c>required init</c> and the factory
+    /// leaves it at its default, so the identifier the join needs is written back through reflection
+    /// rather than by opening the entity up with a test-only setter.
+    /// </summary>
+    private static PushNotification Push(PushNotificationIdentifierType id, string? scopeKey)
+    {
+        PushNotification notification = PushNotification
+            .Create("Title", "Body", sentByUserId: 1, recipientCount: 1, scopeKey: scopeKey).Value!;
+        typeof(PushNotification).GetProperty(nameof(PushNotification.Id))!.SetValue(notification, id);
+        return notification;
+    }
+
     private sealed record HandlerMocks(
         Mock<IUnitOfWork> UnitOfWork,
         Mock<IQueryableExecutor> QueryableExecutor);

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/MarkAllNotificationsReadHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/MarkAllNotificationsReadHandlerTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Notifications.UserNotifications.UseCases.MarkAllRead;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.UserNotifications;
 using MMCA.Common.Shared.Abstractions;
 using Moq;
@@ -61,7 +62,97 @@ public sealed class MarkAllNotificationsReadHandlerTests
         mocks.Unread.Should().OnlyContain(n => n.IsRead && n.ReadOn == readInstant.UtcDateTime);
     }
 
+    // ── Scope filtering ──
+    [Fact]
+    public async Task HandleAsync_WithoutScope_NeverJoinsPushNotification()
+    {
+        // Mirrors the unread count: an unconditional join would drag PushNotification's soft-delete
+        // global filter into the legacy command and silently change which rows it clears.
+        var (sut, mocks) = CreateSut(unreadCount: 3);
+
+        Result result = await sut.HandleAsync(new MarkAllNotificationsReadCommand(UserId: 42));
+
+        result.IsSuccess.Should().BeTrue();
+        mocks.UnitOfWork.Verify(x => x.GetRepository<PushNotification, PushNotificationIdentifierType>(), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithScope_MarksMatchingAndUnscopedOnly()
+    {
+        var (sut, notifications) = CreateFilteringSut();
+
+        Result result = await sut.HandleAsync(new MarkAllNotificationsReadCommand(UserId: 1, ScopeKey: "event:2"));
+
+        result.IsSuccess.Should().BeTrue();
+        notifications[0].IsRead.Should().BeTrue("the unscoped notification is visible under every scope");
+        notifications[1].IsRead.Should().BeFalse("an \"event:1\" notification is invisible to an \"event:2\" client");
+        notifications[2].IsRead.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithoutScope_MarksEveryUnreadNotification()
+    {
+        var (sut, notifications) = CreateFilteringSut();
+
+        Result result = await sut.HandleAsync(new MarkAllNotificationsReadCommand(UserId: 1));
+
+        result.IsSuccess.Should().BeTrue();
+        notifications.Should().OnlyContain(n => n.IsRead);
+    }
+
     // ── Helpers ──
+
+    /// <summary>
+    /// Builds a handler over three real unread notifications (unscoped, "event:1", "event:2") with an
+    /// executor that actually enumerates the composed query, so these tests pin the scope predicate
+    /// rather than a mocked result set. The returned list is in that same order.
+    /// </summary>
+    private static (MarkAllNotificationsReadHandler Sut, IReadOnlyList<UserNotification> Notifications) CreateFilteringSut()
+    {
+        List<PushNotification> pushNotifications =
+        [
+            Push(id: 1, scopeKey: null),
+            Push(id: 2, scopeKey: "event:1"),
+            Push(id: 3, scopeKey: "event:2"),
+        ];
+        List<UserNotification> userNotifications =
+            [.. pushNotifications.Select(pn => UserNotification.Create(userId: 1, pushNotificationId: pn.Id).Value!)];
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IRepository<UserNotification, UserNotificationIdentifierType>>();
+        var pushNotificationRepo = new Mock<IRepository<PushNotification, PushNotificationIdentifierType>>();
+        var queryableExecutor = new Mock<IQueryableExecutor>();
+
+        unitOfWork.Setup(x => x.GetRepository<UserNotification, UserNotificationIdentifierType>())
+            .Returns(repository.Object);
+        unitOfWork.Setup(x => x.GetRepository<PushNotification, PushNotificationIdentifierType>())
+            .Returns(pushNotificationRepo.Object);
+        unitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        repository.Setup(x => x.Table).Returns(userNotifications.AsQueryable());
+        pushNotificationRepo.Setup(x => x.TableNoTracking).Returns(pushNotifications.AsQueryable());
+
+        queryableExecutor.Setup(x => x.ToListAsync(It.IsAny<IQueryable<UserNotification>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IQueryable<UserNotification> source, CancellationToken _) => source.ToList());
+
+        var sut = new MarkAllNotificationsReadHandler(unitOfWork.Object, queryableExecutor.Object, TimeProvider.System);
+
+        return (sut, userNotifications);
+    }
+
+    /// <summary>
+    /// Builds a notification that looks persisted. <c>Id</c> is <c>required init</c> and the factory
+    /// leaves it at its default, so the identifier the join needs is written back through reflection
+    /// rather than by opening the entity up with a test-only setter.
+    /// </summary>
+    private static PushNotification Push(PushNotificationIdentifierType id, string? scopeKey)
+    {
+        PushNotification notification = PushNotification
+            .Create("Title", "Body", sentByUserId: 1, recipientCount: 1, scopeKey: scopeKey).Value!;
+        typeof(PushNotification).GetProperty(nameof(PushNotification.Id))!.SetValue(notification, id);
+        return notification;
+    }
+
     private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => utcNow;

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/PushNotificationDTOMapperTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/PushNotificationDTOMapperTests.cs
@@ -65,6 +65,26 @@ public sealed class PushNotificationDTOMapperTests
         dto.Status.Should().Be(nameof(PushNotificationStatus.Failed));
     }
 
+    [Fact]
+    public void MapToDTO_WithScopedEntity_MapsScopeKey()
+    {
+        PushNotification entity = CreateEntity("Title", "Body", scopeKey: "event:2");
+
+        PushNotificationDTO dto = _mapper.MapToDTO(entity);
+
+        dto.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public void MapToDTO_WithUnscopedEntity_MapsScopeKeyAsNull()
+    {
+        PushNotification entity = CreateEntity("Title", "Body");
+
+        PushNotificationDTO dto = _mapper.MapToDTO(entity);
+
+        dto.ScopeKey.Should().BeNull();
+    }
+
     // ── MapToDTOs ──
     [Fact]
     public void MapToDTOs_WithCollection_MapsAllEntities()
@@ -103,9 +123,11 @@ public sealed class PushNotificationDTOMapperTests
         string title = "Title",
         string body = "Body",
         UserIdentifierType sentByUserId = 1,
-        int recipientCount = 5)
+        int recipientCount = 5,
+        string? scopeKey = null)
     {
-        Result<PushNotification> result = PushNotification.Create(title, body, sentByUserId, recipientCount);
+        Result<PushNotification> result = PushNotification.Create(
+            title, body, sentByUserId, recipientCount, scopeKey: scopeKey);
         return result.Value!;
     }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationHandlerTests.cs
@@ -232,6 +232,55 @@ public class SendPushNotificationHandlerTests
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    // -- HandleAsync: scope key --
+    [Fact]
+    public async Task HandleAsync_WithScopedRequest_PersistsScopeKeyAndReturnsItOnTheDTO()
+    {
+        var (sut, mocks) = CreateSut();
+        PushNotification? added = null;
+        mocks.NotificationRepo
+            .Setup(x => x.AddAsync(It.IsAny<PushNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<PushNotification, CancellationToken>((notification, _) => added = notification);
+
+        SendPushNotificationCommand command = CreateCommand(scopeKey: "event:2");
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ScopeKey.Should().Be("event:2");
+        added.Should().NotBeNull();
+        added!.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithUnscopedRequest_LeavesScopeKeyNull()
+    {
+        var (sut, mocks) = CreateSut();
+        PushNotification? added = null;
+        mocks.NotificationRepo
+            .Setup(x => x.AddAsync(It.IsAny<PushNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<PushNotification, CancellationToken>((notification, _) => added = notification);
+
+        SendPushNotificationCommand command = CreateCommand();
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ScopeKey.Should().BeNull();
+        added.Should().NotBeNull();
+        added!.ScopeKey.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithScopeKeyExceedingMaxLength_ReturnsFailure()
+    {
+        var (sut, _) = CreateSut();
+
+        SendPushNotificationCommand command = CreateCommand(scopeKey: new string('x', PushNotification.ScopeKeyMaxLength + 1));
+        Result<PushNotificationDTO> result = await sut.HandleAsync(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Code == "PushNotification.ScopeKey.TooLong");
+    }
+
     // -- Helpers --
     private sealed record HandlerMocks(
         Mock<IUnitOfWork> UnitOfWork,
@@ -276,8 +325,8 @@ public class SendPushNotificationHandlerTests
             It.IsAny<bool>(),
             It.IsAny<CancellationToken>());
 
-    private static SendPushNotificationCommand CreateCommand() =>
-        new(new SendPushNotificationRequest("Test Title", "Test Body"), SentByUserId: 1);
+    private static SendPushNotificationCommand CreateCommand(string? scopeKey = null) =>
+        new(new SendPushNotificationRequest("Test Title", "Test Body") { ScopeKey = scopeKey }, SentByUserId: 1);
 
     private static (SendPushNotificationHandler Sut, HandlerMocks Mocks) CreateSut(
         int recipientCount = 3,

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationRequestValidatorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using FluentValidation.TestHelper;
 using MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
+using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.PushNotifications.Invariants;
 using MMCA.Common.Shared.Notifications.PushNotifications;
 
@@ -80,11 +81,45 @@ public sealed class SendPushNotificationRequestValidatorTests
         result.ShouldNotHaveValidationErrorFor(x => x.Body);
     }
 
+    // ── Scope key ──
+    [Fact]
+    public void Validate_WhenScopeKeyExceedsMaxLength_HasValidationError()
+    {
+        string longScopeKey = new('S', PushNotification.ScopeKeyMaxLength + 1);
+        var request = new SendPushNotificationRequest("Valid title", "Valid body") { ScopeKey = longScopeKey };
+
+        TestValidationResult<SendPushNotificationRequest> result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.ScopeKey)
+            .WithErrorMessage(string.Create(CultureInfo.InvariantCulture, $"Notification scope key cannot exceed {PushNotification.ScopeKeyMaxLength} characters."));
+    }
+
+    [Fact]
+    public void Validate_WhenScopeKeyAtMaxLength_NoScopeKeyError()
+    {
+        string maxScopeKey = new('S', PushNotification.ScopeKeyMaxLength);
+        var request = new SendPushNotificationRequest("Valid title", "Valid body") { ScopeKey = maxScopeKey };
+
+        TestValidationResult<SendPushNotificationRequest> result = _validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.ScopeKey);
+    }
+
+    [Fact]
+    public void Validate_WhenScopeKeyNull_NoScopeKeyError()
+    {
+        var request = new SendPushNotificationRequest("Valid title", "Valid body");
+
+        TestValidationResult<SendPushNotificationRequest> result = _validator.TestValidate(request);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.ScopeKey);
+    }
+
     // ── Valid request ──
     [Fact]
     public void Validate_WhenValid_NoErrors()
     {
-        var request = new SendPushNotificationRequest("Alert", "Something happened");
+        var request = new SendPushNotificationRequest("Alert", "Something happened") { ScopeKey = "event:2" };
 
         TestValidationResult<SendPushNotificationRequest> result = _validator.TestValidate(request);
 

--- a/Tests/Core/MMCA.Common.Domain.Tests/Notifications/PushNotificationTests.cs
+++ b/Tests/Core/MMCA.Common.Domain.Tests/Notifications/PushNotificationTests.cs
@@ -108,6 +108,67 @@ public class PushNotificationTests
         result.Value!.DedupKey.Should().Be(maxKey);
     }
 
+    // -- Create: scope key --
+    [Fact]
+    public void Create_WithoutScopeKey_LeavesScopeKeyNull()
+    {
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 50);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ScopeKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithScopeKey_StoresScopeKey()
+    {
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 50, scopeKey: "event:2");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceScopeKey_NormalizesToNull()
+    {
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 50, scopeKey: "   ");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ScopeKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithScopeKeyExceedingMaxLength_ReturnsFailure()
+    {
+        string longKey = new('x', PushNotification.ScopeKeyMaxLength + 1);
+
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 10, scopeKey: longKey);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Code == "PushNotification.ScopeKey.TooLong");
+    }
+
+    [Fact]
+    public void Create_WithScopeKeyAtMaxLength_ReturnsSuccess()
+    {
+        string maxKey = new('x', PushNotification.ScopeKeyMaxLength);
+
+        var result = PushNotification.Create("Test Title", "Test Body", sentByUserId: 1, recipientCount: 10, scopeKey: maxKey);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ScopeKey.Should().Be(maxKey);
+    }
+
+    [Fact]
+    public void Create_WithBothDedupKeyAndScopeKey_StoresBothIndependently()
+    {
+        var result = PushNotification.Create(
+            "Test Title", "Test Body", sentByUserId: 1, recipientCount: 10, dedupKey: "key-123", scopeKey: "event:2");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.DedupKey.Should().Be("key-123");
+        result.Value.ScopeKey.Should().Be("event:2");
+    }
+
     [Fact]
     public void Create_RaisesPushNotificationCreatedEvent()
     {

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/PushNotificationConfigurationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Configuration/PushNotificationConfigurationTests.cs
@@ -10,7 +10,8 @@ namespace MMCA.Common.Infrastructure.Tests.Persistence.Configuration;
 /// hand-filtered, and <c>SoftDeleteUniqueIndexConvention</c> deliberately leaves a hand-authored
 /// filter alone, so this configuration has to opt into the soft-delete predicate itself. Without it
 /// a soft-deleted notification keeps occupying its dedup slot and blocks every later send under the
-/// same key (BugHunt M58).
+/// same key (BugHunt M58). The scope-key column is pinned here too, including the deliberate absence
+/// of an index on it.
 /// </summary>
 public sealed class PushNotificationConfigurationTests : IDisposable
 {
@@ -27,6 +28,29 @@ public sealed class PushNotificationConfigurationTests : IDisposable
         => DedupKeyIndex().GetFilter().Should().Be(
             "[DedupKey] IS NOT NULL AND [IsDeleted] = 0",
             "a soft-deleted notification must not keep occupying its dedup slot");
+
+    // ── ScopeKey column ──
+    // The scope key is an opaque view filter, so it gets a bounded nullable column and, unlike the
+    // dedup key, no index at all: the filter runs after the primary-key join from UserNotification.
+    [Fact]
+    public void ScopeKey_IsBoundedToTheDomainMaximum()
+        => ScopeKeyProperty().GetMaxLength().Should().Be(PushNotification.ScopeKeyMaxLength);
+
+    [Fact]
+    public void ScopeKey_IsNullable()
+        => ScopeKeyProperty().IsNullable.Should().BeTrue("an unscoped send is the default and stores NULL");
+
+    [Fact]
+    public void ScopeKey_IsNotIndexed()
+        => _dbContext.Model.FindEntityType(typeof(PushNotification))!
+            .GetIndexes()
+            .Should().NotContain(
+                i => i.Properties.Any(p => p.Name == nameof(PushNotification.ScopeKey)),
+                "the table holds one row per send, so an index would cost writes without buying a read");
+
+    private Microsoft.EntityFrameworkCore.Metadata.IProperty ScopeKeyProperty()
+        => _dbContext.Model.FindEntityType(typeof(PushNotification))!
+            .FindProperty(nameof(PushNotification.ScopeKey))!;
 
     private Microsoft.EntityFrameworkCore.Metadata.IIndex DedupKeyIndex()
         => _dbContext.Model.FindEntityType(typeof(PushNotification))!

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/NotificationInboxControllerTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/NotificationInboxControllerTests.cs
@@ -90,6 +90,40 @@ public sealed class NotificationInboxControllerTests
     }
 
     [Fact]
+    public async Task GetInboxAsync_WithScope_ForwardsScopeOnTheQuery()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(42);
+        GetMyNotificationsQuery? capturedQuery = null;
+        _inboxHandlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<GetMyNotificationsQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<GetMyNotificationsQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(Result.Success(new PagedCollectionResult<UserNotificationDTO>()));
+        InboxController sut = CreateController();
+
+        await sut.GetInboxAsync(scope: "event:2");
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public async Task GetInboxAsync_WithoutScope_ForwardsNullScope()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(42);
+        GetMyNotificationsQuery? capturedQuery = null;
+        _inboxHandlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<GetMyNotificationsQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<GetMyNotificationsQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(Result.Success(new PagedCollectionResult<UserNotificationDTO>()));
+        InboxController sut = CreateController();
+
+        await sut.GetInboxAsync();
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.ScopeKey.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetInboxAsync_Failure_ReturnsHandleFailure()
     {
         _currentUserServiceMock.Setup(s => s.UserId).Returns(42);
@@ -152,6 +186,40 @@ public sealed class NotificationInboxControllerTests
 
         capturedQuery.Should().NotBeNull();
         capturedQuery!.UserId.Should().Be(99);
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_WithScope_ForwardsScopeOnTheQuery()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(99);
+        GetUnreadNotificationCountQuery? capturedQuery = null;
+        _unreadCountHandlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<GetUnreadNotificationCountQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<GetUnreadNotificationCountQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(Result.Success(0));
+        InboxController sut = CreateController();
+
+        await sut.GetUnreadCountAsync(scope: "event:2");
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_WithoutScope_ForwardsNullScope()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(99);
+        GetUnreadNotificationCountQuery? capturedQuery = null;
+        _unreadCountHandlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<GetUnreadNotificationCountQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<GetUnreadNotificationCountQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(Result.Success(0));
+        InboxController sut = CreateController();
+
+        await sut.GetUnreadCountAsync();
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.ScopeKey.Should().BeNull();
     }
 
     [Fact]
@@ -277,6 +345,40 @@ public sealed class NotificationInboxControllerTests
 
         capturedCommand.Should().NotBeNull();
         capturedCommand!.UserId.Should().Be(77);
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_WithScope_ForwardsScopeOnTheCommand()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(77);
+        MarkAllNotificationsReadCommand? capturedCommand = null;
+        _markAllReadHandlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<MarkAllNotificationsReadCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<MarkAllNotificationsReadCommand, CancellationToken>((c, _) => capturedCommand = c)
+            .ReturnsAsync(Result.Success());
+        InboxController sut = CreateController();
+
+        await sut.MarkAllReadAsync(scope: "event:2");
+
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_WithoutScope_ForwardsNullScope()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(77);
+        MarkAllNotificationsReadCommand? capturedCommand = null;
+        _markAllReadHandlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<MarkAllNotificationsReadCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<MarkAllNotificationsReadCommand, CancellationToken>((c, _) => capturedCommand = c)
+            .ReturnsAsync(Result.Success());
+        InboxController sut = CreateController();
+
+        await sut.MarkAllReadAsync();
+
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.ScopeKey.Should().BeNull();
     }
 
     [Fact]

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/NotificationsControllerTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Notifications/NotificationsControllerTests.cs
@@ -152,6 +152,31 @@ public sealed class NotificationsControllerTests
         _captured!.DedupKey.Should().BeNull();
     }
 
+    // ── SendAsync: scope key travels on the request body ──
+    [Fact]
+    public async Task SendAsync_WithScopedRequest_PassesScopeKeyThroughOnTheCommand()
+    {
+        ArrangeCapture();
+        NotificationsController sut = CreateController();
+
+        await sut.SendAsync(new SendPushNotificationRequest("Title", "Body") { ScopeKey = "event:2" });
+
+        _captured.Should().NotBeNull();
+        _captured!.Request.ScopeKey.Should().Be("event:2");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithUnscopedRequest_LeavesScopeKeyNull()
+    {
+        ArrangeCapture();
+        NotificationsController sut = CreateController();
+
+        await sut.SendAsync(new SendPushNotificationRequest("Title", "Body"));
+
+        _captured.Should().NotBeNull();
+        _captured!.Request.ScopeKey.Should().BeNull();
+    }
+
     // ── GetHistoryAsync ──
     [Fact]
     public async Task GetHistoryAsync_Success_ReturnsOk()

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationInboxServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationInboxServiceTests.cs
@@ -22,14 +22,23 @@ public sealed class NotificationInboxServiceTests
 {
     private sealed record Mocks(StubHttpMessageHandler Handler, StubHttpClientFactory Factory);
 
+    /// <summary>Scope provider stub: whatever the app currently scopes to, or null for unscoped.</summary>
+    private sealed class StubScopeProvider(string? scopeKey) : INotificationScopeProvider
+    {
+        public Task<string?> GetCurrentScopeKeyAsync(CancellationToken ct = default) => Task.FromResult(scopeKey);
+    }
+
     private static (NotificationInboxService Sut, Mocks Mocks) CreateSut(
-        Func<HttpRequestMessage, HttpResponseMessage> responder)
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        string? scopeKey = null)
     {
         var handler = new StubHttpMessageHandler(responder);
         var factory = new StubHttpClientFactory(handler);
         var tokenStorage = new Mock<ITokenStorageService>();
         tokenStorage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync("stored-access-token");
-        return (new NotificationInboxService(factory, tokenStorage.Object), new Mocks(handler, factory));
+        return (
+            new NotificationInboxService(factory, tokenStorage.Object, new StubScopeProvider(scopeKey)),
+            new Mocks(handler, factory));
     }
 
     private static UserNotificationDTO Notification(int id, bool isRead = false) => new()
@@ -145,5 +154,64 @@ public sealed class NotificationInboxServiceTests
 
         mocks.Handler.LastRequest.Method.Should().Be(HttpMethod.Put);
         mocks.Handler.LastRequest.Uri!.PathAndQuery.Should().Be("/notifications/inbox/read-all");
+    }
+
+    // == Scope key ==
+    // The provider decides the scope; an unscoped app must produce the byte-identical legacy URLs
+    // pinned by the tests above, which is why those tests deliberately assert no scope parameter.
+    [Fact]
+    public async Task GetInboxAsync_WhenAppIsScoped_AppendsScopeToTheQuery()
+    {
+        var (sut, mocks) = CreateSut(_ => InboxResponse(Notification(1)), scopeKey: "event:2");
+
+        await sut.GetInboxAsync(pageNumber: 2, pageSize: 5, TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Uri!.PathAndQuery.Should()
+            .Be("/notifications/inbox?pageNumber=2&pageSize=5&scope=event%3A2");
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_WhenAppIsScoped_AppendsScopeToTheQuery()
+    {
+        var (sut, mocks) = CreateSut(
+            _ => StubHttpMessageHandler.CreateResponse(HttpStatusCode.OK, "3"),
+            scopeKey: "event:2");
+
+        await sut.GetUnreadCountAsync(TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Uri!.PathAndQuery.Should()
+            .Be("/notifications/inbox/unread-count?scope=event%3A2");
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_WhenAppIsScoped_AppendsScopeToTheQuery()
+    {
+        var (sut, mocks) = CreateSut(_ => new HttpResponseMessage(HttpStatusCode.NoContent), scopeKey: "event:2");
+
+        await sut.MarkAllReadAsync(TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Uri!.PathAndQuery.Should()
+            .Be("/notifications/inbox/read-all?scope=event%3A2");
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_WhenAppIsScoped_StaysUnscoped()
+    {
+        // A single mark-read targets one identifier the user already saw, so it needs no filter.
+        var (sut, mocks) = CreateSut(_ => new HttpResponseMessage(HttpStatusCode.NoContent), scopeKey: "event:2");
+
+        await sut.MarkReadAsync(42, TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Uri!.PathAndQuery.Should().Be("/notifications/inbox/42/read");
+    }
+
+    [Fact]
+    public async Task GetInboxAsync_WhenProviderReturnsWhitespace_OmitsTheScopeParameter()
+    {
+        var (sut, mocks) = CreateSut(_ => InboxResponse(Notification(1)), scopeKey: "   ");
+
+        await sut.GetInboxAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Uri!.PathAndQuery.Should().Be("/notifications/inbox?pageNumber=1&pageSize=20");
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/PushNotificationServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/PushNotificationServiceTests.cs
@@ -20,14 +20,23 @@ public sealed class PushNotificationServiceTests
 {
     private sealed record Mocks(StubHttpMessageHandler Handler, StubHttpClientFactory Factory);
 
+    /// <summary>Scope provider stub: whatever the app currently scopes to, or null for unscoped.</summary>
+    private sealed class StubScopeProvider(string? scopeKey) : INotificationScopeProvider
+    {
+        public Task<string?> GetCurrentScopeKeyAsync(CancellationToken ct = default) => Task.FromResult(scopeKey);
+    }
+
     private static (PushNotificationService Sut, Mocks Mocks) CreateSut(
-        Func<HttpRequestMessage, HttpResponseMessage> responder)
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        string? scopeKey = null)
     {
         var handler = new StubHttpMessageHandler(responder);
         var factory = new StubHttpClientFactory(handler);
         var tokenStorage = new Mock<ITokenStorageService>();
         tokenStorage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync("stored-access-token");
-        return (new PushNotificationService(factory, tokenStorage.Object), new Mocks(handler, factory));
+        return (
+            new PushNotificationService(factory, tokenStorage.Object, new StubScopeProvider(scopeKey)),
+            new Mocks(handler, factory));
     }
 
     private static PushNotificationDTO Sent(int id, string title = "Maintenance window") => new()
@@ -70,6 +79,52 @@ public sealed class PushNotificationServiceTests
             TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // == Scope stamping ==
+    [Fact]
+    public async Task SendAsync_WhenAppIsScoped_StampsScopeKeyOnTheRequestBody()
+    {
+        var (sut, mocks) = CreateSut(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Sent(7)) },
+            scopeKey: "event:2");
+
+        await sut.SendAsync(
+            new SendPushNotificationRequest("Maintenance window", "The site goes down at midnight."),
+            TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Body.Should().Contain("\"scopeKey\":\"event:2\"");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenAppIsUnscoped_SendsNullScopeKey()
+    {
+        var (sut, mocks) = CreateSut(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Sent(7)) });
+
+        await sut.SendAsync(
+            new SendPushNotificationRequest("Maintenance window", "The site goes down at midnight."),
+            TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Body.Should().Contain("\"scopeKey\":null");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenRequestAlreadyCarriesAScope_KeepsTheCallersScope()
+    {
+        // An explicit caller choice outranks the ambient one.
+        var (sut, mocks) = CreateSut(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Sent(7)) },
+            scopeKey: "event:2");
+
+        await sut.SendAsync(
+            new SendPushNotificationRequest("Maintenance window", "The site goes down at midnight.")
+            {
+                ScopeKey = "event:9",
+            },
+            TestContext.Current.CancellationToken);
+
+        mocks.Handler.LastRequest.Body.Should().Contain("\"scopeKey\":\"event:9\"");
     }
 
     [Fact]


### PR DESCRIPTION
## What

1. **Event-scoped notifications**: adds an optional opaque `ScopeKey` (nullable, max 128, e.g. `event:2`) to the push-notification feature so a consuming app can scope the inbox, the unread badge, and bulk mark-read to its current context. ADC will use this to keep notifications sent during one conference edition out of the next edition's view.
2. **Dark-mode fixes in the shared stylesheet**: `.mmca-section-heading .mud-icon` and `.mmca-section-description` used hardcoded black values that broke on the dark palette; both now follow the MudBlazor palette variables.

## Semantics

- **Absent/null scope = legacy behavior.** The inbox query keeps its exact shape, and the unread-count and mark-all-read paths keep their no-join queries (an unconditional join would have pulled PushNotification's soft-delete global filter into counts nobody asked to change). Store and Helpdesk register no provider and are unaffected.
- **Supplied scope** shows/counts/marks rows where `ScopeKey IS NULL OR ScopeKey = @scope`. A scoped client never marks rows it cannot see as read.
- Scope is a **view filter, not a security boundary**.
- Sends: `SendPushNotificationRequest.ScopeKey` (init property, no ctor break). The UI `PushNotificationService` stamps the app's current scope on unscoped requests via the new `INotificationScopeProvider` (TryAdd'd null default in `AddNotificationUI`); the same provider drives `NotificationInboxService` reads, so what gets sent and what gets shown always resolve to one scope.
- Organizer history stays unfiltered; hub/live layer and native push untouched; UI components untouched.

## Notes

- SignalR toast/optimistic badge increments ignore scope by design (audience is unchanged); the next scoped API refresh reconciles.
- Consumer follow-up: ADC adds its provider + the `ScopeKey` column migration (with `event:1` backfill) in its own PR after the release.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings / 0 errors
- `dotnet test --solution MMCA.Common.slnx -c Release`: 3019 passed, 0 failed
- Out-of-slnx UI Gallery + E2E: 37/37 (includes dark-mode axe scans over the modified app.css)
- FACTS drift gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENTftX9MwQoS2FpSSubp9Q