### PR TITLE
feat: enterprise capability wave (8 opt-in features)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -856,8 +856,8 @@ dotnet_diagnostic.S8969.severity = suggestion
 #   - Testing.Architecture/Bases/ and Testing.UI/Infrastructure/: the folder is organizational,
 #     but the namespace is the package's flat public API surface (consumers subclass these
 #     bases; ADR-015). Renaming the namespace would be a breaking change for every consumer.
-#   - Aspire/DataProtection/: extension methods stay in the MMCA.Common.Aspire namespace so a
-#     host gets them through the using directive it already has.
+#   - Aspire/DataProtection/ and Aspire/Configuration/: extension methods stay in the
+#     MMCA.Common.Aspire namespace so a host gets them through the using directive it already has.
 #   - API.Tests/Fakes/: the fake controller deliberately carries a consumer-shaped namespace
 #     (Fakes.MMCA.Store...) because the convention under test keys on namespace shape.
 [Source/Hosting/MMCA.Common.Testing.Architecture/Bases/**.cs]
@@ -867,6 +867,9 @@ dotnet_diagnostic.IDE0130.severity = none
 dotnet_diagnostic.IDE0130.severity = none
 
 [Source/Hosting/MMCA.Common.Aspire/DataProtection/**.cs]
+dotnet_diagnostic.IDE0130.severity = none
+
+[Source/Hosting/MMCA.Common.Aspire/Configuration/**.cs]
 dotnet_diagnostic.IDE0130.severity = none
 
 [Tests/Presentation/MMCA.Common.API.Tests/Fakes/**.cs]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,68 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+The enterprise capability wave: eight opt-in features in one release. Everything below is inert
+until a host calls the matching registration extension, so upgrading the pins alone changes no
+behavior.
+
+### Added
+
+- **Multi-tenancy (shared-schema + database-per-tenant).** `ITenantEntity` entities gain a named
+  `"Tenant"` EF query filter composing with the existing `"SoftDelete"` filter (one cached model
+  serves every tenant; the tenant value is a query parameter). `TenantResolutionMiddleware`
+  resolves claim-then-header per `Tenancy` settings (fail-closed `RequireTenant` default),
+  `TenantSaveChangesInterceptor` stamps `TenantId` on insert and throws `CrossTenantWriteException`
+  on cross-tenant writes, and per-tenant `DataSources` overrides route a tenant onto its own
+  database through the same `DataSourceKey` (outbox drained per `(source, tenant)` pair; startup
+  migrations get a per-tenant pass). A null tenant is the system context and sees all rows.
+  Opt in with `AddMultiTenancy(configuration)`.
+- **Recurring job scheduler.** `IScheduledJob` (cron via Cronos, UTC) over a `ScheduledJobs` store
+  in the Default relational source, claim-leased by `ScheduledJobRunner` so exactly one replica
+  runs a due job; missed occurrences run once then advance. Config cron overrides win over code
+  defaults; OTel meter `MMCA.Common.Scheduler`. Opt in with `AddScheduledJobs(configuration)` +
+  `AddScheduledJob<TJob>()`.
+- **Audit trail.** `IAuditedEntity` aggregates get field-level change history
+  (`AuditTrailEntries`, one row per changed property, written in the same transaction as the data;
+  `[Pii]` values are stored as `[REDACTED]` on both sides). Retention ships as the first framework
+  scheduled job (`audit-trail-cleanup`). Minimal `IAuditTrailReader` read surface. Opt in with
+  `AddAuditTrail(configuration)`.
+- **Data-subject export (DSAR).** `ExportUserDataHandlerBase<TUser, TQuery>` hoists the
+  ADC/Store export idiom (ownership gate, best-effort `IUserDataExportSection` fan-out that
+  degrades a failing section to `Available = false`), with a `UserDataExportDTO` wire envelope in
+  Shared and an abstract `DataExportControllerBase` (authorized, gated by the new
+  `Privacy.DataExport` feature flag) for hosts that want the JSON download surface.
+- **CSV export on the generic entity controllers.** `GET {controller}/export` streams RFC 4180
+  CSV (UTF-8 BOM, ISO 8601 invariant dates, columns matching the JSON field names) through the
+  existing query pipeline, honoring `fields`, `filters` and sorting, capped by
+  `ApplicationSettings.MaxExportRows` (default 100000) with an `X-Export-Row-Limit` header and a
+  trailing truncation marker. A distinct route by design: the public output-cache policy does not
+  vary by `Accept`.
+- **`Enumeration<TEnumeration>` smart-enum base** in `Shared/ValueObjects` (closed sets with
+  behavior: `FromValue`/`FromName` returning `Result<T>`, frozen lookups, name-based JSON via
+  `EnumerationJsonConverterFactory` registered in `AddAPI`, EF `EnumerationValueConverter` pair).
+- **Azure Key Vault configuration provider.** `AddCommonKeyVaultConfiguration()` (Aspire package)
+  wires `KeyVault:Uri` into the configuration pipeline via `DefaultAzureCredential`; no-op when
+  the key is absent, optional reload interval, requires the Key Vault Secrets User role the
+  deployment sample already grants.
+- **HybridCache substrate (opt-in).** `AddCommonHybridCache()` swaps `ICacheService` to a
+  HybridCache-backed implementation (L1 + L2, stampede protection) under a disjoint
+  `hc:` keyspace so the old and new serialization formats can never cross-read; counters bypass
+  the local cache to keep L2-only semantics. `ICacheService` gains a non-breaking
+  `GetOrCreateAsync` default member. The default path without the call is unchanged.
+
+### Changed
+
+- **`IPhysicalDbContextFactory` gained an abstract member** `Create(DataSourceKey, PhysicalDataSource)`
+  (per-tenant routing). Custom implementors must add it; the framework implementation and all
+  shipped call sites are updated.
+- **Repository `ignoreQueryFilters: true` now means "include soft-deleted rows" only**: the
+  tenant filter survives via the named-filter overload, so an admin read can no longer silently
+  cross tenants. Callers of EF's own parameterless `IgnoreQueryFilters()` on raw `Table` surfaces
+  still bypass every filter; prefer the repository parameter.
+- New pins: `Cronos` 0.13.0, `Microsoft.Extensions.Caching.Hybrid` 10.8.0 (10.9.0 skews shared
+  Microsoft.Extensions transitives to 10.0.11), `Azure.Extensions.AspNetCore.Configuration.Secrets`
+  1.5.1.
+
 > **Consumer versions skipped deliberately.** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
 > 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
 > is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,6 +78,12 @@
          Projects with the AspNetCore framework reference prune this away; consumers WITHOUT it
          (Aspire AppHosts) resolve the transitive as a real package and need the lifted version. -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+    <!-- Azure Key Vault as a configuration source (MMCA.Common.Aspire.AddCommonKeyVaultConfiguration).
+         Opt-in and gated on KeyVault:Uri, so an unconfigured host never contacts a vault and local
+         development stays Azure-free. Reuses the Azure.Identity pin above for the
+         DefaultAzureCredential the provider authenticates with; the host identity needs the
+         Key Vault Secrets User role on the vault (samples/deployment/DEPLOYMENT.md, bootstrap step 3). -->
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,18 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" />
     <PackageVersion Include="MiniProfiler.EntityFrameworkCore" Version="4.5.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
+    <!-- Two-level cache (L1 in-process + L2 distributed) behind the opt-in AddCommonHybridCache
+         (HybridCacheService). Deliberately writes under its own disjoint 'hc:' keyspace so it can
+         never cross-read an entry DistributedCacheService wrote: two serialization formats sharing
+         one key is the WRONGTYPE production failure this framework already paid for once.
+         Held at 10.8.0, the same dotnet/extensions train as Http.Resilience, ServiceDiscovery and
+         TimeProvider.Testing, rather than the newer 10.9.0: 10.9.0 floors Microsoft.Extensions
+         .Caching.Abstractions/Memory (and through them DependencyInjection.Abstractions, Logging
+         .Abstractions, Options, Primitives) at 10.0.11, above the 10.0.10 every other pin here
+         resolves. Projects with the framework reference prune those away, but the ones without it
+         resolve them as real packages, so the newer pin quietly moves five shared transitives across
+         the graph for no functional gain. At 10.8.0 this adds exactly one entry per lock file. -->
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <!-- Messaging (MassTransit) -->
     <!-- Pinned to v8 (free). v9.x introduced a commercial license requirement; the bus fails the

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,6 +60,15 @@
          resolve them as real packages, so the newer pin quietly moves five shared transitives across
          the graph for no functional gain. At 10.8.0 this adds exactly one entry per lock file. -->
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
+    <!-- Cron expression parsing for the opt-in recurring job scheduler (ScheduledJobRunner). MIT,
+         zero-dependency (netstandard2.0, no transitive graph at all), and it does exactly one thing:
+         parse a five-field expression and answer "what is the next occurrence after this UTC
+         instant". Deliberately NOT Hangfire or Quartz: both ship their own persistence, their own
+         worker/thread model and their own dashboards, all of which duplicate machinery this
+         framework already owns and has production history with (the OutboxProcessor claim-lease
+         idiom, the DI scope-per-execution pattern, the OpenTelemetry meters). The only piece the
+         framework lacked was the cron grammar, so that is the only piece taken as a dependency. -->
+    <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <!-- Messaging (MassTransit) -->
     <!-- Pinned to v8 (free). v9.x introduced a commercial license requirement; the bus fails the

--- a/Source/Core/MMCA.Common.Application/Auditing/AuditTrailEntryDTO.cs
+++ b/Source/Core/MMCA.Common.Application/Auditing/AuditTrailEntryDTO.cs
@@ -1,0 +1,49 @@
+namespace MMCA.Common.Application.Auditing;
+
+/// <summary>
+/// One recorded change in an entity's history, as returned by <c>IAuditTrailReader</c>.
+/// </summary>
+/// <remarks>
+/// A read-side projection of the framework's trail row, deliberately minimal in v1: it carries what
+/// a "who changed what, and when" view needs and nothing an infrastructure table happens to also
+/// store. Values are the invariant string forms recorded at capture time, and a value that belonged
+/// to a property marked as personal data reads as the redaction placeholder on both sides.
+/// </remarks>
+public sealed record AuditTrailEntryDTO
+{
+    /// <summary>Gets the identifier of the trail row.</summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>Gets the full CLR type name of the entity that changed.</summary>
+    public required string EntityType { get; init; }
+
+    /// <summary>Gets the invariant string form of the changed entity's primary key.</summary>
+    public required string EntityKey { get; init; }
+
+    /// <summary>
+    /// Gets the name of the property that changed, or <see langword="null"/> on the summary row of
+    /// a create or delete.
+    /// </summary>
+    public string? PropertyName { get; init; }
+
+    /// <summary>Gets the value before the change, or <see langword="null"/>.</summary>
+    public string? OldValue { get; init; }
+
+    /// <summary>Gets the value after the change, or <see langword="null"/>.</summary>
+    public string? NewValue { get; init; }
+
+    /// <summary>Gets the operation: <c>Added</c>, <c>Modified</c> or <c>Deleted</c>.</summary>
+    public required string Operation { get; init; }
+
+    /// <summary>
+    /// Gets the user the change was saved as, or <see langword="null"/> when the save carried no
+    /// identity (a background service, a seeder).
+    /// </summary>
+    public UserIdentifierType? ChangedBy { get; init; }
+
+    /// <summary>Gets the UTC instant the change was recorded.</summary>
+    public required DateTime ChangedOn { get; init; }
+
+    /// <summary>Gets the trace identifier the change was recorded under, or <see langword="null"/>.</summary>
+    public string? CorrelationId { get; init; }
+}

--- a/Source/Core/MMCA.Common.Application/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Application/DependencyInjection.cs
@@ -8,6 +8,7 @@ using MMCA.Common.Application.Services.Query;
 using MMCA.Common.Application.Settings;
 using MMCA.Common.Application.UseCases;
 using MMCA.Common.Application.UseCases.Decorators;
+using MMCA.Common.Application.Users.UseCases.ExportUserData;
 using MMCA.Common.Application.Validation;
 using MMCA.Common.Shared.Abstractions;
 
@@ -174,6 +175,39 @@ public static class DependencyInjection
                 services.TryAddTransient(serviceType, validatorType);
             }
 
+            return services;
+        }
+
+        /// <summary>
+        /// Registers one <see cref="IUserDataExportSection"/> implementation as a contributor to the
+        /// data-subject export.
+        /// </summary>
+        /// <typeparam name="TSection">The section implementation.</typeparam>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// Sections accumulate: each module calls this for the data it owns and every registration is
+        /// added to the same <c>IEnumerable&lt;IUserDataExportSection&gt;</c> the export handler fans
+        /// out over, exactly like the scheduled-job and permission-registry idioms. The same type
+        /// registered twice is added once, and registration order is the order the sections appear in
+        /// the export document.
+        /// </para>
+        /// <para>
+        /// The section is <b>scoped</b>: it runs inside the request's unit of work, so it may take
+        /// scoped dependencies (repositories, gRPC clients, handlers).
+        /// </para>
+        /// <para>
+        /// The export handler itself needs no registration here. Apps subclass
+        /// <c>ExportUserDataHandlerBase&lt;TUser, TQuery&gt;</c> in their own Application assembly,
+        /// and <see cref="ScanModuleApplicationServices{TAssemblyMarker}"/> picks the concrete
+        /// subclass up as an <c>IQueryHandler</c> like any other handler.
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddUserDataExportSection<TSection>()
+            where TSection : class, IUserDataExportSection
+        {
+            services.TryAddScoped<TSection>();
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<IUserDataExportSection, TSection>());
             return services;
         }
 

--- a/Source/Core/MMCA.Common.Application/Interfaces/IAuditTrailReader.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/IAuditTrailReader.cs
@@ -1,0 +1,43 @@
+using MMCA.Common.Application.Auditing;
+
+namespace MMCA.Common.Application.Interfaces;
+
+/// <summary>
+/// Reads the recorded change history of one entity. Registered by <c>AddAuditTrail</c>; a host that
+/// never opted in has no implementation to resolve.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The framework ships the read, not the exposure: there is no shipped endpoint or page in v1,
+/// because who may see an entity's history is an application decision (an admin screen, a support
+/// tool, a data-subject request) rather than a framework one. Consumers wrap this in whatever query
+/// and authorization their domain calls for.
+/// </para>
+/// <para>
+/// Rows come back newest first, so the first page is the most recent activity.
+/// </para>
+/// </remarks>
+public interface IAuditTrailReader
+{
+    /// <summary>
+    /// Returns one page of the change history recorded for a single entity, newest change first.
+    /// </summary>
+    /// <param name="entityType">
+    /// The full CLR type name of the entity, as recorded on the trail row (for example
+    /// <c>typeof(Order).FullName</c>).
+    /// </param>
+    /// <param name="entityKey">
+    /// The invariant string form of the entity's primary key; the parts of a composite key joined
+    /// with <c>|</c> in the model's key order.
+    /// </param>
+    /// <param name="page">The 1-based page number; values below 1 are treated as 1.</param>
+    /// <param name="pageSize">The page size; values below 1 are treated as 1.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The recorded changes for that entity, or an empty list when it has no history.</returns>
+    Task<IReadOnlyList<AuditTrailEntryDTO>> GetForEntityAsync(
+        string entityType,
+        string entityKey,
+        int page = 1,
+        int pageSize = 50,
+        CancellationToken cancellationToken = default);
+}

--- a/Source/Core/MMCA.Common.Application/Interfaces/ICacheService.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/ICacheService.cs
@@ -1,3 +1,5 @@
+using MMCA.Common.Shared.Concurrency;
+
 namespace MMCA.Common.Application.Interfaces;
 
 /// <summary>
@@ -61,4 +63,84 @@ public interface ICacheService
         await SetAsync(key, next, expiration, cancellationToken).ConfigureAwait(false);
         return next;
     }
+
+    /// <summary>
+    /// Returns the cached value for <paramref name="key"/>, or invokes <paramref name="factory"/>
+    /// and caches its result. Concurrent misses on one key run the factory once per process
+    /// (stampede protection), the same shape
+    /// <see cref="UseCases.Decorators.CachingQueryDecorator{TQuery,TResult}"/> applies to cacheable
+    /// queries.
+    /// </summary>
+    /// <typeparam name="T">The cached value type.</typeparam>
+    /// <param name="key">The cache key.</param>
+    /// <param name="factory">Produces the value when the key is absent.</param>
+    /// <param name="expiration">Optional expiration applied to the value the factory produced.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cached value, or the value the factory produced.</returns>
+    /// <remarks>
+    /// <para>
+    /// Caching is unconditional: whatever the factory returns is stored, including a failed
+    /// <see cref="Shared.Abstractions.Result"/> or a <see langword="null"/>-equivalent value. A
+    /// caller that must not cache failures has to keep its own read/execute/write sequence, which
+    /// is exactly why the caching decorators do NOT route through this member.
+    /// </para>
+    /// <para>
+    /// Stampede protection is best-effort and per process: the stripe is a process-wide table, so
+    /// with several replicas over one shared cache the factory can still run once per replica.
+    /// A cluster-wide guarantee would need a distributed lock and is deliberately not attempted.
+    /// </para>
+    /// <para>
+    /// The default implementation is get, then per-key stripe, then a double-check, then factory and
+    /// set: correct for every backing store and a non-breaking addition (the
+    /// <see cref="IncrementAsync"/> precedent). Implementations with a native two-level primitive
+    /// (<c>HybridCacheService</c>) override it.
+    /// </para>
+    /// </remarks>
+    async Task<T> GetOrCreateAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T>> factory,
+        TimeSpan? expiration = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        // Fast path: no lock on a hit.
+        var cached = await GetAsync<T>(key, cancellationToken).ConfigureAwait(false);
+        if (cached is not null)
+            return cached;
+
+        using (await CacheKeyLocks.Locks.AcquireAsync(key, cancellationToken).ConfigureAwait(false))
+        {
+            // Double-check: the request that held the stripe has populated the key by now, so the
+            // waiters read the fresh entry instead of re-running the factory.
+            cached = await GetAsync<T>(key, cancellationToken).ConfigureAwait(false);
+            if (cached is not null)
+                return cached;
+
+            var created = await factory(cancellationToken).ConfigureAwait(false);
+            await SetAsync(key, created, expiration, cancellationToken).ConfigureAwait(false);
+            return created;
+        }
+    }
+}
+
+/// <summary>
+/// Process-wide per-cache-key locks for the default
+/// <see cref="ICacheService.GetOrCreateAsync{T}(string, Func{CancellationToken, Task{T}}, TimeSpan?, CancellationToken)"/>
+/// implementation. Kept in a non-generic holder so every closed generic call shares one table
+/// (statics on a generic method's declaring type would still be shared, but a holder keeps the
+/// table addressable and matches <c>QueryCacheKeyLocks</c>).
+/// </summary>
+/// <remarks>
+/// Striped rather than one semaphore per key, for the reasons documented on
+/// <see cref="KeyedSemaphoreStripe"/>: a per-key table forces a choice between dropping the entry
+/// on release (two callers then run concurrently) and never dropping it (a parameterized cache key
+/// grows the table without bound). Separate from the caching decorator's table on purpose: these
+/// are different call sites over different keys, and sharing stripes would only widen the
+/// unrelated-key collisions striping already tolerates.
+/// </remarks>
+internal static class CacheKeyLocks
+{
+    /// <summary>Fixed-width stripes shared by every caller of the default implementation.</summary>
+    internal static readonly KeyedSemaphoreStripe Locks = new();
 }

--- a/Source/Core/MMCA.Common.Application/Interfaces/IScheduledJob.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/IScheduledJob.cs
@@ -1,0 +1,79 @@
+namespace MMCA.Common.Application.Interfaces;
+
+/// <summary>
+/// A unit of recurring work driven by a cron schedule. Implementations are registered with
+/// <c>AddScheduledJob&lt;TJob&gt;()</c> and executed by the framework's scheduler once
+/// <c>AddScheduledJobs(configuration)</c> has been called and <c>Scheduler:Enabled</c> is true.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Lifetime.</b> Jobs are resolved <b>scoped</b>, in a fresh DI scope created for each
+/// execution, exactly like a request. A job may therefore take scoped dependencies (a unit of
+/// work, a repository, a command handler) and must not hold state between executions: the
+/// instance that ran the previous occurrence is already disposed.
+/// </para>
+/// <para>
+/// <b>Single runner across replicas.</b> A scaled-out service runs one scheduler per replica, but
+/// an occurrence executes exactly once: the persistent job store hands out a claim lease per row
+/// (the outbox processor's claim idiom), so the replica that wins the claim is the only one that
+/// runs the job. A replica that dies mid-execution releases its claim implicitly when the lease
+/// expires, and the occurrence is picked up again.
+/// </para>
+/// <para>
+/// <b>Missed occurrences do not pile up.</b> After an outage (or any window where no replica was
+/// running), a job whose schedule elapsed several times runs <b>once</b> and its next run is then
+/// computed from the current instant, not from the backlog. There is no catch-up storm: a job that
+/// missed forty hourly occurrences overnight runs once at startup and returns to its hourly
+/// cadence. Work that must not be skipped therefore has to be idempotent and range-driven
+/// (process everything since the last successful run) rather than relying on one run per tick.
+/// </para>
+/// <para>
+/// <b>Failures are recorded, not fatal.</b> An exception thrown by <see cref="ExecuteAsync"/> is
+/// caught, logged and stamped on the job row as a failed outcome; the schedule still advances and
+/// the scheduler loop survives. A job is never retried within its own occurrence.
+/// </para>
+/// </remarks>
+public interface IScheduledJob
+{
+    /// <summary>
+    /// Gets the stable identity of this job, unique within the host. It is the primary key of the
+    /// persisted job row and the value the scheduler resolves back to this implementation, so it
+    /// must not change once deployed (renaming it strands the old row and starts a new schedule)
+    /// and two registered jobs must never share it.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the default schedule as a <b>five-field</b> cron expression
+    /// (<c>minute hour day-of-month month day-of-week</c>), parsed by Cronos.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Examples: <c>*/5 * * * *</c> (every five minutes), <c>0 * * * *</c> (hourly, on the hour),
+    /// <c>0 3 * * *</c> (daily at 03:00), <c>0 2 * * 1</c> (Mondays at 02:00). Cronos also accepts
+    /// ranges (<c>1-5</c>), lists (<c>1,15</c>), steps (<c>*/10</c>), and <c>L</c> / <c>W</c> /
+    /// <c>#</c> in the day fields.
+    /// </para>
+    /// <para>
+    /// <b>All times are UTC.</b> Occurrences are computed against the UTC clock, never a local or
+    /// configured time zone, so a schedule never shifts, doubles or vanishes across a daylight
+    /// saving transition. A job that must fire at a wall-clock local hour has to encode the offset
+    /// itself and accept the seasonal one-hour drift.
+    /// </para>
+    /// <para>
+    /// This value is the <b>default</b>. A host overrides it per job without touching code through
+    /// <c>Scheduler:Jobs:{Name}:Cron</c> in configuration, which wins whenever it is present.
+    /// </para>
+    /// </remarks>
+    string CronExpression { get; }
+
+    /// <summary>
+    /// Runs one occurrence of the job.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// Cancelled on host shutdown. Long-running jobs should honor it: work that ignores it delays
+    /// shutdown and can outlive its claim lease.
+    /// </param>
+    /// <returns>A task that completes when the occurrence has finished.</returns>
+    Task ExecuteAsync(CancellationToken cancellationToken);
+}

--- a/Source/Core/MMCA.Common.Application/Interfaces/ITenantContext.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/ITenantContext.cs
@@ -1,0 +1,42 @@
+namespace MMCA.Common.Application.Interfaces;
+
+/// <summary>
+/// Provides access to the tenant the current scope runs as. Set by
+/// <c>TenantResolutionMiddleware</c> from a claim or a header, and read by the persistence layer
+/// (query filters, the tenant save interceptor, per-tenant database routing) and by the caching
+/// decorators.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors <see cref="ICorrelationContext"/>: one scoped instance per request, populated once at
+/// the edge. Unlike the correlation id there is no generated fallback. An unresolved tenant is a
+/// meaningful state (a background service, a seeder, an admin flow) and reads as "see everything",
+/// so inventing a value would silently scope a system operation to a tenant that does not exist.
+/// </para>
+/// <para>
+/// <b>One scope, one tenant.</b> <see cref="SetTenant"/> accepts the value it already holds and
+/// throws on a different one. A scope whose tenant changed mid-flight would have already read rows
+/// under the previous tenant, and there is no honest way to reconcile that after the fact.
+/// </para>
+/// </remarks>
+public interface ITenantContext
+{
+    /// <summary>
+    /// Gets the tenant identifier for the current scope, or <see langword="null"/> when no tenant
+    /// has been resolved.
+    /// </summary>
+    string? TenantId { get; }
+
+    /// <summary>Gets a value indicating whether a tenant has been resolved for this scope.</summary>
+    bool IsResolved { get; }
+
+    /// <summary>
+    /// Sets the tenant for the current scope. Idempotent for the value already held.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier to set.</param>
+    /// <exception cref="ArgumentException"><paramref name="tenantId"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A different tenant was already resolved for this scope.
+    /// </exception>
+    void SetTenant(string tenantId);
+}

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
@@ -11,6 +11,11 @@ namespace MMCA.Common.Application.Interfaces.Infrastructure;
 /// </summary>
 /// <typeparam name="TEntity">The entity type.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
+/// <remarks>
+/// Every <c>ignoreQueryFilters</c> parameter on this interface means "include soft-deleted rows",
+/// nothing more. It drops the named <c>SoftDelete</c> filter and leaves the named <c>Tenant</c>
+/// filter applied.
+/// </remarks>
 public interface IEntityReader<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull
@@ -31,7 +36,11 @@ public interface IEntityReader<TEntity, TIdentifierType>
     /// <param name="ids">The collection of primary keys to look up.</param>
     /// <param name="includes">Navigation properties to eager-load.</param>
     /// <param name="asTracking">Whether to track the returned entities for changes.</param>
-    /// <param name="ignoreQueryFilters">Whether to bypass EF global query filters (e.g., soft-delete).</param>
+    /// <param name="ignoreQueryFilters">
+    /// Whether to include soft-deleted rows. It drops the <c>SoftDelete</c> global query filter and
+    /// <b>only</b> that one: the <c>Tenant</c> filter stays in force, so a caller asking for deleted
+    /// rows can never read another tenant's data.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A read-only collection of matching entities (may be fewer than requested if some IDs don't exist).</returns>
     Task<IReadOnlyCollection<TEntity>> GetByIdsAsync(
@@ -61,6 +70,11 @@ public interface IEntityReader<TEntity, TIdentifierType>
 /// </summary>
 /// <typeparam name="TEntity">The entity type.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
+/// <remarks>
+/// Every <c>ignoreQueryFilters</c> parameter on this interface means "include soft-deleted rows",
+/// nothing more. It drops the named <c>SoftDelete</c> filter and leaves the named <c>Tenant</c>
+/// filter applied.
+/// </remarks>
 public interface IEntityQuerier<TEntity, TIdentifierType>
     where TEntity : AuditableBaseEntity<TIdentifierType>
     where TIdentifierType : notnull

--- a/Source/Core/MMCA.Common.Application/Settings/ApplicationSettings.cs
+++ b/Source/Core/MMCA.Common.Application/Settings/ApplicationSettings.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace MMCA.Common.Application.Settings;
 
 /// <summary>
@@ -13,6 +15,18 @@ public sealed class ApplicationSettings : IApplicationSettings
 
     /// <inheritdoc />
     public int MaxPageSize { get; init; } = 500;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// 100,000 rows is roughly a 10-25 MB file for a typical grid DTO: large enough that no real
+    /// operational export hits the cap, small enough that one caller cannot pin a request thread to a
+    /// full-table scan. This is the only property on this class carrying a validation attribute today;
+    /// it is honored by hosts that opt into <c>ValidateDataAnnotations</c> on the options binding, and
+    /// the export endpoint independently falls back to this default when a host configures a
+    /// non-positive value.
+    /// </remarks>
+    [Range(1, 10_000_000)]
+    public int MaxExportRows { get; init; } = 100_000;
 
     /// <inheritdoc />
     public string DatabaseInitStrategy { get; init; } = "Migrate";

--- a/Source/Core/MMCA.Common.Application/Settings/IApplicationSettings.cs
+++ b/Source/Core/MMCA.Common.Application/Settings/IApplicationSettings.cs
@@ -13,6 +13,13 @@ public interface IApplicationSettings
     int MaxPageSize { get; init; }
 
     /// <summary>
+    /// Maximum number of rows a single CSV export may stream before it stops and marks itself
+    /// truncated. The export endpoint page-loops the query service at <see cref="MaxPageSize"/> per
+    /// page, so this is the ceiling on the whole file, not on one page.
+    /// </summary>
+    int MaxExportRows { get; init; }
+
+    /// <summary>
     /// Controls database initialization strategy on startup.
     /// <list type="bullet">
     ///   <item><c>"Migrate"</c> — applies pending EF Core migrations (development/testing).</item>

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingCommandDecorator.cs
@@ -20,13 +20,20 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// any failure is logged at warning level and swallowed rather than propagated: a cache outage must
 /// never turn a committed command into a failure. Entries left behind expire on their own TTL.
 /// </para>
+/// <para>
+/// Under multi-tenancy the prefix is scoped to the resolved tenant (<c>t:{tenantId}:</c>) by the
+/// same transformation <see cref="CachingQueryDecorator{TQuery, TResult}"/> applies to its keys, so
+/// an invalidation evicts exactly the entries this tenant's queries wrote and can never evict
+/// another tenant's cache. With no tenant resolved the prefix is untouched.
+/// </para>
 /// </summary>
 /// <typeparam name="TCommand">The command type.</typeparam>
 /// <typeparam name="TResult">The result type returned by the handler.</typeparam>
 public sealed partial class CachingCommandDecorator<TCommand, TResult>(
     ICommandHandler<TCommand, TResult> inner,
     ICacheService cacheService,
-    ILogger<CachingCommandDecorator<TCommand, TResult>> logger) : ICommandHandler<TCommand, TResult>
+    ILogger<CachingCommandDecorator<TCommand, TResult>> logger,
+    ITenantContext? tenantContext = null) : ICommandHandler<TCommand, TResult>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CachingCommandDecorator{TCommand, TResult}"/> class
@@ -70,11 +77,15 @@ public sealed partial class CachingCommandDecorator<TCommand, TResult>(
             && !string.IsNullOrWhiteSpace(cacheInvalidating.CachePrefix)
             && !IsFailure(result))
         {
+            // Scoped to the tenant the command ran as, exactly as the query decorator scoped the
+            // keys it wrote.
+            var cachePrefix = TenantCacheKey.Scope(tenantContext, cacheInvalidating.CachePrefix);
+
             try
             {
                 // CancellationToken.None, not the request token: the command has committed, so the
                 // cleanup must outlive a caller that has already walked away.
-                await cacheService.RemoveByPrefixAsync(cacheInvalidating.CachePrefix, CancellationToken.None)
+                await cacheService.RemoveByPrefixAsync(cachePrefix, CancellationToken.None)
                     .ConfigureAwait(false);
 
                 // A read that missed the cache before this command committed can still be running its
@@ -82,13 +93,13 @@ public sealed partial class CachingCommandDecorator<TCommand, TResult>(
                 // A second, delayed eviction removes that repopulated entry. Best-effort like the
                 // first one: ICacheService is a singleton, so the follow-up outlives the request scope
                 // safely, and anything it cannot evict expires on its own TTL.
-                InvalidationFollowUp = ReInvalidateAfterDelayAsync(cacheInvalidating.CachePrefix);
+                InvalidationFollowUp = ReInvalidateAfterDelayAsync(cachePrefix);
             }
 #pragma warning disable CA1031 // Do not catch general exception types: invalidation is best-effort and must never fail a committed command
             catch (Exception ex)
 #pragma warning restore CA1031
             {
-                LogCacheInvalidationFailed(logger, cacheInvalidating.CachePrefix, typeof(TCommand).Name, ex);
+                LogCacheInvalidationFailed(logger, cachePrefix, typeof(TCommand).Name, ex);
             }
         }
 

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingQueryDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/CachingQueryDecorator.cs
@@ -21,13 +21,21 @@ namespace MMCA.Common.Application.UseCases.Decorators;
 /// <see cref="OperationCanceledException"/> is excluded from the guard, so a genuinely cancelled
 /// request still surfaces exactly as the inner handler would.
 /// </para>
+/// <para>
+/// <b>Tenant isolation lives here, not in the cache.</b> <c>ICacheService</c> is a singleton and
+/// cannot see the scoped tenant, so a cache key that two tenants both compute would serve one
+/// tenant's rows to the other. When a tenant is resolved the decorator prefixes the key (and the
+/// stampede lock) with <c>t:{tenantId}:</c>; when none is, keys are exactly what they were before
+/// tenancy shipped.
+/// </para>
 /// </summary>
 /// <typeparam name="TQuery">The query type.</typeparam>
 /// <typeparam name="TResult">The result type returned by the handler.</typeparam>
 public sealed partial class CachingQueryDecorator<TQuery, TResult>(
     IQueryHandler<TQuery, TResult> inner,
     ICacheService cacheService,
-    ILogger<CachingQueryDecorator<TQuery, TResult>> logger) : IQueryHandler<TQuery, TResult>
+    ILogger<CachingQueryDecorator<TQuery, TResult>> logger,
+    ITenantContext? tenantContext = null) : IQueryHandler<TQuery, TResult>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CachingQueryDecorator{TQuery, TResult}"/> class
@@ -45,6 +53,16 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
     {
     }
 
+    /// <summary>
+    /// The cache key for this query in the current tenant: the query's own key, prefixed with the
+    /// tenant when one is resolved. Two tenants therefore never share an entry, and a host that
+    /// resolves no tenant keeps byte-identical keys to the pre-tenancy framework.
+    /// </summary>
+    /// <param name="cacheable">The cacheable query carrying the key.</param>
+    /// <returns>The effective cache key.</returns>
+    private string EffectiveKey(IQueryCacheable cacheable) =>
+        TenantCacheKey.Scope(tenantContext, cacheable.CacheKey);
+
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TQuery query, CancellationToken cancellationToken = default)
     {
@@ -53,8 +71,12 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
 
         var queryName = typeof(TQuery).Name;
 
+        // Tenant-scoped from here down: read, stampede lock and populate must all agree, or one
+        // tenant would wait on another's lock and read another's entry.
+        var cacheKey = EffectiveKey(cacheable);
+
         // Fast path: no lock on a hit.
-        var cached = await TryReadAsync(cacheable, queryName, cancellationToken).ConfigureAwait(false);
+        var cached = await TryReadAsync(cacheKey, queryName, cancellationToken).ConfigureAwait(false);
         if (cached is not null)
         {
             CqrsMetrics.RecordCacheHit(queryName);
@@ -64,9 +86,9 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
         // Slow path: per-key double-check locking (same pattern as IdempotencyFilter). On
         // expiry of a hot key only one concurrent request runs the handler; the rest wait
         // and are served the freshly cached entry.
-        using (await QueryCacheKeyLocks.Locks.AcquireAsync(cacheable.CacheKey, cancellationToken).ConfigureAwait(false))
+        using (await QueryCacheKeyLocks.Locks.AcquireAsync(cacheKey, cancellationToken).ConfigureAwait(false))
         {
-            cached = await TryReadAsync(cacheable, queryName, cancellationToken).ConfigureAwait(false);
+            cached = await TryReadAsync(cacheKey, queryName, cancellationToken).ConfigureAwait(false);
             if (cached is not null)
             {
                 CqrsMetrics.RecordCacheHit(queryName);
@@ -88,7 +110,7 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
             {
                 try
                 {
-                    await cacheService.SetAsync(cacheable.CacheKey, result, cacheable.CacheDuration, cancellationToken)
+                    await cacheService.SetAsync(cacheKey, result, cacheable.CacheDuration, cancellationToken)
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
@@ -96,7 +118,7 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
                     // The handler already produced the answer, so a cache blip must not fail the
                     // query. The request token is kept, so real cancellation still propagates
                     // through the filter.
-                    LogCachePopulateFailed(logger, cacheable.CacheKey, queryName, ex);
+                    LogCachePopulateFailed(logger, cacheKey, queryName, ex);
                 }
             }
 
@@ -126,23 +148,23 @@ public sealed partial class CachingQueryDecorator<TQuery, TResult>(
     /// Reads the cache fail-open: a cache fault is logged at warning level and reported as a miss
     /// so the caller falls through to the inner handler. Cancellation is deliberately not caught.
     /// </summary>
-    /// <param name="cacheable">The cacheable query carrying the key.</param>
+    /// <param name="cacheKey">The tenant-scoped cache key.</param>
     /// <param name="queryName">The query type name, used for logging.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The cached value, or the default when the key is absent or the cache is unreachable.</returns>
     private async Task<TResult?> TryReadAsync(
-        IQueryCacheable cacheable,
+        string cacheKey,
         string queryName,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await cacheService.GetAsync<TResult>(cacheable.CacheKey, cancellationToken)
+            return await cacheService.GetAsync<TResult>(cacheKey, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogCacheReadFailed(logger, cacheable.CacheKey, queryName, ex);
+            LogCacheReadFailed(logger, cacheKey, queryName, ex);
             return default;
         }
     }

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/TenantCacheKey.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/TenantCacheKey.cs
@@ -1,0 +1,41 @@
+using MMCA.Common.Application.Interfaces;
+
+namespace MMCA.Common.Application.UseCases.Decorators;
+
+/// <summary>
+/// Builds the tenant-scoped form of a cache key or prefix for the caching decorators.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache is a singleton and cannot see the scoped tenant, so isolation has to be applied where
+/// the key is computed. Both decorators use this one helper, which is what keeps reads and
+/// invalidations symmetric: a query cached under <c>t:acme:products</c> is evicted by a command
+/// whose prefix became <c>t:acme:products</c> through exactly the same transformation.
+/// </para>
+/// <para>
+/// The scoped form is a PREFIX, not a suffix, so prefix eviction keeps working: evicting
+/// <c>t:acme:products</c> removes only that tenant's product entries, and nothing a command in one
+/// tenant does can evict another tenant's cache.
+/// </para>
+/// <para>
+/// With no tenant resolved the key is returned untouched, so a single-tenant host has exactly the
+/// keyspace it had before tenancy shipped and no cache entry is orphaned by upgrading.
+/// </para>
+/// </remarks>
+internal static class TenantCacheKey
+{
+    /// <summary>The marker that opens a tenant-scoped key; short, because it is on every key.</summary>
+    internal const string Marker = "t:";
+
+    /// <summary>
+    /// Scopes <paramref name="key"/> to the resolved tenant, or returns it unchanged when no tenant
+    /// is resolved.
+    /// </summary>
+    /// <param name="tenantContext">The scope's tenant context, or null when tenancy is not registered.</param>
+    /// <param name="key">The cache key or prefix to scope.</param>
+    /// <returns>The effective cache key or prefix.</returns>
+    internal static string Scope(ITenantContext? tenantContext, string key) =>
+        tenantContext is { IsResolved: true, TenantId: { } tenantId }
+            ? string.Concat(Marker, tenantId, ":", key)
+            : key;
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/ExportUserData/ExportUserDataHandlerBase.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/ExportUserData/ExportUserDataHandlerBase.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Privacy;
+
+namespace MMCA.Common.Application.Users.UseCases.ExportUserData;
+
+/// <summary>
+/// The shared data-subject export workflow (GDPR/CCPA access and portability): owner-or-privileged-role
+/// authorization, a read-only load of the account, the app's own subject snapshot, then a best-effort
+/// fan-out over every registered <see cref="IUserDataExportSection"/>. The result is one JSON-ready
+/// package a data subject can be handed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything genuinely app-specific stays in the subclass:
+/// <list type="bullet">
+///   <item><see cref="HasExportPrivilege"/> - the role that bypasses ownership (Organizer vs Admin),
+///     evaluated app-side because the role vocabulary stays app-owned.</item>
+///   <item><see cref="BuildSubjectSnapshotAsync"/> - which of the account's own fields are portable
+///     personal data. It is asynchronous, and receives the query, because an app may need to read a
+///     second owned aggregate for the snapshot (Store's linked <c>Customer</c> profile does exactly
+///     that).</item>
+///   <item><see cref="OnExportCompletedAsync"/> - the app's tail (an access-log row, a metric), run
+///     after the package is assembled and before it is returned.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Sections never fail the export.</b> Each registered section is invoked inside its own
+/// try/catch: a throwing section is logged at warning level and degrades to an envelope reporting
+/// <c>Available = false</c>, so one unreachable peer costs the subject one section rather than the
+/// whole document. Section order is the registration order, so the package shape is stable across
+/// runs. Cancellation is not degradation: an <see cref="OperationCanceledException"/> propagates.
+/// </para>
+/// <para>
+/// This is a query handler, so it never calls <c>SaveChangesAsync</c>, and the account is fetched
+/// through <c>GetReadRepository</c> rather than the read-write repository the two pre-hoist app
+/// copies used: a no-tracking read is the correct choice for a projection both apps only read.
+/// </para>
+/// <para>
+/// The document it produces is <b>PII by design</b>. It must never be logged or cached; the caching
+/// query decorator is not applicable to it (the query implements no <c>IQueryCacheable</c>).
+/// </para>
+/// </remarks>
+/// <typeparam name="TUser">The app's <c>User</c> aggregate.</typeparam>
+/// <typeparam name="TQuery">The app's export-user-data query record.</typeparam>
+public abstract class ExportUserDataHandlerBase<TUser, TQuery>(
+    IUnitOfWork unitOfWork,
+    IEnumerable<IUserDataExportSection> sections,
+    TimeProvider timeProvider,
+    ILogger logger) : IQueryHandler<TQuery, Result<UserDataExportDTO>>
+    where TUser : AuditableAggregateRootEntity<UserIdentifierType>
+    where TQuery : IUserOwnedRequest
+{
+    /// <summary>
+    /// The version stamped into <see cref="UserDataExportDTO.FormatVersion"/>. It versions the
+    /// envelope only; an app changing its own subject or section payloads does not move it.
+    /// </summary>
+    public const string CurrentFormatVersion = "1.0";
+
+    /// <summary>The unit of work (exposed so a subject-snapshot override can read further aggregates).</summary>
+    protected IUnitOfWork UnitOfWork => unitOfWork;
+
+    /// <summary>
+    /// The name reported as the <c>source</c> of any error this handler returns. Defaults to the
+    /// runtime type name, so an app subclass that keeps the pre-hoist class name
+    /// (<c>ExportUserDataHandler</c>) reports the identical error payload it did before.
+    /// </summary>
+    protected virtual string HandlerName => GetType().Name;
+
+    /// <inheritdoc />
+    public async Task<Result<UserDataExportDTO>> HandleAsync(
+        TQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // Authorization: owner or the app's privileged role (case-insensitive; claims may carry any casing).
+        var forbidden = UserOwnershipRule.CheckOwnership(
+            query,
+            HasExportPrivilege(query.CurrentUserRole),
+            code: "User.ExportForbidden",
+            message: "You can only export your own account data.",
+            source: HandlerName);
+        if (forbidden is not null)
+        {
+            return Result.Failure<UserDataExportDTO>(forbidden);
+        }
+
+        var repository = unitOfWork.GetReadRepository<TUser, UserIdentifierType>();
+        var user = await repository.GetByIdAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+        if (user is null)
+        {
+            return Result.Failure<UserDataExportDTO>(
+                Error.NotFound.WithSource(HandlerName).WithTarget(typeof(TUser).Name));
+        }
+
+        var subject = await BuildSubjectSnapshotAsync(user, query, cancellationToken).ConfigureAwait(false);
+
+        // Sequential on purpose: sections share the scoped unit of work and its DbContext, which is
+        // not thread-safe, and registration order is the published order of the document.
+        var envelopes = new List<UserDataExportSectionDTO>();
+        foreach (var section in sections)
+        {
+            envelopes.Add(await RunSectionAsync(section, query.UserId, cancellationToken).ConfigureAwait(false));
+        }
+
+        var export = new UserDataExportDTO
+        {
+            FormatVersion = CurrentFormatVersion,
+            GeneratedOn = timeProvider.GetUtcNow(),
+            UserId = query.UserId,
+            Subject = subject,
+            Sections = envelopes,
+        };
+
+        await OnExportCompletedAsync(user, query, export, cancellationToken).ConfigureAwait(false);
+
+        return Result.Success(export);
+    }
+
+    /// <summary>
+    /// Whether the caller's role bypasses the ownership requirement (e.g.
+    /// <c>UserRole.IsOrganizer(currentUserRole)</c> for ADC, <c>UserRole.IsAdmin(...)</c> for Store).
+    /// </summary>
+    /// <param name="currentUserRole">The caller's role claim; may be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when the caller may export any account.</returns>
+    protected abstract bool HasExportPrivilege(string? currentUserRole);
+
+    /// <summary>
+    /// Projects the account itself into the app's portable subject snapshot: the fields the app
+    /// considers personal data, deliberately excluding credentials (password hash and salt, refresh
+    /// token, external-provider key), which are secrets rather than portable personal data.
+    /// </summary>
+    /// <param name="user">The loaded account.</param>
+    /// <param name="query">The originating query (carries the caller, for apps that vary the snapshot).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The snapshot object, or <see langword="null"/> when the app publishes no subject fields. It
+    /// must be JSON-serializable.
+    /// </returns>
+    protected abstract Task<object?> BuildSubjectSnapshotAsync(
+        TUser user,
+        TQuery query,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The app's export tail, invoked once the package is assembled and before it is returned
+    /// (default: nothing). Use it for an access-log row or a metric. It must not mutate the export,
+    /// and a failure here is the app's to handle: the export has already succeeded.
+    /// </summary>
+    /// <param name="user">The loaded account.</param>
+    /// <param name="query">The originating query.</param>
+    /// <param name="export">The assembled package.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the tail is done.</returns>
+    protected virtual Task OnExportCompletedAsync(
+        TUser user,
+        TQuery query,
+        UserDataExportDTO export,
+        CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+
+    private async Task<UserDataExportSectionDTO> RunSectionAsync(
+        IUserDataExportSection section,
+        UserIdentifierType userId,
+        CancellationToken cancellationToken)
+    {
+        var sectionName = section.SectionName;
+
+        try
+        {
+            var result = await section.ExportAsync(userId, cancellationToken).ConfigureAwait(false);
+
+            return new UserDataExportSectionDTO
+            {
+                SectionName = result.SectionName,
+                Available = result.Available,
+                Data = result.Data,
+                UnavailableReason = result.UnavailableReason,
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Best-effort: the contributor failed after whatever resilience pipeline it uses.
+            // Degrade the section instead of failing the whole export. The reason handed back is
+            // deliberately generic; the exception detail goes to the log, never to the subject.
+            UserUseCaseLog.ExportSectionUnavailable(logger, ex, sectionName, userId);
+
+            return new UserDataExportSectionDTO
+            {
+                SectionName = sectionName,
+                Available = false,
+                UnavailableReason = UserDataExportSectionDefaults.UnavailableReason,
+            };
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Users/UseCases/ExportUserData/IUserDataExportSection.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UseCases/ExportUserData/IUserDataExportSection.cs
@@ -1,0 +1,114 @@
+namespace MMCA.Common.Application.Users.UseCases.ExportUserData;
+
+/// <summary>
+/// One contributor to a data-subject export: a module (or a cross-service peer client) that holds
+/// personal data keyed by user and can hand it over on request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sections are <b>best-effort</b>. The export handler wraps every call, so a section that throws
+/// degrades to <c>Available = false</c> and the export still succeeds: one unreachable peer never
+/// denies a data subject the rest of their data. A section that simply holds nothing for the user
+/// returns <see cref="UserDataExportSectionResult.Complete"/> with an empty payload, which is a
+/// truthful answer rather than an unknown one.
+/// </para>
+/// <para>
+/// Register each implementation with <c>AddUserDataExportSection&lt;TSection&gt;()</c>; they
+/// accumulate across modules and are exported in registration order.
+/// </para>
+/// </remarks>
+public interface IUserDataExportSection
+{
+    /// <summary>
+    /// Gets the stable name this section is published under in the export document (e.g.
+    /// "Engagement", "Sales"). It appears verbatim in the package a data subject reads, so treat it
+    /// as part of the contract rather than a label to reword.
+    /// </summary>
+    string SectionName { get; }
+
+    /// <summary>
+    /// Produces this section's data for one user.
+    /// </summary>
+    /// <param name="userId">The data subject.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The section result. Throwing is permitted (the handler degrades the section), but returning
+    /// <see cref="UserDataExportSectionResult.Unavailable"/> is preferred where the reason is known.
+    /// </returns>
+    Task<UserDataExportSectionResult> ExportAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// What one <see cref="IUserDataExportSection"/> hands back: its payload, or the fact that it could
+/// not be produced.
+/// </summary>
+public sealed record UserDataExportSectionResult
+{
+    /// <summary>Gets the section name, echoed into the export envelope.</summary>
+    public required string SectionName { get; init; }
+
+    /// <summary>Gets whether the section was produced successfully.</summary>
+    public required bool Available { get; init; }
+
+    /// <summary>
+    /// Gets the section payload: the contributor's own DTO. It must be JSON-serializable, because
+    /// the export is handed to the data subject as a JSON document, and it is <b>PII by design</b>:
+    /// never log it, never cache it.
+    /// </summary>
+    public object? Data { get; init; }
+
+    /// <summary>
+    /// Gets a short, caller-safe explanation of why the section is unavailable. It reaches the data
+    /// subject, so it must never carry internal exception details (messages, stack traces, peer
+    /// addresses, connection strings).
+    /// </summary>
+    public string? UnavailableReason { get; init; }
+
+    /// <summary>Creates a successfully produced section.</summary>
+    /// <param name="sectionName">The section name.</param>
+    /// <param name="data">The section payload (may be null when the section publishes no body).</param>
+    /// <returns>An available section result.</returns>
+    public static UserDataExportSectionResult Complete(string sectionName, object? data)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sectionName);
+
+        return new UserDataExportSectionResult
+        {
+            SectionName = sectionName,
+            Available = true,
+            Data = data,
+        };
+    }
+
+    /// <summary>Creates a degraded section.</summary>
+    /// <param name="sectionName">The section name.</param>
+    /// <param name="reason">
+    /// A short, caller-safe reason. Defaults to a generic message; do not pass exception text.
+    /// </param>
+    /// <returns>An unavailable section result.</returns>
+    public static UserDataExportSectionResult Unavailable(string sectionName, string? reason = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sectionName);
+
+        return new UserDataExportSectionResult
+        {
+            SectionName = sectionName,
+            Available = false,
+            UnavailableReason = reason ?? UserDataExportSectionDefaults.UnavailableReason,
+        };
+    }
+}
+
+/// <summary>Shared defaults for degraded export sections.</summary>
+public static class UserDataExportSectionDefaults
+{
+    /// <summary>
+    /// The reason reported when a section fails and the app supplied none. Deliberately generic: the
+    /// data subject learns the section is incomplete and retryable, and learns nothing about the
+    /// internal failure.
+    /// </summary>
+    public const string UnavailableReason =
+        "This section could not be retrieved. The data is unchanged; the export can be requested again later.";
+}

--- a/Source/Core/MMCA.Common.Application/Users/UserUseCaseLog.cs
+++ b/Source/Core/MMCA.Common.Application/Users/UserUseCaseLog.cs
@@ -18,4 +18,7 @@ internal static partial class UserUseCaseLog
 
     [LoggerMessage(Level = LogLevel.Information, Message = "User {UserId} account deleted and personal data anonymized")]
     internal static partial void UserErased(ILogger logger, UserIdentifierType userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Data-subject export section {Section} unavailable for user {UserId}; export continues with Available=false")]
+    internal static partial void ExportSectionUnavailable(ILogger logger, Exception exception, string section, UserIdentifierType userId);
 }

--- a/Source/Core/MMCA.Common.Domain/Interfaces/IAuditedEntity.cs
+++ b/Source/Core/MMCA.Common.Domain/Interfaces/IAuditedEntity.cs
@@ -1,0 +1,34 @@
+namespace MMCA.Common.Domain.Interfaces;
+
+/// <summary>
+/// Opt-in marker: an entity carrying this interface has every insert, update and delete recorded
+/// as an immutable change-history trail (who changed which field, from what to what, and when).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a marker rather than a global default.</b> A change trail is one row per changed property
+/// per save, so trailing every entity in a busy system multiplies write volume and storage without
+/// anyone asking for it. Marking entities one at a time makes the volume a deliberate decision:
+/// trail the aggregates whose history someone will actually be asked to produce (an order, a
+/// permission grant, a ticket) and leave high-churn bookkeeping tables alone.
+/// </para>
+/// <para>
+/// <b>It composes with <see cref="IAuditableEntity"/> but does not require it.</b> The two answer
+/// different questions. <see cref="IAuditableEntity"/> stamps the CURRENT state (who touched this
+/// row last, and when); this marker records the SEQUENCE that produced it. An entity may carry
+/// either, both, or neither. When both are present the trail rows see the freshly stamped values,
+/// because the trail is captured after the stamping interceptor has run.
+/// </para>
+/// <para>
+/// <b>Recording is host-gated.</b> Nothing is written unless the host opted in with
+/// <c>AddAuditTrail(configuration)</c> and <c>AuditTrail:Enabled</c>. Marking an entity in a host
+/// that never opted in is inert: no table, no rows, no cost.
+/// </para>
+/// <para>
+/// <b>Personal data is redacted at capture.</b> A property marked with
+/// <c>MMCA.Common.Domain.Attributes.PiiAttribute</c> records a redaction placeholder on both sides
+/// of the change instead of its value, so the trail never becomes a second, unerasable copy of a
+/// data subject's personal data (ADR-005).
+/// </para>
+/// </remarks>
+public interface IAuditedEntity;

--- a/Source/Core/MMCA.Common.Domain/Interfaces/ITenantEntity.cs
+++ b/Source/Core/MMCA.Common.Domain/Interfaces/ITenantEntity.cs
@@ -1,0 +1,40 @@
+namespace MMCA.Common.Domain.Interfaces;
+
+/// <summary>
+/// Opt-in marker: an entity carrying this interface belongs to exactly one tenant, and every read
+/// and write the framework performs on it is scoped to the tenant resolved for the current request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Reads.</b> A named <c>Tenant</c> global query filter is applied to every non-owned entity
+/// carrying this interface, alongside the existing <c>SoftDelete</c> filter; named filters compose
+/// with AND, so a tenant never sees another tenant's rows and never sees soft-deleted ones. When no
+/// tenant is resolved (a background service, a seeder, an admin flow) the filter is inert and the
+/// query sees every tenant's rows: the system context is deliberately unrestricted.
+/// </para>
+/// <para>
+/// <b>Writes.</b> <c>TenantSaveChangesInterceptor</c> stamps <see cref="TenantId"/> on insert and
+/// refuses a save that would write across the tenant boundary. The property is therefore read-only
+/// on the domain type: the value is not a caller's to choose, and EF writes it through the backing
+/// field.
+/// </para>
+/// <para>
+/// <b>The identifier is a <see langword="string"/>, capped at 64 characters.</b> It arrives from a
+/// claim, a header, or configuration, all of which are strings, so a stronger domain type would
+/// only add a conversion at every boundary without adding a guarantee.
+/// </para>
+/// <para>
+/// <b>Marking is host-gated in practice.</b> A host that never resolves a tenant behaves exactly as
+/// it did before: the filter short-circuits and the interceptor stamps nothing. Adopting tenancy is
+/// the combination of marking entities, calling <c>AddMultiTenancy(configuration)</c>, and setting
+/// <c>Tenancy:Enabled</c>.
+/// </para>
+/// </remarks>
+public interface ITenantEntity
+{
+    /// <summary>
+    /// Gets the identifier of the tenant that owns this entity. Assigned by the framework on
+    /// insert; never set by application code.
+    /// </summary>
+    string TenantId { get; }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/CacheOptions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/CacheOptions.cs
@@ -9,11 +9,19 @@ namespace MMCA.Common.Infrastructure.Caching;
 public static class CacheOptions
 {
     /// <summary>
+    /// Gets the default time-to-live applied when a caller passes no expiration. Exposed as a bare
+    /// <see cref="TimeSpan"/> so implementations that do not speak
+    /// <see cref="DistributedCacheEntryOptions"/> (<c>HybridCacheService</c>, whose entry options are
+    /// its own type) still default to the same policy rather than a second hard-coded 30 seconds.
+    /// </summary>
+    public static TimeSpan DefaultDuration { get; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Gets the default cache entry options with a 30-second absolute expiration.
     /// </summary>
     public static DistributedCacheEntryOptions DefaultExpiration => new()
     {
-        AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30)
+        AbsoluteExpirationRelativeToNow = DefaultDuration
     };
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/DistributedCacheService.cs
@@ -21,9 +21,6 @@ internal sealed partial class DistributedCacheService(
     IConnectionMultiplexer? connectionMultiplexer = null,
     CacheKeyNamespace? keyNamespace = null) : ICacheService
 {
-    /// <summary>Single-key deletes issued and awaited as one group during prefix invalidation.</summary>
-    private const int DeleteBatchSize = 512;
-
     /// <summary>
     /// Namespace applied to every key so services sharing one cache instance cannot collide.
     /// Defaults to no prefix, which is correct for a host that owns its cache outright.
@@ -70,12 +67,16 @@ internal sealed partial class DistributedCacheService(
     /// command. A multi-key DEL cannot span hash slots under Redis cluster policy, and
     /// StackExchange.Redis rejects a cross-slot multi-key command by throwing rather than
     /// under-deleting, which would fault the whole invalidation. Round trips still stay bounded:
-    /// up to <see cref="DeleteBatchSize"/> single-key deletes are in flight at a time and awaited
-    /// as one group.
+    /// a fixed number of single-key deletes are in flight at a time and awaited as one group.
     /// </para>
     /// <para>
     /// Each server is scanned inside its own try/catch, so one unreachable or failing server is
     /// logged and skipped instead of aborting invalidation on the servers that are healthy.
+    /// </para>
+    /// <para>
+    /// The scan itself lives in <see cref="RedisPrefixScanner"/>, shared with
+    /// <see cref="HybridCacheService"/>. This method supplies the raw <c>KeyDeleteAsync</c> as the
+    /// per-key delete and keeps the log messages, which name the caller-supplied prefix.
     /// </para>
     /// </remarks>
     public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
@@ -90,67 +91,18 @@ internal sealed partial class DistributedCacheService(
             return;
         }
 
-        // Replicas mirror a primary's keyspace, so scanning them is redundant, and a DEL against a
-        // replica fails outright. Everything else is scanned: a key that lives on another primary
-        // is invisible to the first server's SCAN and would survive the invalidation.
-        IServer[] servers = [.. connectionMultiplexer.GetServers().Where(s => !s.IsReplica)];
-        if (servers.Length == 0)
-        {
-            LogPrefixEvictionNoServer(logger, prefix);
-            return;
-        }
+        // Resolved on the first delete rather than up front: a host whose multiplexer reports no
+        // scannable server never asks for a database at all.
+        IDatabase? db = null;
 
-        var pattern = $"{_keys.Qualify(prefix)}*";
-        var db = connectionMultiplexer.GetDatabase();
-
-        foreach (var server in servers)
-        {
-            try
-            {
-                await ScanAndDeleteAsync(db, server, pattern, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is RedisException or RedisCommandException or TimeoutException)
-            {
-                // Best-effort per server: a transport or command fault on one node must not leave the
-                // remaining nodes un-invalidated. Cancellation is deliberately not caught here.
-                LogPrefixEvictionServerFailed(logger, Describe(server), prefix, ex);
-            }
-        }
+        await RedisPrefixScanner.RemoveMatchingAsync(
+            connectionMultiplexer,
+            $"{_keys.Qualify(prefix)}*",
+            key => (db ??= connectionMultiplexer.GetDatabase()).KeyDeleteAsync(key),
+            () => LogPrefixEvictionNoServer(logger, prefix),
+            (server, ex) => LogPrefixEvictionServerFailed(logger, server, prefix, ex),
+            cancellationToken).ConfigureAwait(false);
     }
-
-    /// <summary>Scans one server for the pattern and deletes every match, one key per command.</summary>
-    private static async Task ScanAndDeleteAsync(
-        IDatabase db,
-        IServer server,
-        string pattern,
-        CancellationToken cancellationToken)
-    {
-        // Deletes go out one key at a time. Under Redis cluster policy a multi-key DEL must not span
-        // hash slots, and StackExchange.Redis answers a cross-slot multi-key command by throwing, so
-        // batching the keys of a prefix (which hash to arbitrary slots) would fault the invalidation
-        // instead of speeding it up. Single-key deletes are always slot-safe; the round-trip count
-        // stays bounded by keeping a group of them in flight and awaiting the group.
-        var pending = new List<Task<bool>>(DeleteBatchSize);
-
-        await foreach (var key in server.KeysAsync(pattern: pattern)
-            .WithCancellation(cancellationToken)
-            .ConfigureAwait(false))
-        {
-            pending.Add(db.KeyDeleteAsync(key));
-            if (pending.Count == DeleteBatchSize)
-            {
-                await Task.WhenAll(pending).ConfigureAwait(false);
-                pending.Clear();
-            }
-        }
-
-        if (pending.Count > 0)
-            await Task.WhenAll(pending).ConfigureAwait(false);
-    }
-
-    /// <summary>Stable identifier for a server in log output, tolerating an unknown endpoint.</summary>
-    private static string Describe(IServer server) =>
-        server.EndPoint?.ToString() ?? "unknown";
 
     /// <inheritdoc />
     /// <remarks>

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/HybridCacheService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/HybridCacheService.cs
@@ -1,0 +1,341 @@
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces;
+using StackExchange.Redis;
+
+namespace MMCA.Common.Infrastructure.Caching;
+
+/// <summary>
+/// Two-level cache backed by <see cref="HybridCache"/>: an in-process L1 in front of the registered
+/// <see cref="Microsoft.Extensions.Caching.Distributed.IDistributedCache"/> L2, with serialization,
+/// L1 promotion and stampede protection supplied by the platform.
+/// <para>
+/// Registered only by <c>AddCommonHybridCache</c>. A host that does not call it keeps
+/// <see cref="DistributedCacheService"/> or <see cref="MemoryCacheService"/> untouched.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every key is written under a disjoint <c>hc:</c> keyspace</b> (<c>{prefix}hc:{key}</c>). This is
+/// the structural form of the lesson recorded on <see cref="DistributedCacheService.IncrementAsync"/>:
+/// two serialization formats must never share one key. <see cref="HybridCache"/> writes its own
+/// payload layout, which is not the UTF-8 JSON <see cref="DistributedCacheService"/> writes, so
+/// letting the two meet at one key would reproduce that failure at every key rather than at one
+/// counter. With the keyspaces separated, an old-format entry is simply invisible to this service
+/// (a clean miss) and a new-format entry is invisible to the old one, including while a rolling
+/// deploy runs both. Old entries age out on their TTL; <see cref="RemoveByPrefixAsync"/> evicts both
+/// keyspaces so long-lived records (24h idempotency responses) stay evictable through the migration
+/// window.
+/// </para>
+/// <para>
+/// Replica L1 staleness after an invalidation is bounded by the local expiration (30 seconds), not
+/// by the eviction: only the evicting process's L1 is cleared. That is the accepted cost of the L1
+/// hit rate, and it is the same order as the delayed re-invalidation the caching command decorator
+/// already performs.
+/// </para>
+/// </remarks>
+internal sealed partial class HybridCacheService(
+    HybridCache hybrid,
+    ILogger<HybridCacheService> logger,
+    IConnectionMultiplexer? connectionMultiplexer = null,
+    CacheKeyNamespace? keyNamespace = null) : ICacheService
+{
+    /// <summary>
+    /// Segment separating this service's keyspace from the one <see cref="DistributedCacheService"/>
+    /// writes. Applied inside the configured namespace, so a key reads <c>{prefix}hc:{key}</c>.
+    /// </summary>
+    internal const string KeyspaceSegment = "hc:";
+
+    /// <summary>
+    /// Default in-process (L1) lifetime, and the ceiling applied to every entry: a replica that never
+    /// sees an invalidation still re-reads L2 within this window. Matches the default
+    /// <c>AddCommonHybridCache</c> configures.
+    /// </summary>
+    internal static readonly TimeSpan LocalCacheDefault = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Read without a factory: <see cref="HybridCacheEntryFlags.DisableUnderlyingData"/> tells
+    /// <see cref="HybridCache"/> not to invoke the factory and not to write anything, so a miss is a
+    /// miss and stays one. An L2 hit is still promoted into L1, which is the whole point of the
+    /// two-level cache.
+    /// </summary>
+    private static readonly HybridCacheEntryOptions ReadOnlyOptions = new()
+    {
+        Flags = HybridCacheEntryFlags.DisableUnderlyingData,
+    };
+
+    /// <summary>
+    /// The read leg of <see cref="IncrementAsync"/>: the read-only flags plus a full L1 bypass. See
+    /// the remarks on <see cref="IncrementAsync"/> for why a counter must not touch L1.
+    /// </summary>
+    private static readonly HybridCacheEntryOptions CounterReadOptions = new()
+    {
+        Flags = HybridCacheEntryFlags.DisableUnderlyingData
+            | HybridCacheEntryFlags.DisableLocalCacheRead
+            | HybridCacheEntryFlags.DisableLocalCacheWrite,
+    };
+
+    /// <summary>
+    /// Namespace applied to every key so services sharing one cache instance cannot collide.
+    /// Defaults to no prefix, which is correct for a host that owns its cache outright.
+    /// </summary>
+    private readonly CacheKeyNamespace _keys = keyNamespace ?? CacheKeyNamespace.None;
+
+    /// <summary>Set once (via <see cref="Interlocked"/>) after the missing-multiplexer no-op is logged, so the steady state warns once rather than on every command.</summary>
+    private int _noMultiplexerWarned;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Fail-soft, mirroring the fail-open posture of the caching decorators: the cache is an
+    /// optimization, never the system of record. A fault (an entry this build can no longer
+    /// deserialize, a transport blip) is logged at warning level and answered as a miss, and the
+    /// offending entry is deleted best-effort so the next write repopulates it instead of the
+    /// process failing the same read forever. Only <see cref="OperationCanceledException"/> is
+    /// excluded, so a genuinely cancelled request still surfaces as cancellation.
+    /// </remarks>
+    public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        var fullKey = HybridKey(key);
+
+        try
+        {
+            return await hybrid.GetOrCreateAsync(
+                fullKey,
+                static _ => ValueTask.FromResult<T?>(default),
+                ReadOnlyOptions,
+                tags: null,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogReadFailed(logger, key, ex);
+            await SelfHealAsync(fullKey, cancellationToken).ConfigureAwait(false);
+            return default;
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The absolute expiration is the caller's, or the framework default when omitted (the same
+    /// <see cref="CacheOptions.DefaultDuration"/> <see cref="DistributedCacheService"/> applies). The
+    /// L1 copy is capped at the shorter of that TTL and <see cref="LocalCacheDefault"/>, so a
+    /// long-lived entry does not sit in another replica's memory for its whole TTL after an
+    /// invalidation this process cannot see.
+    /// </remarks>
+    public Task SetAsync<T>(
+        string key,
+        T value,
+        TimeSpan? expiration = null,
+        CancellationToken cancellationToken = default) =>
+        hybrid.SetAsync(HybridKey(key), value, WriteOptions(expiration), tags: null, cancellationToken).AsTask();
+
+    /// <inheritdoc />
+    /// <remarks>Removes both levels: <see cref="HybridCache"/> clears this process's L1 copy along with the L2 entry.</remarks>
+    public Task RemoveAsync(string key, CancellationToken cancellationToken = default) =>
+        hybrid.RemoveAsync(HybridKey(key), cancellationToken).AsTask();
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Runs the shared <see cref="RedisPrefixScanner"/> TWICE, over two disjoint patterns: this
+    /// service's <c>{prefix}hc:{key}</c> keyspace and the legacy <c>{prefix}{key}</c> keyspace that
+    /// <see cref="DistributedCacheService"/> wrote. A host switching to
+    /// <c>AddCommonHybridCache</c> inherits live entries under the old shape (a 24h idempotency
+    /// record outlives any deploy), and a prefix eviction that skipped them would leave a stale
+    /// answer addressable for the rest of its TTL. The two patterns cannot overlap, so nothing is
+    /// visited twice.
+    /// </para>
+    /// <para>
+    /// Hybrid keys are deleted through <see cref="HybridCache.RemoveAsync(string, CancellationToken)"/>
+    /// rather than by raw key: a raw delete would clear L2 and leave this process's own L1 copy
+    /// serving the value it just invalidated. Legacy keys have no L1 to clear and are deleted raw.
+    /// </para>
+    /// <para>
+    /// Without an <see cref="IConnectionMultiplexer"/> prefix eviction cannot run at all and is
+    /// warned once, exactly as in <see cref="DistributedCacheService.RemoveByPrefixAsync"/>.
+    /// </para>
+    /// </remarks>
+    public async Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+    {
+        if (connectionMultiplexer is null)
+        {
+            // No multiplexer: prefix eviction cannot run, so cached entries expire on TTL alone. Warn
+            // once so this dead invalidation is visible without flooding the log on every mutating
+            // command.
+            if (Interlocked.Exchange(ref _noMultiplexerWarned, 1) == 0)
+                LogPrefixEvictionNoMultiplexer(logger);
+            return;
+        }
+
+        // Resolved on the first legacy delete rather than up front: a host whose multiplexer reports
+        // no scannable server, or that holds no legacy entries at all, never asks for a database.
+        IDatabase? db = null;
+
+        // Both passes share one multiplexer, so an empty server list is one condition, not two.
+        var noServersLogged = false;
+        void OnNoServers()
+        {
+            if (!noServersLogged)
+            {
+                noServersLogged = true;
+                LogPrefixEvictionNoServer(logger, prefix);
+            }
+        }
+
+        void OnServerFailed(string server, Exception ex) =>
+            LogPrefixEvictionServerFailed(logger, server, prefix, ex);
+
+        // This service's own keyspace: routed back through HybridCache so L1 goes with L2.
+        await RedisPrefixScanner.RemoveMatchingAsync(
+            connectionMultiplexer,
+            $"{HybridKey(prefix)}*",
+            key => hybrid.RemoveAsync(key.ToString(), cancellationToken).AsTask(),
+            OnNoServers,
+            OnServerFailed,
+            cancellationToken).ConfigureAwait(false);
+
+        // The legacy keyspace left behind by DistributedCacheService; raw deletes, nothing holds
+        // these in an L1.
+        await RedisPrefixScanner.RemoveMatchingAsync(
+            connectionMultiplexer,
+            $"{_keys.Qualify(prefix)}*",
+            key => (db ??= connectionMultiplexer.GetDatabase()).KeyDeleteAsync(key),
+            OnNoServers,
+            OnServerFailed,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// A read-modify-write, like <see cref="DistributedCacheService.IncrementAsync"/> and with the
+    /// same honest limitation: concurrent increments can undercount. It is not routed through
+    /// <see cref="GetAsync{T}"/> and <see cref="SetAsync{T}"/> because both legs must bypass L1
+    /// (<see cref="HybridCacheEntryFlags.DisableLocalCacheRead"/> and
+    /// <see cref="HybridCacheEntryFlags.DisableLocalCacheWrite"/>), which those members deliberately
+    /// do not.
+    /// </para>
+    /// <para>
+    /// The reason is that a counter is the one value in this cache whose correctness depends on
+    /// every replica seeing the same number. An L1 copy would let a process read its own stale count
+    /// for up to the local expiration and write it back, so a brute-force counter could be held near
+    /// its starting value indefinitely by a steady stream of attempts against one replica: a
+    /// security control silently weakened by a cache optimization. Keeping both legs on L2 preserves
+    /// exactly today's semantics (ADR-029) and gives up only the L1 hit, which a counter that
+    /// changes on every read was never going to benefit from.
+    /// </para>
+    /// <para>
+    /// Faults are deliberately NOT swallowed here, unlike <see cref="GetAsync{T}"/>: a counter that
+    /// silently reads as zero would reset the limit it exists to enforce, so the caller decides.
+    /// </para>
+    /// </remarks>
+    public async Task<long> IncrementAsync(string key, TimeSpan expiration, CancellationToken cancellationToken = default)
+    {
+        var fullKey = HybridKey(key);
+
+        var current = await hybrid.GetOrCreateAsync(
+            fullKey,
+            static _ => ValueTask.FromResult<long?>(null),
+            CounterReadOptions,
+            tags: null,
+            cancellationToken).ConfigureAwait(false) ?? 0;
+
+        var next = current + 1;
+
+        await hybrid.SetAsync(
+            fullKey,
+            next,
+            WriteOptions(expiration, HybridCacheEntryFlags.DisableLocalCacheRead | HybridCacheEntryFlags.DisableLocalCacheWrite),
+            tags: null,
+            cancellationToken).ConfigureAwait(false);
+
+        return next;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Overrides the interface default (get, stripe, double-check, factory, set) with
+    /// <see cref="HybridCache"/>'s own implementation, which folds the same double-check and
+    /// stampede protection into one call and additionally deduplicates concurrent callers before
+    /// they reach L2. The guarantees the default member documents are unchanged: the factory result
+    /// is cached unconditionally, and stampede protection is process-local, so several replicas can
+    /// still each run the factory once.
+    /// </remarks>
+    public Task<T> GetOrCreateAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T>> factory,
+        TimeSpan? expiration = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        // The factory is passed as state rather than captured, so the delegate stays static and no
+        // closure is allocated per call.
+        return hybrid.GetOrCreateAsync(
+            HybridKey(key),
+            factory,
+            static async (state, ct) => await state(ct).ConfigureAwait(false),
+            WriteOptions(expiration),
+            tags: null,
+            cancellationToken).AsTask();
+    }
+
+    /// <summary>Qualifies a caller-supplied key into this service's disjoint keyspace.</summary>
+    /// <param name="key">The caller-supplied key or prefix.</param>
+    /// <returns>The fully qualified key, <c>{prefix}hc:{key}</c>.</returns>
+    private string HybridKey(string key) => _keys.Qualify(string.Concat(KeyspaceSegment, key));
+
+    /// <summary>
+    /// Builds the entry options for a write: the caller's TTL (or the framework default), with the
+    /// L1 copy capped at <see cref="LocalCacheDefault"/> or the TTL, whichever is shorter.
+    /// </summary>
+    /// <param name="expiration">The caller-supplied expiration, if any.</param>
+    /// <param name="flags">Optional flags; <see langword="null"/> inherits the configured defaults.</param>
+    /// <returns>The entry options to pass to <see cref="HybridCache"/>.</returns>
+    private static HybridCacheEntryOptions WriteOptions(TimeSpan? expiration, HybridCacheEntryFlags? flags = null)
+    {
+        var ttl = expiration ?? CacheOptions.DefaultDuration;
+
+        return new HybridCacheEntryOptions
+        {
+            Expiration = ttl,
+            LocalCacheExpiration = ttl < LocalCacheDefault ? ttl : LocalCacheDefault,
+            Flags = flags,
+        };
+    }
+
+    /// <summary>
+    /// Drops an entry that could not be read, so the next write repopulates it. Best-effort by
+    /// definition: this runs while the cache is already misbehaving, so a failure here is logged and
+    /// nothing more.
+    /// </summary>
+    /// <param name="fullKey">The fully qualified key to drop.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private async Task SelfHealAsync(string fullKey, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await hybrid.RemoveAsync(fullKey, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogSelfHealFailed(logger, fullKey, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Two-level cache read failed for key '{CacheKey}'; the read is treated as a miss and the entry is dropped so the next write repopulates it.")]
+    private static partial void LogReadFailed(ILogger logger, string cacheKey, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Two-level cache could not drop the unreadable entry '{CacheKey}'; it stays unreadable until its TTL expires.")]
+    private static partial void LogSelfHealFailed(ILogger logger, string cacheKey, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation is a no-op: no IConnectionMultiplexer is registered, so cached entries are bounded only by their TTL. Register a Redis client (AddRedisClient) to enable prefix eviction.")]
+    private static partial void LogPrefixEvictionNoMultiplexer(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation skipped for prefix '{Prefix}': the connection multiplexer reports no non-replica servers.")]
+    private static partial void LogPrefixEvictionNoServer(ILogger logger, string prefix);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Prefix-based cache invalidation failed on server '{Server}' for prefix '{Prefix}'; the remaining servers are still processed, so entries on this one are bounded only by their TTL.")]
+    private static partial void LogPrefixEvictionServerFailed(ILogger logger, string server, string prefix, Exception exception);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Caching/RedisPrefixScanner.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Caching/RedisPrefixScanner.cs
@@ -1,0 +1,124 @@
+using StackExchange.Redis;
+
+namespace MMCA.Common.Infrastructure.Caching;
+
+/// <summary>
+/// Prefix eviction over a real Redis: SCAN every non-replica server for a key pattern and delete
+/// every match. Shared by <see cref="DistributedCacheService"/> and <see cref="HybridCacheService"/>
+/// so both evict through one implementation, and so the Redis-tier tests that cover one cover both.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The delete is a caller-supplied callback rather than a fixed <c>KeyDeleteAsync</c>: the two
+/// services have to remove a key differently. <see cref="DistributedCacheService"/> deletes the raw
+/// Redis key, while <see cref="HybridCacheService"/> routes the delete back through
+/// <c>HybridCache.RemoveAsync</c> so the caller's in-process L1 copy is evicted too, not just the
+/// L2 entry a raw delete would clear.
+/// </para>
+/// <para>
+/// Logging stays with the caller (two <see cref="Action"/> hooks): each service owns its own
+/// <c>LoggerMessage</c> definitions and its own notion of the prefix being evicted, so the message
+/// text and its structured fields do not move into a shared helper.
+/// </para>
+/// </remarks>
+internal static class RedisPrefixScanner
+{
+    /// <summary>Single-key deletes issued and awaited as one group during prefix invalidation.</summary>
+    private const int DeleteBatchSize = 512;
+
+    /// <summary>
+    /// Scans every non-replica server for <paramref name="pattern"/> and deletes each matching key
+    /// through <paramref name="deleteAsync"/>.
+    /// </summary>
+    /// <param name="connectionMultiplexer">The connected Redis multiplexer.</param>
+    /// <param name="pattern">The glob pattern to match, already namespace-qualified by the caller.</param>
+    /// <param name="deleteAsync">Removes one matched key; awaited in batches.</param>
+    /// <param name="onNoServers">Invoked when the multiplexer reports no non-replica server.</param>
+    /// <param name="onServerFailed">Invoked with the server description and the fault when one server fails.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// <para>
+    /// Every non-replica server is scanned, not just the first one the multiplexer reports. Keys
+    /// are distributed across primaries, so scanning one server leaves the entries held by the
+    /// others alive until their TTL expires. Replicas are skipped: their keyspace mirrors a
+    /// primary already scanned, and a delete against a replica is rejected.
+    /// </para>
+    /// <para>
+    /// Each server is scanned inside its own try/catch, so one unreachable or failing server is
+    /// logged and skipped instead of aborting invalidation on the servers that are healthy.
+    /// Cancellation is deliberately not caught.
+    /// </para>
+    /// </remarks>
+    internal static async Task RemoveMatchingAsync(
+        IConnectionMultiplexer connectionMultiplexer,
+        string pattern,
+        Func<RedisKey, Task> deleteAsync,
+        Action onNoServers,
+        Action<string, Exception> onServerFailed,
+        CancellationToken cancellationToken)
+    {
+        // Replicas mirror a primary's keyspace, so scanning them is redundant, and a DEL against a
+        // replica fails outright. Everything else is scanned: a key that lives on another primary
+        // is invisible to the first server's SCAN and would survive the invalidation.
+        IServer[] servers = [.. connectionMultiplexer.GetServers().Where(s => !s.IsReplica)];
+        if (servers.Length == 0)
+        {
+            onNoServers();
+            return;
+        }
+
+        foreach (var server in servers)
+        {
+            try
+            {
+                await ScanAndDeleteAsync(server, pattern, deleteAsync, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is RedisException or RedisCommandException or TimeoutException)
+            {
+                // Best-effort per server: a transport or command fault on one node must not leave the
+                // remaining nodes un-invalidated. Cancellation is deliberately not caught here.
+                onServerFailed(Describe(server), ex);
+            }
+        }
+    }
+
+    /// <summary>Scans one server for the pattern and deletes every match, one key per command.</summary>
+    /// <param name="server">The server to scan.</param>
+    /// <param name="pattern">The glob pattern to match.</param>
+    /// <param name="deleteAsync">Removes one matched key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private static async Task ScanAndDeleteAsync(
+        IServer server,
+        string pattern,
+        Func<RedisKey, Task> deleteAsync,
+        CancellationToken cancellationToken)
+    {
+        // Deletes go out one key at a time. Under Redis cluster policy a multi-key DEL must not span
+        // hash slots, and StackExchange.Redis answers a cross-slot multi-key command by throwing, so
+        // batching the keys of a prefix (which hash to arbitrary slots) would fault the invalidation
+        // instead of speeding it up. Single-key deletes are always slot-safe; the round-trip count
+        // stays bounded by keeping a group of them in flight and awaiting the group.
+        var pending = new List<Task>(DeleteBatchSize);
+
+        await foreach (var key in server.KeysAsync(pattern: pattern)
+            .WithCancellation(cancellationToken)
+            .ConfigureAwait(false))
+        {
+            pending.Add(deleteAsync(key));
+            if (pending.Count == DeleteBatchSize)
+            {
+                await Task.WhenAll(pending).ConfigureAwait(false);
+                pending.Clear();
+            }
+        }
+
+        if (pending.Count > 0)
+            await Task.WhenAll(pending).ConfigureAwait(false);
+    }
+
+    /// <summary>Stable identifier for a server in log output, tolerating an unknown endpoint.</summary>
+    private static string Describe(IServer server) =>
+        server.EndPoint?.ToString() ?? "unknown";
+}

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -57,6 +57,11 @@ public static class DependencyInjection
             services.TryAddSingleton<AuditSaveChangesInterceptor>();
             services.TryAddSingleton<DomainEventSaveChangesInterceptor>();
 
+            // Always registered, like the other two: it is a no-op for every entity that does not
+            // carry ITenantEntity, so a host that never adopts tenancy pays nothing, while a host
+            // that does can never accidentally leave the write-side guard off.
+            services.TryAddSingleton<TenantSaveChangesInterceptor>();
+
             services.TryAddSingleton<IJwtSettings>(sp => sp.GetRequiredService<IOptions<JwtSettings>>().Value);
 
             services.AddOptions<ConnectionStringSettings>()
@@ -389,6 +394,48 @@ public static class DependencyInjection
         }
 
         /// <summary>
+        /// Enables multi-tenancy: binds the <c>Tenancy</c> settings section, validates it at
+        /// startup, and turns on tenant resolution at the API edge.
+        /// </summary>
+        /// <param name="configuration">Application configuration for binding the <c>Tenancy</c> section.</param>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// This call binds configuration; it does not install isolation. The <c>Tenant</c> query
+        /// filter, <see cref="TenantSaveChangesInterceptor"/> and <see cref="ITenantContext"/> are
+        /// always present and always inert until a tenant is resolved, so the framework can never be
+        /// in the state where entities are marked <c>ITenantEntity</c> but only half the guard is
+        /// wired.
+        /// </para>
+        /// <para>
+        /// What this DOES switch on is resolution: with <c>Tenancy:Enabled</c> true,
+        /// <c>TenantResolutionMiddleware</c> reads the tenant from the configured claim or header
+        /// and, by default (<c>Tenancy:RequireTenant</c>), rejects a request that carries none.
+        /// </para>
+        /// <para>
+        /// <b>Database-per-tenant is configuration only.</b> A tenant listed under
+        /// <c>Tenancy:Tenants:{id}:DataSources:{sourceName}</c> is routed to its own database for
+        /// that source; a tenant with no entry shares the database and is isolated by the filter.
+        /// The override keys are PHYSICAL data source names, and startup validation fails the host
+        /// when one names a source that does not exist, because the alternative is a silent fall
+        /// back to the shared database.
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddMultiTenancy(IConfiguration configuration)
+        {
+            services.AddOptions<TenancySettings>()
+                .Bind(configuration.GetSection(TenancySettings.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            // TryAddEnumerable: two modules calling this must not run the same validation twice.
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IValidateOptions<TenancySettings>, TenancySettingsValidator>());
+
+            return services;
+        }
+
+        /// <summary>
         /// Registers application services: current user, token, password hashing, email, and time provider.
         /// </summary>
         /// <returns>The service collection for chaining.</returns>
@@ -397,6 +444,13 @@ public static class DependencyInjection
             services.AddHttpContextAccessor();
 
             services.TryAddScoped<ICorrelationContext, CorrelationContext>();
+
+            // Registered whether or not the host called AddMultiTenancy: everything that reads it
+            // (the query filter's accessor, the save interceptor, the caching decorators) treats an
+            // unresolved tenant as "no tenancy", so the always-on registration costs one object per
+            // scope and removes a whole class of "works until someone forgets the opt-in" bug.
+            services.TryAddScoped<ITenantContext, TenantContext>();
+
             services.TryAddScoped<ICurrentUserService, CurrentUserService>();
             // Singleton: TokenService owns RSA handles (RS256) disposed in IDisposable.Dispose.
             // Scoped lifetime caused the underlying RSA to be disposed at end-of-request while

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using MassTransit;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -199,6 +200,76 @@ public static class DependencyInjection
                 var fallbackLogger = sp.GetService<ILogger<InProcessDistributedLock>>()
                     ?? NullLogger<InProcessDistributedLock>.Instance;
                 return new InProcessDistributedLock(fallbackLogger);
+            });
+
+            return services;
+        }
+
+        /// <summary>
+        /// Replaces the registered <see cref="ICacheService"/> with the two-level
+        /// <see cref="HybridCache"/> implementation: an in-process L1 in front of the host's
+        /// distributed cache.
+        /// </summary>
+        /// <param name="configure">Optional hook to adjust the <see cref="HybridCacheOptions"/> after the framework defaults are applied.</param>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// Opt-in, and intended for hosts that already register a distributed L2 (Redis). A
+        /// memory-only host gains nothing: <see cref="MemoryCacheService"/> is already in-process, and
+        /// the default registration stays byte-identical to today for every host that does not call
+        /// this.
+        /// </para>
+        /// <para>
+        /// Order-independent with <c>AddInfrastructure</c> and
+        /// <c>AddCaching</c>, in both directions. Called first, this
+        /// registration is already present when <c>AddCaching</c>'s <c>TryAddSingleton</c> runs, so
+        /// that one no-ops; called second, <c>RemoveAll</c> drops what <c>AddCaching</c> registered
+        /// before adding this one. Either way the host ends with exactly one
+        /// <see cref="ICacheService"/> and it is this one.
+        /// </para>
+        /// <para>
+        /// <b>That includes a host's own custom <see cref="ICacheService"/>:</b> <c>RemoveAll</c> does
+        /// not distinguish the framework's registration from anyone else's. Calling this is a
+        /// statement that the two-level cache is the cache, so a host with a bespoke implementation
+        /// should not call it.
+        /// </para>
+        /// <para>
+        /// Cache keys are namespaced exactly as in <c>AddCaching</c> (the <c>Cache:KeyPrefix</c>
+        /// section), and the optional <see cref="IConnectionMultiplexer"/> is resolved the same way,
+        /// since prefix eviction still needs SCAN.
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddCommonHybridCache(Action<HybridCacheOptions>? configure = null)
+        {
+            services.AddHybridCache(options =>
+            {
+                // Same TTL policy the rest of the framework applies, expressed in HybridCache's own
+                // option type; the local copy is capped so a replica that misses an invalidation
+                // re-reads L2 within the window.
+                options.DefaultEntryOptions = new HybridCacheEntryOptions
+                {
+                    Expiration = CacheOptions.DefaultDuration,
+                    LocalCacheExpiration = HybridCacheService.LocalCacheDefault,
+                };
+
+                configure?.Invoke(options);
+            });
+
+            // Deliberately RemoveAll + Add rather than TryAdd: this call is the host stating which
+            // cache wins, and it has to win whether it runs before or after AddInfrastructure.
+            services.RemoveAll<ICacheService>();
+            services.AddSingleton<ICacheService>(sp =>
+            {
+                var logger = sp.GetService<ILogger<HybridCacheService>>()
+                    ?? NullLogger<HybridCacheService>.Instance;
+                var multiplexer = sp.GetService<IConnectionMultiplexer>();
+                var keyNamespace = CacheKeyNamespace.From(sp.GetService<IOptions<CacheKeyPrefixOptions>>());
+
+                return new HybridCacheService(
+                    sp.GetRequiredService<HybridCache>(),
+                    logger,
+                    multiplexer,
+                    keyNamespace);
             });
 
             return services;

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -340,6 +340,55 @@ public static class DependencyInjection
         }
 
         /// <summary>
+        /// Enables the entity change-history trail: binds the <c>AuditTrail</c> settings section,
+        /// registers the interceptor that records changes to <c>IAuditedEntity</c> entities, the read
+        /// surface (<see cref="IAuditTrailReader"/>), and the retention job.
+        /// </summary>
+        /// <param name="configuration">Application configuration for binding the <c>AuditTrail</c> section.</param>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// Call this once per host. Registering the trail is not the same as turning it on: the
+        /// interceptor and the <c>AuditTrailEntries</c> table both stay inert until
+        /// <c>AuditTrail:Enabled</c> is true, so a host can ship the registration and enable it per
+        /// environment. A host that never calls this keeps exactly the model and the save pipeline it
+        /// had before the trail shipped, because <c>ApplicationDbContext</c> resolves the interceptor
+        /// with <c>GetService</c> and finds nothing.
+        /// </para>
+        /// <para>
+        /// <b>Retention needs the scheduler.</b> This registers <c>AuditTrailCleanupJob</c>, but a
+        /// job only runs when the host ALSO calls <c>AddScheduledJobs(configuration)</c> and sets
+        /// <c>Scheduler:Enabled</c>. Without the scheduler the trail still records every change and
+        /// nothing is ever purged: pruning the table is then the operator's job, and
+        /// <c>AuditTrail:RetentionDays</c> is inert.
+        /// </para>
+        /// <para>
+        /// Marking entities is the other half: an entity records nothing until it carries
+        /// <c>IAuditedEntity</c>. That is deliberate, and it is where the write volume is decided.
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddAuditTrail(IConfiguration configuration)
+        {
+            services.AddOptions<AuditTrailSettings>()
+                .Bind(configuration.GetSection(AuditTrailSettings.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            // Singleton for the same reason as the other two save interceptors: stateless, with any
+            // per-save state held in a ConditionalWeakTable keyed by context.
+            services.TryAddSingleton<Persistence.AuditTrail.AuditTrailSaveChangesInterceptor>();
+
+            services.TryAddScoped<IAuditTrailReader, Persistence.AuditTrail.AuditTrailReader>();
+
+            // The framework's own scheduled job. Registering it here rather than in AddScheduledJobs
+            // keeps the two features independent: the trail can be enabled without the scheduler, and
+            // the scheduler without the trail.
+            services.AddScheduledJob<Persistence.AuditTrail.AuditTrailCleanupJob>();
+
+            return services;
+        }
+
+        /// <summary>
         /// Registers application services: current user, token, password hashing, email, and time provider.
         /// </summary>
         /// <returns>The service collection for chaining.</returns>

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -272,6 +273,69 @@ public static class DependencyInjection
                     keyNamespace);
             });
 
+            return services;
+        }
+
+        /// <summary>
+        /// Enables the recurring job scheduler: binds the <c>Scheduler</c> settings section and
+        /// registers the background runner that executes registered
+        /// <see cref="IScheduledJob"/>s on their cron schedules.
+        /// </summary>
+        /// <param name="configuration">Application configuration for binding the <c>Scheduler</c> section.</param>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// Call this <b>once</b> per host, and <c>AddScheduledJob&lt;TJob&gt;</c> any number of
+        /// times. The two are order-free: a module may register its jobs before the host enables the
+        /// scheduler, or after. Calling this more than once is harmless, since the runner is
+        /// registered through <c>TryAddEnumerable</c> and would otherwise run twice in one process.
+        /// </para>
+        /// <para>
+        /// Registering the scheduler is not the same as turning it on. The runner and the
+        /// <c>ScheduledJobs</c> table both stay inert until <c>Scheduler:Enabled</c> is true, so a
+        /// host can ship the registration and enable it per environment.
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddScheduledJobs(IConfiguration configuration)
+        {
+            services.AddOptions<SchedulerSettings>()
+                .Bind(configuration.GetSection(SchedulerSettings.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            // TryAddEnumerable, not AddHostedService: the latter appends a descriptor per call, so a
+            // host (or two modules) calling this twice would run two runners in one process, and both
+            // would race for the same job rows.
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IHostedService, Scheduling.ScheduledJobRunner>());
+
+            return services;
+        }
+
+        /// <summary>
+        /// Registers one <see cref="IScheduledJob"/> implementation with the scheduler.
+        /// </summary>
+        /// <typeparam name="TJob">The job implementation.</typeparam>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// Jobs accumulate: each module calls this for the jobs it owns and every registration is
+        /// added to the same <c>IEnumerable&lt;IScheduledJob&gt;</c>, exactly like the permission
+        /// registry's accumulate-across-modules idiom. Registration order does not matter, and the
+        /// same type registered twice is added once.
+        /// </para>
+        /// <para>
+        /// The job is <b>scoped</b>: the runner resolves it in a fresh scope per execution, so it may
+        /// take scoped dependencies (unit of work, repositories, handlers) and must hold no state
+        /// between runs. The concrete type is registered too, so a host can resolve it directly (a
+        /// test, or an admin endpoint that triggers the job on demand).
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddScheduledJob<TJob>()
+            where TJob : class, IScheduledJob
+        {
+            services.TryAddScoped<TJob>();
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<IScheduledJob, TJob>());
             return services;
         }
 

--- a/Source/Core/MMCA.Common.Infrastructure/MMCA.Common.Infrastructure.csproj
+++ b/Source/Core/MMCA.Common.Infrastructure/MMCA.Common.Infrastructure.csproj
@@ -45,6 +45,10 @@
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" />
+    <!-- Two-level caching behind the opt-in AddCommonHybridCache (HybridCacheService). Referenced
+         unconditionally so the type is available to hosts that call it; a host that does not is
+         unaffected, since nothing registers HybridCache until AddCommonHybridCache runs. -->
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MMCA.Common.Application\MMCA.Common.Application.csproj" />

--- a/Source/Core/MMCA.Common.Infrastructure/MMCA.Common.Infrastructure.csproj
+++ b/Source/Core/MMCA.Common.Infrastructure/MMCA.Common.Infrastructure.csproj
@@ -49,6 +49,11 @@
          unconditionally so the type is available to hosts that call it; a host that does not is
          unaffected, since nothing registers HybridCache until AddCommonHybridCache runs. -->
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
+    <!-- Cron grammar for the opt-in recurring job scheduler (ScheduledJobRunner). MIT and
+         zero-dependency, so it adds one entry to a consumer's lock file and nothing else.
+         Referenced unconditionally so the types are available to hosts that call AddScheduledJobs;
+         a host that does not call it registers no runner and maps no table. -->
+    <PackageReference Include="Cronos" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MMCA.Common.Application\MMCA.Common.Application.csproj" />

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailCleanupJob.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailCleanupJob.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
@@ -36,12 +37,22 @@ namespace MMCA.Common.Infrastructure.Persistence.AuditTrail;
 /// <param name="logger">Logger for sweep diagnostics.</param>
 /// <param name="options">Bound audit-trail settings (the retention window).</param>
 /// <param name="timeProvider">Clock abstraction for the retention cutoff.</param>
+/// <param name="scopeFactory">
+/// Creates the per-tenant scope a database-per-tenant sweep needs. Defaulted: a host without
+/// tenancy never leaves the job's own scope.
+/// </param>
+/// <param name="tenancyOptions">
+/// Bound tenancy settings, used only to discover tenants whose own database holds its own trail
+/// table (which the shared sweep never reaches).
+/// </param>
 internal sealed partial class AuditTrailCleanupJob(
     IDbContextFactory dbContextFactory,
     IEntityDataSourceRegistry entityDataSourceRegistry,
     ILogger<AuditTrailCleanupJob> logger,
     IOptions<AuditTrailSettings> options,
-    TimeProvider timeProvider) : IScheduledJob
+    TimeProvider timeProvider,
+    IServiceScopeFactory? scopeFactory = null,
+    IOptions<TenancySettings>? tenancyOptions = null) : IScheduledJob
 {
     /// <summary>The number of rows removed per statement.</summary>
     internal const int BatchSize = 1000;
@@ -65,25 +76,62 @@ internal sealed partial class AuditTrailCleanupJob(
 
         var cutoff = timeProvider.GetUtcNow().UtcDateTime.Subtract(TimeSpan.FromDays(_settings.RetentionDays));
 
-        foreach (var source in entityDataSourceRegistry.GetPhysicalSourcesInUse()
+        var relationalSources = entityDataSourceRegistry.GetPhysicalSourcesInUse()
             .Where(key => key.Engine != DataSource.CosmosDB)
-            .Distinct())
+            .Distinct();
+
+        foreach (var target in TenantDataSourceTargets.Expand(relationalSources, tenancyOptions?.Value))
         {
-            var context = dbContextFactory.GetDbContext(source);
+            await PurgeTargetAsync(target, cutoff, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
-            // Cosmos is already excluded, but a relational source can still lack the table when the
-            // host disabled the trail after it was written, so the model is the authority.
-            if (context.Model.FindEntityType(typeof(AuditTrailEntry)) is null)
-            {
-                continue;
-            }
+    /// <summary>
+    /// Sweeps one target. The shared database is swept on the job's own scope; a tenant that keeps
+    /// its own database needs a fresh scope with that tenant set, because the scoped context factory
+    /// binds one database per scope and the job's scope is already bound to the shared one.
+    /// </summary>
+    private async Task PurgeTargetAsync(
+        TenantDataSourceTarget target,
+        DateTime cutoff,
+        CancellationToken cancellationToken)
+    {
+        if (target.TenantId is null || scopeFactory is null)
+        {
+            await PurgeWithFactoryAsync(dbContextFactory, target, cutoff, cancellationToken).ConfigureAwait(false);
+            return;
+        }
 
-            var deleted = await PurgeSourceAsync(context, cutoff, cancellationToken).ConfigureAwait(false);
-            if (deleted > 0)
-            {
-                var sourceName = source.ToString();
-                LogPurged(logger, deleted, sourceName);
-            }
+        using var scope = scopeFactory.CreateScope();
+        scope.ServiceProvider.GetRequiredService<ITenantContext>().SetTenant(target.TenantId);
+        await PurgeWithFactoryAsync(
+            scope.ServiceProvider.GetRequiredService<IDbContextFactory>(),
+            target,
+            cutoff,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Resolves the target's context from <paramref name="factory"/> and purges it.</summary>
+    private async Task PurgeWithFactoryAsync(
+        IDbContextFactory factory,
+        TenantDataSourceTarget target,
+        DateTime cutoff,
+        CancellationToken cancellationToken)
+    {
+        var context = factory.GetDbContext(target.Source);
+
+        // Cosmos is already excluded, but a relational source can still lack the table when the
+        // host disabled the trail after it was written, so the model is the authority.
+        if (context.Model.FindEntityType(typeof(AuditTrailEntry)) is null)
+        {
+            return;
+        }
+
+        var deleted = await PurgeSourceAsync(context, cutoff, cancellationToken).ConfigureAwait(false);
+        if (deleted > 0)
+        {
+            var sourceName = target.ToString();
+            LogPurged(logger, deleted, sourceName);
         }
     }
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailCleanupJob.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailCleanupJob.cs
@@ -1,0 +1,135 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Persistence.AuditTrail;
+
+/// <summary>
+/// The framework's own recurring job: purges <see cref="AuditTrailEntry"/> rows older than
+/// <see cref="AuditTrailSettings.RetentionDays"/> from every relational data source in use.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A change trail grows monotonically and stores values that may describe a data subject, so a
+/// retention window is not optional housekeeping: it is what keeps the table from becoming both a
+/// cost centre and an unbounded data-protection liability (ADR-005).
+/// </para>
+/// <para>
+/// <b>It only runs if the host also runs the scheduler.</b> <c>AddAuditTrail</c> registers this job,
+/// but a job with no runner never executes: the host must also call <c>AddScheduledJobs</c> and set
+/// <c>Scheduler:Enabled</c>. A host that records the trail without the scheduler is fully supported
+/// and keeps recording; pruning is then the operator's job.
+/// </para>
+/// <para>
+/// Deletion is set-based and batched: ids are read a page at a time and removed with
+/// <c>ExecuteDelete</c>, so a first sweep over a long-neglected table does not become one enormous
+/// transaction, and no row is ever materialized as an entity.
+/// </para>
+/// </remarks>
+/// <param name="dbContextFactory">Scoped factory for the context of each data source being swept.</param>
+/// <param name="entityDataSourceRegistry">Registry enumerating the physical data sources in use.</param>
+/// <param name="logger">Logger for sweep diagnostics.</param>
+/// <param name="options">Bound audit-trail settings (the retention window).</param>
+/// <param name="timeProvider">Clock abstraction for the retention cutoff.</param>
+internal sealed partial class AuditTrailCleanupJob(
+    IDbContextFactory dbContextFactory,
+    IEntityDataSourceRegistry entityDataSourceRegistry,
+    ILogger<AuditTrailCleanupJob> logger,
+    IOptions<AuditTrailSettings> options,
+    TimeProvider timeProvider) : IScheduledJob
+{
+    /// <summary>The number of rows removed per statement.</summary>
+    internal const int BatchSize = 1000;
+
+    private readonly AuditTrailSettings _settings = options.Value;
+
+    /// <inheritdoc />
+    public string Name => "audit-trail-cleanup";
+
+    /// <inheritdoc />
+    /// <remarks>Daily at 03:00 UTC: off the daily peak for every time zone this framework runs in.</remarks>
+    public string CronExpression => "0 3 * * *";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        if (!_settings.Enabled)
+        {
+            return;
+        }
+
+        var cutoff = timeProvider.GetUtcNow().UtcDateTime.Subtract(TimeSpan.FromDays(_settings.RetentionDays));
+
+        foreach (var source in entityDataSourceRegistry.GetPhysicalSourcesInUse()
+            .Where(key => key.Engine != DataSource.CosmosDB)
+            .Distinct())
+        {
+            var context = dbContextFactory.GetDbContext(source);
+
+            // Cosmos is already excluded, but a relational source can still lack the table when the
+            // host disabled the trail after it was written, so the model is the authority.
+            if (context.Model.FindEntityType(typeof(AuditTrailEntry)) is null)
+            {
+                continue;
+            }
+
+            var deleted = await PurgeSourceAsync(context, cutoff, cancellationToken).ConfigureAwait(false);
+            if (deleted > 0)
+            {
+                var sourceName = source.ToString();
+                LogPurged(logger, deleted, sourceName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes every trail row older than <paramref name="cutoff"/> from one data source, a batch at
+    /// a time.
+    /// </summary>
+    private static async Task<int> PurgeSourceAsync(
+        DbContext context,
+        DateTime cutoff,
+        CancellationToken cancellationToken)
+    {
+        var total = 0;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            // The ids are read first and deleted by id, rather than deleting straight from a limited
+            // query: every relational provider translates an IN list, while a limited DELETE is not
+            // universally supported.
+            var ids = await context.Set<AuditTrailEntry>().AsNoTracking()
+                .Where(row => row.ChangedOn < cutoff)
+                .OrderBy(row => row.ChangedOn)
+                .Select(row => row.Id)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (ids.Count == 0)
+            {
+                break;
+            }
+
+            total += await context.Set<AuditTrailEntry>()
+                .Where(row => ids.Contains(row.Id))
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (ids.Count < BatchSize)
+            {
+                break;
+            }
+        }
+
+        return total;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Purged {Count} audit trail rows older than retention from {DataSourceName}")]
+    private static partial void LogPurged(ILogger logger, int count, string dataSourceName);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailEntry.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailEntry.cs
@@ -1,0 +1,99 @@
+namespace MMCA.Common.Infrastructure.Persistence.AuditTrail;
+
+/// <summary>
+/// One recorded change to an entity marked with <c>IAuditedEntity</c>, written in the same
+/// transaction as the change it describes by <see cref="AuditTrailSaveChangesInterceptor"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately <b>not</b> an <c>IAuditableEntity</c>, exactly like <c>OutboxMessage</c> and
+/// <c>ScheduledJobEntry</c>: this is framework bookkeeping, not domain state. It carries no
+/// soft-delete flag (so no global query filter applies to it), no audit stamps of its own, and no
+/// concurrency token. Rows are append-only: nothing in the framework ever updates one, and the only
+/// deletion is the retention sweep in <see cref="AuditTrailCleanupJob"/>.
+/// </para>
+/// <para>
+/// <b>Row shape.</b> A <c>Modified</c> save produces one row per property whose value actually
+/// changed, so a trail reads as a field-level history. An <c>Added</c> or <c>Deleted</c> save
+/// produces a single summary row with a null <see cref="PropertyName"/>: the interesting fact there
+/// is the lifecycle event, and one row per column at insert time would multiply the table for no
+/// extra information (the created state is already the first Modified baseline).
+/// </para>
+/// </remarks>
+public sealed class AuditTrailEntry
+{
+    /// <summary>Gets the unique identifier for this trail row.</summary>
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Gets the full CLR type name of the entity that changed. Stored as a string rather than a
+    /// foreign key because the trail outlives the row it describes (a deleted entity keeps its
+    /// history) and spans every audited type in one table.
+    /// </summary>
+    public required string EntityType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the invariant string form of the changed entity's primary key. A composite key
+    /// is joined with <c>|</c> in the model's key order, so one column addresses every audited
+    /// entity regardless of its key shape.
+    /// </summary>
+    /// <remarks>
+    /// Settable, unlike every other property here, for exactly one reason: an entity with a
+    /// store-generated key (the framework's identity columns) has no key yet when the change is
+    /// captured, so <see cref="AuditTrailSaveChangesInterceptor"/> rewrites this one column once the
+    /// insert has assigned it. Nothing else ever changes a trail row.
+    /// </remarks>
+    public required string EntityKey { get; set; }
+
+    /// <summary>
+    /// Gets the name of the property that changed, or <see langword="null"/> on the summary row of
+    /// an <c>Added</c> or <c>Deleted</c> operation.
+    /// </summary>
+    public string? PropertyName { get; init; }
+
+    /// <summary>
+    /// Gets the invariant string form of the value before the change, or <see langword="null"/>
+    /// when the property was null, when the operation has no before-state (<c>Added</c>), or when
+    /// the property carries <c>PiiAttribute</c> (in which case it holds the redaction placeholder).
+    /// </summary>
+    public string? OldValue { get; init; }
+
+    /// <summary>
+    /// Gets the invariant string form of the value after the change, or <see langword="null"/>
+    /// when the property became null, when the operation has no after-state (<c>Deleted</c>), or
+    /// when the property carries <c>PiiAttribute</c> (in which case it holds the redaction
+    /// placeholder).
+    /// </summary>
+    public string? NewValue { get; init; }
+
+    /// <summary>
+    /// Gets the operation that produced this row: <c>Added</c>, <c>Modified</c> or <c>Deleted</c>.
+    /// A soft delete arrives here as <c>Modified</c> on <c>IsDeleted</c>, which is exactly what it
+    /// is at the database level.
+    /// </summary>
+    public required string Operation { get; init; }
+
+    /// <summary>
+    /// Gets the identifier of the user the save ran as, or <see langword="null"/> when the save
+    /// carried no identity (a background service, a seeder, a plain <c>SaveChangesAsync</c>).
+    /// </summary>
+    public UserIdentifierType? ChangedBy { get; init; }
+
+    /// <summary>Gets the UTC instant the change was captured.</summary>
+    public DateTime ChangedOn { get; init; }
+
+    /// <summary>
+    /// Gets the ambient trace identifier the change was captured under, or <see langword="null"/>
+    /// when the save ran outside any activity. It ties a trail row back to the request or job in
+    /// the telemetry pipeline. See <see cref="AuditTrailSaveChangesInterceptor"/> for why this is a
+    /// trace id rather than the scoped <c>ICorrelationContext</c> value.
+    /// </summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>
+    /// Gets the owning tenant, or <see langword="null"/>. Always null today: the column exists so
+    /// the multi-tenancy feature can start populating it without a schema migration on every
+    /// consumer that has already adopted the trail.
+    /// </summary>
+    public string? TenantId { get; init; }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailEntry.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailEntry.cs
@@ -91,9 +91,10 @@ public sealed class AuditTrailEntry
     public string? CorrelationId { get; init; }
 
     /// <summary>
-    /// Gets the owning tenant, or <see langword="null"/>. Always null today: the column exists so
-    /// the multi-tenancy feature can start populating it without a schema migration on every
-    /// consumer that has already adopted the trail.
+    /// Gets the tenant the change was made under, or <see langword="null"/> when the save resolved
+    /// no tenant (a background service, a seeder, a single-tenant host). Recorded from
+    /// <c>ApplicationDbContext.CurrentTenantId</c> at capture, so a trail row can be read back per
+    /// tenant even where the trail table itself is shared.
     /// </summary>
     public string? TenantId { get; init; }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailReader.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailReader.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Auditing;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Persistence.AuditTrail;
+
+/// <summary>
+/// Reads recorded changes from the <c>AuditTrailEntries</c> table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Known v1 limitation: the Default source only.</b> Trail rows are written to whichever database
+/// holds the entity that changed (that is what makes the write atomic), so a host that splits its
+/// modules across several databases has several trail tables. This reader queries exactly one of
+/// them: the <c>Default</c> database of the engine named by <c>AuditTrail:DataSource</c>. For the
+/// monolith, where every source collapses onto <c>Default</c>, that is the whole trail. For a
+/// database-per-module host it is the trail of the modules living in the default database; reading
+/// another module's history needs a per-source overload, which is deliberately deferred rather than
+/// guessed at.
+/// </para>
+/// <para>
+/// Returns an empty list rather than throwing when the trail is not enabled: the read surface is
+/// registered by <c>AddAuditTrail</c>, which a host may call before flipping
+/// <c>AuditTrail:Enabled</c> per environment.
+/// </para>
+/// </remarks>
+/// <param name="dbContextFactory">Scoped factory resolving the context for the trail's data source.</param>
+/// <param name="dataSourceResolver">Resolver mapping the configured engine to its physical Default source.</param>
+/// <param name="options">Bound audit-trail settings.</param>
+internal sealed class AuditTrailReader(
+    IDbContextFactory dbContextFactory,
+    IDataSourceResolver dataSourceResolver,
+    IOptions<AuditTrailSettings> options) : IAuditTrailReader
+{
+    private readonly AuditTrailSettings _settings = options.Value;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditTrailEntryDTO>> GetForEntityAsync(
+        string entityType,
+        string entityKey,
+        int page = 1,
+        int pageSize = 50,
+        CancellationToken cancellationToken = default)
+    {
+        var effectivePage = page < 1 ? 1 : page;
+        var effectivePageSize = pageSize < 1 ? 1 : pageSize;
+
+        var context = dbContextFactory.GetDbContext(
+            dataSourceResolver.ResolveLogical(_settings.DataSource, DataSourceKey.DefaultName));
+
+        if (context.Model.FindEntityType(typeof(AuditTrailEntry)) is null)
+        {
+            return [];
+        }
+
+        return await context.Set<AuditTrailEntry>().AsNoTracking()
+            .Where(row => row.EntityType == entityType && row.EntityKey == entityKey)
+            .OrderByDescending(row => row.ChangedOn)
+            .ThenByDescending(row => row.Id)
+            .Skip((effectivePage - 1) * effectivePageSize)
+            .Take(effectivePageSize)
+            .Select(row => new AuditTrailEntryDTO
+            {
+                Id = row.Id,
+                EntityType = row.EntityType,
+                EntityKey = row.EntityKey,
+                PropertyName = row.PropertyName,
+                OldValue = row.OldValue,
+                NewValue = row.NewValue,
+                Operation = row.Operation,
+                ChangedBy = row.ChangedBy,
+                ChangedOn = row.ChangedOn,
+                CorrelationId = row.CorrelationId,
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailSaveChangesInterceptor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailSaveChangesInterceptor.cs
@@ -1,0 +1,538 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MMCA.Common.Domain.Attributes;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Domain.Privacy;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Inbox;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Scheduling;
+
+namespace MMCA.Common.Infrastructure.Persistence.AuditTrail;
+
+/// <summary>
+/// EF Core interceptor that records a field-level change history for every entity marked with
+/// <see cref="IAuditedEntity"/>, writing <see cref="AuditTrailEntry"/> rows in the <b>same
+/// transaction</b> as the change they describe (the outbox precedent: a trail that can be committed
+/// without its data, or the other way round, is worse than no trail).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Position in the pipeline.</b> Registered last, after
+/// <see cref="Interceptors.AuditSaveChangesInterceptor"/> and
+/// <see cref="Interceptors.DomainEventSaveChangesInterceptor"/>, so the values it captures are the
+/// final ones: the audit stamps (<c>LastModifiedBy/On</c>) are already written when the diff runs.
+/// Its own rows, and the framework's own bookkeeping tables, are never audited.
+/// </para>
+/// <para>
+/// <b>Opt-in twice over.</b> Nothing happens unless the host called <c>AddAuditTrail</c> (this
+/// interceptor is resolved with <c>GetService</c>, so its absence is a silent no-op) AND
+/// <c>AuditTrail:Enabled</c> mapped the table into the model. Both are checked cheaply per save.
+/// </para>
+/// <para>
+/// <b>Personal data never reaches the table.</b> A property carrying <see cref="PiiAttribute"/>
+/// records <see cref="PiiRedactor.RedactedToken"/> on both sides of the change. Redaction happens
+/// at capture, not at read, so the trail cannot become a second copy of a data subject's personal
+/// data that erasure would have to chase (ADR-005).
+/// </para>
+/// <para>
+/// <b>Correlation.</b> The row records the ambient <see cref="Activity"/> trace id, not the scoped
+/// <c>ICorrelationContext</c>. This interceptor is a singleton, and the only service provider a
+/// <see cref="ApplicationDbContext"/> carries is the ROOT provider (contexts are built by the
+/// singleton <c>PhysicalDbContextFactory</c>), so a scoped service is not reachable from here and
+/// capturing one would be a lifetime bug rather than a feature. The trace id is ambient, is what
+/// the telemetry pipeline correlates on, and is the same value
+/// <c>CorrelationIdMiddleware</c> itself falls back to when a request carries no
+/// <c>X-Correlation-ID</c> header. A caller-supplied header value is therefore NOT recorded in v1;
+/// honoring it needs a live accessor on the context assigned by the scoped factory (the shape the
+/// multi-tenancy work introduces for <c>TenantId</c>), which is deliberately out of scope here.
+/// </para>
+/// </remarks>
+/// <param name="timeProvider">Provides the UTC capture timestamp.</param>
+public sealed class AuditTrailSaveChangesInterceptor(TimeProvider timeProvider) : SaveChangesInterceptor
+{
+    /// <summary>Operation recorded for an inserted entity (one summary row).</summary>
+    internal const string OperationAdded = "Added";
+
+    /// <summary>Operation recorded for an updated entity (one row per changed property).</summary>
+    internal const string OperationModified = "Modified";
+
+    /// <summary>Operation recorded for a hard-deleted entity (one summary row).</summary>
+    internal const string OperationDeleted = "Deleted";
+
+    /// <summary>Column width of <c>EntityType</c>; longer names are truncated to fit.</summary>
+    internal const int MaxEntityTypeLength = 256;
+
+    /// <summary>Column width of <c>EntityKey</c> and <c>PropertyName</c>; longer values are truncated to fit.</summary>
+    internal const int MaxKeyLength = 128;
+
+    /// <summary>Column width of <c>CorrelationId</c>; longer values are truncated to fit.</summary>
+    internal const int MaxCorrelationIdLength = 64;
+
+    /// <summary>Separator joining the parts of a composite primary key into one <c>EntityKey</c> value.</summary>
+    internal const char KeySeparator = '|';
+
+    /// <summary>
+    /// Trail rows whose <see cref="AuditTrailEntry.EntityKey"/> could not be known before the save,
+    /// keyed by context. Used only by the store-generated-key fix-up below.
+    /// </summary>
+    private static readonly ConditionalWeakTable<DbContext, List<PendingEntityKey>> PendingKeyTable = [];
+
+    /// <summary>
+    /// Marks a context whose capture has staged rows but whose save has not completed. Present only
+    /// between <c>SavingChanges</c> and <c>SavedChanges</c>, so the discard below can tell an
+    /// abandoned attempt from rows someone else legitimately added.
+    /// </summary>
+    private static readonly ConditionalWeakTable<DbContext, object> CaptureMarkerTable = [];
+
+    /// <summary>The value stored in <see cref="CaptureMarkerTable"/>; only its presence matters.</summary>
+    private static readonly object CaptureMarker = new();
+
+    /// <summary>Caches the <see cref="PiiAttribute"/> verdict per (declaring type, property name).</summary>
+    private static readonly ConcurrentDictionary<(Type DeclaringType, string PropertyName), bool> PiiCache = new();
+
+    /// <summary>
+    /// The framework's own bookkeeping entities, which are never audited whatever markers they
+    /// carry. Guarding by CLR type rather than by the absence of <see cref="IAuditedEntity"/> keeps
+    /// the trail from ever recording its own rows (an unbounded feedback loop) and keeps the outbox,
+    /// inbox and job tables out of a history nobody asked for.
+    /// </summary>
+    private static readonly HashSet<Type> FrameworkEntityTypes =
+    [
+        typeof(AuditTrailEntry),
+        typeof(OutboxMessage),
+        typeof(InboxMessage),
+        typeof(ScheduledJobEntry),
+    ];
+
+    /// <inheritdoc />
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is ApplicationDbContext context)
+            CaptureChanges(context);
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        if (eventData.Context is ApplicationDbContext context)
+            CaptureChanges(context);
+
+        return base.SavingChanges(eventData, result);
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is ApplicationDbContext context)
+            await ResolveGeneratedKeysAsync(context, cancellationToken).ConfigureAwait(false);
+
+        return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
+    {
+        if (eventData.Context is ApplicationDbContext context)
+            ResolveGeneratedKeys(context);
+
+        return base.SavedChanges(eventData, result);
+    }
+
+    /// <summary>
+    /// Indicates whether <paramref name="type"/> is one of the framework's own bookkeeping entities,
+    /// which the trail never records.
+    /// </summary>
+    /// <param name="type">The entity CLR type to test.</param>
+    /// <returns><see langword="true"/> when the type must never be audited.</returns>
+    internal static bool IsFrameworkEntity(Type type) => FrameworkEntityTypes.Contains(type);
+
+    /// <summary>
+    /// Walks the change tracker and adds one <see cref="AuditTrailEntry"/> per changed property
+    /// (<c>Modified</c>) or one summary row (<c>Added</c> / <c>Deleted</c>).
+    /// </summary>
+    private void CaptureChanges(ApplicationDbContext context)
+    {
+        // Two gates in one lookup: a host that never opted in has no AuditTrailEntry in its model,
+        // and neither does Cosmos (which skips the relational tables entirely). Set<AuditTrailEntry>
+        // would throw for both, so nothing may run before this check.
+        if (context.Model.FindEntityType(typeof(AuditTrailEntry)) is null)
+        {
+            return;
+        }
+
+        DiscardAbandonedCapture(context);
+
+        var capture = new CaptureContext(
+            context.CurrentSaveUserId,
+            timeProvider.GetUtcNow().UtcDateTime,
+            Truncate(Activity.Current?.TraceId.ToString(), MaxCorrelationIdLength));
+
+        // Snapshot before adding: the rows this method writes land in the same tracker, and
+        // enumerating it lazily while adding to it would throw.
+        var entries = context.ChangeTracker.Entries().Where(ShouldAudit).ToArray();
+        if (entries.Length == 0)
+        {
+            return;
+        }
+
+        List<PendingEntityKey>? pending = null;
+
+        foreach (var entry in entries)
+        {
+            if (CaptureEntry(context, entry, capture) is { } pendingRow)
+            {
+                (pending ??= []).Add(pendingRow);
+            }
+        }
+
+        if (pending is not null)
+        {
+            PendingKeyTable.AddOrUpdate(context, pending);
+        }
+
+        CaptureMarkerTable.AddOrUpdate(context, CaptureMarker);
+    }
+
+    /// <summary>
+    /// Whether a tracked entry belongs in the trail: it opted in, it is not one of the framework's
+    /// own bookkeeping entities, and it is actually being written.
+    /// </summary>
+    private static bool ShouldAudit(EntityEntry entry) =>
+        entry.Entity is IAuditedEntity
+        && !IsFrameworkEntity(entry.Metadata.ClrType)
+        && entry.State is EntityState.Added or EntityState.Modified or EntityState.Deleted;
+
+    /// <summary>
+    /// Records one changed entry: a row per changed property for an update, one summary row for an
+    /// insert or a delete.
+    /// </summary>
+    /// <returns>
+    /// The inserted row awaiting a store-generated key, or <see langword="null"/> when the key was
+    /// already known (or the entry was not an insert).
+    /// </returns>
+    private static PendingEntityKey? CaptureEntry(
+        ApplicationDbContext context,
+        EntityEntry entry,
+        CaptureContext capture)
+    {
+        var entityType = Truncate(entry.Metadata.ClrType.FullName ?? entry.Metadata.ClrType.Name, MaxEntityTypeLength)!;
+        var entityKey = BuildEntityKey(entry);
+
+        if (entry.State == EntityState.Modified)
+        {
+            CaptureModifiedProperties(context, entry, entityType, entityKey, capture);
+            return null;
+        }
+
+        var row = AddRow(context, new AuditTrailEntry
+        {
+            EntityType = entityType,
+            EntityKey = entityKey,
+            Operation = entry.State == EntityState.Added ? OperationAdded : OperationDeleted,
+            ChangedBy = capture.ChangedBy,
+            ChangedOn = capture.ChangedOn,
+            CorrelationId = capture.CorrelationId,
+        });
+
+        // A store-generated key (the framework's identity columns) does not exist yet at this point:
+        // EF holds a temporary sentinel that would make the row unfindable by key. Remember it and
+        // rewrite the column once the insert has assigned the real value, inside the same
+        // transaction when one is open.
+        return entry.State == EntityState.Added && HasTemporaryKey(entry)
+            ? new PendingEntityKey(row, entry)
+            : null;
+    }
+
+    /// <summary>
+    /// Adds one row per property whose value actually changed. A property EF flagged as modified but
+    /// whose value is unchanged (the whole-entity <c>Update</c> idiom) writes nothing: a trail that
+    /// records non-changes is noise, and the volume is the reason the feature is opt-in per entity.
+    /// </summary>
+    private static void CaptureModifiedProperties(
+        ApplicationDbContext context,
+        EntityEntry entry,
+        string entityType,
+        string entityKey,
+        CaptureContext capture)
+    {
+        // One reflection pass per entity type, cached by the redactor: when nothing on the type is
+        // personal data, the per-property attribute lookup below is skipped entirely.
+        var typeHasPii = PiiRedactor.HasPii(entry.Metadata.ClrType);
+
+        foreach (var property in entry.Properties)
+        {
+            if (!property.IsModified)
+            {
+                continue;
+            }
+
+            var original = property.OriginalValue;
+            var current = property.CurrentValue;
+            if (ValuesEqual(original, current))
+            {
+                continue;
+            }
+
+            var isPii = typeHasPii && IsPiiProperty(property);
+
+            AddRow(context, new AuditTrailEntry
+            {
+                EntityType = entityType,
+                EntityKey = entityKey,
+                PropertyName = Truncate(property.Metadata.Name, MaxKeyLength),
+                OldValue = isPii ? PiiRedactor.RedactedToken : FormatValue(original),
+                NewValue = isPii ? PiiRedactor.RedactedToken : FormatValue(current),
+                Operation = OperationModified,
+                ChangedBy = capture.ChangedBy,
+                ChangedOn = capture.ChangedOn,
+                CorrelationId = capture.CorrelationId,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Tracks one trail row for insertion in the current save. Mutation is <c>Add</c> only: the save
+    /// runs under <c>DetectChangesOnce</c> with automatic detection off, and <c>Add</c> takes effect
+    /// on the entry immediately.
+    /// </summary>
+    private static AuditTrailEntry AddRow(ApplicationDbContext context, AuditTrailEntry row)
+    {
+#pragma warning disable VSTHRD103 // EF DbSet.Add is intentionally synchronous (in-memory); AddAsync is only for special value generators (EF guidance).
+        context.Set<AuditTrailEntry>().Add(row);
+#pragma warning restore VSTHRD103
+        return row;
+    }
+
+    /// <summary>
+    /// Detaches the trail rows written by a capture whose save never completed. An execution
+    /// strategy that retries a failed save re-runs <c>SavingChanges</c> against a tracker that still
+    /// holds the previous attempt's Added rows, so without this a retried operation writes one trail
+    /// row per attempt.
+    /// </summary>
+    private static void DiscardAbandonedCapture(ApplicationDbContext context)
+    {
+        // Only when a previous capture staged rows and never reached SavedChanges. Discarding
+        // unconditionally would also throw away trail rows a caller added deliberately (a data
+        // import, a test fixture), which is not this method's business.
+        if (!CaptureMarkerTable.TryGetValue(context, out _))
+        {
+            return;
+        }
+
+        CaptureMarkerTable.Remove(context);
+        PendingKeyTable.Remove(context);
+
+        // Every Added AuditTrailEntry left on this context came from that abandoned capture: a
+        // completed save leaves none Added.
+        foreach (var entry in context.ChangeTracker.Entries<AuditTrailEntry>()
+            .Where(e => e.State == EntityState.Added)
+            .ToArray())
+        {
+            entry.State = EntityState.Detached;
+        }
+    }
+
+    /// <summary>
+    /// Rewrites the <c>EntityKey</c> of rows captured before a store-generated key existed, now that
+    /// the insert has assigned one. A single set-based <c>UPDATE</c> per row, exactly like
+    /// <c>OutboxFinalizer</c>: it bypasses the change tracker and the interceptor pipeline, and it
+    /// joins the ambient transaction when the save runs inside one.
+    /// </summary>
+    private static async Task ResolveGeneratedKeysAsync(ApplicationDbContext context, CancellationToken cancellationToken)
+    {
+        // The save completed, so nothing is abandoned any more.
+        CaptureMarkerTable.Remove(context);
+
+        if (!PendingKeyTable.TryGetValue(context, out var pending))
+        {
+            return;
+        }
+
+        PendingKeyTable.Remove(context);
+
+        foreach (var item in pending)
+        {
+            var resolvedKey = BuildEntityKey(item.Entry);
+            if (string.Equals(resolvedKey, item.Row.EntityKey, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rowId = item.Row.Id;
+            await context.Set<AuditTrailEntry>()
+                .Where(r => r.Id == rowId)
+                .ExecuteUpdateAsync(s => s.SetProperty(r => r.EntityKey, resolvedKey), cancellationToken)
+                .ConfigureAwait(false);
+
+            SyncTrackedKey(context, item.Row, resolvedKey);
+        }
+    }
+
+    /// <summary>
+    /// Synchronous counterpart of <see cref="ResolveGeneratedKeysAsync"/> for the
+    /// <c>SaveChanges</c> path.
+    /// </summary>
+    private static void ResolveGeneratedKeys(ApplicationDbContext context)
+    {
+        // The save completed, so nothing is abandoned any more.
+        CaptureMarkerTable.Remove(context);
+
+        if (!PendingKeyTable.TryGetValue(context, out var pending))
+        {
+            return;
+        }
+
+        PendingKeyTable.Remove(context);
+
+        foreach (var item in pending)
+        {
+            var resolvedKey = BuildEntityKey(item.Entry);
+            if (string.Equals(resolvedKey, item.Row.EntityKey, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rowId = item.Row.Id;
+            context.Set<AuditTrailEntry>()
+                .Where(r => r.Id == rowId)
+                .ExecuteUpdate(s => s.SetProperty(r => r.EntityKey, resolvedKey));
+
+            SyncTrackedKey(context, item.Row, resolvedKey);
+        }
+    }
+
+    /// <summary>
+    /// Brings the tracked instance and its snapshot in line with the value just written by
+    /// <c>ExecuteUpdate</c>, so a later save on the same context does not re-issue the update. The
+    /// original-value write must precede clearing <c>IsModified</c>: clearing the flag reverts the
+    /// current value to the original.
+    /// </summary>
+    private static void SyncTrackedKey(ApplicationDbContext context, AuditTrailEntry row, string resolvedKey)
+    {
+        var property = context.Entry(row).Property(nameof(AuditTrailEntry.EntityKey));
+        row.EntityKey = resolvedKey;
+        property.OriginalValue = resolvedKey;
+        property.IsModified = false;
+    }
+
+    /// <summary>
+    /// Whether any part of this entry's primary key is still a temporary value, i.e. the database
+    /// assigns it during the insert.
+    /// </summary>
+    private static bool HasTemporaryKey(EntityEntry entry)
+    {
+        var key = entry.Metadata.FindPrimaryKey();
+        if (key is null)
+        {
+            return false;
+        }
+
+        foreach (var property in key.Properties)
+        {
+            if (entry.Property(property.Name).IsTemporary)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Renders the entry's primary key as one invariant string, joining the parts of a composite key
+    /// with <see cref="KeySeparator"/> in the model's key order. A keyless entity yields an empty
+    /// string rather than throwing: it is still worth recording that it changed.
+    /// </summary>
+    private static string BuildEntityKey(EntityEntry entry)
+    {
+        var key = entry.Metadata.FindPrimaryKey();
+        if (key is null)
+        {
+            return string.Empty;
+        }
+
+        var parts = key.Properties
+            .Select(property => FormatValue(entry.Property(property.Name).CurrentValue) ?? string.Empty);
+
+        return Truncate(string.Join(KeySeparator, parts), MaxKeyLength)!;
+    }
+
+    /// <summary>Whether the CLR property behind an EF property carries <see cref="PiiAttribute"/>.</summary>
+    /// <remarks>
+    /// A shadow property has no <see cref="System.Reflection.PropertyInfo"/> and therefore cannot
+    /// carry the attribute, so it is never treated as personal data.
+    /// </remarks>
+    private static bool IsPiiProperty(PropertyEntry property)
+    {
+        var info = property.Metadata.PropertyInfo;
+        if (info?.DeclaringType is null)
+        {
+            return false;
+        }
+
+        return PiiCache.GetOrAdd(
+            (info.DeclaringType, info.Name),
+            static (_, propertyInfo) => propertyInfo.IsDefined(typeof(PiiAttribute), inherit: false),
+            info);
+    }
+
+    /// <summary>
+    /// Renders a value for storage. Culture-invariant on purpose: a trail read years later, or on a
+    /// replica with a different locale, must show the value that was written.
+    /// </summary>
+    private static string? FormatValue(object? value) =>
+        value is null ? null : Convert.ToString(value, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Compares two property values structurally. Byte arrays (row versions, hashes) need explicit
+    /// handling: reference equality would report every save as a change.
+    /// </summary>
+    private static bool ValuesEqual(object? original, object? current)
+    {
+        if (original is null || current is null)
+        {
+            return original is null && current is null;
+        }
+
+        if (original is byte[] originalBytes && current is byte[] currentBytes)
+        {
+            return originalBytes.AsSpan().SequenceEqual(currentBytes);
+        }
+
+        return original.Equals(current);
+    }
+
+    /// <summary>Truncates a value to a column width, preserving null.</summary>
+    private static string? Truncate(string? value, int maxLength) =>
+        value is null || value.Length <= maxLength ? value : value[..maxLength];
+
+    /// <summary>The values every row of one save shares.</summary>
+    /// <param name="ChangedBy">The user the save runs as, or null.</param>
+    /// <param name="ChangedOn">The UTC capture instant.</param>
+    /// <param name="CorrelationId">The ambient trace identifier, or null.</param>
+    private readonly record struct CaptureContext(
+        UserIdentifierType? ChangedBy,
+        DateTime ChangedOn,
+        string? CorrelationId);
+
+    /// <summary>A trail row awaiting the store-generated key of the entity it describes.</summary>
+    /// <param name="Row">The tracked trail row whose <c>EntityKey</c> must be rewritten.</param>
+    /// <param name="Entry">The audited entry whose key the database assigns during the insert.</param>
+    private sealed record PendingEntityKey(AuditTrailEntry Row, EntityEntry Entry);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailSaveChangesInterceptor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/AuditTrail/AuditTrailSaveChangesInterceptor.cs
@@ -48,9 +48,14 @@ namespace MMCA.Common.Infrastructure.Persistence.AuditTrail;
 /// capturing one would be a lifetime bug rather than a feature. The trace id is ambient, is what
 /// the telemetry pipeline correlates on, and is the same value
 /// <c>CorrelationIdMiddleware</c> itself falls back to when a request carries no
-/// <c>X-Correlation-ID</c> header. A caller-supplied header value is therefore NOT recorded in v1;
-/// honoring it needs a live accessor on the context assigned by the scoped factory (the shape the
-/// multi-tenancy work introduces for <c>TenantId</c>), which is deliberately out of scope here.
+/// <c>X-Correlation-ID</c> header. A caller-supplied header value is therefore NOT recorded;
+/// honoring it needs a live accessor on the context assigned by the scoped factory, which is the
+/// shape multi-tenancy introduced for <c>TenantId</c> and could be reused here later.
+/// </para>
+/// <para>
+/// <b>Tenant.</b> The row records <c>ApplicationDbContext.CurrentTenantId</c>, which does reach this
+/// interceptor: it is read off the context rather than off a scoped service, through the live
+/// accessor the scoped context factory assigns. It is null in a host that never resolved a tenant.
 /// </para>
 /// </remarks>
 /// <param name="timeProvider">Provides the UTC capture timestamp.</param>
@@ -73,6 +78,9 @@ public sealed class AuditTrailSaveChangesInterceptor(TimeProvider timeProvider) 
 
     /// <summary>Column width of <c>CorrelationId</c>; longer values are truncated to fit.</summary>
     internal const int MaxCorrelationIdLength = 64;
+
+    /// <summary>Column width of <c>TenantId</c>; longer values are truncated to fit.</summary>
+    internal const int MaxTenantIdLength = 64;
 
     /// <summary>Separator joining the parts of a composite primary key into one <c>EntityKey</c> value.</summary>
     internal const char KeySeparator = '|';
@@ -181,7 +189,8 @@ public sealed class AuditTrailSaveChangesInterceptor(TimeProvider timeProvider) 
         var capture = new CaptureContext(
             context.CurrentSaveUserId,
             timeProvider.GetUtcNow().UtcDateTime,
-            Truncate(Activity.Current?.TraceId.ToString(), MaxCorrelationIdLength));
+            Truncate(Activity.Current?.TraceId.ToString(), MaxCorrelationIdLength),
+            Truncate(context.CurrentTenantId, MaxTenantIdLength));
 
         // Snapshot before adding: the rows this method writes land in the same tracker, and
         // enumerating it lazily while adding to it would throw.
@@ -248,6 +257,7 @@ public sealed class AuditTrailSaveChangesInterceptor(TimeProvider timeProvider) 
             ChangedBy = capture.ChangedBy,
             ChangedOn = capture.ChangedOn,
             CorrelationId = capture.CorrelationId,
+            TenantId = capture.TenantId,
         });
 
         // A store-generated key (the framework's identity columns) does not exist yet at this point:
@@ -302,6 +312,7 @@ public sealed class AuditTrailSaveChangesInterceptor(TimeProvider timeProvider) 
                 ChangedBy = capture.ChangedBy,
                 ChangedOn = capture.ChangedOn,
                 CorrelationId = capture.CorrelationId,
+                TenantId = capture.TenantId,
             });
         }
     }
@@ -526,10 +537,12 @@ public sealed class AuditTrailSaveChangesInterceptor(TimeProvider timeProvider) 
     /// <param name="ChangedBy">The user the save runs as, or null.</param>
     /// <param name="ChangedOn">The UTC capture instant.</param>
     /// <param name="CorrelationId">The ambient trace identifier, or null.</param>
+    /// <param name="TenantId">The tenant the saving scope resolved, or null for a system save.</param>
     private readonly record struct CaptureContext(
         UserIdentifierType? ChangedBy,
         DateTime ChangedOn,
-        string? CorrelationId);
+        string? CorrelationId,
+        string? TenantId);
 
     /// <summary>A trail row awaiting the store-generated key of the entity it describes.</summary>
     /// <param name="Row">The tracked trail row whose <c>EntityKey</c> must be rewritten.</param>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Conversions/EnumerationValueConverter.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Conversions/EnumerationValueConverter.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Persistence.Conversions;
+
+/// <summary>
+/// EF Core value converter that stores an <see cref="Enumeration{TEnumeration}"/> member as its
+/// <see cref="Enumeration{TEnumeration}.Value"/> and rebuilds the member on read. Mapping through
+/// <c>HasConversion</c> rather than <c>OwnsOne</c> keeps the backing column a plain
+/// <see langword="int"/> column, so replacing a CLR enum property with a smart enumeration is not a
+/// schema change.
+/// <para>
+/// <b>Usage:</b> apply to a non-nullable enumeration property in an entity configuration:
+/// <code>
+/// builder.Property(p => p.Priority)
+///     .HasConversion(new EnumerationValueConverter&lt;Priority&gt;())
+///     .IsRequired();
+/// </code>
+/// Column facets (requiredness, default value, precision) deliberately stay at the call site: they
+/// differ per entity and are not the converter's business. Use
+/// <see cref="NullableEnumerationValueConverter{TEnumeration}"/> for an optional property.
+/// </para>
+/// <para>
+/// <b>Read-leg contract:</b> the read leg trusts the column.
+/// <see cref="Enumeration{TEnumeration}.FromValue"/> returns a failed <c>Result</c> for a value no
+/// member declares, and the null-forgiving <c>.Value!</c> then materializes a <see langword="null"/>
+/// reference for that row. Every value the write leg can produce round-trips, because the write leg
+/// can only persist an already-declared member; only a value written outside EF (a manual script, a
+/// data fix, a member deleted from the enumeration after rows were written) can break the contract.
+/// </para>
+/// </summary>
+/// <typeparam name="TEnumeration">The concrete enumeration type being mapped.</typeparam>
+public sealed class EnumerationValueConverter<TEnumeration> : ValueConverter<TEnumeration, int>
+    where TEnumeration : Enumeration<TEnumeration>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnumerationValueConverter{TEnumeration}"/> class.
+    /// </summary>
+    public EnumerationValueConverter()
+        : base(
+            member => member.Value,
+            value => Enumeration<TEnumeration>.FromValue(value).Value!)
+    {
+    }
+}
+
+/// <summary>
+/// Nullable counterpart of <see cref="EnumerationValueConverter{TEnumeration}"/> for an optional
+/// enumeration property. Both legs pass <see langword="null"/> straight through, so "no member
+/// selected" stays a NULL column value rather than collapsing onto whichever member happens to
+/// declare the value zero.
+/// <para>
+/// <b>Usage:</b>
+/// <code>
+/// builder.Property(p => p.Priority)
+///     .HasConversion(new NullableEnumerationValueConverter&lt;Priority&gt;())
+///     .IsRequired(false);
+/// </code>
+/// </para>
+/// </summary>
+/// <typeparam name="TEnumeration">The concrete enumeration type being mapped.</typeparam>
+public sealed class NullableEnumerationValueConverter<TEnumeration> : ValueConverter<TEnumeration?, int?>
+    where TEnumeration : Enumeration<TEnumeration>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NullableEnumerationValueConverter{TEnumeration}"/> class.
+    /// </summary>
+    public NullableEnumerationValueConverter()
+        : base(
+            member => member == null ? null : member.Value,
+            value => value == null ? null : Enumeration<TEnumeration>.FromValue(value.Value).Value)
+    {
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/TenantDataSourceTargets.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/TenantDataSourceTargets.cs
@@ -1,0 +1,80 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Persistence.DataSources;
+
+/// <summary>
+/// One unit of work for a background sweep: a physical data source, optionally viewed as one
+/// tenant. <see cref="TenantId"/> is <see langword="null"/> for the shared database and set for a
+/// tenant that keeps its own copy of the source.
+/// </summary>
+/// <param name="Source">The physical data source to work against.</param>
+/// <param name="TenantId">The tenant whose own database to work against, or null for the shared one.</param>
+public readonly record struct TenantDataSourceTarget(DataSourceKey Source, string? TenantId)
+{
+    /// <summary>A log-friendly rendering that names the tenant when there is one.</summary>
+    /// <returns>The source name, with the tenant appended for a per-tenant target.</returns>
+    public override string ToString() =>
+        TenantId is null
+            ? Source.ToString()
+            : string.Concat(Source.ToString(), " (tenant ", TenantId, ")");
+}
+
+/// <summary>
+/// Expands the physical data sources a background service owns into the targets it must actually
+/// visit once database-per-tenant is in play.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A shared-schema tenant needs nothing here: its rows live in the shared database, which the
+/// null-tenant target already drains, and the outbox has no tenant column precisely so adopting
+/// tenancy never forces a migration on a consumer.
+/// </para>
+/// <para>
+/// A tenant with its own database is invisible to the shared sweep: its outbox rows, and its trail
+/// rows, are in a database nothing else opens. So each such tenant contributes one extra target per
+/// source it overrides, and the sweep sets the tenant on its scope before asking for the context,
+/// which is what routes the context at that tenant's connection string.
+/// </para>
+/// </remarks>
+public static class TenantDataSourceTargets
+{
+    /// <summary>
+    /// Produces the shared target for every source, followed by one target per (tenant, overridden
+    /// source) pair.
+    /// </summary>
+    /// <param name="sources">The physical sources the caller owns.</param>
+    /// <param name="settings">Bound tenancy settings, or null when tenancy was never registered.</param>
+    /// <returns>The targets to sweep, in a deterministic order.</returns>
+    public static List<TenantDataSourceTarget> Expand(
+        IEnumerable<DataSourceKey> sources,
+        TenancySettings? settings)
+    {
+        var sourceList = sources as IReadOnlyCollection<DataSourceKey> ?? [.. sources];
+        var targets = new List<TenantDataSourceTarget>(sourceList.Count);
+
+        foreach (var source in sourceList)
+        {
+            targets.Add(new TenantDataSourceTarget(source, null));
+        }
+
+        if (settings is null || settings.Tenants.Count == 0)
+        {
+            return targets;
+        }
+
+        foreach (var (tenantId, tenant) in settings.Tenants)
+        {
+            foreach (var source in sourceList)
+            {
+                if (tenant.DataSources.TryGetValue(source.Name, out var over)
+                    && !string.IsNullOrWhiteSpace(TenancySettingsValidator.ConnectionStringFor(source.Engine, over)))
+                {
+                    targets.Add(new TenantDataSourceTarget(source, tenantId));
+                }
+            }
+        }
+
+        return targets;
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -23,7 +23,8 @@ namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
 /// Base DbContext shared by all data-source-specific contexts (SQL Server, Cosmos, SQLite).
 /// Cross-cutting concerns (audit stamping, domain event capture/dispatch) are handled by
 /// <see cref="AuditSaveChangesInterceptor"/> and <see cref="DomainEventSaveChangesInterceptor"/>.
-/// This class provides global soft-delete query filters and model configuration.
+/// This class provides the global named query filters (<c>SoftDelete</c> and <c>Tenant</c>) and
+/// model configuration.
 /// <para>
 /// One instance exists per <b>physical data source</b> (database): the same context class is
 /// instantiated multiple times with different <see cref="PhysicalDataSource"/> values, each
@@ -74,6 +75,28 @@ public abstract class ApplicationDbContext(
 
     /// <summary>Gets the resolved connection information for this context's physical data source.</summary>
     internal PhysicalDataSource PhysicalSource => physicalDataSource;
+
+    /// <summary>
+    /// Live accessor for the tenant the owning scope runs as, assigned by the scoped
+    /// <see cref="Factory.DbContextFactory"/> at context creation. Left <see langword="null"/> for a
+    /// context created outside a scope (design time, a directly-constructed test context), which
+    /// reads as "no tenant".
+    /// </summary>
+    /// <remarks>
+    /// An accessor rather than a copied value on purpose. A context can be created before the
+    /// request's tenant is resolved (a middleware ordering detail no persistence code should depend
+    /// on), and a copy taken at that moment would pin the context to the wrong answer for its whole
+    /// life. Reading through the delegate at query and save time removes the ordering hazard
+    /// entirely.
+    /// </remarks>
+    internal Func<string?>? TenantIdAccessor { get; set; }
+
+    /// <summary>
+    /// Gets the tenant this context is currently scoped to, or <see langword="null"/> when no
+    /// tenant is resolved (background services, seeders, admin flows), in which case the
+    /// <c>Tenant</c> query filter is inert and every tenant's rows are visible.
+    /// </summary>
+    public string? CurrentTenantId => TenantIdAccessor?.Invoke();
 
     /// <summary>
     /// Keyless entity used to map scalar SQL results (e.g. from raw queries) without a backing table.
@@ -212,7 +235,20 @@ public abstract class ApplicationDbContext(
         // rather than inline in SaveChangesAsync.
         var auditInterceptor = serviceProvider.GetRequiredService<AuditSaveChangesInterceptor>();
         var domainEventInterceptor = serviceProvider.GetRequiredService<DomainEventSaveChangesInterceptor>();
-        optionsBuilder.AddInterceptors(auditInterceptor, domainEventInterceptor);
+
+        // Registration order IS execution order, and the tenant interceptor belongs BETWEEN the two:
+        // after the audit stamps (it must not run against half-stamped entries) and before the
+        // domain-event interceptor serializes outbox rows, so those rows describe an entity whose
+        // tenant is already final. GetService, not GetRequiredService: a directly-constructed test
+        // or design-time context that never registered it must still build.
+        if (serviceProvider.GetService<TenantSaveChangesInterceptor>() is { } tenantInterceptor)
+        {
+            optionsBuilder.AddInterceptors(auditInterceptor, tenantInterceptor, domainEventInterceptor);
+        }
+        else
+        {
+            optionsBuilder.AddInterceptors(auditInterceptor, domainEventInterceptor);
+        }
 
         // Registration order IS execution order, and the change trail must run last: it diffs the
         // final values, after the audit stamps are written and after the outbox rows are added.
@@ -268,6 +304,7 @@ public abstract class ApplicationDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ApplySoftDeleteFilters(modelBuilder);
+        ApplyTenantFilters(modelBuilder);
         ConfigureConcurrencyTokens(modelBuilder);
 
         // Register keyless ValReturn<T> types mapped to no table/view — used for raw SQL scalar queries.
@@ -308,7 +345,100 @@ public abstract class ApplicationDbContext(
                 Expression.Equal(property, Expression.Constant(false)),
                 parameter
             );
-            modelBuilder.Entity(clrType).HasQueryFilter("SoftDelete", filter);
+            modelBuilder.Entity(clrType).HasQueryFilter(SoftDeleteFilterName, filter);
+        }
+    }
+
+    /// <summary>
+    /// The name of the soft-delete query filter. Named so that a caller asking to include
+    /// soft-deleted rows (<c>ignoreQueryFilters: true</c>) drops exactly this filter and leaves the
+    /// tenant filter in force.
+    /// </summary>
+    internal const string SoftDeleteFilterName = "SoftDelete";
+
+    /// <summary>The name of the tenant query filter, used to keep it out of soft-delete bypasses.</summary>
+    internal const string TenantFilterName = "Tenant";
+
+    /// <summary>The shadow-safe name of the tenant discriminator column on every tenant-owned entity.</summary>
+    internal const string TenantIdPropertyName = nameof(ITenantEntity.TenantId);
+
+    /// <summary>Column width of <c>TenantId</c>, matching the claim/header values it is fed from.</summary>
+    internal const int TenantIdMaxLength = 64;
+
+    /// <summary>
+    /// Configures the tenant column and applies the named <c>Tenant</c> global query filter to every
+    /// non-owned <see cref="ITenantEntity"/>. Owned types are excluded: they inherit their parent's
+    /// filter, exactly as they do for soft delete.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Two named filters, composed by EF.</b> This one sits beside <c>SoftDelete</c>; EF combines
+    /// named filters with AND, so a tenant-owned soft-deletable entity is filtered on both without
+    /// either filter knowing about the other, and <c>IgnoreQueryFilters(["SoftDelete"])</c> can drop
+    /// one without dropping the other.
+    /// </para>
+    /// <para>
+    /// <b>One model serves every tenant.</b> The filter body embeds this context instance as a
+    /// constant typed as the context; EF rewrites context-typed constants to the executing context
+    /// at query compile time and lifts <see cref="CurrentTenantId"/> into a SQL parameter. The model
+    /// cache is keyed by (context type, physical source), so two scopes on two tenants share one
+    /// compiled model and still read disjoint rows.
+    /// </para>
+    /// <para>
+    /// <b>A null tenant sees everything.</b> The <c>CurrentTenantId == null</c> disjunct is what
+    /// keeps the outbox processor, the seeders and the retention jobs working: they run with no
+    /// tenant and must see every tenant's rows.
+    /// </para>
+    /// </remarks>
+    /// <param name="modelBuilder">The model builder to apply the filter to.</param>
+    protected void ApplyTenantFilters(ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        // The tenant value is read off THIS context at query time. Typed as ApplicationDbContext so
+        // EF's context-constant rewrite matches (it tests assignability from the executing context's
+        // runtime type, which is always a subclass of this one).
+        var contextConstant = Expression.Constant(this, typeof(ApplicationDbContext));
+        var currentTenant = Expression.Property(contextConstant, nameof(CurrentTenantId));
+        var nullTenant = Expression.Constant(null, typeof(string));
+
+        foreach (var clrType in modelBuilder.Model.GetEntityTypes()
+            .Where(et => typeof(ITenantEntity).IsAssignableFrom(et.ClrType) && !et.IsOwned())
+            .Select(et => et.ClrType))
+        {
+            var entity = modelBuilder.Entity(clrType);
+
+            entity.Property(TenantIdPropertyName)
+                .IsRequired()
+                .HasMaxLength(TenantIdMaxLength)
+                .IsUnicode(false);
+
+            // Every tenant-scoped read carries "TenantId = @tenant" as its leading predicate, so the
+            // column that answers it must be indexed or shared-schema tenancy degrades into a scan
+            // per query.
+            if (physicalDataSource.Key.Engine != DataSource.CosmosDB)
+            {
+                entity.HasIndex(TenantIdPropertyName);
+            }
+
+            var parameter = Expression.Parameter(clrType, "e");
+
+            // EF.Property rather than a CLR member access: it works for an explicitly implemented
+            // interface member and for a shadow property, and translates identically otherwise.
+            var tenantOfEntity = Expression.Call(
+                typeof(EF),
+                nameof(EF.Property),
+                [typeof(string)],
+                parameter,
+                Expression.Constant(TenantIdPropertyName));
+
+            var filter = Expression.Lambda(
+                Expression.OrElse(
+                    Expression.Equal(currentTenant, nullTenant),
+                    Expression.Equal(tenantOfEntity, currentTenant)),
+                parameter);
+
+            entity.HasQueryFilter(TenantFilterName, filter);
         }
     }
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -59,6 +59,19 @@ public abstract class ApplicationDbContext(
     /// </summary>
     private bool _schedulerTableEnabled;
 
+    /// <summary>
+    /// Whether the <c>AuditTrailEntries</c> table belongs in THIS context's model. Resolved once in
+    /// <see cref="OnConfiguring"/> from the root provider and read by <see cref="ConfigureAuditTrail"/>,
+    /// for the same reason as <see cref="_schedulerTableEnabled"/>.
+    /// <para>
+    /// One condition only, unlike the scheduler: <c>AuditTrail:Enabled</c>. The trail table belongs
+    /// in EVERY relational source, because a trail row must commit in the same transaction as the
+    /// change it describes, and a transaction does not span databases (the outbox precedent, not the
+    /// host-scoped job table).
+    /// </para>
+    /// </summary>
+    private bool _auditTrailTableEnabled;
+
     /// <summary>Gets the resolved connection information for this context's physical data source.</summary>
     internal PhysicalDataSource PhysicalSource => physicalDataSource;
 
@@ -201,12 +214,25 @@ public abstract class ApplicationDbContext(
         var domainEventInterceptor = serviceProvider.GetRequiredService<DomainEventSaveChangesInterceptor>();
         optionsBuilder.AddInterceptors(auditInterceptor, domainEventInterceptor);
 
+        // Registration order IS execution order, and the change trail must run last: it diffs the
+        // final values, after the audit stamps are written and after the outbox rows are added.
+        // GetService, not GetRequiredService: a host that never calls AddAuditTrail registers no
+        // interceptor, and that absence must read as "the trail is off" rather than fail every
+        // context construction in the application.
+        if (serviceProvider.GetService<AuditTrail.AuditTrailSaveChangesInterceptor>() is { } auditTrailInterceptor)
+        {
+            optionsBuilder.AddInterceptors(auditTrailInterceptor);
+        }
+
         // Settings-gated table (see the field's remarks). GetService, not GetRequiredService: a host
         // that never calls AddScheduledJobs registers no SchedulerSettings, and that absence must
         // read as "disabled" rather than fail every context construction in the application.
         _schedulerTableEnabled =
             serviceProvider.GetService<IOptions<SchedulerSettings>>()?.Value.Enabled == true
             && string.Equals(physicalDataSource.Key.Name, DataSourceKey.DefaultName, StringComparison.Ordinal);
+
+        // Same gate treatment, no source condition: see the field's remarks.
+        _auditTrailTableEnabled = serviceProvider.GetService<IOptions<AuditTrailSettings>>()?.Value.Enabled == true;
 
         // Key EF's model cache by (context type, physical source name): the same context class is
         // instantiated once per database, each with a different model. Without this, the first
@@ -258,6 +284,9 @@ public abstract class ApplicationDbContext(
 
         // Configure the recurring job table (used when Scheduler:Enabled, Default source only).
         ConfigureScheduler(modelBuilder);
+
+        // Configure the entity change-history table (used when AuditTrail:Enabled, every source).
+        ConfigureAuditTrail(modelBuilder);
     }
 
     /// <summary>
@@ -400,6 +429,44 @@ public abstract class ApplicationDbContext(
             entity.HasIndex(e => e.NextRunOn)
                   .IncludeProperties(e => new { e.LockedUntil, e.LockToken })
                   .HasDatabaseName("IX_ScheduledJobs_NextRunOn");
+        });
+    }
+
+    /// <summary>
+    /// Configures the <see cref="AuditTrail.AuditTrailEntry"/> entity (the change-history table).
+    /// Gated on <c>AuditTrail:Enabled</c> like the scheduler table, but mapped into <b>every</b>
+    /// relational source rather than one: a trail row commits in the same transaction as the change
+    /// it describes, and a transaction does not span databases. Cosmos DB never reaches this method
+    /// (it overrides <see cref="OnModelCreating"/>).
+    /// </summary>
+    private void ConfigureAuditTrail(ModelBuilder modelBuilder)
+    {
+        if (!_auditTrailTableEnabled)
+        {
+            return;
+        }
+
+        modelBuilder.Entity<AuditTrail.AuditTrailEntry>(entity =>
+        {
+            entity.ToTable("AuditTrailEntries", "dbo");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.EntityType).IsRequired().HasMaxLength(256).IsUnicode(false);
+            entity.Property(e => e.EntityKey).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.PropertyName).HasMaxLength(128).IsUnicode(false);
+            entity.Property(e => e.Operation).IsRequired().HasMaxLength(16).IsUnicode(false);
+            entity.Property(e => e.CorrelationId).HasMaxLength(64).IsUnicode(false);
+            entity.Property(e => e.TenantId).HasMaxLength(64).IsUnicode(false);
+
+            // Read path: one entity's history, newest first. Every shipped query and every consumer
+            // screen asks the same question, so the index carries the whole predicate plus the sort.
+            entity.HasIndex(e => new { e.EntityType, e.EntityKey, e.ChangedOn })
+                  .HasDatabaseName("IX_AuditTrailEntries_Entity");
+
+            // Retention path (AuditTrailCleanupJob): rows older than the cutoff, across all types.
+            // The read index above leads with EntityType, so without this the nightly sweep scans
+            // the largest table the framework writes (the outbox precedent).
+            entity.HasIndex(e => e.ChangedOn)
+                  .HasDatabaseName("IX_AuditTrailEntries_ChangedOn");
         });
     }
 

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Domain.Interfaces;
@@ -12,6 +13,8 @@ using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Inbox;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Scheduling;
+using MMCA.Common.Infrastructure.Settings;
 using StackExchange.Profiling;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts;
@@ -41,6 +44,20 @@ public abstract class ApplicationDbContext(
 {
     /// <summary>Gets the physical data source key (engine + database name) this context targets.</summary>
     public DataSourceKey DataSourceKey => physicalDataSource.Key;
+
+    /// <summary>
+    /// Whether the <c>ScheduledJobs</c> table belongs in THIS context's model. Resolved once in
+    /// <see cref="OnConfiguring"/> from the root provider (the same place the interceptors are
+    /// resolved) and read by <see cref="ConfigureScheduler"/>, because <c>OnModelCreating</c> must
+    /// not depend on anything the model cache key does not cover.
+    /// <para>
+    /// Two conditions, both required. <c>Scheduler:Enabled</c> keeps the model of a host that never
+    /// opted in byte-identical to what it was before the scheduler shipped, so its migrations never
+    /// see the table. The <c>Default</c>-source condition keeps the table in exactly one database:
+    /// jobs are host-scoped, unlike the outbox, which exists once per physical source.
+    /// </para>
+    /// </summary>
+    private bool _schedulerTableEnabled;
 
     /// <summary>Gets the resolved connection information for this context's physical data source.</summary>
     internal PhysicalDataSource PhysicalSource => physicalDataSource;
@@ -184,6 +201,13 @@ public abstract class ApplicationDbContext(
         var domainEventInterceptor = serviceProvider.GetRequiredService<DomainEventSaveChangesInterceptor>();
         optionsBuilder.AddInterceptors(auditInterceptor, domainEventInterceptor);
 
+        // Settings-gated table (see the field's remarks). GetService, not GetRequiredService: a host
+        // that never calls AddScheduledJobs registers no SchedulerSettings, and that absence must
+        // read as "disabled" rather than fail every context construction in the application.
+        _schedulerTableEnabled =
+            serviceProvider.GetService<IOptions<SchedulerSettings>>()?.Value.Enabled == true
+            && string.Equals(physicalDataSource.Key.Name, DataSourceKey.DefaultName, StringComparison.Ordinal);
+
         // Key EF's model cache by (context type, physical source name): the same context class is
         // instantiated once per database, each with a different model. Without this, the first
         // built model would silently be reused for every database.
@@ -231,6 +255,9 @@ public abstract class ApplicationDbContext(
 
         // Configure the inbox table for consumer-side idempotency (used when MessageBus:EnableInbox).
         ConfigureInbox(modelBuilder);
+
+        // Configure the recurring job table (used when Scheduler:Enabled, Default source only).
+        ConfigureScheduler(modelBuilder);
     }
 
     /// <summary>
@@ -340,6 +367,41 @@ public abstract class ApplicationDbContext(
             entity.HasIndex(e => e.ProcessedOn)
                   .HasDatabaseName("IX_InboxMessages_ProcessedOn");
         });
+
+    /// <summary>
+    /// Configures the <see cref="ScheduledJobEntry"/> entity (the recurring job store). Unlike the
+    /// outbox and inbox tables this one is <b>gated</b>: it is mapped only when the host opted in
+    /// via <c>Scheduler:Enabled</c> AND this context targets the <c>Default</c> data source. A host
+    /// that did not opt in gets exactly the model it had before the scheduler shipped, so the table
+    /// never appears in its migrations. Cosmos DB never reaches this method (it overrides
+    /// <see cref="OnModelCreating"/>).
+    /// </summary>
+    private void ConfigureScheduler(ModelBuilder modelBuilder)
+    {
+        if (!_schedulerTableEnabled)
+        {
+            return;
+        }
+
+        modelBuilder.Entity<ScheduledJobEntry>(entity =>
+        {
+            entity.ToTable("ScheduledJobs", "dbo");
+            entity.HasKey(e => e.JobName);
+            entity.Property(e => e.JobName).HasMaxLength(128).IsUnicode(false);
+            entity.Property(e => e.CronExpression).IsRequired().HasMaxLength(128).IsUnicode(false);
+            entity.Property(e => e.LastOutcome).HasMaxLength(32).IsUnicode(false);
+            entity.Property(e => e.LastError).HasMaxLength(2048);
+
+            // Claim path (ScheduledJobRunner): due rows, earliest first. Deliberately NOT filtered to
+            // unlocked rows: the poll must also find rows whose lease has EXPIRED (that is how a dead
+            // replica's work is reclaimed), and "LockedUntil IS NULL" would hide exactly those. The
+            // lease columns ride along as included columns instead, so the predicate is answered from
+            // the index without a key lookup per candidate row.
+            entity.HasIndex(e => e.NextRunOn)
+                  .IncludeProperties(e => new { e.LockedUntil, e.LockToken })
+                  .HasDatabaseName("IX_ScheduledJobs_NextRunOn");
+        });
+    }
 
     /// <summary>
     /// Discovers and applies the EF entity configurations for the given engine from module

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/CosmosDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/CosmosDbContext.cs
@@ -88,8 +88,10 @@ public sealed class CosmosDbContext(
 
         // Does NOT call base.OnModelCreating because the base also registers
         // ValReturn<T> keyless types mapped to views (a relational-only construct that
-        // the Cosmos provider does not support). Soft-delete filters are applied
-        // independently via the extracted helper method.
+        // the Cosmos provider does not support). Soft-delete and tenant filters are applied
+        // independently via the extracted helper methods; the tenant helper skips its index for
+        // Cosmos, which indexes every property itself.
         ApplySoftDeleteFilters(modelBuilder);
+        ApplyTenantFilters(modelBuilder);
     }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
 using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
@@ -73,6 +74,12 @@ public static class DesignTimeDbContextHelper
         // disabled) so `dotnet ef` behaves identically for consumers with and without the flag.
         services.AddSingleton<IOptions<SchedulerSettings>>(
             Options.Create(new SchedulerSettings { Enabled = designOptions.EnableScheduler }));
+        // Same treatment for the change-history table, and the interceptor that writes to it: the
+        // context resolves the interceptor with GetService, so omitting it here would still work,
+        // but registering it keeps the design-time pipeline identical to the runtime one.
+        services.AddSingleton<IOptions<AuditTrailSettings>>(
+            Options.Create(new AuditTrailSettings { Enabled = designOptions.EnableAuditTrail }));
+        services.AddSingleton<AuditTrailSaveChangesInterceptor>();
         services.AddSingleton<IEntityConfigurationAssemblyProvider>(assemblyProvider);
         services.AddSingleton<IDataSourceResolver>(resolver);
         services.AddSingleton<IEntityDataSourceRegistry>(registry);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Domain.Interfaces;
@@ -67,6 +68,11 @@ public static class DesignTimeDbContextHelper
         services.AddSingleton<IOutboxSignal, OutboxSignal>();
         services.AddSingleton<AuditSaveChangesInterceptor>();
         services.AddSingleton<DomainEventSaveChangesInterceptor>();
+        // The context reads Scheduler:Enabled from the root provider to decide whether the
+        // ScheduledJobs table is part of the model. Registered unconditionally (defaulting to
+        // disabled) so `dotnet ef` behaves identically for consumers with and without the flag.
+        services.AddSingleton<IOptions<SchedulerSettings>>(
+            Options.Create(new SchedulerSettings { Enabled = designOptions.EnableScheduler }));
         services.AddSingleton<IEntityConfigurationAssemblyProvider>(assemblyProvider);
         services.AddSingleton<IDataSourceResolver>(resolver);
         services.AddSingleton<IEntityDataSourceRegistry>(registry);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextHelper.cs
@@ -69,6 +69,13 @@ public static class DesignTimeDbContextHelper
         services.AddSingleton<IOutboxSignal, OutboxSignal>();
         services.AddSingleton<AuditSaveChangesInterceptor>();
         services.AddSingleton<DomainEventSaveChangesInterceptor>();
+        // The tenant interceptor and the tenancy options are registered unconditionally (the
+        // options defaulting to disabled), so `dotnet ef` builds exactly the runtime pipeline for
+        // consumers with and without tenancy. Design time never resolves a tenant, so the
+        // interceptor is inert and the Tenant query filter short-circuits: the scaffolded migration
+        // is identical either way, apart from the TenantId column and index the model declares.
+        services.AddSingleton<TenantSaveChangesInterceptor>();
+        services.AddSingleton<IOptions<TenancySettings>>(Options.Create(new TenancySettings()));
         // The context reads Scheduler:Enabled from the root provider to decide whether the
         // ScheduledJobs table is part of the model. Registered unconditionally (defaulting to
         // disabled) so `dotnet ef` behaves identically for consumers with and without the flag.

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
@@ -41,6 +41,20 @@ public sealed class DesignTimeDbContextOptions
     public bool EnableScheduler { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the change-history table (<c>AuditTrailEntries</c>) is
+    /// part of the design-time model, mirroring <c>AuditTrail:Enabled</c> at runtime. Defaults to
+    /// <see langword="false"/>, so <c>dotnet ef</c> keeps producing exactly the migrations it
+    /// produced before the audit trail shipped.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="EnableScheduler"/>, set it in the migrations project of <b>every</b> data
+    /// source whose entities are audited: a trail row is written to the database holding the entity
+    /// that changed, so each of those databases needs the table. The flag must match the host's
+    /// configuration, or the scaffolded migrations and the running model disagree.
+    /// </remarks>
+    public bool EnableAuditTrail { get; set; }
+
+    /// <summary>
     /// Gets the assemblies containing the entity type configurations to include in the model.
     /// Must be listed explicitly — the AppDomain scan used at runtime sees nothing at design time.
     /// </summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Design/DesignTimeDbContextOptions.cs
@@ -27,6 +27,20 @@ public sealed class DesignTimeDbContextOptions
     public Dictionary<string, DataSourceEntrySettings> DataSources { get; } = [];
 
     /// <summary>
+    /// Gets or sets a value indicating whether the recurring job table (<c>ScheduledJobs</c>) is part
+    /// of the design-time model, mirroring <c>Scheduler:Enabled</c> at runtime. Defaults to
+    /// <see langword="false"/>, so <c>dotnet ef</c> keeps producing exactly the migrations it
+    /// produced before the scheduler shipped.
+    /// </summary>
+    /// <remarks>
+    /// Set it to <see langword="true"/> in the migrations project for the <c>Default</c> data source
+    /// of a host that calls <c>AddScheduledJobs</c>, and only there: the table is host-scoped, so a
+    /// second migrations project that also enabled it would create a second copy. The flag must
+    /// match the host's configuration, or the scaffolded migrations and the running model disagree.
+    /// </remarks>
+    public bool EnableScheduler { get; set; }
+
+    /// <summary>
     /// Gets the assemblies containing the entity type configurations to include in the model.
     /// Must be listed explicitly — the AppDomain scan used at runtime sees nothing at design time.
     /// </summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -1,10 +1,14 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Settings;
 using MMCA.Common.Shared.Abstractions;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
@@ -14,12 +18,31 @@ namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 /// <see cref="DataSourceKey"/> (engine + database). Each physical source yields at most one
 /// context per scope; subsequent calls return the cached instance.
 /// Coordinates save, transaction, and disposal across all active contexts.
+/// <para>
+/// Under database-per-tenant it is also the routing point: a source the current tenant declares an
+/// override for is created against that tenant's connection string, keeping the same
+/// <see cref="DataSourceKey"/> so EF still compiles one model per source across every tenant.
+/// </para>
 /// </summary>
+/// <param name="physicalDbContextFactory">Creates the raw contexts.</param>
+/// <param name="entityDataSourceRegistry">Registry enumerating the physical sources in use.</param>
+/// <param name="dataSourceResolver">Resolves connection information per physical source.</param>
+/// <param name="currentUserService">Supplies the user id used for audit stamps on save.</param>
+/// <param name="tenantContext">
+/// The scope's tenant, or <see langword="null"/> in a container that never registered tenancy.
+/// Read live by every context this factory creates.
+/// </param>
+/// <param name="tenancySettings">
+/// Bound tenancy configuration, consulted only for per-tenant connection overrides. Defaulted so
+/// the pre-tenancy constructor shape keeps resolving.
+/// </param>
 public sealed class DbContextFactory(
     IPhysicalDbContextFactory physicalDbContextFactory,
     IEntityDataSourceRegistry entityDataSourceRegistry,
     IDataSourceResolver dataSourceResolver,
-    ICurrentUserService currentUserService
+    ICurrentUserService currentUserService,
+    ITenantContext? tenantContext = null,
+    IOptions<TenancySettings>? tenancySettings = null
 ) : IDbContextFactory
 {
     /// <summary>
@@ -38,6 +61,13 @@ public sealed class DbContextFactory(
     /// Caches one context per physical data source so all repositories within a scope share the same change tracker.
     /// </summary>
     private readonly Dictionary<DataSourceKey, ApplicationDbContext> _dbContexts = [];
+
+    /// <summary>
+    /// The tenant each per-tenant-routed context was created for. Only sources the tenant actually
+    /// overrides appear here: everything else is shared and needs no guard, because the query filter
+    /// and the save interceptor already scope it.
+    /// </summary>
+    private readonly Dictionary<DataSourceKey, string?> _routedContextTenants = [];
 
     /// <summary>
     /// Tracks whether a transaction is active so that contexts created lazily (after
@@ -61,20 +91,111 @@ public sealed class DbContextFactory(
 
         if (!_dbContexts.TryGetValue(dataSourceKey, out var context) || context is null)
         {
-            context = _physicalDbContextFactory.Create(dataSourceKey);
+            var tenantOverride = ResolveTenantOverride(dataSourceKey);
+            context = tenantOverride is null
+                ? _physicalDbContextFactory.Create(dataSourceKey)
+                : _physicalDbContextFactory.Create(dataSourceKey, tenantOverride);
+
             _dbContexts[dataSourceKey] = context;
+
+            if (tenantOverride is not null)
+                _routedContextTenants[dataSourceKey] = tenantContext?.TenantId;
+
+            AttachTenantAccessor(context);
 
             // Enlist late-created contexts in the active transaction so that all
             // persistence within a transactional command shares the same boundary.
             if (_transactionActive && SupportsTransactions(context))
                 context.Database.BeginTransaction();
         }
+        else
+        {
+            // A routed context is bound to one tenant's database; hand it back only to that tenant.
+            GuardRoutedTenantUnchanged(dataSourceKey);
+        }
+
         return context;
     }
 
     /// <inheritdoc />
     public ApplicationDbContext GetDbContext(DataSource dataSource) =>
         GetDbContext(DataSourceKey.Default(dataSource));
+
+    /// <summary>
+    /// Gives a freshly created context a live view of the scope's tenant. An accessor, not a copied
+    /// value: the context can be created before the request's tenant is resolved, and the query
+    /// filter must read the answer that holds at query time rather than at construction time.
+    /// </summary>
+    /// <remarks>
+    /// Written as a method taking a non-nullable parameter, and null-guarding inside, so the null
+    /// tolerance a test double needs (a mocked physical factory can hand back no context at all)
+    /// does not leak a maybe-null flow state back into the caller.
+    /// </remarks>
+    private void AttachTenantAccessor(ApplicationDbContext context)
+    {
+        if (context is null)
+            return;
+
+        context.TenantIdAccessor = () => tenantContext?.TenantId;
+    }
+
+    /// <summary>
+    /// The tenant's own connection information for one source, or <see langword="null"/> when this
+    /// source stays shared. The clone keeps the ORIGINAL <see cref="DataSourceKey"/>: the key is
+    /// what EF's model cache is keyed on, so replacing only the connection string is what lets one
+    /// compiled model serve every tenant's database.
+    /// </summary>
+    private PhysicalDataSource? ResolveTenantOverride(DataSourceKey dataSourceKey)
+    {
+        if (tenantContext?.TenantId is not { } tenantId
+            || tenancySettings?.Value is not { } settings
+            || !settings.Tenants.TryGetValue(tenantId, out var tenant)
+            || !tenant.DataSources.TryGetValue(dataSourceKey.Name, out var over))
+        {
+            return null;
+        }
+
+        var connectionString = TenancySettingsValidator.ConnectionStringFor(dataSourceKey.Engine, over);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            // The tenant overrides this source on a different engine only; this one stays shared.
+            return null;
+        }
+
+        var shared = _dataSourceResolver.GetPhysical(dataSourceKey);
+        return shared with
+        {
+            ConnectionString = connectionString,
+            CosmosDatabaseName = string.IsNullOrWhiteSpace(over.CosmosDatabaseName)
+                ? shared.CosmosDatabaseName
+                : over.CosmosDatabaseName,
+        };
+    }
+
+    /// <summary>
+    /// Refuses to hand back a per-tenant-routed context after the scope's tenant changed. The
+    /// cached context is bound to one physical database, so serving it to a second tenant would
+    /// read and write the first tenant's data with the second tenant's filter value: the one
+    /// failure mode database-per-tenant exists to make impossible.
+    /// </summary>
+    private void GuardRoutedTenantUnchanged(DataSourceKey dataSourceKey)
+    {
+        if (!_routedContextTenants.TryGetValue(dataSourceKey, out var creationTenant))
+            return;
+
+        var current = tenantContext?.TenantId;
+        if (string.Equals(creationTenant, current, StringComparison.Ordinal))
+            return;
+
+        throw new InvalidOperationException(string.Format(
+            CultureInfo.InvariantCulture,
+            "The context for \"{0}\" was created for tenant \"{1}\" but this scope's tenant is now \"{2}\". "
+            + "A per-tenant data source is bound to one database for the life of the scope; "
+            + "use a fresh scope per tenant.",
+            dataSourceKey,
+            creationTenant ?? "<none>",
+            current ?? "<none>"));
+    }
 
     /// <inheritdoc />
     public async Task EnsureCreatedAsync(CancellationToken cancellationToken = default)

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IPhysicalDbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IPhysicalDbContextFactory.cs
@@ -1,4 +1,5 @@
 using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
 
 namespace MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
 
@@ -19,4 +20,19 @@ public interface IPhysicalDbContextFactory
     /// <param name="key">The physical data source key.</param>
     /// <returns>A new context targeting that database.</returns>
     ApplicationDbContext Create(DataSourceKey key);
+
+    /// <summary>
+    /// Creates a new context for <paramref name="key"/> against explicitly supplied connection
+    /// information rather than the resolver's, which is how database-per-tenant routing works: the
+    /// caller clones the resolved <see cref="PhysicalDataSource"/> with the tenant's connection
+    /// string and keeps the SAME <paramref name="key"/>, so EF's model cache still serves one model
+    /// per (context type, source name) across every tenant.
+    /// </summary>
+    /// <param name="key">The physical data source key; decides the context class and the EF model.</param>
+    /// <param name="physicalDataSource">
+    /// The connection information to use. Its <see cref="PhysicalDataSource.Key"/> is expected to
+    /// equal <paramref name="key"/>.
+    /// </param>
+    /// <returns>A new context targeting that database.</returns>
+    ApplicationDbContext Create(DataSourceKey key, PhysicalDataSource physicalDataSource);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/PhysicalDbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/PhysicalDbContextFactory.cs
@@ -31,9 +31,12 @@ public sealed class PhysicalDbContextFactory(
         new DbContextOptionsBuilder<CosmosDbContext>().Options;
 
     /// <inheritdoc />
-    public ApplicationDbContext Create(DataSourceKey key)
+    public ApplicationDbContext Create(DataSourceKey key) => Create(key, resolver.GetPhysical(key));
+
+    /// <inheritdoc />
+    public ApplicationDbContext Create(DataSourceKey key, PhysicalDataSource physicalDataSource)
     {
-        var physical = resolver.GetPhysical(key);
+        var physical = physicalDataSource ?? throw new ArgumentNullException(nameof(physicalDataSource));
 
         return key.Engine switch
         {

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/CrossTenantWriteException.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/CrossTenantWriteException.cs
@@ -1,0 +1,112 @@
+using System.Globalization;
+
+namespace MMCA.Common.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// Thrown by <see cref="TenantSaveChangesInterceptor"/> when a save would write across the tenant
+/// boundary: inserting, updating or deleting a row owned by a tenant other than the one the current
+/// scope resolved, or inserting an untenanted row from a scope that resolved no tenant at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Isolation on the read side is a query filter, which silently returns nothing when it disagrees
+/// with the caller. The write side cannot be silent: a save that has reached the interceptor is
+/// about to persist, and the only honest outcomes are "the correct tenant" or "no write". So this
+/// throws rather than filtering, and the message names the entity type and both tenants, because
+/// the failure is nearly always a scope that was never given a tenant (a background job, a queued
+/// handler) rather than a genuine attempt to cross the boundary.
+/// </para>
+/// <para>
+/// It derives from <see cref="InvalidOperationException"/> so existing handler and middleware
+/// catch-sites treat it exactly as they treat the framework's other save-time invariant failures.
+/// </para>
+/// </remarks>
+public sealed class CrossTenantWriteException : InvalidOperationException
+{
+    private const string DefaultMessage =
+        "The save would write across the tenant boundary and was rejected.";
+
+    /// <summary>Initializes a new instance with the default message.</summary>
+    public CrossTenantWriteException()
+        : base(DefaultMessage) { }
+
+    /// <summary>Initializes a new instance with a custom message.</summary>
+    /// <param name="message">The exception message.</param>
+    public CrossTenantWriteException(string message)
+        : base(message) { }
+
+    /// <summary>Initializes a new instance with a custom message and an inner exception.</summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The underlying failure.</param>
+    public CrossTenantWriteException(string message, Exception innerException)
+        : base(message, innerException) { }
+
+    private CrossTenantWriteException(
+        string message,
+        string entityType,
+        string? currentTenantId,
+        string? entityTenantId)
+        : base(message)
+    {
+        EntityType = entityType;
+        CurrentTenantId = currentTenantId;
+        EntityTenantId = entityTenantId;
+    }
+
+    /// <summary>Gets the CLR type name of the entity the rejected save touched, when known.</summary>
+    public string? EntityType { get; }
+
+    /// <summary>
+    /// Gets the tenant the saving scope resolved, or <see langword="null"/> when it resolved none.
+    /// </summary>
+    public string? CurrentTenantId { get; }
+
+    /// <summary>
+    /// Gets the tenant recorded on the entity, or <see langword="null"/> when the entity carried
+    /// none.
+    /// </summary>
+    public string? EntityTenantId { get; }
+
+    /// <summary>
+    /// Creates the failure for an entity whose recorded tenant differs from the scope's tenant.
+    /// </summary>
+    /// <param name="entityType">The entity CLR type name.</param>
+    /// <param name="operation">The save operation (<c>insert</c>, <c>update</c>, <c>delete</c>).</param>
+    /// <param name="currentTenantId">The tenant the scope resolved.</param>
+    /// <param name="entityTenantId">The tenant recorded on the entity.</param>
+    /// <returns>The exception to throw.</returns>
+    internal static CrossTenantWriteException ForMismatch(
+        string entityType,
+        string operation,
+        string currentTenantId,
+        string entityTenantId) =>
+        new(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "The {0} of \"{1}\" was rejected: the entity belongs to tenant \"{2}\" but this scope "
+                + "resolved tenant \"{3}\". A scope may only write its own tenant's rows.",
+                operation,
+                entityType,
+                entityTenantId,
+                currentTenantId),
+            entityType,
+            currentTenantId,
+            entityTenantId);
+
+    /// <summary>
+    /// Creates the failure for an insert of an untenanted entity from a scope with no tenant.
+    /// </summary>
+    /// <param name="entityType">The entity CLR type name.</param>
+    /// <returns>The exception to throw.</returns>
+    internal static CrossTenantWriteException ForUnresolvedTenant(string entityType) =>
+        new(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "The insert of \"{0}\" was rejected: the entity is tenant-owned, it carries no tenant, "
+                + "and this scope resolved none. Resolve a tenant for the scope (ITenantContext.SetTenant) "
+                + "or assign the tenant on the entity before saving.",
+                entityType),
+            entityType,
+            currentTenantId: null,
+            entityTenantId: null);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
@@ -1,0 +1,176 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+
+namespace MMCA.Common.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// EF Core interceptor that owns the write side of multi-tenancy: it stamps
+/// <see cref="ITenantEntity.TenantId"/> on inserts and refuses any save that would touch another
+/// tenant's row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>A separate interceptor, one concern each.</b> The audit interceptor stamps identity and
+/// timestamps, the domain-event interceptor writes outbox rows, this one enforces the tenant
+/// boundary. Registration order in <c>ApplicationDbContext.OnConfiguring</c> is execution order and
+/// puts this between them: audit stamps are already written when it runs, and the outbox rows the
+/// domain-event interceptor adds afterwards see the final tenant value.
+/// </para>
+/// <para>
+/// <b>Always registered, inert by default.</b> It is a no-op for every entity that does not carry
+/// <see cref="ITenantEntity"/>, which is every entity in a host that never adopted tenancy. It also
+/// stays out of the way of the system context: when the scope resolved no tenant, an entity that
+/// already carries one is written as-is (that is how a background worker drains one tenant's work),
+/// and only an untenanted insert is refused, because nothing could supply the missing value.
+/// </para>
+/// <para>
+/// The read side is the named <c>Tenant</c> query filter applied in
+/// <c>ApplicationDbContext.ApplyTenantFilters</c>. The two are deliberately independent: a caller
+/// who bypasses the filter with EF's own parameterless <c>IgnoreQueryFilters()</c> can read across
+/// tenants, but still cannot write across them.
+/// </para>
+/// </remarks>
+public sealed class TenantSaveChangesInterceptor : SaveChangesInterceptor
+{
+    /// <inheritdoc />
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is ApplicationDbContext context)
+            ApplyTenant(context);
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        if (eventData.Context is ApplicationDbContext context)
+            ApplyTenant(context);
+
+        return base.SavingChanges(eventData, result);
+    }
+
+    /// <summary>
+    /// Stamps or verifies the tenant on every tracked <see cref="ITenantEntity"/> being written.
+    /// </summary>
+    private static void ApplyTenant(ApplicationDbContext context)
+    {
+        // Read once per save, not once per entry: CurrentTenantId walks a live accessor into the
+        // scoped tenant context, and a save must be decided against a single value anyway.
+        var currentTenantId = context.CurrentTenantId;
+
+        // Owned types are excluded on both sides of the boundary. The query filter skips them
+        // because they are only ever reached through their owner, and the write side skips them for
+        // the same reason: an owned value has no independent existence, so the owner's tenant is
+        // already the row's tenant and stamping the copy would only invite the two to disagree.
+        foreach (var entry in context.ChangeTracker.Entries<ITenantEntity>()
+            .Where(entry => !entry.Metadata.IsOwned()))
+        {
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    StampOrVerifyInsert(entry, currentTenantId);
+                    break;
+                case EntityState.Modified:
+                    VerifyExistingRow(entry, currentTenantId, "update");
+                    break;
+                case EntityState.Deleted:
+                    VerifyExistingRow(entry, currentTenantId, "delete");
+                    break;
+                case EntityState.Detached:
+                case EntityState.Unchanged:
+                default:
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Assigns the scope's tenant to a new row, or rejects the insert when the row already names a
+    /// different one. An untenanted insert from an untenanted scope is rejected: silently writing a
+    /// row no tenant can ever read is worse than failing the save.
+    /// </summary>
+    private static void StampOrVerifyInsert(EntityEntry<ITenantEntity> entry, string? currentTenantId)
+    {
+        var property = entry.Property(nameof(ITenantEntity.TenantId));
+        var declared = property.CurrentValue as string;
+        var entityType = EntityTypeName(entry);
+
+        if (currentTenantId is null)
+        {
+            if (string.IsNullOrEmpty(declared))
+                throw CrossTenantWriteException.ForUnresolvedTenant(entityType);
+
+            // A system scope inserting an explicitly tenanted row (a seeder, a per-tenant job).
+            return;
+        }
+
+        if (string.IsNullOrEmpty(declared))
+        {
+            property.CurrentValue = currentTenantId;
+            return;
+        }
+
+        if (!string.Equals(declared, currentTenantId, StringComparison.Ordinal))
+            throw CrossTenantWriteException.ForMismatch(entityType, "insert", currentTenantId, declared);
+    }
+
+    /// <summary>
+    /// Rejects an update or delete of a row belonging to another tenant, and an update that would
+    /// move a row between tenants. Inert when the scope resolved no tenant: the system context is
+    /// deliberately unrestricted, exactly as it is on the read side.
+    /// </summary>
+    private static void VerifyExistingRow(
+        EntityEntry<ITenantEntity> entry,
+        string? currentTenantId,
+        string operation)
+    {
+        if (currentTenantId is null)
+            return;
+
+        var property = entry.Property(nameof(ITenantEntity.TenantId));
+
+        // Both sides are checked: the original value catches touching another tenant's row, the
+        // current value catches reassigning this row to another tenant in the same save.
+        var offending = FirstForeignTenant(
+            property.OriginalValue as string,
+            property.CurrentValue as string,
+            currentTenantId);
+
+        if (offending is not null)
+        {
+            throw CrossTenantWriteException.ForMismatch(
+                EntityTypeName(entry), operation, currentTenantId, offending);
+        }
+    }
+
+    /// <summary>
+    /// The first of the two recorded tenant values that belongs to someone other than
+    /// <paramref name="currentTenantId"/>, or <see langword="null"/> when both are this tenant's (or
+    /// absent). The original is reported in preference to the current one, because "you touched
+    /// another tenant's row" is the more useful diagnosis than "you renamed its owner".
+    /// </summary>
+    private static string? FirstForeignTenant(string? original, string? current, string currentTenantId)
+    {
+        if (IsForeign(original, currentTenantId))
+            return original;
+
+        return IsForeign(current, currentTenantId) ? current : null;
+    }
+
+    /// <summary>Whether a recorded tenant value is present and names a different tenant.</summary>
+    private static bool IsForeign(string? value, string currentTenantId) =>
+        !string.IsNullOrEmpty(value) && !string.Equals(value, currentTenantId, StringComparison.Ordinal);
+
+    /// <summary>The entity's CLR type name, used in the failure message.</summary>
+    private static string EntityTypeName(EntityEntry entry) =>
+        entry.Metadata.ClrType.FullName ?? entry.Metadata.ClrType.Name;
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxCleanupService.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxCleanupService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
@@ -32,6 +33,10 @@ namespace MMCA.Common.Infrastructure.Persistence.Outbox;
 /// <param name="dataSourceResolver">Resolver for the configured outbox publish target.</param>
 /// <param name="timeProvider">Clock abstraction for the sweep interval and the retention cutoff; defaults to
 /// <see cref="TimeProvider.System"/> so tests can drive the hour-scale loop deterministically.</param>
+/// <param name="tenancyOptions">
+/// Bound tenancy settings, used only to discover tenants that keep their own copy of a source: each
+/// such database has its own outbox and inbox tables, which the shared sweep never reaches.
+/// </param>
 public sealed partial class OutboxCleanupService(
     IServiceScopeFactory scopeFactory,
     ILogger<OutboxCleanupService> logger,
@@ -39,7 +44,8 @@ public sealed partial class OutboxCleanupService(
     IOptions<MessageBusSettings> messageBusOptions,
     IEntityDataSourceRegistry entityDataSourceRegistry,
     IDataSourceResolver dataSourceResolver,
-    TimeProvider? timeProvider = null) : BackgroundService
+    TimeProvider? timeProvider = null,
+    IOptions<TenancySettings>? tenancyOptions = null) : BackgroundService
 {
     private readonly OutboxSettings _settings = outboxOptions.Value;
     private readonly bool _inboxEnabled = messageBusOptions.Value.EnableInbox;
@@ -80,14 +86,22 @@ public sealed partial class OutboxCleanupService(
     {
         var cutoff = _timeProvider.GetUtcNow().UtcDateTime.Subtract(TimeSpan.FromDays(_settings.RetentionDays));
 
-        foreach (var source in GetRelationalSources())
+        foreach (var target in GetRelationalTargets())
         {
-            var sourceName = source.ToString();
+            var sourceName = target.ToString();
             try
             {
                 using var scope = scopeFactory.CreateScope();
+
+                // Set before the context is asked for: the tenant is what routes the scoped factory
+                // to this tenant's own database.
+                if (target.TenantId is { } tenantId)
+                {
+                    scope.ServiceProvider.GetRequiredService<ITenantContext>().SetTenant(tenantId);
+                }
+
                 var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
-                var context = dbContextFactory.GetDbContext(source);
+                var context = dbContextFactory.GetDbContext(target.Source);
 
                 var deleted = await context.Set<OutboxMessage>()
                     .Where(m => m.ProcessedOn != null && m.ProcessedOn < cutoff)
@@ -177,6 +191,14 @@ public sealed partial class OutboxCleanupService(
 
         return [.. sources.Distinct()];
     }
+
+    /// <summary>
+    /// The units this sweep visits: every owned source against the shared database, plus one extra
+    /// unit per tenant that keeps its own copy of a source (whose outbox and inbox tables live in a
+    /// database nothing else opens).
+    /// </summary>
+    internal List<TenantDataSourceTarget> GetRelationalTargets() =>
+        TenantDataSourceTargets.Expand(GetRelationalSources(), tenancyOptions?.Value);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Outbox cleanup disabled: Outbox:RetentionDays is 0")]
     private static partial void LogCleanupDisabled(ILogger logger);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Outbox/OutboxProcessor.cs
@@ -42,6 +42,11 @@ namespace MMCA.Common.Infrastructure.Persistence.Outbox;
 /// <param name="dataSourceResolver">Resolver for the configured outbox publish target.</param>
 /// <param name="timeProvider">Clock abstraction for the startup delay and lease/eligibility timestamps;
 /// defaults to <see cref="TimeProvider.System"/> so tests can drive the loop deterministically.</param>
+/// <param name="tenancyOptions">
+/// Bound tenancy settings, used only to discover tenants that keep their own copy of a source: each
+/// such database has its own outbox table that nothing else would drain. Defaulted, so a host
+/// without tenancy keeps the previous constructor shape and behavior.
+/// </param>
 public sealed partial class OutboxProcessor(
     IServiceScopeFactory scopeFactory,
     ILogger<OutboxProcessor> logger,
@@ -49,7 +54,8 @@ public sealed partial class OutboxProcessor(
     IOutboxSignal outboxSignal,
     IEntityDataSourceRegistry entityDataSourceRegistry,
     IDataSourceResolver dataSourceResolver,
-    TimeProvider? timeProvider = null) : BackgroundService
+    TimeProvider? timeProvider = null,
+    IOptions<TenancySettings>? tenancyOptions = null) : BackgroundService
 {
     private readonly OutboxSettings _settings = outboxOptions.Value;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
@@ -80,7 +86,7 @@ public sealed partial class OutboxProcessor(
         // Brief startup delay so the application finishes initializing before we start polling.
         await _timeProvider.Delay(TimeSpan.FromSeconds(5), stoppingToken).ConfigureAwait(false);
 
-        if (GetOutboxSources().Count == 0)
+        if (GetOutboxTargets().Count == 0)
         {
             LogOutboxDisabled(logger);
             return;
@@ -167,6 +173,15 @@ public sealed partial class OutboxProcessor(
     }
 
     /// <summary>
+    /// The units this cycle visits: every owned source against the shared database, plus one extra
+    /// unit per tenant that keeps its own copy of a source. A tenant database has its own
+    /// <c>OutboxMessages</c> table, and nothing else opens that database, so without this its events
+    /// would sit undelivered forever.
+    /// </summary>
+    internal List<TenantDataSourceTarget> GetOutboxTargets() =>
+        TenantDataSourceTargets.Expand(GetOutboxSources(), tenancyOptions?.Value);
+
+    /// <summary>
     /// Drains every outbox source once and aggregates the per-source results: any source with
     /// more eligible work triggers an immediate re-poll, the earliest pending timestamp
     /// across all sources drives the smart wait, and the backlog observed across all sources is
@@ -178,12 +193,12 @@ public sealed partial class OutboxProcessor(
         DateTime? earliestPendingOccurredOn = null;
         var pendingDepth = 0L;
 
-        foreach (var source in GetOutboxSources())
+        foreach (var target in GetOutboxTargets())
         {
             try
             {
                 (OutboxCycleResult result, long sourcePendingDepth) =
-                    await ProcessSourceAsync(source, cancellationToken).ConfigureAwait(false);
+                    await ProcessSourceAsync(target, cancellationToken).ConfigureAwait(false);
                 pendingDepth += sourcePendingDepth;
                 hasMoreEligibleWork |= result.HasMoreEligibleWork;
                 if (result.EarliestPendingOccurredOn is { } pending
@@ -201,7 +216,7 @@ public sealed partial class OutboxProcessor(
                 // One unreachable database must not starve the other sources' outboxes.
                 // A failing source contributes nothing to the wait — its rows are retried
                 // on the next signal or polling interval.
-                LogSourceProcessingError(logger, source.ToString(), ex);
+                LogSourceProcessingError(logger, target.ToString(), ex);
             }
         }
 
@@ -217,11 +232,20 @@ public sealed partial class OutboxProcessor(
     /// caller can sum the depth across sources for the <c>outbox.pending.depth</c> gauge.
     /// </summary>
     private async Task<(OutboxCycleResult Cycle, long PendingDepth)> ProcessSourceAsync(
-        DataSourceKey source,
+        TenantDataSourceTarget target,
         CancellationToken cancellationToken)
     {
-        var sourceName = source.ToString();
+        var source = target.Source;
+        var sourceName = target.ToString();
         using var scope = scopeFactory.CreateScope();
+
+        // Before the context is asked for, not after: the tenant is what routes the scoped factory
+        // to this tenant's database, and it is also what the query filter reads.
+        if (target.TenantId is { } tenantId)
+        {
+            scope.ServiceProvider.GetRequiredService<ITenantContext>().SetTenant(tenantId);
+        }
+
         var dbContextFactory = scope.ServiceProvider.GetRequiredService<DbContexts.Factory.IDbContextFactory>();
         var context = dbContextFactory.GetDbContext(source);
         var dispatcher = scope.ServiceProvider.GetRequiredService<IDomainEventDispatcher>();

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
@@ -20,6 +20,14 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
 {
     protected readonly DbContext _context = context ?? throw new ArgumentNullException(nameof(context));
 
+    /// <summary>
+    /// The single global filter <c>ignoreQueryFilters: true</c> is allowed to drop. EF 10 names
+    /// filters, and the framework registers two: <c>SoftDelete</c> and <c>Tenant</c>. Dropping both
+    /// (EF's parameterless <c>IgnoreQueryFilters()</c>) would let a caller asking to see deleted rows
+    /// silently read every tenant's data, so the repository names the one it means.
+    /// </summary>
+    private static readonly string[] SoftDeleteFilterOnly = [DbContexts.ApplicationDbContext.SoftDeleteFilterName];
+
     protected virtual DbSet<TEntity> Entities => _context.Set<TEntity>();
 
     /// <inheritdoc />
@@ -37,7 +45,7 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
             : TableNoTracking;
 
         if (ignoreQueryFilters)
-            query = query.IgnoreQueryFilters();
+            query = query.IgnoreQueryFilters(SoftDeleteFilterOnly);
 
         query = ApplyIncludes(query, includes);
 
@@ -142,7 +150,7 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
         var query = asTracking ? Table : TableNoTracking;
 
         if (ignoreQueryFilters)
-            query = query.IgnoreQueryFilters();
+            query = query.IgnoreQueryFilters(SoftDeleteFilterOnly);
 
         if (includes is not null)
             query = ApplyIncludes(query, includes);
@@ -206,7 +214,7 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
         ArgumentNullException.ThrowIfNull(id);
 
         return await AnyAsync(
-            ignoreQueryFilters ? Entities.IgnoreQueryFilters() : Entities,
+            ignoreQueryFilters ? Entities.IgnoreQueryFilters(SoftDeleteFilterOnly) : Entities,
             e => e.Id.Equals(id),
             cancellationToken).ConfigureAwait(false);
     }
@@ -220,7 +228,7 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
         ArgumentNullException.ThrowIfNull(where);
 
         return await AnyAsync(
-            ignoreQueryFilters ? Entities.IgnoreQueryFilters() : Entities,
+            ignoreQueryFilters ? Entities.IgnoreQueryFilters(SoftDeleteFilterOnly) : Entities,
             where,
             cancellationToken).ConfigureAwait(false);
     }

--- a/Source/Core/MMCA.Common.Infrastructure/Scheduling/ScheduledJobEntry.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Scheduling/ScheduledJobEntry.cs
@@ -1,0 +1,75 @@
+namespace MMCA.Common.Infrastructure.Scheduling;
+
+/// <summary>
+/// The persisted schedule and last-run record for one registered
+/// <see cref="Application.Interfaces.IScheduledJob"/>. One row per job name, upserted by
+/// <see cref="ScheduledJobRunner"/> on every cycle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately <b>not</b> an <c>IAuditableEntity</c>, exactly like <c>OutboxMessage</c>: this is
+/// framework bookkeeping, not domain state. It carries no soft-delete flag (so no global query
+/// filter applies to it), no audit stamps, and no concurrency token. Its concurrency control is
+/// the explicit claim lease below, which is what makes a scaled-out host safe.
+/// </para>
+/// <para>
+/// The table is host-scoped and lives in the <b>Default</b> data source only, unlike the outbox,
+/// which exists once per physical source. Jobs belong to a host, not to a database.
+/// </para>
+/// </remarks>
+public sealed class ScheduledJobEntry
+{
+    /// <summary>
+    /// Gets the job's stable name, matching <see cref="Application.Interfaces.IScheduledJob.Name"/>.
+    /// This is the primary key: a job has exactly one schedule row per host.
+    /// </summary>
+    public required string JobName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the five-field UTC cron expression currently in force, which is either the
+    /// job's code default or the <c>Scheduler:Jobs:{Name}:Cron</c> configuration override. The
+    /// runner compares this against the resolved expression on every cycle and recomputes
+    /// <see cref="NextRunOn"/> whenever it has changed.
+    /// </summary>
+    public required string CronExpression { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC instant at which this job next becomes due. A row whose expression
+    /// cannot be parsed is parked at <see cref="DateTime.MaxValue"/> so it is never claimed.
+    /// </summary>
+    public DateTime NextRunOn { get; set; }
+
+    /// <summary>Gets or sets the UTC instant the most recent execution started. Null until the job has run once.</summary>
+    public DateTime? LastRunOn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the result of the most recent execution: <c>Succeeded</c>, <c>Failed</c>, or
+    /// <c>Skipped</c> (the schedule could not be honored, e.g. an unparsable cron expression or a
+    /// row whose job is no longer registered in this host).
+    /// </summary>
+    public string? LastOutcome { get; set; }
+
+    /// <summary>
+    /// Gets or sets the failure message from the most recent execution, truncated to the column
+    /// width. Cleared on a successful run so the column always describes the last outcome rather
+    /// than the last failure at any point in history.
+    /// </summary>
+    public string? LastError { get; set; }
+
+    /// <summary>Gets or sets how long, in milliseconds, the most recent execution took.</summary>
+    public long? LastDurationMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC instant until which this row is claimed by one scheduler replica.
+    /// Other replicas skip rows with an unexpired lease, so an occurrence runs exactly once even
+    /// with several replicas polling. Null or expired means claimable.
+    /// </summary>
+    public DateTime? LockedUntil { get; set; }
+
+    /// <summary>
+    /// Gets or sets the claim token written together with <see cref="LockedUntil"/>. The claiming
+    /// replica stamps the outcome only on a row still carrying its own token, so a replica whose
+    /// lease expired mid-execution cannot overwrite the record of the replica that took over.
+    /// </summary>
+    public Guid? LockToken { get; set; }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Scheduling/ScheduledJobRunner.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Scheduling/ScheduledJobRunner.cs
@@ -1,0 +1,592 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Settings;
+using CronSchedule = Cronos.CronExpression;
+
+namespace MMCA.Common.Infrastructure.Scheduling;
+
+/// <summary>
+/// Background service that runs the host's registered <see cref="IScheduledJob"/>s on their cron
+/// schedules, using a persistent job store and the outbox processor's claim-lease idiom so an
+/// occurrence executes exactly once across every replica.
+/// <para>
+/// Each cycle: reconcile the <c>ScheduledJobs</c> rows against the registered jobs, claim due rows
+/// one at a time with a lease, execute each claimed job in its own DI scope, stamp the outcome and
+/// advance the schedule, then sleep until the earliest upcoming occurrence (capped at
+/// <c>Scheduler:PollingIntervalSeconds</c>).
+/// </para>
+/// <para>
+/// Missed occurrences never accumulate: the next run is computed from the instant the execution
+/// finished, not from the occurrence that was missed, so a host that was down for a day runs each
+/// job once on startup and returns to its cadence rather than replaying the backlog.
+/// </para>
+/// </summary>
+/// <param name="scopeFactory">Factory for the per-cycle scope and the fresh per-execution scope.</param>
+/// <param name="logger">Logger for scheduling diagnostics.</param>
+/// <param name="schedulerOptions">Configurable scheduler settings.</param>
+/// <param name="dataSourceResolver">Resolver for the Default data source holding the job table.</param>
+/// <param name="timeProvider">Clock abstraction for the startup delay, the smart wait, and every
+/// scheduling timestamp; defaults to <see cref="TimeProvider.System"/> so tests can drive the loop
+/// deterministically.</param>
+public sealed partial class ScheduledJobRunner(
+    IServiceScopeFactory scopeFactory,
+    ILogger<ScheduledJobRunner> logger,
+    IOptions<SchedulerSettings> schedulerOptions,
+    IDataSourceResolver dataSourceResolver,
+    TimeProvider? timeProvider = null) : BackgroundService
+{
+    private readonly SchedulerSettings _settings = schedulerOptions.Value;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    /// <summary>Outcome recorded when a job's <c>ExecuteAsync</c> returned without throwing.</summary>
+    internal const string OutcomeSucceeded = "Succeeded";
+
+    /// <summary>Outcome recorded when a job's <c>ExecuteAsync</c> threw.</summary>
+    internal const string OutcomeFailed = "Failed";
+
+    /// <summary>
+    /// Outcome recorded when the schedule could not be honored at all: the cron expression does not
+    /// parse, or the claimed row's job is no longer registered in this host.
+    /// </summary>
+    internal const string OutcomeSkipped = "Skipped";
+
+    /// <summary>Column width of <c>LastError</c>; longer messages are truncated to fit.</summary>
+    internal const int MaxErrorLength = 2048;
+
+    /// <summary>
+    /// Brief startup delay so the host finishes initializing (module registration, database
+    /// migration) before the first cycle touches the job table. Matches
+    /// <c>PeriodicBackgroundService</c>'s delay.
+    /// </summary>
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(15);
+
+    /// <summary>Floor for the computed wait so an overdue row cannot hot-loop the runner.</summary>
+    private static readonly TimeSpan MinimumWait = TimeSpan.FromSeconds(1);
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_settings.Enabled)
+        {
+            // Logged once, at startup, and then never again: a disabled scheduler must be visible in
+            // the logs of a host that expected it to run, without costing a line per cycle.
+            LogSchedulerDisabled(logger);
+            return;
+        }
+
+        try
+        {
+            await _timeProvider.Delay(StartupDelay, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            DateTime? earliestNextRun = null;
+            try
+            {
+                earliestNextRun = await RunCycleAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Normal shutdown — exit gracefully.
+                break;
+            }
+            catch (Exception ex)
+            {
+                // One bad cycle (an unreachable database, a model mismatch) must not take the
+                // scheduler down for the life of the process: log it and wait out the interval.
+                LogCycleError(logger, ex);
+            }
+
+            var wait = ComputeWaitTime(
+                earliestNextRun,
+                _timeProvider.GetUtcNow().UtcDateTime,
+                TimeSpan.FromSeconds(_settings.PollingIntervalSeconds));
+
+            try
+            {
+                await _timeProvider.Delay(wait, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Computes how long to sleep before the next cycle: until the earliest upcoming occurrence,
+    /// capped at the polling interval and floored at one second so an overdue row that could not be
+    /// claimed (another replica holds it) cannot spin the loop.
+    /// </summary>
+    /// <param name="earliestNextRun">The earliest <c>NextRunOn</c> across the registered jobs, or null when none are registered.</param>
+    /// <param name="utcNow">The current UTC instant.</param>
+    /// <param name="pollingInterval">The configured fallback polling interval.</param>
+    /// <returns>The wait before the next cycle.</returns>
+    internal static TimeSpan ComputeWaitTime(DateTime? earliestNextRun, DateTime utcNow, TimeSpan pollingInterval)
+    {
+        if (earliestNextRun is null)
+        {
+            return pollingInterval;
+        }
+
+        var untilDue = earliestNextRun.Value - utcNow;
+        if (untilDue < MinimumWait)
+        {
+            untilDue = MinimumWait;
+        }
+
+        return untilDue < pollingInterval ? untilDue : pollingInterval;
+    }
+
+    /// <summary>
+    /// Resolves the five-field cron expression in force for a job: the
+    /// <c>Scheduler:Jobs:{Name}:Cron</c> override when configured and non-blank, otherwise the
+    /// job's compiled-in default.
+    /// </summary>
+    /// <param name="settings">The bound scheduler settings.</param>
+    /// <param name="job">The registered job.</param>
+    /// <returns>The expression the schedule should be computed from.</returns>
+    internal static string ResolveCronExpression(SchedulerSettings settings, IScheduledJob job) =>
+        settings.Jobs.TryGetValue(job.Name, out var overrideSettings)
+            && !string.IsNullOrWhiteSpace(overrideSettings.Cron)
+                ? overrideSettings.Cron
+                : job.CronExpression;
+
+    /// <summary>
+    /// Computes the first occurrence strictly after <paramref name="afterUtc"/>, or null when the
+    /// expression does not parse or has no further occurrence.
+    /// </summary>
+    /// <param name="cronExpression">The five-field UTC cron expression.</param>
+    /// <param name="afterUtc">The exclusive lower bound.</param>
+    /// <param name="error">The parse failure message when the expression is invalid, otherwise null.</param>
+    /// <returns>The next occurrence in UTC, or null.</returns>
+    internal static DateTime? TryGetNextOccurrence(string cronExpression, DateTime afterUtc, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(cronExpression))
+        {
+            error = "The cron expression is empty.";
+            return null;
+        }
+
+        try
+        {
+            error = null;
+            return CronSchedule.Parse(cronExpression).GetNextOccurrence(afterUtc, inclusive: false);
+        }
+        catch (Exception ex) when (ex is Cronos.CronFormatException or ArgumentException)
+        {
+            // The parser reports a malformed expression as CronFormatException and a structurally
+            // impossible argument as ArgumentException. Neither is a reason to take the runner down:
+            // both park this one row and leave every other job scheduled.
+            error = ex.Message;
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Runs one full cycle and reports the earliest upcoming occurrence, which drives the smart wait.
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the cycle.</param>
+    /// <returns>The earliest upcoming occurrence, or null when no jobs are registered.</returns>
+    /// <remarks>Internal so tests can drive one cycle without advancing the loop's timers.</remarks>
+    internal async Task<DateTime?> RunCycleAsync(CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var jobs = ResolveRegisteredJobs(scope.ServiceProvider);
+        if (jobs.Count == 0)
+        {
+            return null;
+        }
+
+        var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
+        var context = dbContextFactory.GetDbContext(
+            dataSourceResolver.ResolveLogical(_settings.DataSource, DataSourceKey.DefaultName));
+
+        await SyncRegistrationsAsync(context, jobs, cancellationToken).ConfigureAwait(false);
+        await RunDueJobsAsync(context, jobs, cancellationToken).ConfigureAwait(false);
+
+        string[] names = [.. jobs.Keys];
+        return await context.Set<ScheduledJobEntry>().AsNoTracking()
+            .Where(e => names.Contains(e.JobName))
+            .OrderBy(e => e.NextRunOn)
+            .Select(e => (DateTime?)e.NextRunOn)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves this host's registered jobs, keyed by name. A duplicate name is a registration bug
+    /// (two jobs would share one schedule row): the first registration wins and the collision is
+    /// logged rather than thrown, so one mis-registered module cannot stop every other job.
+    /// </summary>
+    private Dictionary<string, IScheduledJob> ResolveRegisteredJobs(IServiceProvider serviceProvider)
+    {
+        var jobs = new Dictionary<string, IScheduledJob>(StringComparer.Ordinal);
+        foreach (var group in serviceProvider.GetServices<IScheduledJob>()
+            .GroupBy(job => job.Name, StringComparer.Ordinal))
+        {
+            IScheduledJob[] registered = [.. group];
+            jobs[group.Key] = registered[0];
+            if (registered.Length > 1)
+            {
+                LogDuplicateJobName(logger, group.Key);
+            }
+        }
+
+        return jobs;
+    }
+
+    /// <summary>
+    /// Reconciles the store against the registered jobs: inserts a row for a job seen for the first
+    /// time, and rewrites the expression plus the next occurrence for a job whose schedule changed
+    /// in code or configuration. An unparsable expression parks the row at
+    /// <see cref="DateTime.MaxValue"/> and records <see cref="OutcomeSkipped"/> instead of throwing:
+    /// one bad cron string in configuration must not stop every other job in the host.
+    /// </summary>
+    private async Task SyncRegistrationsAsync(
+        ApplicationDbContext context,
+        Dictionary<string, IScheduledJob> jobs,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        string[] names = [.. jobs.Keys];
+
+        var existing = await context.Set<ScheduledJobEntry>().AsNoTracking()
+            .Where(e => names.Contains(e.JobName))
+            .Select(e => new { e.JobName, e.CronExpression })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var storedCron = existing.ToDictionary(e => e.JobName, e => e.CronExpression, StringComparer.Ordinal);
+        var inserted = false;
+
+        foreach (var job in jobs.Values)
+        {
+            var cron = ResolveCronExpression(_settings, job);
+            if (storedCron.TryGetValue(job.Name, out var current)
+                && string.Equals(current, cron, StringComparison.Ordinal))
+            {
+                // Unchanged: leave the row (and its computed NextRunOn) exactly as it is. Recomputing
+                // here would push every schedule forward on every cycle and nothing would ever fire.
+                continue;
+            }
+
+            var nextRun = TryGetNextOccurrence(cron, now, out var parseError);
+            if (parseError is not null)
+            {
+                LogInvalidCronExpression(logger, job.Name, cron, parseError);
+            }
+
+            if (storedCron.ContainsKey(job.Name))
+            {
+                await UpdateScheduleAsync(context, job.Name, cron, nextRun, parseError, cancellationToken)
+                    .ConfigureAwait(false);
+                LogScheduleChanged(logger, job.Name, current!, cron);
+            }
+            else
+            {
+                context.Add(new ScheduledJobEntry
+                {
+                    JobName = job.Name,
+                    CronExpression = cron,
+                    NextRunOn = nextRun ?? DateTime.MaxValue,
+                    LastOutcome = parseError is null ? null : OutcomeSkipped,
+                    LastError = Truncate(parseError),
+                });
+                inserted = true;
+                LogJobRegistered(logger, job.Name, cron);
+            }
+        }
+
+        if (inserted)
+        {
+            // Plain SaveChangesAsync without a user id: ScheduledJobEntry is neither auditable nor an
+            // aggregate root, so the interceptors have nothing to stamp and no events to capture.
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Rewrites one row's expression and next occurrence through a set-based update, so a row a
+    /// replica is currently executing is not disturbed by the change tracker.
+    /// </summary>
+    private static async Task UpdateScheduleAsync(
+        ApplicationDbContext context,
+        string jobName,
+        string cron,
+        DateTime? nextRun,
+        string? parseError,
+        CancellationToken cancellationToken)
+    {
+        var effectiveNextRun = nextRun ?? DateTime.MaxValue;
+
+        if (parseError is null)
+        {
+            await context.Set<ScheduledJobEntry>()
+                .Where(e => e.JobName == jobName)
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(e => e.CronExpression, cron)
+                          .SetProperty(e => e.NextRunOn, effectiveNextRun),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        var truncated = Truncate(parseError);
+        await context.Set<ScheduledJobEntry>()
+            .Where(e => e.JobName == jobName)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.CronExpression, cron)
+                      .SetProperty(e => e.NextRunOn, effectiveNextRun)
+                      .SetProperty(e => e.LastOutcome, OutcomeSkipped)
+                      .SetProperty(e => e.LastError, truncated),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Claims and runs every due job once, one row at a time. Each name is attempted at most once
+    /// per cycle, so a row another replica claims between the read and the update simply falls
+    /// through to the next cycle instead of spinning this one.
+    /// </summary>
+    private async Task RunDueJobsAsync(
+        ApplicationDbContext context,
+        Dictionary<string, IScheduledJob> jobs,
+        CancellationToken cancellationToken)
+    {
+        var attempted = new HashSet<string>(StringComparer.Ordinal);
+
+        while (!cancellationToken.IsCancellationRequested && attempted.Count < jobs.Count)
+        {
+            string[] candidates = [.. jobs.Keys.Where(name => !attempted.Contains(name))];
+            var claim = await TryClaimNextDueAsync(context, candidates, cancellationToken).ConfigureAwait(false);
+
+            if (claim is null)
+            {
+                return;
+            }
+
+            attempted.Add(claim.JobName);
+
+            // A null token means another replica won the race for that row: skip it and look for the
+            // next due one rather than spinning on a row this replica will never own.
+            if (claim.LockToken is { } lockToken)
+            {
+                await ExecuteClaimedJobAsync(
+                        context, claim.JobName, claim.DueOn, claim.CronExpression, lockToken, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds the earliest due, unleased row among <paramref name="candidates"/> and tries to claim it.
+    /// </summary>
+    /// <returns>
+    /// Null when nothing is due; otherwise the row, with a non-null
+    /// <see cref="JobClaim.LockToken"/> when this replica won the claim and null when it lost it.
+    /// </returns>
+    private async Task<JobClaim?> TryClaimNextDueAsync(
+        ApplicationDbContext context,
+        string[] candidates,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var due = await context.Set<ScheduledJobEntry>().AsNoTracking()
+            .Where(e => candidates.Contains(e.JobName)
+                && e.NextRunOn <= now
+                && (e.LockedUntil == null || e.LockedUntil < now))
+            .OrderBy(e => e.NextRunOn)
+            .Select(e => new { e.JobName, e.NextRunOn, e.CronExpression })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (due is null)
+        {
+            return null;
+        }
+
+        var lockToken = Guid.NewGuid();
+        var leaseUntil = now.AddSeconds(_settings.LeaseSeconds);
+        var jobName = due.JobName;
+
+        // The claim is what makes scale-out safe: two replicas racing on the same row both issue this
+        // update, and exactly one of them matches the still-unleased predicate.
+        var claimed = await context.Set<ScheduledJobEntry>()
+            .Where(e => e.JobName == jobName
+                && e.NextRunOn <= now
+                && (e.LockedUntil == null || e.LockedUntil < now))
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.LockedUntil, leaseUntil)
+                      .SetProperty(e => e.LockToken, lockToken),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return new JobClaim(due.JobName, due.NextRunOn, due.CronExpression, claimed == 0 ? null : lockToken);
+    }
+
+    /// <summary>One due row and the outcome of this replica's attempt to claim it.</summary>
+    /// <param name="JobName">The row's job name.</param>
+    /// <param name="DueOn">The occurrence the row was due at, used for the lag metric.</param>
+    /// <param name="CronExpression">The expression the next occurrence is computed from.</param>
+    /// <param name="LockToken">This replica's claim token, or null when another replica won the row.</param>
+    private sealed record JobClaim(string JobName, DateTime DueOn, string CronExpression, Guid? LockToken);
+
+    /// <summary>
+    /// Executes one claimed job in a fresh DI scope, then stamps the outcome and advances the
+    /// schedule. A job exception is caught and recorded: the schedule still advances (so a
+    /// permanently failing job cannot hot-loop) and the runner survives.
+    /// </summary>
+    private async Task ExecuteClaimedJobAsync(
+        ApplicationDbContext context,
+        string jobName,
+        DateTime dueOn,
+        string cronExpression,
+        Guid lockToken,
+        CancellationToken cancellationToken)
+    {
+        var startedOn = _timeProvider.GetUtcNow().UtcDateTime;
+
+        // Lag is floored at zero: DateTime.MaxValue rows are never claimed, but a clock adjustment
+        // between the claim and the start must not publish a negative duration into the histogram.
+        var lagSeconds = Math.Max((startedOn - dueOn).TotalSeconds, 0);
+        SchedulerMetrics.LagHistogram.Record(lagSeconds, new KeyValuePair<string, object?>("job", jobName));
+
+        var startTimestamp = _timeProvider.GetTimestamp();
+        (string outcome, string? error) = await InvokeJobAsync(jobName, cancellationToken).ConfigureAwait(false);
+        var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
+        var jobTag = new KeyValuePair<string, object?>("job", jobName);
+        SchedulerMetrics.DurationHistogram.Record(elapsed.TotalSeconds, jobTag);
+        SchedulerMetrics.RunCounter.Add(1, jobTag, new KeyValuePair<string, object?>("outcome", outcome));
+
+        // Missed-run policy: the next occurrence is computed from NOW, not from the occurrence that
+        // just ran, so a schedule that elapsed many times while the host was down advances past the
+        // present in one step instead of replaying the backlog.
+        var completedOn = _timeProvider.GetUtcNow().UtcDateTime;
+        var nextRun = TryGetNextOccurrence(cronExpression, completedOn, out var parseError) ?? DateTime.MaxValue;
+        if (parseError is not null)
+        {
+            LogInvalidCronExpression(logger, jobName, cronExpression, parseError);
+        }
+
+        var durationMs = (long)elapsed.TotalMilliseconds;
+        var truncatedError = Truncate(error);
+
+        // Guarded by the claim token: a replica whose lease expired mid-execution (another replica
+        // has since claimed and possibly re-run the row) matches nothing here and silently drops its
+        // stale outcome rather than overwriting the current holder's record.
+        var stamped = await context.Set<ScheduledJobEntry>()
+            .Where(e => e.JobName == jobName && e.LockToken == lockToken)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.LastRunOn, startedOn)
+                      .SetProperty(e => e.LastOutcome, outcome)
+                      .SetProperty(e => e.LastError, truncatedError)
+                      .SetProperty(e => e.LastDurationMs, durationMs)
+                      .SetProperty(e => e.NextRunOn, nextRun)
+                      .SetProperty(e => e.LockedUntil, (DateTime?)null)
+                      .SetProperty(e => e.LockToken, (Guid?)null),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (stamped == 0)
+        {
+            LogLeaseLost(logger, jobName);
+            return;
+        }
+
+        LogJobCompleted(logger, jobName, outcome, durationMs, nextRun);
+    }
+
+    /// <summary>
+    /// Resolves the job in a fresh DI scope and runs it, returning the outcome and, on failure, the
+    /// message to record. Exactly like a request: the job and every scoped dependency it takes (unit
+    /// of work, repositories, handlers) are built and disposed around this one run.
+    /// </summary>
+    private async Task<(string Outcome, string? Error)> InvokeJobAsync(
+        string jobName,
+        CancellationToken cancellationToken)
+    {
+        using var jobScope = scopeFactory.CreateScope();
+        var job = jobScope.ServiceProvider.GetServices<IScheduledJob>()
+            .FirstOrDefault(candidate => string.Equals(candidate.Name, jobName, StringComparison.Ordinal));
+
+        if (job is null)
+        {
+            LogJobNotResolvable(logger, jobName);
+            return (OutcomeSkipped, "The job is no longer registered in this host.");
+        }
+
+        try
+        {
+            LogJobStarting(logger, jobName);
+            await job.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            return (OutcomeSucceeded, null);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Host shutdown, not a job failure. Leave the row leased: it becomes claimable again when
+            // the lease expires, and the occurrence is retried then rather than being recorded as a
+            // failure it never was.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogJobFailed(logger, jobName, ex);
+            return (OutcomeFailed, ex.Message);
+        }
+    }
+
+    /// <summary>Truncates a message to the <c>LastError</c> column width, preserving null.</summary>
+    private static string? Truncate(string? message) =>
+        message is null || message.Length <= MaxErrorLength ? message : message[..MaxErrorLength];
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Scheduled job runner disabled: set Scheduler:Enabled to true to run recurring jobs")]
+    private static partial void LogSchedulerDisabled(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Scheduled job cycle failed")]
+    private static partial void LogCycleError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Scheduled job {JobName} registered with schedule \"{CronExpression}\"")]
+    private static partial void LogJobRegistered(ILogger logger, string jobName, string cronExpression);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Scheduled job {JobName} schedule changed from \"{PreviousCronExpression}\" to \"{CronExpression}\"; next occurrence recomputed")]
+    private static partial void LogScheduleChanged(ILogger logger, string jobName, string previousCronExpression, string cronExpression);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Scheduled job {JobName} has an invalid cron expression \"{CronExpression}\" and will never run: {ParseError}")]
+    private static partial void LogInvalidCronExpression(ILogger logger, string jobName, string cronExpression, string parseError);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Two scheduled jobs are registered under the name {JobName}; only the first is scheduled")]
+    private static partial void LogDuplicateJobName(ILogger logger, string jobName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Scheduled job {JobName} has a stored schedule but is no longer registered in this host")]
+    private static partial void LogJobNotResolvable(ILogger logger, string jobName);
+
+    // Debug, not Information: this fires once per occurrence and pairs with the completion line
+    // below, so a busy schedule would otherwise double this runner's steady-state log volume
+    // (rubric §31, the published COST guide). Failures stay loud.
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Scheduled job {JobName} starting")]
+    private static partial void LogJobStarting(ILogger logger, string jobName);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Scheduled job {JobName} finished with outcome {Outcome} in {DurationMs} ms; next occurrence {NextRunOn:O}")]
+    private static partial void LogJobCompleted(ILogger logger, string jobName, string outcome, long durationMs, DateTime nextRunOn);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Scheduled job {JobName} failed")]
+    private static partial void LogJobFailed(ILogger logger, string jobName, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Scheduled job {JobName} outlived its claim lease; its outcome was discarded because another replica now owns the row")]
+    private static partial void LogLeaseLost(ILogger logger, string jobName);
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Scheduling/SchedulerMetrics.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Scheduling/SchedulerMetrics.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.Metrics;
+
+namespace MMCA.Common.Infrastructure.Scheduling;
+
+/// <summary>
+/// OpenTelemetry instruments for the recurring job scheduler, emitted by
+/// <see cref="ScheduledJobRunner"/>. A host exports them by registering the
+/// <see cref="MeterName"/> meter: the Aspire service defaults (<c>ConfigureOpenTelemetry</c>)
+/// already do. The meter name is duplicated as a literal in MMCA.Common.Aspire because that
+/// package has no reference to Infrastructure.
+/// <para>
+/// One meter serves every scheduler instrument: run outcomes, execution duration, and schedule
+/// lag. Never create a second <see cref="Meter"/> with this name.
+/// </para>
+/// </summary>
+internal static class SchedulerMetrics
+{
+    /// <summary>OpenTelemetry meter name for scheduler metrics.</summary>
+    internal const string MeterName = "MMCA.Common.Scheduler";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    /// <summary>
+    /// Job occurrences executed, tagged by <c>job</c> and by <c>outcome</c> (<c>Succeeded</c>,
+    /// <c>Failed</c> or <c>Skipped</c>). The failure rate of a schedule is this counter split by
+    /// outcome, which is the number an operator alerts on.
+    /// </summary>
+    internal static readonly Counter<long> RunCounter = Meter.CreateCounter<long>(
+        "scheduler.job.runs",
+        unit: "runs",
+        description: "Number of scheduled job occurrences executed, tagged by job name and outcome.");
+
+    /// <summary>
+    /// Wall-clock execution time in SECONDS for one occurrence, tagged by <c>job</c>. Measured
+    /// around the job's own <c>ExecuteAsync</c> only, so it excludes claim and bookkeeping cost.
+    /// A job whose duration approaches <c>Scheduler:LeaseSeconds</c> is about to lose its claim
+    /// mid-run, which is exactly what this histogram is for.
+    /// </summary>
+    internal static readonly Histogram<double> DurationHistogram = Meter.CreateHistogram<double>(
+        "scheduler.job.duration",
+        unit: "s",
+        description: "Seconds spent executing one scheduled job occurrence, tagged by job name.");
+
+    /// <summary>
+    /// Schedule lag in SECONDS: the interval between the instant an occurrence became due
+    /// (<c>NextRunOn</c>) and the instant it actually started, tagged by <c>job</c>. This is the
+    /// number that answers "is the scheduler keeping up"; it is floored at zero, and a value near
+    /// the polling interval is normal for a job whose occurrence landed just after a cycle.
+    /// </summary>
+    internal static readonly Histogram<double> LagHistogram = Meter.CreateHistogram<double>(
+        "scheduler.job.lag",
+        unit: "s",
+        description: "Seconds between a scheduled job becoming due and its execution starting, tagged by job name.");
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Services/TenantContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/TenantContext.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using MMCA.Common.Application.Interfaces;
+
+namespace MMCA.Common.Infrastructure.Services;
+
+/// <summary>
+/// Scoped service holding the tenant the current request runs as. Unresolved until
+/// <see cref="SetTenant"/> is called, which is the state every background service, seeder and
+/// design-time tool stays in.
+/// </summary>
+public sealed class TenantContext : ITenantContext
+{
+    /// <inheritdoc />
+    public string? TenantId { get; private set; }
+
+    /// <inheritdoc />
+    public bool IsResolved => TenantId is not null;
+
+    /// <inheritdoc />
+    public void SetTenant(string tenantId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        if (TenantId is null)
+        {
+            TenantId = tenantId;
+            return;
+        }
+
+        // Idempotent for the same value: the middleware and a background worker that re-asserts the
+        // tenant on the same scope must not fight each other.
+        if (string.Equals(TenantId, tenantId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(string.Format(
+            CultureInfo.InvariantCulture,
+            "The tenant for this scope is already \"{0}\" and cannot be changed to \"{1}\". "
+            + "Anything already read or tracked in this scope was scoped to the first tenant; "
+            + "start a new scope for a different tenant.",
+            TenantId,
+            tenantId));
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/AuditTrailSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/AuditTrailSettings.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// Configuration for the entity change-history trail, bound from the <c>AuditTrail</c> section.
+/// Every property has a default, so a host that opts in only needs <c>AuditTrail:Enabled</c>.
+/// </summary>
+/// <remarks>
+/// <see cref="Enabled"/> is the single gate: it decides both whether changes are recorded and
+/// whether the <c>AuditTrailEntries</c> table is mapped into the model at all. A host that leaves
+/// it false has exactly the model it had before the trail existed, so its migrations never see the
+/// table.
+/// </remarks>
+public sealed class AuditTrailSettings
+{
+    /// <summary>Configuration section name used for options binding.</summary>
+    public static readonly string SectionName = "AuditTrail";
+
+    /// <summary>
+    /// Gets a value indicating whether changes to <c>IAuditedEntity</c> entities are recorded.
+    /// Defaults to <see langword="false"/>: adopting the framework must never add a table or a
+    /// write per change to a host that did not ask for one.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the number of days a trail row is kept before <c>AuditTrailCleanupJob</c> purges it.
+    /// Defaults to <c>90</c>.
+    /// </summary>
+    /// <remarks>
+    /// Retention only happens if the host also runs the scheduler (<c>AddScheduledJobs</c> plus
+    /// <c>Scheduler:Enabled</c>). Without it the trail still records and this value is inert: the
+    /// table grows until an operator prunes it.
+    /// </remarks>
+    [Range(1, 3650)]
+    public int RetentionDays { get; init; } = 90;
+
+    /// <summary>
+    /// Gets the engine whose <c>Default</c> database the read surface (<c>IAuditTrailReader</c>)
+    /// queries. Trail rows are written to every relational source alongside the data they describe;
+    /// this only says which one the v1 reader looks in. Defaults to
+    /// <see cref="DataSource.SQLServer"/>. Cosmos DB is not a valid value (the table is relational).
+    /// </summary>
+    public DataSource DataSource { get; init; } = DataSource.SQLServer;
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/SchedulerSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/SchedulerSettings.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel.DataAnnotations;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// Configuration for the recurring job scheduler, bound from the <c>Scheduler</c> section.
+/// Every property has a default, so a host that opts in only needs <c>Scheduler:Enabled</c>.
+/// </summary>
+/// <remarks>
+/// <see cref="Enabled"/> is the single gate: it decides both whether the runner does any work and
+/// whether the <c>ScheduledJobs</c> table is mapped into the model at all. A host that leaves it
+/// false has exactly the model it had before the scheduler existed, so its migrations never see
+/// the table.
+/// </remarks>
+public sealed class SchedulerSettings
+{
+    /// <summary>Configuration section name used for options binding.</summary>
+    public static readonly string SectionName = "Scheduler";
+
+    /// <summary>
+    /// Gets a value indicating whether the scheduler is active. Defaults to <see langword="false"/>:
+    /// adopting the framework must never add a table or a background loop to a host that did not
+    /// ask for one.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the fallback polling interval in seconds. The runner normally sleeps until the earliest
+    /// due job (the smart wait), so this only bounds how long it can sleep when the next occurrence
+    /// is far away, and how quickly it notices a configuration-driven schedule change.
+    /// </summary>
+    [Range(1, 3600)]
+    public int PollingIntervalSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Gets how long, in seconds, a replica's claim on a job row lasts. Other replicas skip rows
+    /// with an unexpired lease, so concurrent replicas never run the same occurrence twice; if a
+    /// replica dies mid-execution, the row becomes claimable again once the lease expires. Set it
+    /// comfortably above the longest expected job duration.
+    /// </summary>
+    [Range(10, 3600)]
+    public int LeaseSeconds { get; init; } = 300;
+
+    /// <summary>
+    /// Gets the engine whose <c>Default</c> database holds the <c>ScheduledJobs</c> table. Jobs are
+    /// host-scoped, so there is exactly one table per host rather than one per data source; this
+    /// only says which relational engine that one table lives on.
+    /// Defaults to <see cref="DataSource.SQLServer"/>. Cosmos DB is not a valid value (the table is
+    /// relational).
+    /// </summary>
+    public DataSource DataSource { get; init; } = DataSource.SQLServer;
+
+    /// <summary>
+    /// Gets the per-job configuration overrides, keyed by
+    /// <see cref="Application.Interfaces.IScheduledJob.Name"/> and bound from
+    /// <c>Scheduler:Jobs:{Name}</c>. An entry lets a host retime a job without touching code; an
+    /// absent entry leaves the job's compiled-in default in force.
+    /// </summary>
+    public Dictionary<string, ScheduledJobOverrideSettings> Jobs { get; } = [];
+}
+
+/// <summary>
+/// Per-job configuration overrides bound from <c>Scheduler:Jobs:{Name}</c>.
+/// </summary>
+public sealed class ScheduledJobOverrideSettings
+{
+    /// <summary>
+    /// Gets the five-field UTC cron expression that replaces the job's compiled-in
+    /// <see cref="Application.Interfaces.IScheduledJob.CronExpression"/>. Null or blank leaves the
+    /// code default in force. A change here is picked up on the next scheduler cycle: the runner
+    /// rewrites the stored expression and recomputes the next occurrence from the current instant.
+    /// </summary>
+    public string? Cron { get; init; }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/TenancySettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/TenancySettings.cs
@@ -1,0 +1,154 @@
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// How <c>TenantResolutionMiddleware</c> looks for the tenant on an inbound request.
+/// </summary>
+public enum TenantResolutionStrategy
+{
+    /// <summary>
+    /// Read the tenant from a claim on the authenticated principal
+    /// (<see cref="TenancySettings.ClaimType"/>). The trustworthy source: the claim was signed by
+    /// the token issuer, so a caller cannot pick its own tenant.
+    /// </summary>
+    Claim = 0,
+
+    /// <summary>
+    /// Read the tenant from a request header (<see cref="TenancySettings.HeaderName"/>). Intended
+    /// for service-to-service calls behind a trusted gateway; a public edge that honors this header
+    /// lets any caller name any tenant.
+    /// </summary>
+    Header = 1,
+
+    /// <summary>
+    /// Derive the tenant from the request host name. <b>Defined but not implemented.</b> The member
+    /// exists so the configuration contract is stable when host-based resolution ships; selecting it
+    /// today fails options validation at startup rather than silently resolving nothing.
+    /// </summary>
+    Host = 2,
+}
+
+/// <summary>
+/// Configuration for multi-tenancy, bound from the <c>Tenancy</c> section by
+/// <c>AddMultiTenancy(configuration)</c>. Every property has a default, so a host that opts in only
+/// needs <c>Tenancy:Enabled</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Enabled"/> gates <b>resolution</b>, not isolation. The query filter and the save
+/// interceptor are always present and are inert whenever no tenant is resolved, so a host that
+/// never enables this keeps exactly the behavior it had before tenancy shipped.
+/// </para>
+/// <para>
+/// <b>Collection defaults are expressed as "empty means the default".</b>
+/// <see cref="ResolutionOrder"/> and <see cref="ExcludedPathPrefixes"/> bind as empty lists and the
+/// framework reads <see cref="EffectiveResolutionOrder"/> / <see cref="EffectiveExcludedPathPrefixes"/>
+/// instead. The configuration binder ADDS to a pre-populated collection rather than replacing it, so
+/// a non-empty default would leave a host that configured its own order running the framework's
+/// entries as well.
+/// </para>
+/// </remarks>
+public sealed class TenancySettings
+{
+    /// <summary>Configuration section name used for options binding.</summary>
+    public static readonly string SectionName = "Tenancy";
+
+    /// <summary>The resolution order used when <see cref="ResolutionOrder"/> is left empty.</summary>
+    private static readonly TenantResolutionStrategy[] DefaultResolutionOrder =
+        [TenantResolutionStrategy.Claim, TenantResolutionStrategy.Header];
+
+    /// <summary>The excluded prefixes used when <see cref="ExcludedPathPrefixes"/> is left empty.</summary>
+    private static readonly string[] DefaultExcludedPathPrefixes =
+        ["/health", "/alive", "/.well-known"];
+
+    /// <summary>
+    /// Gets a value indicating whether tenant resolution runs. Defaults to <see langword="false"/>:
+    /// adopting the framework must never start rejecting requests that carry no tenant.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the strategies tried, in order, until one yields a tenant. Empty means
+    /// <see cref="EffectiveResolutionOrder"/> (claim, then header).
+    /// </summary>
+    public List<TenantResolutionStrategy> ResolutionOrder { get; } = [];
+
+    /// <summary>Gets the resolution order actually used, falling back to the framework default.</summary>
+    public IReadOnlyList<TenantResolutionStrategy> EffectiveResolutionOrder =>
+        ResolutionOrder.Count == 0 ? DefaultResolutionOrder : ResolutionOrder;
+
+    /// <summary>
+    /// Gets the claim type carrying the tenant on the authenticated principal. Defaults to
+    /// <c>tenant_id</c>.
+    /// </summary>
+    public string ClaimType { get; init; } = "tenant_id";
+
+    /// <summary>
+    /// Gets the request header carrying the tenant. Defaults to <c>X-Tenant-Id</c>. Only honored
+    /// when <see cref="TenantResolutionStrategy.Header"/> is in the resolution order.
+    /// </summary>
+    public string HeaderName { get; init; } = "X-Tenant-Id";
+
+    /// <summary>
+    /// Gets a value indicating whether a request that resolves no tenant is rejected with
+    /// <c>400 Bad Request</c>. Defaults to <see langword="true"/>: with tenancy switched on, an
+    /// unscoped request would read across every tenant, so the safe answer is to fail closed.
+    /// </summary>
+    public bool RequireTenant { get; init; } = true;
+
+    /// <summary>
+    /// Gets the request path prefixes that bypass resolution entirely (probes and discovery
+    /// documents, which are not tenant-scoped and must answer before any tenant exists). Empty
+    /// means <see cref="EffectiveExcludedPathPrefixes"/>.
+    /// </summary>
+    public List<string> ExcludedPathPrefixes { get; } = [];
+
+    /// <summary>Gets the excluded prefixes actually used, falling back to the framework default.</summary>
+    public IReadOnlyList<string> EffectiveExcludedPathPrefixes =>
+        ExcludedPathPrefixes.Count == 0 ? DefaultExcludedPathPrefixes : ExcludedPathPrefixes;
+
+    /// <summary>
+    /// Gets the declared tenants, keyed by tenant identifier and bound from
+    /// <c>Tenancy:Tenants:{tenantId}</c>. Declaring a tenant is only required for the
+    /// database-per-tenant case: shared-schema tenants need no entry, because isolation there comes
+    /// from the query filter and the save interceptor rather than from configuration.
+    /// </summary>
+    public Dictionary<string, TenantEntrySettings> Tenants { get; } = [];
+}
+
+/// <summary>
+/// One declared tenant, bound from <c>Tenancy:Tenants:{tenantId}</c>.
+/// </summary>
+public sealed class TenantEntrySettings
+{
+    /// <summary>
+    /// Gets this tenant's per-data-source connection overrides, keyed by <b>physical</b> data
+    /// source name (the name <c>IDataSourceResolver</c> produces, e.g. <c>Default</c> or
+    /// <c>Conference</c>). A source with an entry here is routed to the tenant's own database; a
+    /// source without one stays shared and is isolated by the query filter.
+    /// </summary>
+    public Dictionary<string, TenantDataSourceOverrideSettings> DataSources { get; } = [];
+}
+
+/// <summary>
+/// A tenant's connection override for one physical data source, bound from
+/// <c>Tenancy:Tenants:{tenantId}:DataSources:{sourceName}</c>. Exactly the connection information
+/// the framework needs to clone the resolved <c>PhysicalDataSource</c>; the migrations assembly is
+/// deliberately not overridable, since a tenant database has the same schema as the shared one.
+/// </summary>
+public sealed class TenantDataSourceOverrideSettings
+{
+    /// <summary>Gets the SQL Server connection string for this tenant's copy of the source.</summary>
+    public string? SQLServerConnectionString { get; init; }
+
+    /// <summary>Gets the SQLite connection string for this tenant's copy of the source.</summary>
+    public string? SqliteConnectionString { get; init; }
+
+    /// <summary>Gets the Azure Cosmos DB connection string for this tenant's copy of the source.</summary>
+    public string? CosmosConnectionString { get; init; }
+
+    /// <summary>
+    /// Gets the Cosmos DB database name for this tenant. Optional: when omitted the shared source's
+    /// database name is kept, which is how one Cosmos account serves per-tenant accounts.
+    /// </summary>
+    public string? CosmosDatabaseName { get; init; }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/TenancySettingsValidator.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/TenancySettingsValidator.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+
+namespace MMCA.Common.Infrastructure.Settings;
+
+/// <summary>
+/// Startup validation for <see cref="TenancySettings"/>, registered by <c>AddMultiTenancy</c> with
+/// <c>ValidateOnStart</c>. Every failure here is a misconfiguration that would otherwise surface as
+/// silent cross-tenant behavior at runtime, which is exactly the class of bug tenancy exists to
+/// prevent, so it is worth a failed boot.
+/// </summary>
+/// <remarks>
+/// The data-source checks need the resolved physical sources, so they run only when
+/// <see cref="IDataSourceResolver"/> is registered (it is, whenever <c>AddInfrastructure</c> ran).
+/// A container without it still gets the strategy and connection-string checks.
+/// </remarks>
+/// <param name="resolver">
+/// The resolver used to confirm an override names a real physical source, or <see langword="null"/>
+/// when persistence was not registered.
+/// </param>
+internal sealed class TenancySettingsValidator(IDataSourceResolver? resolver = null)
+    : IValidateOptions<TenancySettings>
+{
+    /// <summary>The engines an override can carry a connection string for.</summary>
+    private static readonly DataSource[] Engines =
+        [DataSource.SQLServer, DataSource.Sqlite, DataSource.CosmosDB];
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, TenancySettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+
+        ValidateResolutionOrder(options, failures);
+
+        foreach (var (tenantId, tenant) in options.Tenants)
+        {
+            ValidateTenant(tenantId, tenant, failures);
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    /// <summary>
+    /// Rejects a resolution order naming a strategy the framework does not implement. The enum
+    /// member exists so the configuration contract is stable, but selecting it must not read as
+    /// "resolve nothing".
+    /// </summary>
+    private static void ValidateResolutionOrder(TenancySettings options, List<string> failures)
+    {
+        foreach (var strategy in options.EffectiveResolutionOrder)
+        {
+            if (strategy == TenantResolutionStrategy.Host)
+            {
+                failures.Add(
+                    "Tenancy:ResolutionOrder includes \"Host\", which is defined but not implemented. "
+                    + "Use \"Claim\" and/or \"Header\".");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks one tenant's overrides: each must name a real physical source and carry a connection
+    /// string for the engine that source runs on.
+    /// </summary>
+    private void ValidateTenant(string tenantId, TenantEntrySettings tenant, List<string> failures)
+    {
+        foreach (var (sourceName, over) in tenant.DataSources)
+        {
+            var engines = DeclaredEngines(over);
+            if (engines.Count == 0)
+            {
+                failures.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Tenancy:Tenants:{0}:DataSources:{1} declares no connection string. "
+                    + "A per-tenant override must set SQLServerConnectionString, SqliteConnectionString "
+                    + "or CosmosConnectionString; remove the entry to keep the source shared.",
+                    tenantId,
+                    sourceName));
+                continue;
+            }
+
+            if (resolver is null)
+            {
+                continue;
+            }
+
+            foreach (var engine in engines.Where(engine => !IsKnownPhysicalSource(engine, sourceName)))
+            {
+                failures.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Tenancy:Tenants:{0}:DataSources:{1} overrides a {2} data source that does not exist. "
+                    + "Per-tenant overrides are keyed by PHYSICAL data source name (\"{3}\", or a name "
+                    + "declared under the DataSources section).",
+                    tenantId,
+                    sourceName,
+                    engine,
+                    DataSourceKey.DefaultName));
+            }
+        }
+    }
+
+    /// <summary>The engines this override actually declares a connection string for.</summary>
+    private static List<DataSource> DeclaredEngines(TenantDataSourceOverrideSettings over) =>
+        [.. Engines.Where(engine => !string.IsNullOrWhiteSpace(ConnectionStringFor(engine, over)))];
+
+    /// <summary>
+    /// Whether <paramref name="sourceName"/> is a physical source name for the engine. An unknown
+    /// logical name resolves to <c>Default</c>, so a name that does not round-trip was never a
+    /// physical source to begin with.
+    /// </summary>
+    private bool IsKnownPhysicalSource(DataSource engine, string sourceName) =>
+        string.Equals(sourceName, DataSourceKey.DefaultName, StringComparison.Ordinal)
+        || string.Equals(resolver!.ResolveLogical(engine, sourceName).Name, sourceName, StringComparison.Ordinal);
+
+    /// <summary>The override's connection string for one engine, or null when it declares none.</summary>
+    internal static string? ConnectionStringFor(DataSource engine, TenantDataSourceOverrideSettings over) =>
+        engine switch
+        {
+            DataSource.SQLServer => over.SQLServerConnectionString,
+            DataSource.Sqlite => over.SqliteConnectionString,
+            DataSource.CosmosDB => over.CosmosConnectionString,
+            _ => null,
+        };
+}

--- a/Source/Core/MMCA.Common.Infrastructure/packages.lock.json
+++ b/Source/Core/MMCA.Common.Infrastructure/packages.lock.json
@@ -21,6 +21,12 @@
           "Azure.Storage.Common": "12.28.0"
         }
       },
+      "Cronos": {
+        "type": "Direct",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
+      },
       "MassTransit": {
         "type": "Direct",
         "requested": "[8.5.10, )",

--- a/Source/Core/MMCA.Common.Infrastructure/packages.lock.json
+++ b/Source/Core/MMCA.Common.Infrastructure/packages.lock.json
@@ -145,6 +145,12 @@
           "Microsoft.EntityFrameworkCore.Design": "10.0.10"
         }
       },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "Direct",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA=="
+      },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Direct",
         "requested": "[10.8.0, )",

--- a/Source/Core/MMCA.Common.Shared/Privacy/PrivacyFeatures.cs
+++ b/Source/Core/MMCA.Common.Shared/Privacy/PrivacyFeatures.cs
@@ -1,0 +1,10 @@
+namespace MMCA.Common.Shared.Privacy;
+
+/// <summary>
+/// Feature flag constants for the privacy (data-subject rights) surface.
+/// </summary>
+public static class PrivacyFeatures
+{
+    /// <summary>Feature flag controlling the data-subject export (DSAR) endpoint.</summary>
+    public const string DataExport = "Privacy.DataExport";
+}

--- a/Source/Core/MMCA.Common.Shared/Privacy/UserDataExportDTO.cs
+++ b/Source/Core/MMCA.Common.Shared/Privacy/UserDataExportDTO.cs
@@ -1,0 +1,89 @@
+using System.Runtime.Serialization;
+
+namespace MMCA.Common.Shared.Privacy;
+
+/// <summary>
+/// The portable data-subject export package (GDPR/CCPA access and portability): a snapshot of the
+/// account itself plus one envelope per registered section of the user's data.
+/// <para>
+/// This document is <b>PII by design</b>. It exists to hand a data subject everything an app holds
+/// about them, so it must only ever be produced for the account owner (or a privileged role) and
+/// must never be logged, cached, or persisted by the pipeline that serves it.
+/// </para>
+/// </summary>
+[DataContract]
+public sealed record UserDataExportDTO
+{
+    /// <summary>
+    /// Gets the version of the export document shape itself (not the app's data). Consumers read
+    /// this before parsing, so a later change to the envelope can be detected rather than guessed.
+    /// </summary>
+    [DataMember(Order = 1)]
+    public required string FormatVersion { get; init; }
+
+    /// <summary>Gets the UTC instant the export was produced, from the injected time provider.</summary>
+    [DataMember(Order = 2)]
+    public required DateTimeOffset GeneratedOn { get; init; }
+
+    /// <summary>Gets the user the export describes.</summary>
+    [DataMember(Order = 3)]
+    public required UserIdentifierType UserId { get; init; }
+
+    /// <summary>
+    /// Gets the app-specific snapshot of the account aggregate (the app's own subject DTO), or
+    /// <see langword="null"/> when the app publishes no subject fields. Declared as
+    /// <see cref="object"/> deliberately: the framework owns the envelope, each app owns which of
+    /// its own fields are portable personal data, and a property typed <see cref="object"/>
+    /// serializes by its runtime type under System.Text.Json.
+    /// </summary>
+    [DataMember(Order = 4)]
+    public object? Subject { get; init; }
+
+    /// <summary>
+    /// Gets the section envelopes, in the order the sections were registered. A section that could
+    /// not be produced is still present, reporting <c>Available = false</c>, so the reader can tell
+    /// "no data" apart from "not retrieved".
+    /// </summary>
+    [DataMember(Order = 5)]
+    public IReadOnlyList<UserDataExportSectionDTO> Sections { get; init; } = [];
+}
+
+/// <summary>
+/// One section of a <see cref="UserDataExportDTO"/>: the data a single contributor holds for the
+/// subject, plus whether that contributor could be reached at all.
+/// </summary>
+/// <remarks>
+/// Sections are best-effort. When a contributor fails, the export still succeeds with this envelope
+/// reporting <see cref="Available"/> false and a caller-safe <see cref="UnavailableReason"/>, so one
+/// outage degrades one section rather than denying the data subject their whole export.
+/// </remarks>
+[DataContract]
+public sealed record UserDataExportSectionDTO
+{
+    /// <summary>Gets the stable name identifying this section (e.g. "Engagement", "Sales").</summary>
+    [DataMember(Order = 1)]
+    public required string SectionName { get; init; }
+
+    /// <summary>
+    /// Gets whether the section was produced successfully. False means the section is incomplete and
+    /// the export can be retried later; it does not mean the subject has no data here.
+    /// </summary>
+    [DataMember(Order = 2)]
+    public required bool Available { get; init; }
+
+    /// <summary>
+    /// Gets the section payload (the contributor's own DTO), or <see langword="null"/> when the
+    /// section is unavailable. Declared as <see cref="object"/> for the same reason
+    /// <see cref="UserDataExportDTO.Subject"/> is: the payload shape is owned by the contributor.
+    /// </summary>
+    [DataMember(Order = 3)]
+    public object? Data { get; init; }
+
+    /// <summary>
+    /// Gets a short, caller-safe explanation of why the section is unavailable, or
+    /// <see langword="null"/> when it is available. Never carries exception messages, stack traces,
+    /// connection strings, or peer addresses: this string is handed to the data subject.
+    /// </summary>
+    [DataMember(Order = 4)]
+    public string? UnavailableReason { get; init; }
+}

--- a/Source/Core/MMCA.Common.Shared/ValueObjects/Enumeration.cs
+++ b/Source/Core/MMCA.Common.Shared/ValueObjects/Enumeration.cs
@@ -1,0 +1,244 @@
+using System.Collections.Frozen;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Shared.ValueObjects;
+
+/// <summary>
+/// Abstract base for a smart enumeration: a closed set of named, integer-valued members declared on
+/// the derived type as <c>public static readonly</c> fields. Unlike a CLR enum, a member is a real
+/// object, so behavior (policies, rates, display rules) can hang off it instead of living in a
+/// switch statement somewhere else.
+/// </summary>
+/// <typeparam name="TEnumeration">
+/// The concrete enumeration type. The self-referencing constraint keeps <see cref="All"/>,
+/// <see cref="FromValue"/> and <see cref="FromName"/> strongly typed per enumeration, so each closed
+/// type gets its own lookup tables.
+/// </typeparam>
+/// <remarks>
+/// Lives in <c>MMCA.Common.Shared</c> so it stays dependency-free and usable from Blazor WASM/UI as
+/// well as Domain. It deliberately does NOT derive from <see cref="ValueObject"/>: the
+/// <c>ValueObjectsAreImmutableSealedInShared</c> fitness rule forces every <see cref="ValueObject"/>
+/// derivative to be a sealed record living in the Shared layer, which would forbid the static-member
+/// idiom this type exists for. <c>RoleValue</c> is the shipped precedent for the same trade-off.
+/// <para>
+/// Members are discovered by reflection over the <c>public static readonly</c> fields declared on
+/// <typeparamref name="TEnumeration"/> itself, on first use, and then frozen. Two members sharing a
+/// <see cref="Value"/> or a <see cref="Name"/> (case-insensitively) are a declaration bug and fail
+/// fast with an <see cref="ArgumentException"/> the first time the enumeration is touched.
+/// </para>
+/// <para>
+/// Intentionally does not implement <see cref="IEquatable{T}"/> (S4035: an unsealed
+/// <c>IEquatable&lt;T&gt;</c> breaks the equality contract for subclasses). Equality is provided via
+/// the <see cref="object.Equals(object?)"/> override below, type-guarded so two members are equal
+/// only when they are the same concrete type with the same value; a sealed derived type may add a
+/// strongly-typed <c>IEquatable&lt;TSelf&gt;</c> and <c>==</c>/<c>!=</c> operators on top.
+/// </para>
+/// <para>
+/// <b>Usage:</b> repeat the <see cref="JsonConverterAttribute"/> on the concrete type.
+/// System.Text.Json reads that attribute off the type it is converting without walking base types,
+/// so the declaration on this base class only covers a member typed as the base itself. The
+/// alternative, for a host that would rather not annotate each type, is registering
+/// <see cref="EnumerationJsonConverterFactory"/> once in <c>JsonSerializerOptions.Converters</c>
+/// (the shipped <c>CurrencyJsonConverter</c> registration in <c>AddAPI</c> is the precedent).
+/// <code>
+/// [JsonConverter(typeof(EnumerationJsonConverterFactory))]
+/// public sealed class Priority : Enumeration&lt;Priority&gt;
+/// {
+///     public static readonly Priority Low = new(1, "Low");
+///     public static readonly Priority High = new(2, "High");
+///
+///     private Priority(int value, string name)
+///         : base(value, name)
+///     {
+///     }
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+[DataContract]
+[JsonConverter(typeof(EnumerationJsonConverterFactory))]
+[SuppressMessage(
+    "Design",
+    "CA1000:Do not declare static members on generic types",
+    Justification = "The self-referencing generic constraint is the point: All/FromValue/FromName are per-enumeration lookups over the closed type's own members, and calls read as Priority.FromValue(2) with no type argument written by hand. A non-generic sibling would return the base type and force every call site to cast.")]
+public abstract class Enumeration<TEnumeration>
+    where TEnumeration : Enumeration<TEnumeration>
+{
+    private static readonly Lazy<ReadOnlyCollection<TEnumeration>> MembersLazy = new(DiscoverMembers);
+
+    private static readonly Lazy<FrozenDictionary<int, TEnumeration>> ByValueLazy =
+        new(() => MembersLazy.Value.ToFrozenDictionary(member => member.Value));
+
+    private static readonly Lazy<FrozenDictionary<string, TEnumeration>> ByNameLazy =
+        new(() => MembersLazy.Value.ToFrozenDictionary(
+            member => member.Name,
+            StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>Initializes a new instance of the <see cref="Enumeration{TEnumeration}"/> class.</summary>
+    /// <param name="value">The member's stable integer value, used as the persisted representation.</param>
+    /// <param name="name">The member's canonical name, used as the serialized representation.</param>
+    protected Enumeration(int value, string name)
+    {
+        Value = value;
+        Name = name;
+    }
+
+    /// <summary>Gets the member's canonical name. This is the JSON and display representation.</summary>
+    [DataMember(Order = 1)]
+    public string Name { get; }
+
+    /// <summary>Gets the member's stable integer value. This is the persisted representation.</summary>
+    [DataMember(Order = 2)]
+    public int Value { get; }
+
+    /// <summary>
+    /// Gets every member declared on <typeparamref name="TEnumeration"/>, ordered by
+    /// <see cref="Value"/>. Built once on first use and cached for the lifetime of the closed type.
+    /// </summary>
+    public static IReadOnlyCollection<TEnumeration> All => MembersLazy.Value;
+
+    /// <summary>
+    /// Resolves the member carrying <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The member value to resolve.</param>
+    /// <returns>
+    /// The matching member on success, or an invariant failure with code
+    /// <c>Enumeration.UnknownValue</c> when no member declares that value.
+    /// </returns>
+    public static Result<TEnumeration> FromValue(int value)
+    {
+        if (ByValueLazy.Value.TryGetValue(value, out TEnumeration? member))
+            return Result.Success(member);
+
+        return Result.Failure<TEnumeration>(Error.Invariant(
+            code: "Enumeration.UnknownValue",
+            message: $"'{value.ToString(CultureInfo.InvariantCulture)}' is not a known {typeof(TEnumeration).Name} value.",
+            source: nameof(FromValue),
+            target: nameof(value)));
+    }
+
+    /// <summary>
+    /// Resolves the member carrying <paramref name="name"/>. The match is case-insensitive, matching
+    /// the comparison <c>RoleValue</c> uses for the same kind of closed string set.
+    /// </summary>
+    /// <param name="name">The member name to resolve.</param>
+    /// <returns>
+    /// The matching member on success, or an invariant failure with code
+    /// <c>Enumeration.UnknownName</c> when no member declares that name.
+    /// </returns>
+    public static Result<TEnumeration> FromName(string name)
+    {
+        if (ByNameLazy.Value.TryGetValue(name ?? string.Empty, out TEnumeration? member))
+            return Result.Success(member);
+
+        return Result.Failure<TEnumeration>(Error.Invariant(
+            code: "Enumeration.UnknownName",
+            message: $"'{name}' is not a known {typeof(TEnumeration).Name} name.",
+            source: nameof(FromName),
+            target: nameof(name)));
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Name;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) =>
+        obj is Enumeration<TEnumeration> other
+        && GetType() == other.GetType()
+        && Value == other.Value;
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(GetType(), Value);
+
+    /// <summary>
+    /// Reflects over the <c>public static readonly</c> fields declared directly on
+    /// <typeparamref name="TEnumeration"/> and materializes them as the member set. Inherited fields
+    /// are excluded, so a derived hierarchy never inherits another type's members.
+    /// </summary>
+    private static ReadOnlyCollection<TEnumeration> DiscoverMembers() =>
+        typeof(TEnumeration)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(memberField => memberField.IsInitOnly
+                && typeof(TEnumeration).IsAssignableFrom(memberField.FieldType))
+            .Select(memberField => memberField.GetValue(null))
+            .OfType<TEnumeration>()
+            .OrderBy(member => member.Value)
+            .ToArray()
+            .AsReadOnly();
+}
+
+/// <summary>
+/// Serializes every <see cref="Enumeration{TEnumeration}"/> member as its <c>Name</c> string in JSON.
+/// Deserialization resolves the name through <see cref="Enumeration{TEnumeration}.FromName"/>; a
+/// non-string token (number, object, array, boolean) and an unknown name both throw
+/// <see cref="JsonException"/>, matching <c>CurrencyJsonConverter</c> so non-MVC paths (cache,
+/// outbox, integration events, typed HttpClient calls) fail the same way MVC model binding does.
+/// </summary>
+/// <remarks>
+/// Declared on <see cref="Enumeration{TEnumeration}"/> via <see cref="JsonConverterAttribute"/>, but
+/// System.Text.Json resolves that attribute off the type being converted without walking base types,
+/// so a concrete enumeration either repeats the attribute or the host registers this factory once in
+/// <see cref="JsonSerializerOptions.Converters"/>. Both routes select the same converter.
+/// <para>
+/// <see cref="JsonConverter{T}.HandleNull"/> is left at its default (<see langword="false"/>), so
+/// the serializer short-circuits a JSON null token before the converter runs and nullable members
+/// keep deserializing to <see langword="null"/>.
+/// </para>
+/// </remarks>
+public sealed class EnumerationJsonConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert) =>
+        GetEnumerationArgument(typeToConvert) == typeToConvert;
+
+    /// <inheritdoc />
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
+        (JsonConverter?)Activator.CreateInstance(
+            typeof(EnumerationConverter<>).MakeGenericType(typeToConvert));
+
+    /// <summary>
+    /// Walks the base chain of <paramref name="typeToConvert"/> looking for
+    /// <c>Enumeration&lt;T&gt;</c> and returns its <c>T</c>. The caller compares that argument with
+    /// the type itself: only the self-referencing closed type (the one the constraint is written
+    /// for) is converted, so a type deriving further from a concrete enumeration is left to the
+    /// default converter rather than silently serialized as its base.
+    /// </summary>
+    private static Type? GetEnumerationArgument(Type? typeToConvert)
+    {
+        for (Type? type = typeToConvert; type is not null; type = type.BaseType)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Enumeration<>))
+                return type.GetGenericArguments()[0];
+        }
+
+        return null;
+    }
+
+    private sealed class EnumerationConverter<TEnumeration> : JsonConverter<TEnumeration>
+        where TEnumeration : Enumeration<TEnumeration>
+    {
+        public override TEnumeration? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"{typeof(TEnumeration).Name} must be a string.");
+
+            string name = reader.GetString() ?? string.Empty;
+
+            var result = Enumeration<TEnumeration>.FromName(name);
+            if (result.IsFailure)
+                throw new JsonException($"'{name}' is not a known {typeof(TEnumeration).Name} name.");
+
+            return result.Value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, TEnumeration value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.Name);
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/Configuration/KeyVaultConfigurationExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Configuration/KeyVaultConfigurationExtensions.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace MMCA.Common.Aspire;
+
+/// <summary>
+/// Registration extension that layers an Azure Key Vault over the host configuration.
+/// <para>
+/// Connection strings, signing keys and provider client secrets have to reach the process somehow,
+/// and the two easy answers are both wrong. A value checked into an appsettings file is readable by
+/// everyone who can read the repository, and it stays readable in the history after it is removed.
+/// A value injected as a deployment-time environment variable is readable by anything that can read
+/// the process environment, and it is frozen until the next deployment, so rotating it means
+/// redeploying. Reading the values from a vault under the host's own managed identity keeps them out
+/// of both places and lets a rotation take effect on its own.
+/// </para>
+/// </summary>
+public static class KeyVaultConfigurationExtensions
+{
+    extension<TBuilder>(TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        /// <summary>
+        /// Adds an Azure Key Vault configuration source to the host configuration, so every secret in
+        /// the vault is readable through <see cref="IConfiguration"/> exactly like any other setting
+        /// and overrides the sources added before it.
+        /// <para>
+        /// Configuration keys:
+        /// <list type="bullet">
+        ///   <item><c>KeyVault:Uri</c> (the gate): the vault URI, e.g.
+        ///     <c>https://myvault.vault.azure.net/</c>. When absent or whitespace this method does
+        ///     nothing at all, so local development and tests keep the configuration sources they
+        ///     already have and take no Azure dependency at startup.</item>
+        ///   <item><c>KeyVault:ReloadIntervalMinutes</c> (optional): how often the provider re-reads
+        ///     the vault, in whole minutes. Left unset, the vault is read once during startup and a
+        ///     rotated secret only reaches the host on its next restart.</item>
+        /// </list>
+        /// </para>
+        /// <para>
+        /// A secret name cannot contain a colon, so the provider maps a double dash onto the
+        /// configuration separator: the secret <c>ConnectionStrings--Default</c> arrives as the
+        /// configuration key <c>ConnectionStrings:Default</c>, and <c>Jwt--SigningKey</c> as
+        /// <c>Jwt:SigningKey</c>. Name the secrets that way and the host binds them with the settings
+        /// classes it already has, with no code change at the binding side.
+        /// </para>
+        /// <para>
+        /// Authentication uses <see cref="DefaultAzureCredential"/>, so a deployed host authenticates
+        /// with its managed identity and a developer machine falls back to the local Azure CLI or
+        /// Visual Studio sign-in. The identity needs the Key Vault Secrets User role on the vault,
+        /// which the one-time bootstrap in <c>samples/deployment/DEPLOYMENT.md</c> (step 3) already
+        /// grants to the application identity, so an app deployed that way needs no extra grant.
+        /// </para>
+        /// <para>
+        /// This is deliberately NOT called from <c>AddServiceDefaults()</c>, for the same reason
+        /// <c>AddCommonDataProtection</c> is not: service defaults run in every host, a developer
+        /// machine and a test host and the Helpdesk seed included, and an unconditional Azure
+        /// dependency at startup would be a liability there rather than a feature. A host that wants
+        /// vault-backed configuration opts in with this one call.
+        /// </para>
+        /// <para>
+        /// The source goes onto <c>builder.Configuration</c>, whose <c>ConfigurationManager</c> builds
+        /// and loads each source as it is added, so the vault is read synchronously at this point in
+        /// startup. That is what makes the secrets available to everything registered after this call,
+        /// and it is also why this call belongs early in the host builder, before the settings binding
+        /// and the service registrations that read them.
+        /// </para>
+        /// </summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        /// <exception cref="UriFormatException">
+        /// <c>KeyVault:Uri</c> is present but is not a valid absolute URI.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// <c>KeyVault:ReloadIntervalMinutes</c> is present but is not a positive whole number.
+        /// </exception>
+        public TBuilder AddCommonKeyVaultConfiguration()
+        {
+            var vaultUri = builder.Configuration["KeyVault:Uri"];
+
+            // The gate. Absent means "do nothing": a developer machine, a test host and the Helpdesk
+            // seed all read their configuration from files and user secrets, where reaching for a vault
+            // at startup buys nothing and costs a hard Azure dependency on every run.
+            if (string.IsNullOrWhiteSpace(vaultUri))
+            {
+                return builder;
+            }
+
+            var options = new AzureKeyVaultConfigurationOptions();
+
+            // A misspelled reload interval fails LOUDLY rather than falling back to "never reload".
+            // Silently ignoring it would leave the host serving the secret values it read at startup
+            // forever, and the operator would only find out when a rotated credential failed to take
+            // effect, which is exactly the wrong moment.
+            var reloadInterval = builder.Configuration["KeyVault:ReloadIntervalMinutes"];
+            if (!string.IsNullOrWhiteSpace(reloadInterval))
+            {
+                if (!int.TryParse(reloadInterval, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes)
+                    || minutes <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"KeyVault:ReloadIntervalMinutes must be a positive whole number of minutes, but was \"{reloadInterval}\".");
+                }
+
+                options.ReloadInterval = TimeSpan.FromMinutes(minutes);
+            }
+
+            builder.Configuration.AddAzureKeyVault(new Uri(vaultUri), new DefaultAzureCredential(), options);
+
+            return builder;
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -154,11 +154,13 @@ public static class Extensions
 
                     // MMCA.Common meters (literal names, because Aspire has no reference to the
                     // defining assemblies): outbox counters and dispatch lag, CQRS RED histograms
-                    // plus query cache hit/miss, and the idempotency filter's replay, conflict and
-                    // degraded counters.
+                    // plus query cache hit/miss, the idempotency filter's replay, conflict and
+                    // degraded counters, and the recurring scheduler's run outcomes, duration and
+                    // schedule lag (inert in a host that never enables Scheduler:Enabled).
                     metrics.AddMeter("MMCA.Common.Outbox")
                         .AddMeter("MMCA.Common.Cqrs")
-                        .AddMeter("MMCA.Common.Idempotency");
+                        .AddMeter("MMCA.Common.Idempotency")
+                        .AddMeter("MMCA.Common.Scheduler");
                 })
                 .WithTracing(tracing =>
                 {

--- a/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
@@ -20,6 +20,10 @@
          antiforgery decryption) plus the optional Key Vault at-rest encryption, both config-gated
          in DataProtection/DataProtectionExtensions.cs. Azure.Identity supplies the
          DefaultAzureCredential used by both sinks. -->
+    <!-- Azure Key Vault as a configuration source, config-gated in
+         Configuration/KeyVaultConfigurationExtensions.cs. Shares the Azure.Identity credential
+         below with the DataProtection sinks. -->
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" />
     <PackageReference Include="Azure.Identity" />

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -32,6 +32,17 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
         }
       },
+      "Azure.Extensions.AspNetCore.Configuration.Secrets": {
+        "type": "Direct",
+        "requested": "[1.5.1, )",
+        "resolved": "1.5.1",
+        "contentHash": "2Io9af/y8GH1jfu//BQrYcwb+MZOJG+au2KCv+ltWM6PBCghbhaDyZWDkYWNWIougZgoHtyKM0CnlGi+9XAu/A==",
+        "dependencies": {
+          "Azure.Core": "1.54.0",
+          "Azure.Security.KeyVault.Secrets": "4.10.0",
+          "Microsoft.Extensions.Configuration": "10.0.3"
+        }
+      },
       "Azure.Extensions.AspNetCore.DataProtection.Blobs": {
         "type": "Direct",
         "requested": "[1.5.3, )",
@@ -229,6 +240,14 @@
         "contentHash": "R5iW7mH0EXdl3wqLQ7qglFQXl5JPGmmYXxDxKFT/TraCw6yRhlt5/G3NCc0Wb98P2P3lRZEI8lqF3BY0m9RkNA==",
         "dependencies": {
           "Azure.Core": "1.54.0"
+        }
+      },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "lcJtcgTkk1gGy59RQhGLJLMyad+zgASMn975PVjMft69q+jjFTo6Nyq5SCtOhPY1WvA0gNI1qYIVN2oikVXDjw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
         }
       },
       "Azure.Storage.Common": {

--- a/Source/Presentation/MMCA.Common.API/Controllers/EntityControllerBase.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/EntityControllerBase.cs
@@ -1,12 +1,16 @@
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Reflection;
 using System.Text.Json;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MMCA.Common.API.Export;
 using MMCA.Common.API.ModelBinders;
 using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Services;
 using MMCA.Common.Application.Settings;
 using MMCA.Common.Domain.Entities;
 using MMCA.Common.Shared.Abstractions;
@@ -53,6 +57,27 @@ public abstract class EntityControllerBase<
         {
             var settings = HttpContext.RequestServices.GetService<IApplicationSettings>();
             return settings?.MaxPageSize ?? 500;
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum number of rows <see cref="ExportAsync"/> streams before it stops and appends
+    /// its truncation marker, from application settings, falling back to
+    /// <see cref="DefaultMaxExportRows"/>. Resolved per-request from DI exactly like
+    /// <see cref="MaxPageSize"/>.
+    /// </summary>
+    /// <remarks>
+    /// A configured value of zero or less is treated as "not configured" and falls back to the
+    /// default: a cap of zero would silently serve every caller a header-only file, which is a far
+    /// worse failure than ignoring a nonsensical setting.
+    /// </remarks>
+    protected int MaxExportRows
+    {
+        get
+        {
+            var settings = HttpContext.RequestServices.GetService<IApplicationSettings>();
+            var configured = settings?.MaxExportRows ?? DefaultMaxExportRows;
+            return configured > 0 ? configured : DefaultMaxExportRows;
         }
     }
 
@@ -146,6 +171,155 @@ public abstract class EntityControllerBase<
     }
 
     /// <summary>
+    /// Streams the same collection the paged endpoint serves as an RFC 4180 CSV file download,
+    /// page-looping the query service server-side so a client gets the whole filtered set in one
+    /// request instead of walking pages itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why a distinct route rather than content negotiation.</b> Serving CSV from
+    /// <c>GET /{controller}/paged</c> on an <c>Accept: text/csv</c> header would be wrong twice over
+    /// in this framework: the public output-cache policy varies by query string but NOT by
+    /// <c>Accept</c>, so a cached JSON body could be replayed to a CSV request; and <c>AddAPI</c> sets
+    /// <c>ReturnHttpNotAcceptable = false</c>, so a negotiation miss falls back to JSON silently
+    /// instead of returning 406. A separate path has neither failure mode.
+    /// </para>
+    /// <para>
+    /// <b>Authorization.</b> This action carries no attributes of its own: it inherits whatever the
+    /// concrete controller declares, so an <c>[Authorize]</c> or <c>[FeatureGate]</c> on the derived
+    /// class governs the export exactly as it governs the paged read. A controller that exposes
+    /// <c>paged</c> anonymously exposes <c>export</c> anonymously; that symmetry is deliberate, since
+    /// the two return the same rows.
+    /// </para>
+    /// <para>
+    /// <b>Row ceiling and the truncation signal.</b> Every response carries
+    /// <c>X-Export-Row-Limit</c> up front, and a truncated export ends with a final
+    /// <c>{"# export truncated at N rows"}</c> line. The ceiling cannot be reported as a
+    /// response header, because it is only known after the last page is read and headers are frozen
+    /// the moment the first body byte is flushed. Buffering the whole file to learn the answer first
+    /// would defeat the streaming this endpoint exists for, so the marker rides in the body where it
+    /// is still writable.
+    /// </para>
+    /// <para>
+    /// <b>Child collections.</b> Unlike the paged endpoint this takes no <c>includeChildren</c>: a
+    /// child collection has no faithful representation in a flat CSV cell.
+    /// </para>
+    /// </remarks>
+    /// <param name="includeFKs">When true, eagerly loads foreign key navigation properties.</param>
+    /// <param name="sortColumn">DTO property name to sort by.</param>
+    /// <param name="sortDirection">Sort direction: "asc" or "desc".</param>
+    /// <param name="fields">Comma-separated list of DTO property names for field projection. The CSV
+    /// columns are the camelCase JSON names, so the same <c>fields=</c> request produces the same
+    /// column set here and on the JSON endpoints.</param>
+    /// <param name="filters">Query string filters parsed by <see cref="QueryFilterModelBinder"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An empty result: the CSV has already been written to the response body. A failure on
+    /// the FIRST page (before any byte is written) returns Problem Details instead.</returns>
+    [HttpGet("export")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
+    public virtual async Task<IActionResult> ExportAsync(
+        bool includeFKs = false,
+        string? sortColumn = null,
+        string? sortDirection = null,
+        [FromQuery] string? fields = null,
+        [ModelBinder(typeof(QueryFilterModelBinder))] Dictionary<string, (string Operator, string Value)>? filters = null,
+        CancellationToken cancellationToken = default)
+    {
+        var maxExportRows = MaxExportRows;
+        var pageSize = Math.Max(1, MaxPageSize);
+        var pageNumber = 1;
+        var rowsWritten = 0;
+        var truncated = false;
+        var started = false;
+        IReadOnlyList<string> columns = [];
+
+        // Constructing the writer sends nothing: the response stays uncommitted until the first
+        // flush below, which is what keeps the "failure on page one still returns Problem Details"
+        // path honest.
+        var writer = new StreamWriter(Response.Body, CsvWriter.Utf8NoPreamble, leaveOpen: true);
+        await using (writer.ConfigureAwait(false))
+        {
+            while (true)
+            {
+                var result = await QueryService.GetAllAsync(
+                    includeFKs: includeFKs,
+                    includeChildren: false,
+                    specification: null,
+                    filters: filters,
+                    sortColumn: sortColumn,
+                    sortDirection: sortDirection,
+                    fields: fields,
+                    pageNumber: pageNumber,
+                    pageSize: pageSize,
+                    asTracking: false,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (result.IsFailure)
+                {
+                    if (!started)
+                        return HandleFailure(result.Errors);
+
+                    // The status line left the building with the header row. A trailing marker is the
+                    // only signal still available, so the file says it is short rather than looking
+                    // like a complete export of fewer rows.
+                    LogExportPageFailure(result.Errors, rowsWritten);
+                    CsvWriter.WriteRow([IncompleteMarker(rowsWritten)], writer);
+                    break;
+                }
+
+                var page = result.Value!;
+                var items = page.Items;
+
+                if (!started)
+                {
+                    columns = ResolveExportColumns(items, fields);
+                    BeginExportResponse(maxExportRows);
+                    CsvWriter.WriteByteOrderMark(writer);
+                    CsvWriter.WriteHeader(columns, writer);
+                    started = true;
+                }
+
+                var pageRows = WriteExportPage(items, columns, fields, maxExportRows - rowsWritten, writer);
+                rowsWritten += pageRows;
+
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                // Stopped mid-page: rows were definitely left behind.
+                if (pageRows < items.Count)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                // A short page is the last page, cap or no cap.
+                if (items.Count < pageSize)
+                    break;
+
+                // The cap landed exactly on a page boundary: only the total says whether anything
+                // remains, and asking for one more page just to find out would be a wasted query.
+                if (rowsWritten >= maxExportRows)
+                {
+                    truncated = page.PaginationMetadata.TotalItemCount > rowsWritten;
+                    break;
+                }
+
+                pageNumber++;
+            }
+
+            if (truncated)
+            {
+                CsvWriter.WriteRow([TruncationMarker(rowsWritten)], writer);
+            }
+
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new EmptyResult();
+    }
+
+    /// <summary>
     /// Returns a lightweight id/name collection suitable for populating dropdowns and autocomplete controls.
     /// </summary>
     /// <param name="nameProperty">The DTO property name to use as the display label in each lookup entry.</param>
@@ -227,5 +401,200 @@ public abstract class EntityControllerBase<
         }
 
         return base.HandleFailure(errorList);
+    }
+
+    /// <summary>
+    /// Row ceiling used by <see cref="ExportAsync"/> when no host setting supplies one. Matches
+    /// <see cref="ApplicationSettings.MaxExportRows"/>'s own default so an unconfigured host and a
+    /// default-configured host behave identically.
+    /// </summary>
+    protected const int DefaultMaxExportRows = 100_000;
+
+    /// <summary>The media type <see cref="ExportAsync"/> serves.</summary>
+    public const string CsvContentType = "text/csv; charset=utf-8";
+
+    /// <summary>
+    /// Response header naming the row ceiling in force for this export. Always sent, so a client can
+    /// tell "exactly at the limit" from "coincidentally that many rows" without parsing the body.
+    /// </summary>
+    public const string ExportRowLimitHeaderName = "X-Export-Row-Limit";
+
+    /// <summary>
+    /// Gets the file name stem for an export download: the routed controller name (so
+    /// <c>ProductsController</c> downloads <c>Products-...csv</c>), falling back to the entity type
+    /// name in the degenerate case of a controller class named nothing else.
+    /// </summary>
+    /// <remarks>
+    /// Derived from the concrete type name rather than read out of <c>RouteData</c>, because that is
+    /// precisely what the <c>[controller]</c> route token resolves to, and it stays correct when the
+    /// action is invoked outside a routed request.
+    /// </remarks>
+    protected virtual string ExportFileNamePrefix
+    {
+        get
+        {
+            const string suffix = "Controller";
+
+            var typeName = GetType().Name;
+            var stem = typeName.EndsWith(suffix, StringComparison.Ordinal)
+                ? typeName[..^suffix.Length]
+                : typeName;
+
+            return string.IsNullOrWhiteSpace(stem) ? EntityName : stem;
+        }
+    }
+
+    /// <summary>
+    /// Sets the response status headers for an export, before the first body byte goes out.
+    /// </summary>
+    /// <param name="maxExportRows">The row ceiling in force, advertised as <see cref="ExportRowLimitHeaderName"/>.</param>
+    private void BeginExportResponse(int maxExportRows)
+    {
+        var timeProvider = HttpContext.RequestServices.GetService<TimeProvider>() ?? TimeProvider.System;
+
+        Response.ContentType = CsvContentType;
+        Response.Headers.ContentDisposition = $"attachment; filename=\"{BuildExportFileName(timeProvider.GetUtcNow())}\"";
+        Response.Headers.Append(ExportRowLimitHeaderName, maxExportRows.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Builds the download file name: <c>{controller}-{yyyyMMddTHHmmssZ}.csv</c>. The timestamp is UTC
+    /// in a basic-format ISO 8601 shape (no separators, so it is legal in a file name on every OS) and
+    /// invariant, so exports sort chronologically by name in any locale.
+    /// </summary>
+    /// <param name="timestamp">When the export was produced.</param>
+    /// <returns>The file name offered in the Content-Disposition header.</returns>
+    protected virtual string BuildExportFileName(DateTimeOffset timestamp) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{ExportFileNamePrefix}-{timestamp.UtcDateTime:yyyyMMdd'T'HHmmss'Z'}.csv");
+
+    /// <summary>
+    /// Writes one page of results as CSV records, stopping early once <paramref name="remainingRows"/>
+    /// have been written (the row ceiling landing inside this page).
+    /// </summary>
+    /// <param name="items">The page of rows.</param>
+    /// <param name="columns">The column names, in output order.</param>
+    /// <param name="fields">The requested field projection, or null for all fields.</param>
+    /// <param name="remainingRows">How many more rows the export may still write.</param>
+    /// <param name="writer">The destination writer.</param>
+    /// <returns>The number of rows written, which is short of the page when the ceiling was reached.</returns>
+    private static int WriteExportPage(
+        ICollection<object> items,
+        IReadOnlyList<string> columns,
+        string? fields,
+        int remainingRows,
+        TextWriter writer)
+    {
+        var written = 0;
+
+        foreach (var item in items)
+        {
+            if (written >= remainingRows)
+                break;
+
+            CsvWriter.WriteRow(BuildExportCells(ShapeExportRow(item, fields), columns), writer);
+            written++;
+        }
+
+        return written;
+    }
+
+    /// <summary>
+    /// Resolves the CSV column names for an export from the first page of results, falling back to the
+    /// DTO's own shape when that page is empty (an export of nothing still owes the caller a header
+    /// row naming the columns).
+    /// </summary>
+    /// <param name="items">The first page of rows, typed DTOs or already-shaped dynamic objects.</param>
+    /// <param name="fields">The requested field projection, or null for all fields.</param>
+    /// <returns>The column names, in output order, as camelCase JSON names.</returns>
+    private static IReadOnlyList<string> ResolveExportColumns(ICollection<object> items, string? fields)
+    {
+        var first = items.FirstOrDefault();
+        if (first is not null)
+            return [.. ShapeExportRow(first, fields).Keys];
+
+        var requested = ParseExportFields(fields);
+
+        // Property declaration order, filtered by the requested fields: exactly the order
+        // QueryFieldService.ShapeCollectionData would have produced had there been a row to shape.
+        return
+        [
+            .. typeof(TEntityDTO)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && (requested.Count == 0 || requested.Contains(p.Name)))
+                .Select(p => JsonNamingPolicy.CamelCase.ConvertName(p.Name))
+        ];
+    }
+
+    /// <summary>
+    /// Normalizes one result row to a camelCase-keyed dictionary. The query service already returns
+    /// shaped dynamic objects when a field subset was requested, and typed DTOs otherwise, so this
+    /// shapes only the second case and reuses <see cref="QueryFieldService"/>'s compiled accessors to
+    /// do it. Either way the keys are the JSON property names.
+    /// </summary>
+    /// <param name="item">The row to normalize.</param>
+    /// <param name="fields">The requested field projection, or null for all fields.</param>
+    /// <returns>The row as a name-to-value dictionary.</returns>
+    private static IDictionary<string, object?> ShapeExportRow(object item, string? fields) =>
+        item as IDictionary<string, object?>
+        ?? QueryFieldService.ShapeData((TEntityDTO)item, fields);
+
+    /// <summary>
+    /// Projects a shaped row onto the resolved column order, substituting null for a column the row
+    /// does not carry.
+    /// </summary>
+    /// <param name="row">The shaped row.</param>
+    /// <param name="columns">The column names, in output order.</param>
+    /// <returns>The cell values for one CSV record.</returns>
+    private static object?[] BuildExportCells(IDictionary<string, object?> row, IReadOnlyList<string> columns)
+    {
+        var cells = new object?[columns.Count];
+        for (var i = 0; i < columns.Count; i++)
+        {
+            cells[i] = row.TryGetValue(columns[i], out var value) ? value : null;
+        }
+
+        return cells;
+    }
+
+    /// <summary>Splits a comma-separated <c>fields=</c> value into a case-insensitive set.</summary>
+    /// <param name="fields">The requested field projection, or null.</param>
+    /// <returns>The requested field names; empty when none were requested.</returns>
+    private static HashSet<string> ParseExportFields(string? fields) =>
+        fields?
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase) ?? [];
+
+    /// <summary>The final line appended to an export stopped by the row ceiling.</summary>
+    /// <param name="rowsWritten">How many data rows were written.</param>
+    /// <returns>The marker text, written as a single-cell record.</returns>
+    private static string TruncationMarker(int rowsWritten) =>
+        string.Create(CultureInfo.InvariantCulture, $"# export truncated at {rowsWritten} rows");
+
+    /// <summary>The final line appended to an export abandoned by a query failure mid-stream.</summary>
+    /// <param name="rowsWritten">How many data rows were written before the failure.</param>
+    /// <returns>The marker text, written as a single-cell record.</returns>
+    private static string IncompleteMarker(int rowsWritten) =>
+        string.Create(CultureInfo.InvariantCulture, $"# export incomplete after {rowsWritten} rows");
+
+    /// <summary>
+    /// Logs a query failure that arrived after the export body had already started, where
+    /// <see cref="HandleFailure"/> is no longer an option.
+    /// </summary>
+    /// <param name="errors">The errors reported by the query service.</param>
+    /// <param name="rowsWritten">How many data rows had been written.</param>
+    private void LogExportPageFailure(IReadOnlyList<Error> errors, int rowsWritten)
+    {
+        if (!Logger.IsEnabled(LogLevel.Warning))
+            return;
+
+        var firstError = errors.Count > 0 ? errors[0] : null;
+        Logger.LogWarning(
+            "Export of {EntityName} stopped after {RowCount} rows: {ErrorCode} - {ErrorMessage}",
+            EntityName,
+            rowsWritten,
+            firstError?.Code,
+            firstError?.Message);
     }
 }

--- a/Source/Presentation/MMCA.Common.API/Controllers/Privacy/DataExportControllerBase.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/Privacy/DataExportControllerBase.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using MMCA.Common.API.Authorization;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Application.Users;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Privacy;
+
+namespace MMCA.Common.API.Controllers.Privacy;
+
+/// <summary>
+/// Base controller for the data-subject export endpoint (GDPR/CCPA access and portability). It hands
+/// the assembled package back as a downloadable JSON file rather than an inline body, because the
+/// document exists to be saved and kept by the person it describes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A derived controller supplies the route and the app's query type, and nothing else:
+/// </para>
+/// <code>
+/// [ApiController]
+/// [Route("Users")]
+/// [ApiVersion("1.0")]
+/// public sealed class UsersDataExportController(
+///     IQueryHandler&lt;ExportUserDataQuery, Result&lt;UserDataExportDTO&gt;&gt; handler,
+///     ICurrentUserService currentUserService)
+///     : DataExportControllerBase&lt;ExportUserDataQuery&gt;(handler, currentUserService)
+/// {
+///     protected override ExportUserDataQuery CreateQuery(
+///         UserIdentifierType userId, UserIdentifierType currentUserId, string? currentUserRole) =&gt;
+///         new(userId, currentUserId, currentUserRole);
+/// }
+/// </code>
+/// <para>
+/// The route lives on the subclass (the <c>AuthControllerBase</c> precedent) because the app owns its
+/// URL space; the action template <c>{userId}/export</c> is fixed here, so a subclass routed at
+/// <c>Users</c> serves the same <c>/Users/{userId}/export</c> path the hand-written controllers do.
+/// </para>
+/// <para>
+/// The query type is app-owned (each app's <c>ExportUserDataQuery</c> lives in its own Application
+/// assembly), which is why this ships as an abstract base with a <see cref="CreateQuery"/> factory
+/// rather than as a concrete controller added through an application part: a concrete controller
+/// could not construct a type it cannot see.
+/// </para>
+/// <para>
+/// Authorization is defence in depth: the policy here requires an authenticated caller, and the
+/// handler independently enforces owner-or-privileged-role, so the endpoint cannot leak another
+/// subject's data even if the route is mounted without an <c>[Authorize]</c> of its own. The feature
+/// gate keeps the whole surface off until a host turns <see cref="PrivacyFeatures.DataExport"/> on.
+/// </para>
+/// </remarks>
+/// <typeparam name="TQuery">The app's export-user-data query record.</typeparam>
+[Authorize(Policy = AuthorizationPolicies.RequireAuthenticated)]
+[FeatureGate(PrivacyFeatures.DataExport)]
+public abstract class DataExportControllerBase<TQuery>(
+    IQueryHandler<TQuery, Result<UserDataExportDTO>> exportHandler,
+    ICurrentUserService currentUserService) : ApiControllerBase
+    where TQuery : IUserOwnedRequest
+{
+    /// <summary>The media type the export package is served as.</summary>
+    public const string ExportContentType = "application/json";
+
+    /// <summary>The current user service for this controller.</summary>
+    protected ICurrentUserService CurrentUserService { get; } = currentUserService;
+
+    /// <summary>
+    /// Exports the personal data held for one user as a downloadable JSON document. The caller must
+    /// be the account owner or hold the app's privileged role (enforced by the handler).
+    /// </summary>
+    /// <param name="userId">The user whose data is exported.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The export package as a file download, or a Problem Details failure.</returns>
+    [HttpGet("{userId}/export")]
+    [ProducesResponseType(typeof(UserDataExportDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    public virtual async Task<IActionResult> ExportAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default)
+    {
+        var currentUserId = CurrentUserService.UserId;
+        if (currentUserId is null)
+        {
+            return HandleFailure([Error.Unauthorized("Privacy.Unauthorized", "User is not authenticated.")]);
+        }
+
+        var query = CreateQuery(userId, currentUserId.Value, CurrentUserService.Role);
+        Result<UserDataExportDTO> result = await exportHandler
+            .HandleAsync(query, cancellationToken).ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            return HandleFailure(result.Errors);
+        }
+
+        UserDataExportDTO export = result.Value!;
+
+        // Serialized here rather than returned as an ObjectResult so the response really is a file:
+        // Ok(export) would negotiate content and render inline, and the point of this endpoint is a
+        // saved document. JsonSerializerOptions.Web keeps the payload byte-shape identical to every
+        // other response this API produces.
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(export, JsonSerializerOptions.Web);
+
+        return File(payload, ExportContentType, BuildFileName(userId, export.GeneratedOn));
+    }
+
+    /// <summary>
+    /// Builds the app's query record from the route and the authenticated caller.
+    /// </summary>
+    /// <param name="userId">The user whose data is exported.</param>
+    /// <param name="currentUserId">The authenticated caller.</param>
+    /// <param name="currentUserRole">The authenticated caller's role claim; may be <see langword="null"/>.</param>
+    /// <returns>The query to dispatch.</returns>
+    protected abstract TQuery CreateQuery(
+        UserIdentifierType userId,
+        UserIdentifierType currentUserId,
+        string? currentUserRole);
+
+    /// <summary>
+    /// The download file name: <c>user-data-{userId}-{yyyyMMdd}.json</c>. The date comes from the
+    /// package's own <see cref="UserDataExportDTO.GeneratedOn"/> (the handler's time provider), so the
+    /// file name and the document always agree, and the format is invariant so a saved file sorts and
+    /// parses the same in every locale.
+    /// </summary>
+    /// <param name="userId">The exported user.</param>
+    /// <param name="generatedOn">When the package was produced.</param>
+    /// <returns>The file name offered in the Content-Disposition header.</returns>
+    protected static string BuildFileName(UserIdentifierType userId, DateTimeOffset generatedOn) =>
+        string.Create(CultureInfo.InvariantCulture, $"user-data-{userId}-{generatedOn:yyyyMMdd}.json");
+}

--- a/Source/Presentation/MMCA.Common.API/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.API/DependencyInjection.cs
@@ -15,6 +15,7 @@ using MMCA.Common.API.Resources;
 using MMCA.Common.API.SessionCookies;
 using MMCA.Common.Application.Modules;
 using MMCA.Common.Application.Settings;
+using EnumerationJsonConverterFactory = MMCA.Common.Shared.ValueObjects.EnumerationJsonConverterFactory;
 
 namespace MMCA.Common.API;
 
@@ -26,7 +27,8 @@ public static class DependencyInjection
     extension(IServiceCollection services)
     {
         /// <summary>
-        /// Registers MVC controllers with JSON (<see cref="CurrencyJsonConverter"/>) and XML formatters,
+        /// Registers MVC controllers with JSON (<see cref="CurrencyJsonConverter"/>,
+        /// <see cref="EnumerationJsonConverterFactory"/>) and XML formatters,
         /// optional module-based controller filtering, and scoped action filters
         /// (<see cref="IdempotencyFilter"/>).
         /// </summary>
@@ -46,7 +48,15 @@ public static class DependencyInjection
                     options.ReturnHttpNotAcceptable = false;
                     options.Filters.Add<UnhandledResultFailureFilter>();
                 })
-                .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new CurrencyJsonConverter()))
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.Converters.Add(new CurrencyJsonConverter());
+
+                    // Concrete enumerations do not inherit the base-class [JsonConverter] attribute
+                    // (System.Text.Json resolves it with inherit: false), so the factory is registered
+                    // here once and every Enumeration<T> serializes by Name across the API surface.
+                    options.JsonSerializerOptions.Converters.Add(new EnumerationJsonConverterFactory());
+                })
                 .AddXmlDataContractSerializerFormatters();
 
             if (modulesSettings is not null)

--- a/Source/Presentation/MMCA.Common.API/Export/CsvWriter.cs
+++ b/Source/Presentation/MMCA.Common.API/Export/CsvWriter.cs
@@ -1,0 +1,157 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+namespace MMCA.Common.API.Export;
+
+/// <summary>
+/// Minimal RFC 4180 CSV writer used by the generic <c>/export</c> endpoint. It writes straight into a
+/// caller-supplied <see cref="TextWriter"/> one row at a time, so an export can stream to the response
+/// body without ever holding the full result set in memory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately hand-written rather than taking a CsvHelper dependency: the framework needs exactly
+/// three behaviours (quote when required, escape embedded quotes, terminate with CRLF), and every
+/// package this repo ships is a dependency every consumer inherits.
+/// </para>
+/// <para>
+/// Value formatting is fixed and invariant, so the same row produces the same bytes on every machine:
+/// <see langword="null"/> writes an empty field; <see langword="string"/> writes verbatim;
+/// <see langword="bool"/> writes lowercase to match the JSON the sibling endpoints emit, not the
+/// capitalized form .NET's own ToString produces; <see cref="DateTime"/> and
+/// <see cref="DateTimeOffset"/> write ISO 8601 round-trip ("O"), chosen over the sortable "s" format
+/// because "O" keeps sub-second precision and the offset, so a parsed value equals the one exported;
+/// anything else <see cref="IFormattable"/> formats with <see cref="CultureInfo.InvariantCulture"/>.
+/// </para>
+/// <para>
+/// The writer does NOT prefix fields that a spreadsheet would evaluate as formulas (values opening
+/// with <c>=</c>, <c>+</c>, <c>-</c>, <c>@</c>). CSV is a data-faithful format here and mangling a
+/// value that begins with a minus sign would corrupt legitimate negative numbers; a host that opens
+/// untrusted exports in a spreadsheet should import them as text.
+/// </para>
+/// </remarks>
+internal static class CsvWriter
+{
+    /// <summary>
+    /// The UTF-8 byte order mark, written as the first characters of an export file.
+    /// </summary>
+    /// <remarks>
+    /// Excel reads a BOM-less UTF-8 CSV in the machine's ANSI code page, which turns every accented
+    /// or non-Latin character into mojibake on the desktops these exports are opened on. The BOM
+    /// costs three bytes and is ignored by every other consumer worth supporting, so it is written
+    /// unconditionally rather than offered as a setting nobody would find in time.
+    /// </remarks>
+    internal const string Utf8ByteOrderMark = "\uFEFF";
+
+    /// <summary>The RFC 4180 record separator: CRLF, regardless of the host operating system.</summary>
+    internal const string LineEnding = "\r\n";
+
+    /// <summary>
+    /// UTF-8 with no encoder preamble, for the <see cref="StreamWriter"/> an export streams through.
+    /// The byte order mark is written explicitly by <see cref="WriteByteOrderMark"/> instead, so the
+    /// file gets exactly one and the decision lives in a single place.
+    /// </summary>
+    internal static readonly Encoding Utf8NoPreamble = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    /// <summary>
+    /// Characters that force a field to be quoted per RFC 4180 section 2: the delimiter itself, the
+    /// quote character, and either half of a line break.
+    /// </summary>
+    private static readonly SearchValues<char> MustQuote = SearchValues.Create(",\"\r\n");
+
+    /// <summary>
+    /// Writes the UTF-8 byte order mark. Call this once, before the header row, on an export written
+    /// through a writer whose encoding does not emit a preamble of its own (otherwise the file gets
+    /// two).
+    /// </summary>
+    /// <param name="writer">The destination writer.</param>
+    internal static void WriteByteOrderMark(TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.Write(Utf8ByteOrderMark);
+    }
+
+    /// <summary>
+    /// Writes the header record: one field per column name, escaped exactly like a data field.
+    /// </summary>
+    /// <param name="columns">The column names, in output order.</param>
+    /// <param name="writer">The destination writer.</param>
+    internal static void WriteHeader(IReadOnlyList<string> columns, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(columns);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(',');
+            }
+
+            WriteField(columns[i] ?? string.Empty, writer);
+        }
+
+        writer.Write(LineEnding);
+    }
+
+    /// <summary>
+    /// Writes one data record. Cell values are formatted per the rules documented on
+    /// <see cref="CsvWriter"/> and quoted only when RFC 4180 requires it.
+    /// </summary>
+    /// <param name="cells">The cell values, in the same order as the header columns.</param>
+    /// <param name="writer">The destination writer.</param>
+    internal static void WriteRow(IReadOnlyList<object?> cells, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(cells);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        for (var i = 0; i < cells.Count; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(',');
+            }
+
+            WriteField(FormatCell(cells[i]), writer);
+        }
+
+        writer.Write(LineEnding);
+    }
+
+    /// <summary>
+    /// Converts a cell value to its invariant text form. See the type remarks for the full table.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <returns>The text written to the field (before any quoting).</returns>
+    internal static string FormatCell(object? value) => value switch
+    {
+        null => string.Empty,
+        string text => text,
+        bool flag => flag ? "true" : "false",
+        DateTime timestamp => timestamp.ToString("O", CultureInfo.InvariantCulture),
+        DateTimeOffset timestamp => timestamp.ToString("O", CultureInfo.InvariantCulture),
+        IFormattable formattable => formattable.ToString(format: null, CultureInfo.InvariantCulture),
+        _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+    };
+
+    /// <summary>
+    /// Writes a single already-formatted field, quoting it and doubling any embedded quote when the
+    /// text contains a comma, a quote, or a line break.
+    /// </summary>
+    /// <param name="field">The formatted field text.</param>
+    /// <param name="writer">The destination writer.</param>
+    private static void WriteField(string field, TextWriter writer)
+    {
+        if (field.AsSpan().IndexOfAny(MustQuote) < 0)
+        {
+            writer.Write(field);
+            return;
+        }
+
+        writer.Write('"');
+        writer.Write(field.Replace("\"", "\"\"", StringComparison.Ordinal));
+        writer.Write('"');
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Middleware/TenantResolutionMiddleware.cs
+++ b/Source/Presentation/MMCA.Common.API/Middleware/TenantResolutionMiddleware.cs
@@ -1,0 +1,152 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.API.Middleware;
+
+/// <summary>
+/// Resolves the tenant for the current request and publishes it on the scoped
+/// <see cref="ITenantContext"/>, which the persistence layer's query filter, save interceptor and
+/// per-tenant database routing all read from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Wired unconditionally, inert by default</b> (the <c>SoftDeletedUserMiddleware</c> precedent).
+/// <c>IOptions&lt;TenancySettings&gt;</c> resolves to defaults in a host that never called
+/// <c>AddMultiTenancy</c>, and those defaults have <c>Enabled</c> false, so the middleware passes
+/// every request straight through.
+/// </para>
+/// <para>
+/// <b>It runs immediately after <c>UseAuthentication</c></b>, and that position is load-bearing:
+/// the claim strategy reads <c>HttpContext.User</c>, which does not carry the token's claims until
+/// authentication has run. Running it earlier would silently demote every request to the header
+/// strategy.
+/// </para>
+/// <para>
+/// <b>It fails closed.</b> With <c>Tenancy:RequireTenant</c> (the default) a request that resolves
+/// no tenant is answered with <c>400 Bad Request</c> rather than allowed through unscoped: an
+/// unscoped request reads across every tenant, which is the exact outcome tenancy exists to prevent.
+/// Health, liveness and discovery paths are excluded, since they must answer before any tenant
+/// exists.
+/// </para>
+/// </remarks>
+/// <param name="next">The next middleware in the pipeline.</param>
+public sealed class TenantResolutionMiddleware(RequestDelegate next)
+{
+    /// <summary>The problem type reported when a required tenant could not be resolved.</summary>
+    internal const string UnresolvedTenantTitle = "Tenant not resolved";
+
+    /// <summary>
+    /// Resolves the tenant per the configured strategy order and either publishes it, passes the
+    /// request through, or rejects it.
+    /// </summary>
+    /// <param name="context">The HTTP context for the current request.</param>
+    /// <param name="tenantContext">The scoped tenant context to populate.</param>
+    /// <param name="tenancyOptions">The bound tenancy settings.</param>
+    /// <param name="problemDetailsService">The service used to write the RFC 9457 rejection.</param>
+    /// <returns>A task representing the middleware execution.</returns>
+    public async Task InvokeAsync(
+        HttpContext context,
+        ITenantContext tenantContext,
+        IOptions<TenancySettings> tenancyOptions,
+        IProblemDetailsService problemDetailsService)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(tenantContext);
+        ArgumentNullException.ThrowIfNull(tenancyOptions);
+
+        var settings = tenancyOptions.Value;
+
+        if (!settings.Enabled || IsExcluded(context, settings))
+        {
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        if (Resolve(context, settings) is { } tenantId)
+        {
+            tenantContext.SetTenant(tenantId);
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        if (!settings.RequireTenant)
+        {
+            // Explicitly opted out of failing closed: the request runs as a system caller and sees
+            // every tenant's rows, which is only ever right behind an internal boundary.
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        await RejectAsync(context, settings, problemDetailsService).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Whether the request path is one of the excluded prefixes (probes and discovery documents).
+    /// </summary>
+    private static bool IsExcluded(HttpContext context, TenancySettings settings)
+    {
+        var path = context.Request.Path;
+        return settings.EffectiveExcludedPathPrefixes
+            .Any(prefix => path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Tries each configured strategy in order and returns the first non-blank tenant, or
+    /// <see langword="null"/> when none yields one.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TenantResolutionStrategy.Host"/> is skipped rather than guessed at: it is defined
+    /// but not implemented, and options validation already refuses to start a host that selected it,
+    /// so reaching it here would mean validation was bypassed.
+    /// </remarks>
+    private static string? Resolve(HttpContext context, TenancySettings settings)
+    {
+        foreach (var strategy in settings.EffectiveResolutionOrder)
+        {
+            var candidate = strategy switch
+            {
+                TenantResolutionStrategy.Claim => context.User?.FindFirst(settings.ClaimType)?.Value,
+                TenantResolutionStrategy.Header => context.Request.Headers[settings.HeaderName].FirstOrDefault(),
+                TenantResolutionStrategy.Host => null,
+                _ => null,
+            };
+
+            if (!string.IsNullOrWhiteSpace(candidate))
+                return candidate.Trim();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Answers an unresolvable request with <c>400 Bad Request</c> as RFC 9457 problem details,
+    /// naming the claim and header that were looked at so the caller can fix the request.
+    /// </summary>
+    private static async Task RejectAsync(
+        HttpContext context,
+        TenancySettings settings,
+        IProblemDetailsService problemDetailsService)
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+
+        var problem = new ProblemDetailsContext
+        {
+            HttpContext = context,
+            ProblemDetails = new ProblemDetails
+            {
+                Status = StatusCodes.Status400BadRequest,
+                Title = UnresolvedTenantTitle,
+                Detail = "This request carries no tenant. Supply it as the \""
+                    + settings.ClaimType
+                    + "\" claim or the \""
+                    + settings.HeaderName
+                    + "\" header.",
+            },
+        };
+
+        await problemDetailsService.TryWriteAsync(problem).ConfigureAwait(false);
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
@@ -1,10 +1,14 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Modules;
 using MMCA.Common.Application.Settings;
 using MMCA.Common.Infrastructure.Persistence.DataSources;
 using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Settings;
 
 namespace MMCA.Common.API.Startup;
 
@@ -84,8 +88,100 @@ public static class DatabaseInitializationExtensions
                         "Valid values are: Migrate, EnsureCreated, None.");
             }
 
+            await InitializeTenantDatabasesAsync(services, applicationSettings, sourcesInUse, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Module seeding runs on the default scope only. A seeder writes reference data an
+            // application needs to boot; running it per tenant would need a per-tenant notion of
+            // "which seeders apply", which no module declares today, and running it twice against a
+            // shared database is worse than not running it per tenant at all.
             await moduleLoader.SeedAllAsync(scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Applies the same schema strategy to each tenant that keeps its own copy of a data source.
+    /// Nothing else opens those databases, so without this pass a per-tenant database is never
+    /// created and never migrated.
+    /// </summary>
+    /// <remarks>
+    /// Each tenant gets a FRESH scope with its tenant set before the context factory is asked for
+    /// anything: the scoped factory binds one physical database per source for the life of a scope,
+    /// so reusing the outer scope would keep handing back the shared database.
+    /// </remarks>
+    private static async Task InitializeTenantDatabasesAsync(
+        IServiceProvider services,
+        ApplicationSettings applicationSettings,
+        IReadOnlyCollection<DataSourceKey> sourcesInUse,
+        CancellationToken cancellationToken)
+    {
+        var settings = services.GetService<IOptions<TenancySettings>>()?.Value;
+        if (settings is null || settings.Tenants.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var target in TenantDataSourceTargets.Expand(sourcesInUse, settings)
+            .Where(t => t.TenantId is not null))
+        {
+            using var tenantScope = services.CreateScope();
+            tenantScope.ServiceProvider.GetRequiredService<ITenantContext>().SetTenant(target.TenantId!);
+
+            var factory = tenantScope.ServiceProvider.GetRequiredService<IDbContextFactory>();
+            var database = factory.GetDbContext(target.Source).Database;
+
+            switch (applicationSettings.DatabaseInitStrategy)
+            {
+                case "Migrate":
+                    if (target.Source.Engine == DataSource.SQLServer)
+                    {
+                        await database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                case "EnsureCreated":
+                    await database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+                    break;
+                case "None":
+                    await ThrowIfTenantPendingMigrationsAsync(database, target, cancellationToken)
+                        .ConfigureAwait(false);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown DatabaseInitStrategy: '{applicationSettings.DatabaseInitStrategy}'. " +
+                        "Valid values are: Migrate, EnsureCreated, None.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Production guard for a tenant database under the <c>"None"</c> strategy: a tenant left
+    /// behind by a migration is exactly as broken as a shared database left behind, and silently so.
+    /// </summary>
+    private static async Task ThrowIfTenantPendingMigrationsAsync(
+        DatabaseFacade database,
+        TenantDataSourceTarget target,
+        CancellationToken cancellationToken)
+    {
+        if (target.Source.Engine != DataSource.SQLServer)
+        {
+            return;
+        }
+
+        var pending = await database.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
+        if (!pending.Any())
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Tenant database has pending migrations that must be applied before starting: "
+            + $"{target}: {string.Join(", ", pending)}. "
+            + "Run 'dotnet ef database update' against the tenant's connection string.");
     }
 
     /// <summary>

--- a/Source/Presentation/MMCA.Common.API/Startup/WebApplicationExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/WebApplicationExtensions.cs
@@ -39,8 +39,8 @@ public static class WebApplicationExtensions
         /// <summary>
         /// Configures the standard MMCA middleware pipeline in the correct order:
         /// exception handling → correlation ID → forwarded headers → HTTPS →
-        /// response compression → routing → CORS → rate limiting → auth →
-        /// soft-delete user filter → authorization → output cache → controllers.
+        /// response compression → routing → CORS → auth → tenant resolution →
+        /// rate limiting → soft-delete user filter → authorization → output cache → controllers.
         /// </summary>
         public WebApplication UseCommonMiddlewarePipeline()
         {
@@ -94,6 +94,13 @@ public static class WebApplicationExtensions
                 ? WebApplicationBuilderExtensions.CorsPolicyAllowAll
                 : WebApplicationBuilderExtensions.CorsPolicyAllowSpecificOrigins);
             app.UseAuthentication();
+
+            // Immediately after authentication, and that order is load-bearing: the claim strategy
+            // reads HttpContext.User, which carries the token's claims only once authentication has
+            // run. Registered unconditionally and inert unless the host called AddMultiTenancy and
+            // set Tenancy:Enabled (the SoftDeletedUserMiddleware precedent).
+            app.UseMiddleware<TenantResolutionMiddleware>();
+
             // Rate limiting runs AFTER authentication on purpose (ADR-019): GlobalRateLimitPartition
             // partitions by the authenticated principal and routes anonymous traffic down a NoLimiter
             // branch, so HttpContext.User must already be populated here — otherwise every request

--- a/Source/Presentation/MMCA.Common.API/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.API/packages.lock.json
@@ -790,6 +790,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -952,6 +953,18 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.10",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {

--- a/Source/Presentation/MMCA.Common.API/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.API/packages.lock.json
@@ -780,6 +780,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -819,6 +820,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -592,6 +592,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -749,6 +750,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -103,6 +103,14 @@
           "Azure.Core": "1.54.0"
         }
       },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "lcJtcgTkk1gGy59RQhGLJLMyad+zgASMn975PVjMft69q+jjFTo6Nyq5SCtOhPY1WvA0gNI1qYIVN2oikVXDjw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Common": {
         "type": "Transitive",
         "resolved": "12.28.0",
@@ -557,6 +565,7 @@
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
+          "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.1, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.3, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.3, )",
           "Azure.Identity": "[1.21.0, )",
@@ -676,6 +685,16 @@
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
+      "Azure.Extensions.AspNetCore.Configuration.Secrets": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.1, )",
+        "resolved": "1.5.1",
+        "contentHash": "2Io9af/y8GH1jfu//BQrYcwb+MZOJG+au2KCv+ltWM6PBCghbhaDyZWDkYWNWIougZgoHtyKM0CnlGi+9XAu/A==",
+        "dependencies": {
+          "Azure.Core": "1.54.0",
+          "Azure.Security.KeyVault.Secrets": "4.10.0"
         }
       },
       "Azure.Extensions.AspNetCore.DataProtection.Blobs": {

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -602,6 +602,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -900,6 +901,12 @@
           "Microsoft.Data.SqlClient": "6.1.1",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA=="
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "CentralTransitive",

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
@@ -1187,6 +1187,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -1289,6 +1290,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/packages.lock.json
@@ -1197,6 +1197,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -1543,6 +1544,18 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.10",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {

--- a/Tests/Core/MMCA.Common.Application.Tests/Auditing/AuditTrailEntryDTOTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Auditing/AuditTrailEntryDTOTests.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using AwesomeAssertions;
+using MMCA.Common.Application.Auditing;
+using MMCA.Common.Application.Interfaces;
+
+namespace MMCA.Common.Application.Tests.Auditing;
+
+/// <summary>
+/// Contract coverage for the audit trail's read surface: the DTO is an immutable value, and the
+/// reader's paging defaults are part of the published signature (a caller that asks for an entity's
+/// history without paging must get the first page, not the whole table).
+/// </summary>
+public sealed class AuditTrailEntryDTOTests
+{
+    [Fact]
+    public void AuditTrailEntryDTO_IsImmutable()
+    {
+        var settableProperties = typeof(AuditTrailEntryDTO)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.SetMethod is { } setter
+                && setter.IsPublic
+                && !setter.ReturnParameter.GetRequiredCustomModifiers()
+                    .Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit"))
+            .Select(p => p.Name);
+
+        settableProperties.Should().BeEmpty("a recorded change is history: nothing may rewrite it after the fact");
+    }
+
+    [Fact]
+    public void AuditTrailEntryDTO_OptionalFields_DefaultToNull()
+    {
+        var dto = new AuditTrailEntryDTO
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "MMCA.Tests.Order",
+            EntityKey = "1",
+            Operation = "Added",
+            ChangedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        dto.PropertyName.Should().BeNull("a create is recorded as one summary row without a property");
+        dto.OldValue.Should().BeNull();
+        dto.NewValue.Should().BeNull();
+        dto.ChangedBy.Should().BeNull("a background save has no identity to attribute the change to");
+        dto.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public void AuditTrailEntryDTO_HasValueSemantics()
+    {
+        var id = Guid.NewGuid();
+        var changedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        AuditTrailEntryDTO Create(string operation) => new()
+        {
+            Id = id,
+            EntityType = "MMCA.Tests.Order",
+            EntityKey = "1",
+            Operation = operation,
+            ChangedOn = changedOn,
+        };
+
+        Create("Added").Should().Be(Create("Added"));
+        Create("Added").Should().NotBe(Create("Deleted"));
+    }
+
+    [Fact]
+    public void IAuditTrailReader_PagingArguments_DefaultToTheFirstPage()
+    {
+        var parameters = typeof(IAuditTrailReader)
+            .GetMethod(nameof(IAuditTrailReader.GetForEntityAsync))!
+            .GetParameters();
+
+        parameters.Single(p => p.Name == "page").DefaultValue.Should().Be(1);
+        parameters.Single(p => p.Name == "pageSize").DefaultValue.Should().Be(50);
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingDecoratorTenantScopingTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/CachingDecoratorTenantScopingTests.cs
@@ -1,0 +1,202 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Application.UseCases.Decorators;
+using MMCA.Common.Shared.Abstractions;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Decorators;
+
+/// <summary>
+/// Coverage for tenant isolation in the caching decorators. <c>ICacheService</c> is a singleton and
+/// cannot see the scoped tenant, so the key transformation is the isolation: without it two tenants
+/// computing the same query key would read each other's rows out of one cache entry.
+/// </summary>
+public sealed class CachingDecoratorTenantScopingTests
+{
+    private const string BareKey = "test-cache-key";
+    private const string AcmeKey = "t:acme:test-cache-key";
+    private const string BarePrefix = "test-prefix";
+    private const string AcmePrefix = "t:acme:test-prefix";
+
+    // ── Query decorator ──
+    [Fact]
+    public async Task Query_WithAResolvedTenant_ReadsAndWritesTheTenantScopedKey()
+    {
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null);
+
+        var sut = QueryDecorator(cacheService, Resolved("acme"), "fresh");
+
+        await sut.HandleAsync(new CacheableTestQuery());
+
+        cacheService.Verify(x => x.GetAsync<Result<string>>(AcmeKey, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        cacheService.Verify(
+            x => x.SetAsync(AcmeKey, It.IsAny<Result<string>>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        cacheService.Verify(x => x.GetAsync<Result<string>>(BareKey, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Query_WithNoTenant_KeepsTheBareKey()
+    {
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null);
+
+        var sut = QueryDecorator(cacheService, Unresolved(), "fresh");
+
+        await sut.HandleAsync(new CacheableTestQuery());
+
+        cacheService.Verify(
+            x => x.SetAsync(BareKey, It.IsAny<Result<string>>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a single-tenant host must keep exactly the keyspace it had before tenancy shipped");
+    }
+
+    [Fact]
+    public async Task Query_WithoutATenantContextAtAll_KeepsTheBareKey()
+    {
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null);
+
+        var sut = QueryDecorator(cacheService, tenantContext: null, "fresh");
+
+        await sut.HandleAsync(new CacheableTestQuery());
+
+        cacheService.Verify(
+            x => x.SetAsync(BareKey, It.IsAny<Result<string>>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Query_OneTenantsEntry_IsNotServedToAnother()
+    {
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>(AcmeKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("acme-data"));
+        cacheService.Setup(x => x.GetAsync<Result<string>>("t:globex:test-cache-key", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null);
+
+        Result<string> acme = await QueryDecorator(cacheService, Resolved("acme"), "unused")
+            .HandleAsync(new CacheableTestQuery());
+        Result<string> globex = await QueryDecorator(cacheService, Resolved("globex"), "globex-data")
+            .HandleAsync(new CacheableTestQuery());
+
+        acme.Value.Should().Be("acme-data");
+        globex.Value.Should().Be("globex-data", "the second tenant missed and ran its own handler");
+    }
+
+    // ── Command decorator ──
+    [Fact]
+    public async Task Command_WithAResolvedTenant_EvictsTheTenantScopedPrefix()
+    {
+        var cacheService = new Mock<ICacheService>();
+        var sut = CommandDecorator(cacheService, Resolved("acme"));
+
+        await sut.HandleAsync(new CacheInvalidatingTestCommand());
+
+        // AtLeastOnce: the decorator also schedules a delayed re-eviction of the same prefix.
+        cacheService.Verify(x => x.RemoveByPrefixAsync(AcmePrefix, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        cacheService.Verify(x => x.RemoveByPrefixAsync(BarePrefix, It.IsAny<CancellationToken>()), Times.Never,
+            "evicting the bare prefix would take out every tenant's entries at once");
+    }
+
+    [Fact]
+    public async Task Command_WithNoTenant_EvictsTheBarePrefix()
+    {
+        var cacheService = new Mock<ICacheService>();
+        var sut = CommandDecorator(cacheService, Unresolved());
+
+        await sut.HandleAsync(new CacheInvalidatingTestCommand());
+
+        cacheService.Verify(x => x.RemoveByPrefixAsync(BarePrefix, It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        cacheService.Verify(
+            x => x.RemoveByPrefixAsync(It.Is<string>(p => p.StartsWith("t:", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Command_AndQuery_TransformTheKeyIdentically()
+    {
+        // Symmetry is the whole point: an entry written under the query's scoped key must be removed
+        // by the command's scoped prefix, or invalidation silently stops working under tenancy.
+        var cacheService = new Mock<ICacheService>();
+        cacheService.Setup(x => x.GetAsync<Result<string>>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Result<string>?)null);
+
+        string? writtenKey = null;
+        cacheService.Setup(x => x.SetAsync(
+                It.IsAny<string>(), It.IsAny<Result<string>>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Result<string>, TimeSpan?, CancellationToken>((key, _, _, _) => writtenKey = key)
+            .Returns(Task.CompletedTask);
+
+        string? evictedPrefix = null;
+        cacheService.Setup(x => x.RemoveByPrefixAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((prefix, _) => evictedPrefix = prefix)
+            .Returns(Task.CompletedTask);
+
+        await QueryDecorator(cacheService, Resolved("acme"), "fresh").HandleAsync(new CacheableTestQuery());
+        await CommandDecorator(cacheService, Resolved("acme")).HandleAsync(new CacheInvalidatingTestCommand());
+
+        writtenKey.Should().NotBeNull();
+        evictedPrefix.Should().NotBeNull();
+        writtenKey.Should().StartWith(evictedPrefix![..^"prefix".Length]);
+        writtenKey.Should().StartWith("t:acme:");
+    }
+
+    // ── Scaffolding ──
+    private static ITenantContext Resolved(string tenantId)
+    {
+        var context = new Mock<ITenantContext>();
+        context.SetupGet(c => c.TenantId).Returns(tenantId);
+        context.SetupGet(c => c.IsResolved).Returns(true);
+        return context.Object;
+    }
+
+    private static ITenantContext Unresolved()
+    {
+        var context = new Mock<ITenantContext>();
+        context.SetupGet(c => c.TenantId).Returns((string?)null);
+        context.SetupGet(c => c.IsResolved).Returns(false);
+        return context.Object;
+    }
+
+    private static CachingQueryDecorator<CacheableTestQuery, Result<string>> QueryDecorator(
+        Mock<ICacheService> cacheService,
+        ITenantContext? tenantContext,
+        string handlerResult)
+    {
+        var inner = new Mock<IQueryHandler<CacheableTestQuery, Result<string>>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheableTestQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(handlerResult));
+
+        return new CachingQueryDecorator<CacheableTestQuery, Result<string>>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingQueryDecorator<CacheableTestQuery, Result<string>>>.Instance,
+            tenantContext);
+    }
+
+    private static CachingCommandDecorator<CacheInvalidatingTestCommand, Result> CommandDecorator(
+        Mock<ICacheService> cacheService,
+        ITenantContext? tenantContext)
+    {
+        var inner = new Mock<ICommandHandler<CacheInvalidatingTestCommand, Result>>();
+        inner.Setup(x => x.HandleAsync(It.IsAny<CacheInvalidatingTestCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        return new CachingCommandDecorator<CacheInvalidatingTestCommand, Result>(
+            inner.Object,
+            cacheService.Object,
+            NullLogger<CachingCommandDecorator<CacheInvalidatingTestCommand, Result>>.Instance,
+            tenantContext)
+        {
+            ReInvalidationDelay = TimeSpan.Zero,
+        };
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Interfaces/CacheServiceGetOrCreateTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Interfaces/CacheServiceGetOrCreateTests.cs
@@ -1,0 +1,241 @@
+using System.Collections.Concurrent;
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Shared.Concurrency;
+
+namespace MMCA.Common.Application.Tests.Interfaces;
+
+/// <summary>
+/// Covers the DEFAULT implementation of
+/// <see cref="ICacheService.GetOrCreateAsync{T}(string, Func{CancellationToken, Task{T}}, TimeSpan?, CancellationToken)"/>,
+/// the one every backing store inherits unless it overrides the member.
+/// <para>
+/// The subject is a hand-written fake rather than a mock: a mocking proxy supplies its own body for
+/// an interface member, which would test the proxy instead of the default implementation under test.
+/// </para>
+/// </summary>
+public sealed class CacheServiceGetOrCreateTests
+{
+    /// <summary>Guards the choreographed tests against hanging the run if the stripe misbehaves.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    // ── Hit path ──
+    [Fact]
+    public async Task GetOrCreateAsync_WhenTheKeyIsCached_ReturnsItWithoutInvokingTheFactory()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+        await cache.SetAsync("k", "cached", cancellationToken: TestContext.Current.CancellationToken);
+
+        var factoryCalls = 0;
+        var result = await cache.GetOrCreateAsync<string>(
+            "k",
+            _ =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                return Task.FromResult("fresh");
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().Be("cached");
+        factoryCalls.Should().Be(0);
+        recorder.Sets.Should().ContainSingle("a hit must not rewrite the entry it just read");
+    }
+
+    // ── Miss path ──
+    [Fact]
+    public async Task GetOrCreateAsync_OnAMiss_InvokesTheFactoryAndCachesTheResult()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+
+        var result = await cache.GetOrCreateAsync(
+            "k",
+            _ => Task.FromResult("fresh"),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().Be("fresh");
+        (await cache.GetAsync<string>("k", TestContext.Current.CancellationToken)).Should().Be("fresh");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_ForwardsTheExpirationToSetAsync()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+        var expiration = TimeSpan.FromMinutes(7);
+
+        await cache.GetOrCreateAsync(
+            "k",
+            _ => Task.FromResult("fresh"),
+            expiration,
+            TestContext.Current.CancellationToken);
+
+        var write = recorder.Sets.Should().ContainSingle().Subject;
+        write.Key.Should().Be("k");
+        write.Expiration.Should().Be(expiration);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_WithNoExpiration_LetsTheStoreApplyItsDefault()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+
+        await cache.GetOrCreateAsync(
+            "k",
+            _ => Task.FromResult("fresh"),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var write = recorder.Sets.Should().ContainSingle().Subject;
+        write.Key.Should().Be("k");
+        write.Expiration.Should().BeNull("the store applies its own default when the caller supplies none");
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_WithoutAFactory_Throws()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            cache.GetOrCreateAsync<string>("k", factory: null!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    // ── Stampede protection ──
+    [Fact]
+    public async Task GetOrCreateAsync_WithConcurrentMissesOnOneKey_InvokesTheFactoryOnce()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+        var factoryEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFactory = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var factoryCalls = 0;
+
+        async Task<string> FactoryAsync(CancellationToken ct)
+        {
+            Interlocked.Increment(ref factoryCalls);
+            factoryEntered.TrySetResult();
+            await releaseFactory.Task.WaitAsync(Timeout, ct);
+            return "fresh";
+        }
+
+        var first = cache.GetOrCreateAsync<string>("hot", FactoryAsync, cancellationToken: TestContext.Current.CancellationToken);
+
+        // The first caller now holds the stripe with the key still absent, which is precisely the
+        // window a stampede would drive a second handler execution through.
+        await factoryEntered.Task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
+
+        var second = cache.GetOrCreateAsync<string>("hot", FactoryAsync, cancellationToken: TestContext.Current.CancellationToken);
+
+        releaseFactory.SetResult();
+
+        var results = await Task.WhenAll(first, second).WaitAsync(Timeout, TestContext.Current.CancellationToken);
+
+        results.Should().AllBe("fresh");
+        factoryCalls.Should().Be(1, "the waiter must be served the freshly cached entry, not run the factory again");
+        recorder.Sets.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_WithMissesOnDistinctKeys_DoesNotSerializeThem()
+    {
+        var recorder = new RecordingCacheService();
+        ICacheService cache = recorder;
+        (string First, string Second) keys = DistinctStripeKeys();
+
+        var firstEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var blocked = cache.GetOrCreateAsync<string>(
+            keys.First,
+            async ct =>
+            {
+                firstEntered.TrySetResult();
+                await releaseFirst.Task.WaitAsync(Timeout, ct);
+                return "first";
+            },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await firstEntered.Task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
+
+        // A different key takes a different stripe, so this must complete while the first caller is
+        // still inside its factory. If the lock were global this await would time out.
+        var independent = await cache.GetOrCreateAsync(
+            keys.Second,
+            _ => Task.FromResult("second"),
+            cancellationToken: TestContext.Current.CancellationToken)
+            .WaitAsync(Timeout, TestContext.Current.CancellationToken);
+
+        independent.Should().Be("second");
+
+        releaseFirst.SetResult();
+        (await blocked.WaitAsync(Timeout, TestContext.Current.CancellationToken)).Should().Be("first");
+    }
+
+    /// <summary>
+    /// Finds two keys that map to DIFFERENT stripes. The mapping is the one
+    /// <see cref="KeyedSemaphoreStripe"/> applies, and string hashing is randomized per process, so
+    /// the pair has to be chosen at run time: two hard-coded keys would collide on some runs and
+    /// deadlock the concurrency test.
+    /// </summary>
+    /// <returns>Two keys guaranteed to sit on different stripes.</returns>
+    private static (string First, string Second) DistinctStripeKeys()
+    {
+        var first = "parallel-0";
+        for (var i = 1; i < 1000; i++)
+        {
+            var candidate = string.Create(System.Globalization.CultureInfo.InvariantCulture, $"parallel-{i}");
+            if (Stripe(candidate) != Stripe(first))
+                return (first, candidate);
+        }
+
+        throw new InvalidOperationException("No two of the candidate keys landed on different stripes.");
+
+        static uint Stripe(string key) =>
+            (uint)string.GetHashCode(key, StringComparison.Ordinal) % KeyedSemaphoreStripe.DefaultWidth;
+    }
+
+    /// <summary>
+    /// Minimal in-memory <see cref="ICacheService"/> that inherits every default member and records
+    /// what was written.
+    /// </summary>
+    private sealed class RecordingCacheService : ICacheService
+    {
+        private readonly ConcurrentDictionary<string, object?> _store = new(StringComparer.Ordinal);
+        private readonly ConcurrentQueue<(string Key, TimeSpan? Expiration)> _sets = new();
+
+        /// <summary>Gets every write, in order.</summary>
+        public IReadOnlyList<(string Key, TimeSpan? Expiration)> Sets => [.. _sets];
+
+        public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_store.TryGetValue(key, out var stored) && stored is T typed ? typed : default);
+
+        public Task SetAsync<T>(
+            string key,
+            T value,
+            TimeSpan? expiration = null,
+            CancellationToken cancellationToken = default)
+        {
+            _store[key] = value;
+            _sets.Enqueue((key, expiration));
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            _store.TryRemove(key, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveByPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+        {
+            foreach (var key in _store.Keys.Where(k => k.StartsWith(prefix, StringComparison.Ordinal)))
+            {
+                _store.TryRemove(key, out _);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/MMCA.Common.Application.Tests.csproj
+++ b/Tests/Core/MMCA.Common.Application.Tests/MMCA.Common.Application.Tests.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Moq" />
+    <!-- FakeTimeProvider pins the generated-on stamp in the data-subject export tests. -->
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Core/MMCA.Common.Application.Tests/Settings/ApplicationSettingsTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Settings/ApplicationSettingsTests.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using AwesomeAssertions;
 using MMCA.Common.Application.Settings;
 
@@ -13,6 +15,10 @@ public sealed class ApplicationSettingsTests
     [Fact]
     public void MaxPageSize_DefaultsTo500() =>
         new ApplicationSettings().MaxPageSize.Should().Be(500);
+
+    [Fact]
+    public void MaxExportRows_DefaultsTo100000() =>
+        new ApplicationSettings().MaxExportRows.Should().Be(100_000);
 
     [Fact]
     public void DatabaseInitStrategy_DefaultsToMigrate() =>
@@ -38,6 +44,26 @@ public sealed class ApplicationSettingsTests
         var settings = new ApplicationSettings { MaxPageSize = 100 };
 
         settings.MaxPageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public void MaxExportRows_CanBeSet()
+    {
+        var settings = new ApplicationSettings { MaxExportRows = 250 };
+
+        settings.MaxExportRows.Should().Be(250);
+    }
+
+    [Fact]
+    public void MaxExportRows_CarriesARangeAttribute()
+    {
+        RangeAttribute? range = typeof(ApplicationSettings)
+            .GetProperty(nameof(ApplicationSettings.MaxExportRows))!
+            .GetCustomAttribute<RangeAttribute>();
+
+        range.Should().NotBeNull(because: "a host that opts into data-annotations validation must reject a nonsensical cap");
+        range!.Minimum.Should().Be(1);
+        range.Maximum.Should().Be(10_000_000);
     }
 
     [Fact]

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/ExportUserDataHandlerBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/ExportUserDataHandlerBaseTests.cs
@@ -1,0 +1,328 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.Users.UseCases.ExportUserData;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Privacy;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Users;
+
+/// <summary>
+/// Exercises the shared data-subject export workflow: the owner-or-privileged-role gate, the
+/// read-only account load, the app's subject snapshot, and the best-effort section fan-out that must
+/// degrade rather than fail.
+/// </summary>
+public sealed class ExportUserDataHandlerBaseTests
+{
+    private const string PrivilegedRole = "Organizer";
+
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 13, 17, 42, 9, TimeSpan.Zero);
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerIsNeitherOwnerNorPrivileged_ReturnsForbiddenWithoutFetchingOrExporting()
+    {
+        var section = new RecordingSection("Engagement");
+        var (sut, mocks) = CreateSut(section);
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 2, "Attendee"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Code == "User.ExportForbidden"
+            && e.Type == ErrorType.Forbidden
+            && e.Source == nameof(TestExportUserDataHandler)
+            && e.Target == "UserId");
+        mocks.Repository.Verify(
+            x => x.GetByIdAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        section.Invocations.Should().Be(0, "a forbidden caller must never reach the data");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCallerHoldsPrivilegedRole_ExportsAnotherAccount()
+    {
+        var (sut, mocks) = CreateSut();
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 2, PrivilegedRole));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.UserId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUserMissing_ReturnsNotFound()
+    {
+        var (sut, mocks) = CreateSut();
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(404, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestIdentityUser?)null);
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 404, CurrentUserId: 404, null));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e =>
+            e.Type == ErrorType.NotFound && e.Target == nameof(TestIdentityUser));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ReadsTheAccountThroughTheReadRepository()
+    {
+        var (sut, mocks) = CreateSut();
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        await sut.HandleAsync(new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        mocks.UnitOfWork.Verify(
+            x => x.GetReadRepository<TestIdentityUser, UserIdentifierType>(),
+            Times.Once,
+            "a query handler never saves, so it takes the no-tracking read repository");
+        mocks.UnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_AssemblesTheEnvelopeFromTheSnapshotAndSections()
+    {
+        var payload = new { Bookmarks = 2 };
+        var (sut, mocks) = CreateSut(new RecordingSection("Engagement", UserDataExportSectionResult.Complete("Engagement", payload)));
+        ArrangeUser(mocks, new TestIdentityUser { Id = 7 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 7, CurrentUserId: 7, null));
+
+        result.IsSuccess.Should().BeTrue();
+        UserDataExportDTO export = result.Value!;
+        export.FormatVersion.Should().Be("1.0");
+        export.UserId.Should().Be(7);
+        export.Subject.Should().BeSameAs(sut.LastSnapshot);
+        export.Sections.Should().ContainSingle();
+        export.Sections[0].SectionName.Should().Be("Engagement");
+        export.Sections[0].Available.Should().BeTrue();
+        export.Sections[0].Data.Should().BeSameAs(payload);
+        export.Sections[0].UnavailableReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_StampsGeneratedOnFromTheTimeProvider()
+    {
+        var (sut, mocks) = CreateSut();
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        result.Value!.GeneratedOn.Should().Be(FixedNow,
+            "the stamp comes from the injected time provider, not from DateTime.UtcNow");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNoSections_StillProducesTheEnvelope()
+    {
+        var (sut, mocks) = CreateSut();
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Sections.Should().BeEmpty("an app with no contributors still owes the subject its account data");
+        result.Value.Subject.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenASectionThrows_DegradesThatSectionAndKeepsTheRest()
+    {
+        var throwing = new ThrowingSection("Engagement");
+        var healthy = new RecordingSection("Notifications", UserDataExportSectionResult.Complete("Notifications", data: null));
+        var (sut, mocks) = CreateSut(throwing, healthy);
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        result.IsSuccess.Should().BeTrue("one failing contributor must never deny the subject the whole export");
+        result.Value!.Sections.Should().HaveCount(2);
+        result.Value.Sections[0].SectionName.Should().Be("Engagement");
+        result.Value.Sections[0].Available.Should().BeFalse();
+        result.Value.Sections[0].Data.Should().BeNull();
+        result.Value.Sections[0].UnavailableReason
+            .Should().Be(UserDataExportSectionDefaults.UnavailableReason)
+            .And.NotContain("Engagement peer exploded", "internal exception detail never reaches the data subject");
+        result.Value.Sections[1].Available.Should().BeTrue();
+        healthy.Invocations.Should().Be(1, "a failing section does not short-circuit the fan-out");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenASectionReportsItselfUnavailable_CarriesItsOwnReason()
+    {
+        var section = new RecordingSection(
+            "Sales",
+            UserDataExportSectionResult.Unavailable("Sales", "The orders service is temporarily unreachable."));
+        var (sut, mocks) = CreateSut(section);
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        result.Value!.Sections[0].Available.Should().BeFalse();
+        result.Value.Sections[0].UnavailableReason.Should().Be("The orders service is temporarily unreachable.");
+    }
+
+    [Fact]
+    public async Task HandleAsync_PreservesRegistrationOrderOfSections()
+    {
+        var (sut, mocks) = CreateSut(
+            new RecordingSection("Alpha"),
+            new RecordingSection("Bravo"),
+            new RecordingSection("Charlie"));
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        result.Value!.Sections.Select(s => s.SectionName).Should().Equal("Alpha", "Bravo", "Charlie");
+    }
+
+    [Fact]
+    public async Task HandleAsync_PassesTheSubjectIdToEverySection()
+    {
+        var section = new RecordingSection("Engagement");
+        var (sut, mocks) = CreateSut(section);
+        ArrangeUser(mocks, new TestIdentityUser { Id = 7 });
+
+        await sut.HandleAsync(new TestExportUserDataQuery(UserId: 7, CurrentUserId: 7, PrivilegedRole));
+
+        section.LastUserId.Should().Be(7, "the export is about the target account, not the caller");
+    }
+
+    [Fact]
+    public async Task HandleAsync_RunsTheCompletionHookWithTheAssembledPackage()
+    {
+        var (sut, mocks) = CreateSut(new RecordingSection("Engagement"));
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Result<UserDataExportDTO> result = await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        sut.CompletedExport.Should().BeSameAs(result.Value);
+        sut.CompletedExport!.Sections.Should().ContainSingle("the hook sees the finished document, not a partial one");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenASectionIsCancelled_PropagatesRatherThanDegrading()
+    {
+        var (sut, mocks) = CreateSut(new CancellingSection("Engagement"));
+        ArrangeUser(mocks, new TestIdentityUser { Id = 1 });
+
+        Func<Task> act = async () => await sut.HandleAsync(
+            new TestExportUserDataQuery(UserId: 1, CurrentUserId: 1, null));
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "cancellation is the caller giving up, not a contributor failing");
+    }
+
+    private static void ArrangeUser(HandlerMocks mocks, TestIdentityUser user) =>
+        mocks.Repository
+            .Setup(x => x.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+    private sealed record HandlerMocks(
+        Mock<IUnitOfWork> UnitOfWork,
+        Mock<IReadRepository<TestIdentityUser, UserIdentifierType>> Repository);
+
+    private static (TestExportUserDataHandler Sut, HandlerMocks Mocks) CreateSut(
+        params IUserDataExportSection[] sections)
+    {
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var repository = new Mock<IReadRepository<TestIdentityUser, UserIdentifierType>>();
+
+        unitOfWork.Setup(x => x.GetReadRepository<TestIdentityUser, UserIdentifierType>()).Returns(repository.Object);
+
+        var sut = new TestExportUserDataHandler(unitOfWork.Object, sections, new FakeTimeProvider(FixedNow));
+        return (sut, new HandlerMocks(unitOfWork, repository));
+    }
+}
+
+/// <summary>Concrete subclass standing in for an app's <c>ExportUserDataHandler</c>.</summary>
+public sealed class TestExportUserDataHandler(
+    IUnitOfWork unitOfWork,
+    IEnumerable<IUserDataExportSection> sections,
+    TimeProvider timeProvider)
+    : ExportUserDataHandlerBase<TestIdentityUser, TestExportUserDataQuery>(
+        unitOfWork, sections, timeProvider, NullLogger.Instance)
+{
+    public object? LastSnapshot { get; private set; }
+
+    public UserDataExportDTO? CompletedExport { get; private set; }
+
+    protected override bool HasExportPrivilege(string? currentUserRole) =>
+        string.Equals(currentUserRole, "Organizer", StringComparison.OrdinalIgnoreCase);
+
+    protected override Task<object?> BuildSubjectSnapshotAsync(
+        TestIdentityUser user,
+        TestExportUserDataQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+
+        LastSnapshot = new { user.Id, user.PreferredCulture };
+        return Task.FromResult<object?>(LastSnapshot);
+    }
+
+    protected override Task OnExportCompletedAsync(
+        TestIdentityUser user,
+        TestExportUserDataQuery query,
+        UserDataExportDTO export,
+        CancellationToken cancellationToken)
+    {
+        CompletedExport = export;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>A section that records its calls and hands back a canned result.</summary>
+public sealed class RecordingSection(string sectionName, UserDataExportSectionResult? result = null)
+    : IUserDataExportSection
+{
+    public string SectionName { get; } = sectionName;
+
+    public int Invocations { get; private set; }
+
+    public UserIdentifierType LastUserId { get; private set; }
+
+    public Task<UserDataExportSectionResult> ExportAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default)
+    {
+        Invocations++;
+        LastUserId = userId;
+        return Task.FromResult(result ?? UserDataExportSectionResult.Complete(SectionName, data: null));
+    }
+}
+
+/// <summary>A section standing in for an unreachable peer.</summary>
+public sealed class ThrowingSection(string sectionName) : IUserDataExportSection
+{
+    public string SectionName { get; } = sectionName;
+
+    public Task<UserDataExportSectionResult> ExportAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default) =>
+        throw new InvalidOperationException("Engagement peer exploded");
+}
+
+/// <summary>A section standing in for a cancelled request.</summary>
+public sealed class CancellingSection(string sectionName) : IUserDataExportSection
+{
+    public string SectionName { get; } = sectionName;
+
+    public Task<UserDataExportSectionResult> ExportAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default) =>
+        throw new OperationCanceledException();
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Users/UserUseCaseTestDoubles.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Users/UserUseCaseTestDoubles.cs
@@ -118,3 +118,9 @@ public sealed record TestDeleteUserCommand(
     UserIdentifierType UserId,
     UserIdentifierType CurrentUserId,
     string? CurrentUserRole) : IUserOwnedRequest;
+
+/// <summary>App-side export-user-data query shape (target plus authenticated caller).</summary>
+public sealed record TestExportUserDataQuery(
+    UserIdentifierType UserId,
+    UserIdentifierType CurrentUserId,
+    string? CurrentUserRole) : IUserOwnedRequest;

--- a/Tests/Core/MMCA.Common.Application.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Application.Tests/packages.lock.json
@@ -20,6 +20,12 @@
         "resolved": "3.0.141",
         "contentHash": "p0mtUYG/36FEnU6P5GovB82mVH4DoWGdHYjePkLnIeTNI0LQfmvjGj2twQEBTosw6/YTTnk8Fknu2VvaFybECA=="
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "xXcxGfXSO/8o7IfYK36r3eZTl9RMKAl5K6x3x6o/QQBolI0t8vsLIGmhc3HJBTd11u1uPLHz61VnOTSTmY7ZVA=="
+      },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
         "requested": "[18.7.23, )",

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/HybridCacheServiceRedisTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/HybridCacheServiceRedisTests.cs
@@ -1,0 +1,265 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Infrastructure.Caching;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+
+namespace MMCA.Common.Infrastructure.Redis.Tests;
+
+/// <summary>
+/// Exercises the two-level cache against a REAL Redis, which is the only place the properties that
+/// matter here are observable.
+/// <para>
+/// The unit tier proves what this service ASKS for (key shape, entry options, flags) against a fake
+/// L2. What it structurally cannot prove is what a server ends up holding, and that is exactly the
+/// class of bug this design exists to prevent: <c>HybridCache</c> and <c>IDistributedCache</c> write
+/// different payload formats, so a shared key would answer a read with a value the reader cannot
+/// parse. Here the two formats genuinely coexist in one server and the assertion is that they never
+/// meet: an entry from the other format is a clean MISS, never an exception.
+/// </para>
+/// <para>
+/// It also covers prefix eviction end to end. <c>RemoveByPrefixAsync</c> runs a real SCAN over two
+/// patterns, and only a real server distinguishes "evicted both keyspaces" from "evicted the one the
+/// test happened to write".
+/// </para>
+/// <para>
+/// These tests need a Docker daemon, so this project is outside <c>MMCA.Common.slnx</c> and runs in
+/// its own CI job.
+/// </para>
+/// </summary>
+public sealed class HybridCacheServiceRedisTests : IAsyncLifetime
+{
+    private readonly RedisContainer _redis = new RedisBuilder().WithImage("redis:7-alpine").Build();
+    private readonly List<ServiceProvider> _providers = [];
+
+    private ConnectionMultiplexer _multiplexer = null!;
+    private IDistributedCache _distributedCache = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _redis.StartAsync();
+
+        var connectionString = _redis.GetConnectionString();
+        _multiplexer = await ConnectionMultiplexer.ConnectAsync(connectionString);
+
+        // The same concrete cache Aspire's AddRedisDistributedCache registers in the service hosts,
+        // and the L2 HybridCache is layered over.
+        _distributedCache = new RedisCache(Options.Create(new RedisCacheOptions
+        {
+            ConnectionMultiplexerFactory = () => Task.FromResult<IConnectionMultiplexer>(_multiplexer),
+        }));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var provider in _providers)
+        {
+            await provider.DisposeAsync();
+        }
+
+        if (_multiplexer is not null)
+            await _multiplexer.DisposeAsync();
+
+        await _redis.DisposeAsync();
+    }
+
+    // ── Round trip and raw key shape ──
+    [Fact]
+    public async Task SetGetRemove_RoundTripsThroughRealRedis()
+    {
+        var sut = CreateSut();
+        var key = $"smoke:{Guid.NewGuid():N}";
+
+        await sut.SetAsync(key, 42, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        (await sut.GetAsync<int?>(key, TestContext.Current.CancellationToken)).Should().Be(42);
+
+        await sut.RemoveAsync(key, TestContext.Current.CancellationToken);
+        (await sut.GetAsync<int?>(key, TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_LandsOnTheServerUnderTheHybridKeyspaceOnly()
+    {
+        var sut = CreateSut();
+        var key = $"catalog:{Guid.NewGuid():N}";
+        var db = _multiplexer.GetDatabase();
+
+        await sut.SetAsync(key, "value", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        (await db.KeyExistsAsync($"hc:{key}")).Should().BeTrue("the server must hold the entry under the segmented key");
+        (await db.KeyExistsAsync(key)).Should().BeFalse("nothing may be written under the legacy shape");
+    }
+
+    // ── The coexistence property the whole design rests on ──
+    [Fact]
+    public async Task AnEntryWrittenByTheOldCache_IsASoftMissHereNeverAFault()
+    {
+        var key = $"coexist:{Guid.NewGuid():N}";
+        var legacy = CreateLegacy();
+        var sut = CreateSut();
+
+        await legacy.SetAsync(key, "old-format", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        // This is the read that WOULD have thrown if both formats shared one key.
+        var read = await sut.GetAsync<string>(key, TestContext.Current.CancellationToken);
+
+        read.Should().BeNull("the old entry lives in a keyspace this service does not address");
+        (await legacy.GetAsync<string>(key, TestContext.Current.CancellationToken)).Should().Be(
+            "old-format",
+            "and the old cache keeps reading its own entry, which is what makes a rolling deploy safe");
+    }
+
+    [Fact]
+    public async Task AnEntryWrittenHere_IsASoftMissForTheOldCache()
+    {
+        var key = $"coexist:{Guid.NewGuid():N}";
+        var legacy = CreateLegacy();
+        var sut = CreateSut();
+
+        await sut.SetAsync(key, "new-format", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        (await legacy.GetAsync<string>(key, TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    // ── Dual-pattern prefix eviction ──
+    [Fact]
+    public async Task RemoveByPrefixAsync_EvictsBothKeyspacesAndLeavesEverythingElse()
+    {
+        var prefix = $"catalog:{Guid.NewGuid():N}:";
+        var sut = CreateSut();
+        var legacy = CreateLegacy();
+
+        await sut.SetAsync($"{prefix}a", "one", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        await sut.SetAsync($"{prefix}b", "two", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        // Written by the PREVIOUS implementation under the same logical prefix: a 24h idempotency
+        // record outlives the deploy that switched the host over, and must still be evictable.
+        await legacy.SetAsync($"{prefix}legacy", "old", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        var survivor = $"other:{Guid.NewGuid():N}";
+        await sut.SetAsync(survivor, "keep", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        await legacy.SetAsync(survivor, "keep-old", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        await sut.RemoveByPrefixAsync(prefix, TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync<string>($"{prefix}a", TestContext.Current.CancellationToken)).Should().BeNull();
+        (await sut.GetAsync<string>($"{prefix}b", TestContext.Current.CancellationToken)).Should().BeNull();
+        (await legacy.GetAsync<string>($"{prefix}legacy", TestContext.Current.CancellationToken)).Should().BeNull(
+            "the legacy pattern is the second half of the eviction, not an afterthought");
+
+        (await sut.GetAsync<string>(survivor, TestContext.Current.CancellationToken)).Should().Be("keep");
+        (await legacy.GetAsync<string>(survivor, TestContext.Current.CancellationToken)).Should().Be("keep-old");
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_AlsoDropsTheEvictingProcessLocalCopy()
+    {
+        var prefix = $"catalog:{Guid.NewGuid():N}:";
+        var sut = CreateSut();
+
+        await sut.SetAsync($"{prefix}a", "one", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        // Read it back first so the value is definitely resident in this instance's L1: a raw key
+        // delete would clear the server and leave this read serving the stale local copy.
+        (await sut.GetAsync<string>($"{prefix}a", TestContext.Current.CancellationToken)).Should().Be("one");
+
+        await sut.RemoveByPrefixAsync(prefix, TestContext.Current.CancellationToken);
+
+        (await sut.GetAsync<string>($"{prefix}a", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    // ── Counters across replicas ──
+    [Fact]
+    public async Task IncrementAsync_AcrossTwoInstancesSharingOneRedis_StaysMonotonic()
+    {
+        // Two services with independent in-process caches over one server: the shape of two replicas
+        // behind a load balancer. A counter served from either L1 would repeat a value here.
+        var replicaA = CreateSut();
+        var replicaB = CreateSut();
+        var key = $"login:attempts:{Guid.NewGuid():N}";
+        var ttl = TimeSpan.FromMinutes(5);
+
+        (await replicaA.IncrementAsync(key, ttl, TestContext.Current.CancellationToken)).Should().Be(1);
+        (await replicaB.IncrementAsync(key, ttl, TestContext.Current.CancellationToken)).Should().Be(2);
+        (await replicaA.IncrementAsync(key, ttl, TestContext.Current.CancellationToken)).Should().Be(3);
+        (await replicaB.IncrementAsync(key, ttl, TestContext.Current.CancellationToken)).Should().Be(4);
+    }
+
+    [Fact]
+    public async Task IncrementAsync_AppliesATtlSoCountersDoNotLeak()
+    {
+        var sut = CreateSut();
+        var key = $"login:attempts:{Guid.NewGuid():N}";
+
+        await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        var ttl = await _multiplexer.GetDatabase().KeyTimeToLiveAsync($"hc:{key}");
+        ttl.Should().NotBeNull("a rate-limit counter without a TTL never resets and locks the subject out forever");
+        ttl!.Value.Should().BeGreaterThan(TimeSpan.Zero).And.BeLessThanOrEqualTo(TimeSpan.FromMinutes(5));
+    }
+
+    // ── GetOrCreateAsync over a real server ──
+    [Fact]
+    public async Task GetOrCreateAsync_RunsTheFactoryOnceAndServesTheStoredValueAfterwards()
+    {
+        var sut = CreateSut();
+        var key = $"factory:{Guid.NewGuid():N}";
+        var calls = 0;
+
+        var first = await sut.GetOrCreateAsync(
+            key,
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult("built");
+            },
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+
+        var second = await sut.GetOrCreateAsync(
+            key,
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                return Task.FromResult("rebuilt");
+            },
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+
+        first.Should().Be("built");
+        second.Should().Be("built");
+        calls.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Builds the service exactly as <c>AddCommonHybridCache</c> does: its own two-level cache over
+    /// the shared Redis, with the multiplexer supplied so prefix eviction can SCAN. Each call gets an
+    /// independent L1, which is what makes the cross-replica assertions meaningful.
+    /// </summary>
+    /// <returns>A service under test.</returns>
+    private HybridCacheService CreateSut()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(_distributedCache);
+        services.AddHybridCache();
+
+        var provider = services.BuildServiceProvider();
+        _providers.Add(provider);
+
+        return new HybridCacheService(
+            provider.GetRequiredService<HybridCache>(),
+            NullLogger<HybridCacheService>.Instance,
+            _multiplexer);
+    }
+
+    /// <summary>The previous implementation, still writing its own format into the same server.</summary>
+    /// <returns>A cache in the legacy keyspace.</returns>
+    private DistributedCacheService CreateLegacy() =>
+        new(_distributedCache, NullLogger<DistributedCacheService>.Instance, _multiplexer);
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
@@ -875,6 +875,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -1037,6 +1038,18 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.10",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {

--- a/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Redis.Tests/packages.lock.json
@@ -865,6 +865,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -904,6 +905,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/AddCommonHybridCacheTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/AddCommonHybridCacheTests.cs
@@ -1,0 +1,147 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Caching;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Caching;
+
+/// <summary>
+/// Covers the opt-in <c>AddCommonHybridCache</c> registration. The load-bearing property is order
+/// independence: a host calls it wherever its composition root happens to put it, before or after
+/// <c>AddInfrastructure</c>, and the two-level cache has to win either way. It is also a negative
+/// contract: a host that does NOT call it must be left exactly as it is today.
+/// </summary>
+public sealed class AddCommonHybridCacheTests
+{
+    [Fact]
+    public void AddCommonHybridCache_CalledBeforeAddCaching_StillWins()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new Mock<IDistributedCache>().Object);
+
+        services.AddCommonHybridCache();
+        services.AddCaching();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<ICacheService>().Should().BeOfType<HybridCacheService>(
+            "AddCaching registers with TryAdd, so an existing registration must survive it");
+    }
+
+    [Fact]
+    public void AddCommonHybridCache_CalledAfterAddCaching_ReplacesTheRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new Mock<IDistributedCache>().Object);
+
+        services.AddCaching();
+        services.AddCommonHybridCache();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<ICacheService>().Should().BeOfType<HybridCacheService>();
+    }
+
+    [Fact]
+    public void AddCommonHybridCache_LeavesExactlyOneCacheServiceRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCaching();
+        services.AddCommonHybridCache();
+
+        services.Count(d => d.ServiceType == typeof(ICacheService)).Should().Be(1);
+    }
+
+    [Fact]
+    public void AddCommonHybridCache_ReplacesAHostsOwnCacheService()
+    {
+        // Documented behavior, not an accident: calling this is a statement that the two-level cache
+        // is the cache for this host.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new Mock<ICacheService>().Object);
+
+        services.AddCommonHybridCache();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<ICacheService>().Should().BeOfType<HybridCacheService>();
+    }
+
+    // ── The untouched default path ──
+    [Fact]
+    public void WithoutAddCommonHybridCache_ADistributedHostKeepsTheDistributedCacheService()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new Mock<IDistributedCache>().Object);
+        services.AddCaching();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<ICacheService>().Should().BeOfType<DistributedCacheService>();
+    }
+
+    [Fact]
+    public void WithoutAddCommonHybridCache_AMemoryOnlyHostKeepsTheMemoryCacheService()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<ICacheService>().Should().BeOfType<MemoryCacheService>();
+    }
+
+    // ── Options ──
+    [Fact]
+    public void AddCommonHybridCache_AppliesTheFrameworkEntryDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCommonHybridCache();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        HybridCacheOptions options = provider.GetRequiredService<IOptions<HybridCacheOptions>>().Value;
+
+        options.DefaultEntryOptions!.Expiration.Should().Be(CacheOptions.DefaultDuration);
+        options.DefaultEntryOptions.LocalCacheExpiration.Should().Be(HybridCacheService.LocalCacheDefault);
+    }
+
+    [Fact]
+    public void AddCommonHybridCache_LetsTheHostOverrideTheDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCommonHybridCache(options =>
+        {
+            options.MaximumPayloadBytes = 4096;
+            options.DefaultEntryOptions = new HybridCacheEntryOptions { Expiration = TimeSpan.FromMinutes(10) };
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        HybridCacheOptions options = provider.GetRequiredService<IOptions<HybridCacheOptions>>().Value;
+
+        options.MaximumPayloadBytes.Should().Be(4096);
+        options.DefaultEntryOptions!.Expiration.Should().Be(TimeSpan.FromMinutes(10),
+            "the host hook runs after the framework defaults, so it has the last word");
+    }
+
+    [Fact]
+    public void AddCommonHybridCache_RegistersTheHybridCacheItself()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCommonHybridCache();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetService<HybridCache>().Should().NotBeNull();
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/HybridCacheServiceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Caching/HybridCacheServiceTests.cs
@@ -1,0 +1,489 @@
+using System.Collections.Concurrent;
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Infrastructure.Caching;
+
+namespace MMCA.Common.Infrastructure.Tests.Caching;
+
+/// <summary>
+/// Exercises <see cref="HybridCacheService"/> over a REAL in-process <c>AddHybridCache</c> with a
+/// recording <see cref="IDistributedCache"/> standing in for the L2, plus two hand-written
+/// <see cref="HybridCache"/> stubs where the assertion is about what this service asks the platform
+/// to do (entry options, flags) or about how it behaves when the platform faults.
+/// <para>
+/// The key shape assertions matter more than they look: the whole design rests on this service
+/// writing under a keyspace no other cache implementation can address, so a silent change to the
+/// key would reintroduce the mixed-format failure the <c>hc:</c> segment exists to prevent.
+/// </para>
+/// </summary>
+public sealed class HybridCacheServiceTests
+{
+    private const string Prefix = "svc:";
+
+    // ── Key shape ──
+    [Fact]
+    public async Task SetAsync_WritesTheL2EntryUnderTheDisjointHybridKeyspace()
+    {
+        var (sut, l2, _) = CreateSut();
+
+        await sut.SetAsync("catalog:1", "value", cancellationToken: TestContext.Current.CancellationToken);
+
+        l2.Keys.Should().ContainSingle()
+            .Which.Should().Be($"{Prefix}hc:catalog:1", "the hc: segment is what keeps the two formats apart");
+    }
+
+    [Fact]
+    public async Task SetAsync_WithoutAKeyNamespace_StillSegmentsTheKeyspace()
+    {
+        var l2 = new RecordingDistributedCache();
+        var sut = new HybridCacheService(BuildHybridCache(l2), NullLogger<HybridCacheService>.Instance);
+
+        await sut.SetAsync("catalog:1", "value", cancellationToken: TestContext.Current.CancellationToken);
+
+        l2.Keys.Should().ContainSingle().Which.Should().Be("hc:catalog:1");
+    }
+
+    // ── Round trip ──
+    [Fact]
+    public async Task SetGetRemove_RoundTripsThroughBothLevels()
+    {
+        var (sut, _, _) = CreateSut();
+
+        await sut.SetAsync("k", 42, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+        (await sut.GetAsync<int?>("k", TestContext.Current.CancellationToken)).Should().Be(42);
+
+        await sut.RemoveAsync("k", TestContext.Current.CancellationToken);
+        (await sut.GetAsync<int?>("k", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_OnAMiss_ReturnsDefaultAndWritesNothing()
+    {
+        var (sut, l2, _) = CreateSut();
+
+        (await sut.GetAsync<string>("absent", TestContext.Current.CancellationToken)).Should().BeNull();
+
+        l2.Keys.Should().BeEmpty("a read must never populate the cache: DisableUnderlyingData means no factory and no write");
+        l2.Writes.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReadsAnEntryWrittenBeforeThisProcessCached_ItLocally()
+    {
+        var l2 = new RecordingDistributedCache();
+        var writer = new HybridCacheService(BuildHybridCache(l2), NullLogger<HybridCacheService>.Instance, keyNamespace: new CacheKeyNamespace(Prefix));
+        await writer.SetAsync("shared", "written-elsewhere", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        // A second process over the same L2: nothing is in its L1, so the value can only come from L2.
+        var reader = new HybridCacheService(BuildHybridCache(l2), NullLogger<HybridCacheService>.Instance, keyNamespace: new CacheKeyNamespace(Prefix));
+
+        (await reader.GetAsync<string>("shared", TestContext.Current.CancellationToken)).Should().Be("written-elsewhere");
+    }
+
+    // ── Coexistence with the legacy keyspace ──
+    [Fact]
+    public async Task GetAsync_WithALegacyEntryAtTheSameLogicalKey_IsACleanMiss()
+    {
+        var l2 = new RecordingDistributedCache();
+        var legacy = new DistributedCacheService(l2, NullLogger<DistributedCacheService>.Instance, keyNamespace: new CacheKeyNamespace(Prefix));
+        await legacy.SetAsync("shared", "old-format", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        var sut = new HybridCacheService(BuildHybridCache(l2), NullLogger<HybridCacheService>.Instance, keyNamespace: new CacheKeyNamespace(Prefix));
+
+        (await sut.GetAsync<string>("shared", TestContext.Current.CancellationToken)).Should().BeNull(
+            "the two keyspaces are disjoint, so the old entry is invisible rather than unreadable");
+        l2.Keys.Should().ContainSingle().Which.Should().Be($"{Prefix}shared");
+    }
+
+    // ── Fail-soft ──
+    [Fact]
+    public async Task GetAsync_WhenTheCacheFaults_ReturnsDefaultAndDropsTheEntry()
+    {
+        var faulting = new FaultingHybridCache();
+        var sut = new HybridCacheService(faulting, NullLogger<HybridCacheService>.Instance, keyNamespace: new CacheKeyNamespace(Prefix));
+
+        (await sut.GetAsync<string>("poison", TestContext.Current.CancellationToken)).Should().BeNull();
+
+        faulting.Removed.Should().ContainSingle()
+            .Which.Should().Be($"{Prefix}hc:poison", "the unreadable entry is dropped so the next write repopulates it");
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenCancelled_DoesNotSwallowTheCancellation()
+    {
+        var faulting = new FaultingHybridCache { Fault = new OperationCanceledException() };
+        var sut = new HybridCacheService(faulting, NullLogger<HybridCacheService>.Instance);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sut.GetAsync<string>("k", TestContext.Current.CancellationToken));
+
+        faulting.Removed.Should().BeEmpty("a cancelled read is not a corrupt entry");
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenTheSelfHealDeleteAlsoFaults_StillAnswersAMiss()
+    {
+        var faulting = new FaultingHybridCache { FaultTheRemove = true };
+        var sut = new HybridCacheService(faulting, NullLogger<HybridCacheService>.Instance);
+
+        (await sut.GetAsync<string>("poison", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    // ── Entry options ──
+    [Fact]
+    public async Task SetAsync_WithNoExpiration_AppliesTheFrameworkDefaultToBothLevels()
+    {
+        var recording = new RecordingHybridCache();
+        var sut = new HybridCacheService(recording, NullLogger<HybridCacheService>.Instance);
+
+        await sut.SetAsync("k", "v", cancellationToken: TestContext.Current.CancellationToken);
+
+        recording.LastSetOptions!.Expiration.Should().Be(CacheOptions.DefaultDuration);
+        recording.LastSetOptions.LocalCacheExpiration.Should().Be(HybridCacheService.LocalCacheDefault);
+    }
+
+    [Fact]
+    public async Task SetAsync_WithALongExpiration_ClampsTheLocalCopyToTheLocalDefault()
+    {
+        var recording = new RecordingHybridCache();
+        var sut = new HybridCacheService(recording, NullLogger<HybridCacheService>.Instance);
+
+        await sut.SetAsync("k", "v", TimeSpan.FromHours(24), TestContext.Current.CancellationToken);
+
+        recording.LastSetOptions!.Expiration.Should().Be(TimeSpan.FromHours(24));
+        recording.LastSetOptions.LocalCacheExpiration.Should().Be(
+            HybridCacheService.LocalCacheDefault,
+            "a 24h entry must not sit in another replica's memory for 24h after an invalidation it cannot see");
+    }
+
+    [Fact]
+    public async Task SetAsync_WithAShortExpiration_KeepsTheLocalCopyNoLongerThanTheEntry()
+    {
+        var recording = new RecordingHybridCache();
+        var sut = new HybridCacheService(recording, NullLogger<HybridCacheService>.Instance);
+
+        await sut.SetAsync("k", "v", TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        recording.LastSetOptions!.Expiration.Should().Be(TimeSpan.FromSeconds(5));
+        recording.LastSetOptions.LocalCacheExpiration.Should().Be(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task GetAsync_ReadsWithTheUnderlyingDataDisabled()
+    {
+        var recording = new RecordingHybridCache();
+        var sut = new HybridCacheService(recording, NullLogger<HybridCacheService>.Instance);
+
+        await sut.GetAsync<string>("k", TestContext.Current.CancellationToken);
+
+        recording.LastGetOptions!.Flags.Should().Be(HybridCacheEntryFlags.DisableUnderlyingData);
+        recording.FactoryInvocations.Should().Be(0, "a read must never run a factory");
+    }
+
+    // ── IncrementAsync: L2-only counter semantics ──
+    [Fact]
+    public async Task IncrementAsync_BypassesTheLocalCacheOnBothLegs()
+    {
+        var recording = new RecordingHybridCache();
+        var sut = new HybridCacheService(recording, NullLogger<HybridCacheService>.Instance);
+
+        await sut.IncrementAsync("login:attempts", TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        const HybridCacheEntryFlags noLocalCache =
+            HybridCacheEntryFlags.DisableLocalCacheRead | HybridCacheEntryFlags.DisableLocalCacheWrite;
+
+        recording.LastGetOptions!.Flags.Should().Be(HybridCacheEntryFlags.DisableUnderlyingData | noLocalCache);
+        recording.LastSetOptions!.Flags.Should().Be(noLocalCache);
+    }
+
+    [Fact]
+    public async Task IncrementAsync_ReadsTheDistributedCopyOnEveryCall()
+    {
+        var (sut, l2, _) = CreateSut();
+        var key = "login:attempts";
+
+        (await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken)).Should().Be(1);
+        (await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken)).Should().Be(2);
+        (await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken)).Should().Be(3);
+
+        l2.ReadCount($"{Prefix}hc:{key}").Should().Be(3, "a counter served from L1 would be stale and would undercount silently");
+    }
+
+    [Fact]
+    public async Task IncrementAsync_LeavesNothingInTheLocalCache()
+    {
+        var (sut, l2, _) = CreateSut();
+        var key = "login:attempts";
+
+        await sut.IncrementAsync(key, TimeSpan.FromMinutes(5), TestContext.Current.CancellationToken);
+
+        // Drop the distributed copy: anything still answering now could only come from L1.
+        l2.Clear();
+
+        (await sut.GetAsync<long?>(key, TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    // ── GetOrCreateAsync override ──
+    [Fact]
+    public async Task GetOrCreateAsync_OnAMiss_RunsTheFactoryAndCachesIt()
+    {
+        var (sut, _, _) = CreateSut();
+        var factoryCalls = 0;
+
+        var first = await sut.GetOrCreateAsync(
+            "k",
+            _ =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                return Task.FromResult("fresh");
+            },
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+
+        var second = await sut.GetOrCreateAsync(
+            "k",
+            _ =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                return Task.FromResult("other");
+            },
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+
+        first.Should().Be("fresh");
+        second.Should().Be("fresh");
+        factoryCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_WritesUnderTheHybridKeyspace()
+    {
+        var (sut, l2, _) = CreateSut();
+
+        await sut.GetOrCreateAsync(
+            "catalog:list",
+            _ => Task.FromResult("value"),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // HybridCache returns the factory result to the caller and backfills L2 in the background,
+        // so the write is observed rather than assumed to have happened by the time the call returns.
+        await WaitForKeyAsync(l2, $"{Prefix}hc:catalog:list", TestContext.Current.CancellationToken);
+
+        l2.Keys.Should().ContainSingle().Which.Should().Be($"{Prefix}hc:catalog:list");
+    }
+
+    /// <summary>Waits for a key to appear in the L2, failing the test rather than hanging it.</summary>
+    /// <param name="l2">The recording distributed cache.</param>
+    /// <param name="key">The raw key expected to appear.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    private static async Task WaitForKeyAsync(RecordingDistributedCache l2, string key, CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt < 100 && !l2.Keys.Contains(key); attempt++)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_WithoutAFactory_Throws()
+    {
+        var (sut, _, _) = CreateSut();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sut.GetOrCreateAsync<string>("k", factory: null!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    // ── Prefix eviction without a multiplexer ──
+    [Fact]
+    public async Task RemoveByPrefixAsync_WithoutAMultiplexer_IsANoOpRatherThanAFailure()
+    {
+        var (sut, l2, _) = CreateSut();
+        await sut.SetAsync("catalog:1", "value", cancellationToken: TestContext.Current.CancellationToken);
+
+        await sut.RemoveByPrefixAsync("catalog:", TestContext.Current.CancellationToken);
+
+        l2.Keys.Should().ContainSingle("prefix eviction needs SCAN; without a multiplexer the entry is bounded by its TTL");
+    }
+
+    /// <summary>Builds the service over a real HybridCache with the recording L2 behind it.</summary>
+    /// <returns>The service under test, its L2, and the provider keeping the cache alive.</returns>
+    private static (HybridCacheService Sut, RecordingDistributedCache L2, ServiceProvider Provider) CreateSut()
+    {
+        var l2 = new RecordingDistributedCache();
+        var provider = BuildProvider(l2);
+
+        var sut = new HybridCacheService(
+            provider.GetRequiredService<HybridCache>(),
+            NullLogger<HybridCacheService>.Instance,
+            connectionMultiplexer: null,
+            keyNamespace: new CacheKeyNamespace(Prefix));
+
+        return (sut, l2, provider);
+    }
+
+    private static HybridCache BuildHybridCache(IDistributedCache l2) =>
+        BuildProvider(l2).GetRequiredService<HybridCache>();
+
+    private static ServiceProvider BuildProvider(IDistributedCache l2)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(l2);
+        services.AddHybridCache();
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IDistributedCache"/> that records the raw keys, the read count per key
+    /// and the number of writes: everything needed to assert the key shape and to prove that a leg
+    /// which must bypass L1 really did reach the distributed level.
+    /// </summary>
+    private sealed class RecordingDistributedCache : IDistributedCache
+    {
+        private readonly ConcurrentDictionary<string, byte[]> _store = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, int> _reads = new(StringComparer.Ordinal);
+        private int _writes;
+
+        public IReadOnlyCollection<string> Keys => [.. _store.Keys];
+
+        public int Writes => Volatile.Read(ref _writes);
+
+        public int ReadCount(string key) => _reads.TryGetValue(key, out var count) ? count : 0;
+
+        public void Clear() => _store.Clear();
+
+        public byte[]? Get(string key)
+        {
+            _reads.AddOrUpdate(key, 1, (_, current) => current + 1);
+            return _store.TryGetValue(key, out var bytes) ? bytes : null;
+        }
+
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default) =>
+            Task.FromResult(Get(key));
+
+        public void Refresh(string key)
+        {
+        }
+
+        public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+
+        public void Remove(string key) => _store.TryRemove(key, out _);
+
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            _store[key] = value;
+            Interlocked.Increment(ref _writes);
+        }
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            Set(key, value, options);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// <see cref="HybridCache"/> stub that records the entry options each call carries. Used where
+    /// the assertion is about the request this service makes (expirations, flags) rather than about
+    /// the value that comes back.
+    /// </summary>
+    private sealed class RecordingHybridCache : HybridCache
+    {
+        private int _factoryInvocations;
+
+        public HybridCacheEntryOptions? LastGetOptions { get; private set; }
+
+        public HybridCacheEntryOptions? LastSetOptions { get; private set; }
+
+        public int FactoryInvocations => Volatile.Read(ref _factoryInvocations);
+
+        public override ValueTask<T> GetOrCreateAsync<TState, T>(
+            string key,
+            TState state,
+            Func<TState, CancellationToken, ValueTask<T>> factory,
+            HybridCacheEntryOptions? options = null,
+            IEnumerable<string>? tags = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastGetOptions = options;
+
+            if (options?.Flags?.HasFlag(HybridCacheEntryFlags.DisableUnderlyingData) == true)
+                return ValueTask.FromResult<T>(default!);
+
+            Interlocked.Increment(ref _factoryInvocations);
+            return factory(state, cancellationToken);
+        }
+
+        public override ValueTask SetAsync<T>(
+            string key,
+            T value,
+            HybridCacheEntryOptions? options = null,
+            IEnumerable<string>? tags = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastSetOptions = options;
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+
+        public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// <see cref="HybridCache"/> stub whose read always faults, so the fail-soft path in
+    /// <see cref="HybridCacheService.GetAsync{T}"/> is exercised against a fault this service can
+    /// actually see (the platform's own L2 error handling is not what is under test here).
+    /// </summary>
+    private sealed class FaultingHybridCache : HybridCache
+    {
+        private readonly ConcurrentQueue<string> _removed = new();
+
+        public Exception Fault { get; init; } = new InvalidOperationException("cache exploded");
+
+        public bool FaultTheRemove { get; init; }
+
+        public IReadOnlyCollection<string> Removed => [.. _removed];
+
+        public override ValueTask<T> GetOrCreateAsync<TState, T>(
+            string key,
+            TState state,
+            Func<TState, CancellationToken, ValueTask<T>> factory,
+            HybridCacheEntryOptions? options = null,
+            IEnumerable<string>? tags = null,
+            CancellationToken cancellationToken = default) =>
+            throw Fault;
+
+        public override ValueTask SetAsync<T>(
+            string key,
+            T value,
+            HybridCacheEntryOptions? options = null,
+            IEnumerable<string>? tags = null,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+
+        public override ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            if (FaultTheRemove)
+                throw new InvalidOperationException("delete failed too");
+
+            _removed.Enqueue(key);
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AddAuditTrailTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AddAuditTrailTests.cs
@@ -1,0 +1,96 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.AuditTrail;
+
+/// <summary>
+/// Coverage for the audit trail's DI surface: what <c>AddAuditTrail</c> registers, that calling it
+/// twice is harmless, and that retention rides on the existing scheduler rather than a second loop.
+/// </summary>
+public sealed class AddAuditTrailTests
+{
+    [Fact]
+    public void AddAuditTrail_BindsTheAuditTrailSection()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["AuditTrail:Enabled"] = "true",
+                ["AuditTrail:RetentionDays"] = "365",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddAuditTrail(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<IOptions<AuditTrailSettings>>().Value;
+
+        settings.Enabled.Should().BeTrue();
+        settings.RetentionDays.Should().Be(365);
+    }
+
+    [Fact]
+    public void AuditTrailSettings_Defaults_AreOffWithNinetyDayRetention()
+    {
+        var settings = new AuditTrailSettings();
+
+        settings.Enabled.Should().BeFalse("adopting the framework must never add a table or a write unasked");
+        settings.RetentionDays.Should().Be(90);
+    }
+
+    [Fact]
+    public void AddAuditTrail_RegistersTheInterceptorAsASingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddAuditTrail(EmptyConfiguration());
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(AuditTrailSaveChangesInterceptor));
+
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton,
+            "per-save state lives in a ConditionalWeakTable keyed by context, so the interceptor is stateless");
+    }
+
+    [Fact]
+    public void AddAuditTrail_RegistersTheReadSurfaceAsScoped()
+    {
+        var services = new ServiceCollection();
+        services.AddAuditTrail(EmptyConfiguration());
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IAuditTrailReader));
+
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        descriptor.ImplementationType.Should().Be<AuditTrailReader>();
+    }
+
+    [Fact]
+    public void AddAuditTrail_RegistersTheRetentionJobWithTheScheduler()
+    {
+        var services = new ServiceCollection();
+        services.AddAuditTrail(EmptyConfiguration());
+
+        services.Count(d => d.ServiceType == typeof(IScheduledJob)
+                && d.ImplementationType == typeof(AuditTrailCleanupJob))
+            .Should().Be(1, "retention rides on the existing scheduler rather than a second background loop");
+    }
+
+    [Fact]
+    public void AddAuditTrail_CalledTwice_RegistersEverythingOnce()
+    {
+        var services = new ServiceCollection();
+        services.AddAuditTrail(EmptyConfiguration());
+        services.AddAuditTrail(EmptyConfiguration());
+
+        services.Count(d => d.ServiceType == typeof(AuditTrailSaveChangesInterceptor)).Should().Be(1);
+        services.Count(d => d.ServiceType == typeof(IAuditTrailReader)).Should().Be(1);
+        services.Count(d => d.ServiceType == typeof(IScheduledJob)
+            && d.ImplementationType == typeof(AuditTrailCleanupJob)).Should().Be(1);
+    }
+
+    private static IConfiguration EmptyConfiguration() => new ConfigurationBuilder().Build();
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailCleanupJobTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailCleanupJobTests.cs
@@ -1,0 +1,147 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.Scheduling;
+using Moq;
+using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.AuditTrail;
+
+/// <summary>
+/// Coverage for <see cref="AuditTrailCleanupJob"/>: the retention window it honors, the sources it
+/// sweeps, and the two ways it does nothing (the trail is off, or the source has no trail table).
+/// </summary>
+public sealed class AuditTrailCleanupJobTests : IDisposable
+{
+    private readonly FakeTimeProvider _timeProvider = AuditTrailTestHarness.CreateTimeProvider();
+    private readonly AuditTrailTestContext _context;
+
+    public AuditTrailCleanupJobTests()
+    {
+        _context = AuditTrailTestContext.Create(_timeProvider);
+
+        // The sweep runs "now minus RetentionDays", so put the clock well past the seeded rows.
+        _timeProvider.SetUtcNow(AuditTrailTestHarness.Epoch.AddDays(200));
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public void Job_Identity_IsStableAndRunsNightly()
+    {
+        var job = CreateJob(new AuditTrailSettings { Enabled = true });
+
+        job.Name.Should().Be("audit-trail-cleanup");
+        job.CronExpression.Should().Be("0 3 * * *");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeletesOnlyRowsOlderThanRetention()
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        await SeedRowsAsync(
+            ("expired-a", now.AddDays(-120)),
+            ("expired-b", now.AddDays(-91)),
+            ("kept-boundary", now.AddDays(-89)),
+            ("kept-recent", now.AddDays(-1)));
+
+        var job = CreateJob(new AuditTrailSettings { Enabled = true, RetentionDays = 90, DataSource = DataSource.Sqlite });
+        await job.ExecuteAsync(CancellationToken.None);
+
+        var remaining = await _context.TrailRows.AsNoTracking().Select(r => r.EntityKey).ToListAsync();
+        remaining.Should().HaveCount(2);
+        remaining.Should().Contain("kept-boundary");
+        remaining.Should().Contain("kept-recent");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TrailDisabled_DeletesNothing()
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        await SeedRowsAsync(("ancient", now.AddDays(-3000)));
+
+        var job = CreateJob(new AuditTrailSettings { Enabled = false, RetentionDays = 1 });
+        await job.ExecuteAsync(CancellationToken.None);
+
+        (await _context.TrailRows.AsNoTracking().ToListAsync()).Should().ContainSingle(
+            "a host that switched the trail off is not asking for its history to be erased");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SourceWithoutTheTrailTable_IsSkippedWithoutThrowing()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        await using var trailless = SchedulerTestHarness.SchedulerTestContext.Create(connection);
+
+        var job = CreateJob(new AuditTrailSettings { Enabled = true, RetentionDays = 1 }, trailless);
+
+        var act = async () => await job.ExecuteAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync("the model is the authority on whether a source has the table");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CosmosSources_AreNeverSwept()
+    {
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse())
+            .Returns([DataSourceKey.Default(DataSource.CosmosDB)]);
+
+        var dbContextFactory = new Mock<IDbContextFactory>();
+        var job = new AuditTrailCleanupJob(
+            dbContextFactory.Object,
+            registry.Object,
+            NullLogger<AuditTrailCleanupJob>.Instance,
+            Options.Create(new AuditTrailSettings { Enabled = true }),
+            _timeProvider);
+
+        await job.ExecuteAsync(CancellationToken.None);
+
+        dbContextFactory.Verify(f => f.GetDbContext(It.IsAny<DataSourceKey>()), Times.Never,
+            "Cosmos has no relational trail table to sweep");
+    }
+
+    private AuditTrailCleanupJob CreateJob(AuditTrailSettings settings, ApplicationDbContext? context = null)
+    {
+        var dbContextFactory = new Mock<IDbContextFactory>();
+        dbContextFactory
+            .Setup(f => f.GetDbContext(It.IsAny<DataSourceKey>()))
+            .Returns(context ?? _context);
+
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse())
+            .Returns([DataSourceKey.Default(DataSource.Sqlite)]);
+
+        return new AuditTrailCleanupJob(
+            dbContextFactory.Object,
+            registry.Object,
+            NullLogger<AuditTrailCleanupJob>.Instance,
+            Options.Create(settings),
+            _timeProvider);
+    }
+
+    private async Task SeedRowsAsync(params (string Key, DateTime ChangedOn)[] rows)
+    {
+        foreach ((var key, var changedOn) in rows)
+        {
+            _context.TrailRows.Add(new AuditTrailEntry
+            {
+                EntityType = typeof(AuditedThing).FullName!,
+                EntityKey = key,
+                Operation = "Modified",
+                ChangedOn = changedOn,
+            });
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailModelGateTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailModelGateTests.cs
@@ -1,0 +1,126 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.AuditTrail;
+
+/// <summary>
+/// The <c>AuditTrailEntries</c> table is settings-gated: a host that never opted in must get exactly
+/// the model it had before the trail shipped, so its migrations never see the table. Unlike the
+/// host-scoped job table it belongs in EVERY relational source, because a trail row commits in the
+/// same transaction as the change it describes. These tests build the real
+/// <see cref="ApplicationDbContext"/> model under each combination.
+/// </summary>
+public sealed class AuditTrailModelGateTests
+{
+    [Fact]
+    public void Model_AuditTrailDisabled_DoesNotContainTheTrailTable()
+    {
+        using var context = GateTestContext.Create(auditTrailEnabled: false, sourceName: DataSourceKey.DefaultName);
+
+        context.Model.FindEntityType(typeof(AuditTrailEntry)).Should().BeNull(
+            "a host that never called AddAuditTrail must not gain a table in its next migration");
+    }
+
+    [Fact]
+    public void Model_NoAuditTrailSettingsRegisteredAtAll_DoesNotContainTheTrailTable()
+    {
+        using var context = GateTestContext.Create(
+            auditTrailEnabled: false, sourceName: DataSourceKey.DefaultName, registerSettings: false);
+
+        context.Model.FindEntityType(typeof(AuditTrailEntry)).Should().BeNull(
+            "the absence of the settings must read as disabled, not fail context construction");
+    }
+
+    [Fact]
+    public void Model_AuditTrailEnabled_ContainsTheTrailTableWithItsReadIndex()
+    {
+        using var context = GateTestContext.Create(auditTrailEnabled: true, sourceName: DataSourceKey.DefaultName);
+
+        var entityType = context.Model.FindEntityType(typeof(AuditTrailEntry));
+        entityType.Should().NotBeNull();
+        entityType!.GetTableName().Should().Be("AuditTrailEntries");
+        entityType.FindPrimaryKey()!.Properties.Select(p => p.Name).Should().Equal(nameof(AuditTrailEntry.Id));
+        entityType.GetIndexes()
+            .Select(index => string.Join(",", index.Properties.Select(p => p.Name)))
+            .Should().Contain("EntityType,EntityKey,ChangedOn");
+    }
+
+    [Fact]
+    public void Model_AuditTrailEnabledOnANonDefaultSource_StillContainsTheTrailTable()
+    {
+        using var context = GateTestContext.Create(auditTrailEnabled: true, sourceName: "Conference");
+
+        context.Model.FindEntityType(typeof(AuditTrailEntry)).Should().NotBeNull(
+            "a trail row must land in the same database as the change it describes, so every "
+            + "relational source needs the table");
+    }
+
+    /// <summary>
+    /// A context that runs the real <see cref="ApplicationDbContext.OnModelCreating"/> (and therefore
+    /// the real gate) with a configurable data source and audit-trail setting.
+    /// </summary>
+    private sealed class GateTestContext : ApplicationDbContext
+    {
+        private GateTestContext(
+            DbContextOptions<GateTestContext> options,
+            IServiceProvider serviceProvider,
+            PhysicalDataSource physicalDataSource)
+            : base(options, serviceProvider, new NullAssemblyProvider(), physicalDataSource)
+        {
+        }
+
+        public static GateTestContext Create(bool auditTrailEnabled, string sourceName, bool registerSettings = true)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(_ =>
+            {
+                var dispatcher = new Mock<IDomainEventDispatcher>();
+                var logger = new Mock<ILogger<DomainEventSaveChangesInterceptor>>();
+                var outboxSignal = new Mock<IOutboxSignal>();
+                return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
+            });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+
+            if (registerSettings)
+            {
+                services.AddSingleton<IOptions<AuditTrailSettings>>(
+                    Options.Create(new AuditTrailSettings { Enabled = auditTrailEnabled }));
+            }
+
+            // EF caches its internal service provider (and with it the built model) per distinct set
+            // of options, and DataSourceModelCacheKeyFactory keys that model by (context type,
+            // source name) only. These tests build the SAME context type against the SAME source
+            // name under different settings, which in production never happens (the flag is fixed
+            // for the life of a host), so caching must be off here.
+            var options = new DbContextOptionsBuilder<GateTestContext>()
+                .UseSqlite("DataSource=:memory:")
+                .EnableServiceProviderCaching(false)
+                .Options;
+
+            var physical = new PhysicalDataSource(
+                new DataSourceKey(DataSource.Sqlite, sourceName), "DataSource=:memory:", null, "Test");
+
+            return new GateTestContext(options, services.BuildServiceProvider(), physical);
+        }
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailReaderTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailReaderTests.cs
@@ -1,0 +1,146 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.Scheduling;
+using Moq;
+using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.AuditTrail;
+
+/// <summary>
+/// Coverage for <see cref="AuditTrailReader"/>: the entity filter, the newest-first order, paging,
+/// and the empty results a host gets before it enables the trail.
+/// </summary>
+public sealed class AuditTrailReaderTests : IDisposable
+{
+    private const string EntityType = "MMCA.Tests.Order";
+
+    private readonly FakeTimeProvider _timeProvider = AuditTrailTestHarness.CreateTimeProvider();
+    private readonly AuditTrailTestContext _context;
+
+    public AuditTrailReaderTests() => _context = AuditTrailTestContext.Create(_timeProvider);
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task GetForEntityAsync_ReturnsOnlyThatEntitysHistoryNewestFirst()
+    {
+        await SeedAsync(
+            (EntityType, "1", "Name", 1),
+            (EntityType, "1", "Quantity", 3),
+            (EntityType, "2", "Name", 2),
+            ("MMCA.Tests.Other", "1", "Name", 4));
+
+        var rows = await CreateReader().GetForEntityAsync(EntityType, "1");
+
+        rows.Select(r => r.PropertyName).Should().Equal("Quantity", "Name");
+        rows.Should().OnlyContain(r => r.EntityType == EntityType && r.EntityKey == "1");
+    }
+
+    [Fact]
+    public async Task GetForEntityAsync_PagesThroughTheHistory()
+    {
+        await SeedAsync(
+            (EntityType, "1", "First", 1),
+            (EntityType, "1", "Second", 2),
+            (EntityType, "1", "Third", 3));
+
+        var reader = CreateReader();
+
+        (await reader.GetForEntityAsync(EntityType, "1", page: 1, pageSize: 2))
+            .Select(r => r.PropertyName).Should().Equal("Third", "Second");
+        (await reader.GetForEntityAsync(EntityType, "1", page: 2, pageSize: 2))
+            .Select(r => r.PropertyName).Should().Equal("First");
+        (await reader.GetForEntityAsync(EntityType, "1", page: 3, pageSize: 2))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetForEntityAsync_NonPositivePagingArguments_AreClampedRatherThanThrowing()
+    {
+        await SeedAsync((EntityType, "1", "First", 1), (EntityType, "1", "Second", 2));
+
+        var rows = await CreateReader().GetForEntityAsync(EntityType, "1", page: 0, pageSize: 0);
+
+        rows.Should().ContainSingle().Which.PropertyName.Should().Be("Second");
+    }
+
+    [Fact]
+    public async Task GetForEntityAsync_ProjectsEveryRecordedField()
+    {
+        await SeedAsync((EntityType, "1", "Name", 1));
+
+        var row = (await CreateReader().GetForEntityAsync(EntityType, "1")).Single();
+
+        row.Operation.Should().Be("Modified");
+        row.OldValue.Should().Be("old-Name");
+        row.NewValue.Should().Be("new-Name");
+        row.ChangedBy.Should().Be(9);
+        row.CorrelationId.Should().Be("trace-Name");
+    }
+
+    [Fact]
+    public async Task GetForEntityAsync_EntityWithNoHistory_ReturnsEmpty()
+    {
+        await SeedAsync((EntityType, "1", "Name", 1));
+
+        (await CreateReader().GetForEntityAsync(EntityType, "does-not-exist")).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetForEntityAsync_WhenTheSourceHasNoTrailTable_ReturnsEmpty()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        await using var trailless = SchedulerTestHarness.SchedulerTestContext.Create(connection);
+
+        var rows = await CreateReader(trailless).GetForEntityAsync(EntityType, "1");
+
+        rows.Should().BeEmpty("the read surface is registered before the trail is switched on");
+    }
+
+    private AuditTrailReader CreateReader(ApplicationDbContext? context = null)
+    {
+        var dbContextFactory = new Mock<IDbContextFactory>();
+        dbContextFactory
+            .Setup(f => f.GetDbContext(It.IsAny<DataSourceKey>()))
+            .Returns(context ?? _context);
+
+        var resolver = new Mock<IDataSourceResolver>();
+        resolver
+            .Setup(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
+            .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
+
+        return new AuditTrailReader(
+            dbContextFactory.Object,
+            resolver.Object,
+            Options.Create(new AuditTrailSettings { Enabled = true, DataSource = DataSource.Sqlite }));
+    }
+
+    private async Task SeedAsync(params (string EntityType, string EntityKey, string PropertyName, int MinutesOffset)[] rows)
+    {
+        foreach (var row in rows)
+        {
+            _context.TrailRows.Add(new AuditTrailEntry
+            {
+                EntityType = row.EntityType,
+                EntityKey = row.EntityKey,
+                PropertyName = row.PropertyName,
+                OldValue = "old-" + row.PropertyName,
+                NewValue = "new-" + row.PropertyName,
+                Operation = "Modified",
+                ChangedBy = 9,
+                ChangedOn = AuditTrailTestHarness.EpochUtc.AddMinutes(row.MinutesOffset),
+                CorrelationId = "trace-" + row.PropertyName,
+            });
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailSaveChangesInterceptorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailSaveChangesInterceptorTests.cs
@@ -1,0 +1,267 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Domain.Privacy;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Persistence.Inbox;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Scheduling;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.AuditTrail;
+
+/// <summary>
+/// Coverage for <see cref="AuditTrailSaveChangesInterceptor"/>: which rows a save produces, how
+/// personal data is masked, where the changing user comes from, and the two mechanical requirements
+/// copied from the domain-event interceptor (retry-discard, and mutation through <c>Add</c> only).
+/// Every assertion runs against a real SQLite round-trip, so what is asserted is what commits.
+/// </summary>
+public sealed class AuditTrailSaveChangesInterceptorTests : IDisposable
+{
+    private readonly FakeTimeProvider _timeProvider = AuditTrailTestHarness.CreateTimeProvider();
+    private readonly AuditTrailTestContext _context;
+
+    public AuditTrailSaveChangesInterceptorTests() =>
+        _context = AuditTrailTestContext.Create(_timeProvider);
+
+    public void Dispose() => _context.Dispose();
+
+    // ── Added: one summary row, carrying the key the insert actually assigned ──
+    [Fact]
+    public async Task SaveChanges_AddedEntity_WritesOneSummaryRowWithTheGeneratedKey()
+    {
+        var thing = new AuditedThing { Name = "First", Email = "someone@example.com", Quantity = 3 };
+        _context.AuditedThings.Add(thing);
+
+        await _context.SaveChangesAsync(userId: 42);
+
+        var row = await SingleRowAsync();
+        row.Operation.Should().Be("Added");
+        row.PropertyName.Should().BeNull("a create is recorded once, not once per column");
+        row.OldValue.Should().BeNull();
+        row.NewValue.Should().BeNull();
+        row.EntityType.Should().Be(typeof(AuditedThing).FullName);
+        row.ChangedBy.Should().Be(42);
+        row.ChangedOn.Should().Be(AuditTrailTestHarness.EpochUtc);
+        thing.Id.Should().BeGreaterThan(0);
+        row.EntityKey.Should().Be(thing.Id.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "the key is store-generated, so the row must be rewritten once the insert assigns it");
+    }
+
+    // ── Added through the synchronous path ──
+    [Fact]
+    public void SaveChanges_Synchronous_RecordsTheSameRowAndResolvesTheKey()
+    {
+        var thing = new AuditedThing { Name = "Sync" };
+        _context.AuditedThings.Add(thing);
+
+        _context.SaveChanges(userId: 7);
+
+        var row = _context.TrailRows.AsNoTracking().Single();
+        row.Operation.Should().Be("Added");
+        row.ChangedBy.Should().Be(7);
+        row.EntityKey.Should().Be(thing.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    // ── Modified: one row per property that really changed ──
+    [Fact]
+    public async Task SaveChanges_ModifiedEntity_WritesOneRowPerChangedProperty()
+    {
+        var thing = await SeedAsync();
+
+        thing.Name = "Renamed";
+        thing.Quantity = 9;
+        await _context.SaveChangesAsync(userId: 5);
+
+        var rows = await ModifiedRowsAsync();
+        rows.Should().HaveCount(2);
+
+        var name = rows.Single(r => r.PropertyName == nameof(AuditedThing.Name));
+        name.OldValue.Should().Be("Original");
+        name.NewValue.Should().Be("Renamed");
+
+        var quantity = rows.Single(r => r.PropertyName == nameof(AuditedThing.Quantity));
+        quantity.OldValue.Should().Be("1");
+        quantity.NewValue.Should().Be("9");
+
+        rows.Should().NotContain(r => r.PropertyName == nameof(AuditedThing.Email),
+            "a property nobody touched is not part of the change");
+    }
+
+    // ── Modified: EF flagged the property, but the value is identical ──
+    [Fact]
+    public async Task SaveChanges_WholeEntityMarkedModifiedButUnchanged_WritesNothing()
+    {
+        var thing = await SeedAsync();
+
+        // The Update idiom flags every property as modified; none of the values moved.
+        _context.Entry(thing).State = EntityState.Modified;
+        await _context.SaveChangesAsync(userId: 5);
+
+        (await ModifiedRowsAsync()).Should().BeEmpty("a trail that records non-changes is noise");
+    }
+
+    // ── Deleted: one summary row ──
+    [Fact]
+    public async Task SaveChanges_DeletedEntity_WritesOneSummaryRow()
+    {
+        var thing = await SeedAsync();
+
+        _context.AuditedThings.Remove(thing);
+        await _context.SaveChangesAsync(userId: 11);
+
+        var rows = await RowsAsync();
+        var deleted = rows.Single(r => r.Operation == "Deleted");
+        deleted.PropertyName.Should().BeNull();
+        deleted.EntityKey.Should().Be(thing.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        deleted.ChangedBy.Should().Be(11);
+    }
+
+    // ── Composite keys ──
+    [Fact]
+    public async Task SaveChanges_CompositeKeyEntity_JoinsTheKeyPartsInModelOrder()
+    {
+        _context.CompositeKeyThings.Add(new CompositeKeyThing { PartA = 7, PartB = "beta", Note = "n" });
+
+        await _context.SaveChangesAsync(userId: 1);
+
+        (await SingleRowAsync()).EntityKey.Should().Be("7|beta");
+    }
+
+    // ── Entities that never opted in ──
+    [Fact]
+    public async Task SaveChanges_EntityWithoutTheMarker_IsNeverRecorded()
+    {
+        _context.PlainThings.Add(new PlainThing { Id = 1, Name = "Ignored" });
+        await _context.SaveChangesAsync(userId: 1);
+
+        var plain = await _context.PlainThings.SingleAsync();
+        plain.Name = "Still ignored";
+        await _context.SaveChangesAsync(userId: 1);
+
+        (await RowsAsync()).Should().BeEmpty("the trail is opt-in per entity, and this one never opted in");
+    }
+
+    // ── The framework's own tables are never audited ──
+    [Fact]
+    public void IsFrameworkEntity_TheFrameworksOwnBookkeepingTypes_AreExcluded()
+    {
+        AuditTrailSaveChangesInterceptor.IsFrameworkEntity(typeof(AuditTrailEntry)).Should().BeTrue(
+            "auditing the trail would be an unbounded feedback loop");
+        AuditTrailSaveChangesInterceptor.IsFrameworkEntity(typeof(OutboxMessage)).Should().BeTrue();
+        AuditTrailSaveChangesInterceptor.IsFrameworkEntity(typeof(InboxMessage)).Should().BeTrue();
+        AuditTrailSaveChangesInterceptor.IsFrameworkEntity(typeof(ScheduledJobEntry)).Should().BeTrue();
+        AuditTrailSaveChangesInterceptor.IsFrameworkEntity(typeof(AuditedThing)).Should().BeFalse();
+    }
+
+    // ── Changing a trail row itself produces no second-order rows ──
+    [Fact]
+    public async Task SaveChanges_ModifyingATrailRow_ProducesNoFurtherRows()
+    {
+        await SeedAsync();
+        var row = await _context.TrailRows.SingleAsync();
+
+        row.EntityKey = "rewritten";
+        await _context.SaveChangesAsync(userId: 1);
+
+        (await RowsAsync()).Should().ContainSingle("the trail must never record itself");
+    }
+
+    // ── PII is redacted at capture, on both sides ──
+    [Fact]
+    public async Task SaveChanges_PiiProperty_RecordsTheRedactionTokenAndNeverTheValue()
+    {
+        var thing = await SeedAsync();
+
+        thing.Email = "new.address@example.com";
+        await _context.SaveChangesAsync(userId: 5);
+
+        var row = (await ModifiedRowsAsync()).Single();
+        row.PropertyName.Should().Be(nameof(AuditedThing.Email));
+        row.OldValue.Should().Be(PiiRedactor.RedactedToken);
+        row.NewValue.Should().Be(PiiRedactor.RedactedToken);
+
+        string?[] everyColumn =
+        [
+            row.EntityType, row.EntityKey, row.PropertyName, row.OldValue, row.NewValue,
+            row.Operation, row.CorrelationId, row.TenantId,
+        ];
+        everyColumn.Should().NotContain(value => value != null
+            && (value.Contains("example.com", StringComparison.Ordinal)
+                || value.Contains("new.address", StringComparison.Ordinal)),
+            "personal data must never reach the trail in clear text, in any column");
+    }
+
+    // ── The changing user comes from the save, and is null when the save carried none ──
+    [Fact]
+    public async Task SaveChanges_WithoutAUserId_RecordsANullChangedBy()
+    {
+        _context.AuditedThings.Add(new AuditedThing { Name = "System" });
+
+        await _context.SaveChangesAsync();
+
+        (await SingleRowAsync()).ChangedBy.Should().BeNull(
+            "a background save has no identity to attribute the change to");
+    }
+
+    // ── A capture whose save never completed does not duplicate rows ──
+    [Fact]
+    public async Task SaveChanges_AfterAFailedSave_WritesOneRowPerChange()
+    {
+        _context.AuditedThings.Add(new AuditedThing { Name = "Retried" });
+
+        _context.FailNextSave = true;
+        var firstAttempt = async () => await _context.SaveChangesAsync(userId: 1);
+        await firstAttempt.Should().ThrowAsync<DbUpdateException>();
+
+        _context.FailNextSave = false;
+        await _context.SaveChangesAsync(userId: 1);
+
+        (await RowsAsync()).Should().ContainSingle("the abandoned attempt's row must be discarded, not duplicated");
+    }
+
+    // ── Same transaction as the data it describes ──
+    [Fact]
+    public async Task SaveChanges_InsideARolledBackTransaction_LeavesNeitherDataNorTrail()
+    {
+        await using var transaction = await _context.Database.BeginTransactionAsync();
+
+        _context.AuditedThings.Add(new AuditedThing { Name = "Doomed" });
+        await _context.SaveChangesAsync(userId: 1);
+
+        await transaction.RollbackAsync();
+
+        (await _context.AuditedThings.AsNoTracking().ToListAsync()).Should().BeEmpty();
+        (await RowsAsync()).Should().BeEmpty("a trail row that survives its own rollback is worse than no trail");
+    }
+
+    // ── A host that never called AddAuditTrail ──
+    [Fact]
+    public async Task SaveChanges_WhenTheInterceptorIsNotRegistered_RecordsNothing()
+    {
+        await using var context = AuditTrailTestContext.Create(_timeProvider, registerInterceptor: false);
+        context.AuditedThings.Add(new AuditedThing { Name = "Untracked" });
+
+        await context.SaveChangesAsync(userId: 1);
+
+        (await context.TrailRows.AsNoTracking().ToListAsync()).Should().BeEmpty(
+            "the context resolves the interceptor with GetService, so its absence is a silent no-op");
+    }
+
+    // ── Helpers ──
+    private async Task<AuditedThing> SeedAsync()
+    {
+        var thing = new AuditedThing { Name = "Original", Email = "original@example.com", Quantity = 1 };
+        _context.AuditedThings.Add(thing);
+        await _context.SaveChangesAsync(userId: 1);
+        return thing;
+    }
+
+    private async Task<List<AuditTrailEntry>> RowsAsync() =>
+        await _context.TrailRows.AsNoTracking().ToListAsync();
+
+    private async Task<List<AuditTrailEntry>> ModifiedRowsAsync() =>
+        await _context.TrailRows.AsNoTracking().Where(r => r.Operation == "Modified").ToListAsync();
+
+    private async Task<AuditTrailEntry> SingleRowAsync() =>
+        await _context.TrailRows.AsNoTracking().SingleAsync();
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailTestHarness.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/AuditTrail/AuditTrailTestHarness.cs
@@ -1,0 +1,191 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Attributes;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.AuditTrail;
+
+/// <summary>
+/// Shared scaffolding for the audit-trail tests: an in-memory SQLite
+/// <see cref="ApplicationDbContext"/> mapping an opted-in entity, an entity that never opted in,
+/// and the trail table itself (the OutboxCleanupServiceTests / SchedulerTestHarness pattern).
+/// The production gate that decides whether the table is in the model at all is covered separately
+/// by <c>AuditTrailModelGateTests</c>, so this harness maps it unconditionally.
+/// </summary>
+internal static class AuditTrailTestHarness
+{
+    /// <summary>Epoch for every audit-trail test, passed explicitly so captured timestamps read plainly.</summary>
+    public static readonly DateTimeOffset Epoch = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The <see cref="Epoch"/> as the UTC <see cref="DateTime"/> the interceptor records.</summary>
+    public static DateTime EpochUtc => Epoch.UtcDateTime;
+
+    public static FakeTimeProvider CreateTimeProvider() => new(Epoch);
+}
+
+/// <summary>An entity that opted in to the change trail, including one personal-data property.</summary>
+public sealed class AuditedThing : IAuditedEntity
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    [Pii]
+    public string Email { get; set; } = string.Empty;
+
+    public int Quantity { get; set; }
+}
+
+/// <summary>An entity that never opted in; nothing it does may reach the trail.</summary>
+public sealed class PlainThing
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>An opted-in entity with a composite, application-assigned key.</summary>
+public sealed class CompositeKeyThing : IAuditedEntity
+{
+    public int PartA { get; set; }
+
+    public string PartB { get; set; } = string.Empty;
+
+    public string Note { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A context that runs the real interceptor pipeline (audit stamps, domain events, then the change
+/// trail) over SQLite, so the trail rows a test asserts on are the rows production would write.
+/// </summary>
+public sealed class AuditTrailTestContext : ApplicationDbContext
+{
+    private AuditTrailTestContext(DbContextOptions<AuditTrailTestContext> options, IServiceProvider serviceProvider)
+        : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+    {
+    }
+
+    public DbSet<AuditedThing> AuditedThings => Set<AuditedThing>();
+
+    public DbSet<PlainThing> PlainThings => Set<PlainThing>();
+
+    public DbSet<CompositeKeyThing> CompositeKeyThings => Set<CompositeKeyThing>();
+
+    public DbSet<AuditTrailEntry> TrailRows => Set<AuditTrailEntry>();
+
+    internal override bool SupportsOutbox => false;
+
+    /// <summary>When set, the next save aborts after the trail has staged its rows.</summary>
+    public bool FailNextSave { get; set; }
+
+    /// <summary>
+    /// Creates the harness context. Omitting the interceptor reproduces a host that never called
+    /// <c>AddAuditTrail</c>: <c>ApplicationDbContext</c> resolves it with <c>GetService</c> and must
+    /// silently record nothing.
+    /// </summary>
+    public static AuditTrailTestContext Create(TimeProvider timeProvider, bool registerInterceptor = true)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new AuditSaveChangesInterceptor(timeProvider));
+        services.AddSingleton(_ =>
+        {
+            var dispatcher = new Mock<IDomainEventDispatcher>();
+            var logger = new Mock<ILogger<DomainEventSaveChangesInterceptor>>();
+            var outboxSignal = new Mock<IOutboxSignal>();
+            return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
+        });
+        services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+
+        if (registerInterceptor)
+        {
+            services.AddSingleton(new AuditTrailSaveChangesInterceptor(timeProvider));
+        }
+
+        var options = new DbContextOptionsBuilder<AuditTrailTestContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        var context = new AuditTrailTestContext(options, services.BuildServiceProvider());
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        // base registers the audit, domain-event and trail interceptors; appending after it means
+        // this one runs last, so the trail rows are already staged when it throws.
+        base.OnConfiguring(optionsBuilder);
+        optionsBuilder.AddInterceptors(new FailingSaveInterceptor(this));
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        modelBuilder.Entity<AuditedThing>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedOnAdd();
+        });
+
+        modelBuilder.Entity<PlainThing>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+        });
+
+        modelBuilder.Entity<CompositeKeyThing>(entity => entity.HasKey(e => new { e.PartA, e.PartB }));
+
+        // SQLite-portable copy of the production mapping: no schema, no filtered indexes.
+        modelBuilder.Entity<AuditTrailEntry>(entity =>
+        {
+            entity.ToTable("AuditTrailEntries");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.EntityType).IsRequired().HasMaxLength(256);
+            entity.Property(e => e.EntityKey).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.PropertyName).HasMaxLength(128);
+            entity.Property(e => e.Operation).IsRequired().HasMaxLength(16);
+            entity.Property(e => e.CorrelationId).HasMaxLength(64);
+            entity.Property(e => e.TenantId).HasMaxLength(64);
+            entity.HasIndex(e => new { e.EntityType, e.EntityKey, e.ChangedOn });
+        });
+    }
+
+    /// <summary>
+    /// Aborts the save after the trail interceptor has staged its rows, reproducing the state an
+    /// execution-strategy retry starts from: rows tracked as Added and <c>SavedChanges</c> never
+    /// reached.
+    /// </summary>
+    private sealed class FailingSaveInterceptor(AuditTrailTestContext owner) : SaveChangesInterceptor
+    {
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (owner.FailNextSave)
+                throw new DbUpdateException("Simulated transient save failure.");
+
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Conversions/EnumerationValueConverterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Conversions/EnumerationValueConverterTests.cs
@@ -1,0 +1,100 @@
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Persistence.Conversions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Conversions;
+
+/// <summary>
+/// Tests for <see cref="EnumerationValueConverter{TEnumeration}"/> and
+/// <see cref="NullableEnumerationValueConverter{TEnumeration}"/>: the packaged replacement for the
+/// <c>m =&gt; m.Value, v =&gt; Enumeration&lt;T&gt;.FromValue(v).Value!</c> lambda pair an entity
+/// configuration would otherwise hand-roll for every smart enumeration.
+/// </summary>
+public sealed class EnumerationValueConverterTests
+{
+    // ── Non-nullable converter ──
+    [Fact]
+    public void Converter_RoundTrips_MemberThroughItsIntegerValue()
+    {
+        var converter = new EnumerationValueConverter<Priority>();
+
+        int stored = converter.ConvertToProviderExpression.Compile()(Priority.High);
+        var read = converter.ConvertFromProviderExpression.Compile()(stored);
+
+        stored.Should().Be(3, "the column stores the member's stable integer value");
+        read.Should().BeSameAs(Priority.High, "the read leg resolves the interned singleton");
+    }
+
+    [Fact]
+    public void Converter_MapsToAndFromInt_SoTheColumnStaysAPlainIntColumn()
+    {
+        var converter = new EnumerationValueConverter<Priority>();
+
+        converter.ModelClrType.Should().Be<Priority>();
+        converter.ProviderClrType.Should().Be<int>();
+    }
+
+    [Fact]
+    public void Converter_ReadLeg_ResolvesEveryDeclaredMember()
+    {
+        var read = new EnumerationValueConverter<Priority>().ConvertFromProviderExpression.Compile();
+
+        read(1).Should().BeSameAs(Priority.Low);
+        read(2).Should().BeSameAs(Priority.Normal);
+        read(3).Should().BeSameAs(Priority.High);
+    }
+
+    [Fact]
+    public void Converter_WriteLeg_MatchesTheHandRolledLambdaItReplaces()
+    {
+        var converter = new EnumerationValueConverter<Priority>();
+
+        converter.ConvertToProviderExpression.Compile()(Priority.Low).Should().Be(HandRolled(Priority.Low));
+
+        static int HandRolled(Priority p) => p.Value;
+    }
+
+    // ── Nullable converter ──
+    [Fact]
+    public void NullableConverter_RoundTripsAValue()
+    {
+        var converter = new NullableEnumerationValueConverter<Priority>();
+
+        int? stored = converter.ConvertToProviderExpression.Compile()(Priority.Low);
+        var read = converter.ConvertFromProviderExpression.Compile()(stored);
+
+        stored.Should().Be(1);
+        read.Should().BeSameAs(Priority.Low);
+    }
+
+    [Fact]
+    public void NullableConverter_PassesNullThroughBothLegs()
+    {
+        var converter = new NullableEnumerationValueConverter<Priority>();
+
+        converter.ConvertToProviderExpression.Compile()(null).Should().BeNull();
+        converter.ConvertFromProviderExpression.Compile()(null).Should().BeNull(
+            "an absent member must stay a NULL column value, not collapse onto the member valued zero");
+    }
+
+    [Fact]
+    public void NullableConverter_MapsToAndFromNullableInt()
+    {
+        var converter = new NullableEnumerationValueConverter<Priority>();
+
+        converter.ModelClrType.Should().Be<Priority>();
+        converter.ProviderClrType.Should().Be<int?>();
+    }
+
+    private sealed class Priority : Enumeration<Priority>
+    {
+        public static readonly Priority Low = new(1, "Low");
+        public static readonly Priority Normal = new(2, "Normal");
+        public static readonly Priority High = new(3, "High");
+
+        private Priority(int value, string name)
+            : base(value, name)
+        {
+        }
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/AddMultiTenancyTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/AddMultiTenancyTests.cs
@@ -1,0 +1,211 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Services;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Tenancy;
+
+/// <summary>
+/// Coverage for the tenancy DI surface: what <c>AddMultiTenancy</c> binds, what startup validation
+/// refuses, and the guarantee that the isolation machinery is registered whether or not the host
+/// ever calls it.
+/// </summary>
+public sealed class AddMultiTenancyTests
+{
+    [Fact]
+    public void TenancySettings_Defaults_AreOffAndFailClosed()
+    {
+        var settings = new TenancySettings();
+
+        settings.Enabled.Should().BeFalse("adopting the framework must never start rejecting requests");
+        settings.RequireTenant.Should().BeTrue("with tenancy on, an unscoped request reads across every tenant");
+        settings.ClaimType.Should().Be("tenant_id");
+        settings.HeaderName.Should().Be("X-Tenant-Id");
+        settings.EffectiveResolutionOrder.Should().Equal(
+            TenantResolutionStrategy.Claim, TenantResolutionStrategy.Header);
+        settings.EffectiveExcludedPathPrefixes.Should().Equal("/health", "/alive", "/.well-known");
+        settings.Tenants.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithoutTheSection_OptionsResolveToTheInertDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenancy(new ConfigurationBuilder().Build());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<TenancySettings>>().Value.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddMultiTenancy_BindsTheTenancySection()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenancy(Configuration(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["Tenancy:Enabled"] = "true",
+            ["Tenancy:RequireTenant"] = "false",
+            ["Tenancy:ClaimType"] = "org",
+            ["Tenancy:HeaderName"] = "X-Org",
+            ["Tenancy:ResolutionOrder:0"] = "Header",
+            ["Tenancy:ExcludedPathPrefixes:0"] = "/ping",
+        }));
+
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<IOptions<TenancySettings>>().Value;
+
+        settings.Enabled.Should().BeTrue();
+        settings.RequireTenant.Should().BeFalse();
+        settings.ClaimType.Should().Be("org");
+        settings.HeaderName.Should().Be("X-Org");
+        settings.EffectiveResolutionOrder.Should().ContainSingle(
+            "a configured order REPLACES the framework default rather than extending it")
+            .Which.Should().Be(TenantResolutionStrategy.Header);
+        settings.EffectiveExcludedPathPrefixes.Should().Equal("/ping");
+    }
+
+    [Fact]
+    public void AddMultiTenancy_BindsPerTenantDataSourceOverrides()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenancy(Configuration(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["Tenancy:Tenants:acme:DataSources:Default:SqliteConnectionString"] = "DataSource=acme.db",
+        }));
+
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<IOptions<TenancySettings>>().Value;
+
+        settings.Tenants["acme"].DataSources["Default"].SqliteConnectionString
+            .Should().Be("DataSource=acme.db");
+    }
+
+    [Fact]
+    public void AddMultiTenancy_CalledTwice_RegistersOneValidator()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenancy(new ConfigurationBuilder().Build());
+        services.AddMultiTenancy(new ConfigurationBuilder().Build());
+
+        services.Count(d => d.ServiceType == typeof(IValidateOptions<TenancySettings>)
+            && d.ImplementationType == typeof(TenancySettingsValidator))
+            .Should().Be(1);
+    }
+
+    // ── Validation ──
+    [Fact]
+    public void Validate_AcceptsAnOverrideOnAKnownPhysicalSource()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = TenantWithOverride(
+            "Default", new TenantDataSourceOverrideSettings { SqliteConnectionString = "DataSource=acme.db" });
+
+        Validate(settings).Failed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_RejectsAnOverrideOnAnUnknownSource()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = TenantWithOverride(
+            "Nowhere", new TenantDataSourceOverrideSettings { SqliteConnectionString = "DataSource=acme.db" });
+
+        var result = Validate(settings);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Nowhere",
+            "an unknown name silently resolves to Default, which would put a tenant back on the shared database");
+    }
+
+    [Fact]
+    public void Validate_RejectsAnOverrideWithNoConnectionString()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = TenantWithOverride("Default", new TenantDataSourceOverrideSettings());
+
+        var result = Validate(settings);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("declares no connection string");
+    }
+
+    [Fact]
+    public void Validate_RejectsTheHostStrategy()
+    {
+        var settings = new TenancySettings();
+        settings.ResolutionOrder.Add(TenantResolutionStrategy.Host);
+
+        var result = Validate(settings);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("not implemented");
+    }
+
+    [Fact]
+    public void Validate_AcceptsClaimAndHeader()
+    {
+        var settings = new TenancySettings();
+        settings.ResolutionOrder.Add(TenantResolutionStrategy.Header);
+        settings.ResolutionOrder.Add(TenantResolutionStrategy.Claim);
+
+        Validate(settings).Failed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_WithoutAResolver_SkipsTheSourceNameCheck()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = TenantWithOverride(
+            "Nowhere", new TenantDataSourceOverrideSettings { SqliteConnectionString = "DataSource=acme.db" });
+
+        new TenancySettingsValidator().Validate(null, settings).Failed.Should().BeFalse(
+            "a container without persistence still gets the strategy and connection-string checks");
+    }
+
+    // ── Always-on registrations (isolation is never half-wired) ──
+    [Fact]
+    public void AddInfrastructure_RegistersTheTenantContextAndInterceptor_WithoutAddMultiTenancy()
+    {
+        var services = new ServiceCollection();
+        services.AddInfrastructure(Configuration(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["ConnectionStrings:SQLServerConnectionString"] = "Server=test;Database=test",
+        }));
+
+        services.Single(d => d.ServiceType == typeof(ITenantContext)).Lifetime
+            .Should().Be(ServiceLifetime.Scoped);
+        services.Single(d => d.ServiceType == typeof(ITenantContext)).ImplementationType
+            .Should().Be<TenantContext>();
+        services.Single(d => d.ServiceType == typeof(TenantSaveChangesInterceptor)).Lifetime
+            .Should().Be(ServiceLifetime.Singleton);
+    }
+
+    private static TenantEntrySettings TenantWithOverride(
+        string sourceName,
+        TenantDataSourceOverrideSettings over)
+    {
+        var tenant = new TenantEntrySettings();
+        tenant.DataSources[sourceName] = over;
+        return tenant;
+    }
+
+    private static ValidateOptionsResult Validate(TenancySettings settings)
+    {
+        var resolver = new DataSourceResolver(
+            new ConnectionStringSettings { SQLServerConnectionString = "Server=test;Database=test" },
+            new DataSourcesSettings(),
+            NullLogger<DataSourceResolver>.Instance);
+
+        return new TenancySettingsValidator(resolver).Validate(null, settings);
+    }
+
+    private static IConfiguration Configuration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/ApplicationDbContextTenantFilterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/ApplicationDbContextTenantFilterTests.cs
@@ -1,0 +1,210 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Repositories;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Tenancy;
+
+/// <summary>
+/// End-to-end coverage for the named <c>Tenant</c> global query filter over SQLite: it composes with
+/// <c>SoftDelete</c>, it is inert for a system context, and one cached model serves two tenants at
+/// once with disjoint results.
+/// </summary>
+public sealed class ApplicationDbContextTenantFilterTests : IDisposable
+{
+    private const string Acme = "acme";
+    private const string Globex = "globex";
+
+    private static readonly string[] SoftDeleteOnly = [ApplicationDbContext.SoftDeleteFilterName];
+
+    private readonly SqliteConnection _connection = TenantTestContext.OpenDatabase();
+
+    public void Dispose() => _connection.Dispose();
+
+    [Fact]
+    public async Task TenantFilter_HidesOtherTenantsRows()
+    {
+        await SeedAsync();
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        var visible = await acme.Things.AsNoTracking().Select(t => t.Name).ToListAsync();
+
+        string[] expected = ["acme-live"];
+        visible.Should().BeEquivalentTo(expected,
+            "the Tenant filter scopes reads to the resolved tenant and SoftDelete removes the deleted row");
+    }
+
+    [Fact]
+    public async Task TenantFilter_ComposesWithSoftDelete_RatherThanReplacingIt()
+    {
+        await SeedAsync();
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        // Dropping ONLY the soft-delete filter: the deleted row comes back, the other tenant's does not.
+        var withDeleted = await acme.Things
+            .IgnoreQueryFilters(SoftDeleteOnly)
+            .AsNoTracking()
+            .Select(t => t.Name)
+            .ToListAsync();
+
+        string[] expected = ["acme-live", "acme-deleted"];
+        withDeleted.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task NullTenant_SeesEveryTenantsRows()
+    {
+        await SeedAsync();
+
+        await using var system = TenantTestContext.Create(_connection, tenantAccessor: null);
+
+        var visible = await system.Things.AsNoTracking().Select(t => t.Name).ToListAsync();
+
+        string[] expected = ["acme-live", "globex-live"];
+        visible.Should().BeEquivalentTo(expected,
+            "a background service resolves no tenant and must see every tenant's rows");
+    }
+
+    // -- The load-bearing one: two tenants, two contexts, ONE compiled model --
+    [Fact]
+    public async Task TwoTenants_ShareOneCachedModel_AndStillReadDisjointRows()
+    {
+        await SeedAsync();
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+        await using var globex = TenantTestContext.Create(_connection, () => Globex);
+
+        acme.Model.Should().BeSameAs(globex.Model,
+            "the model cache is keyed by (context type, physical source), so the tenant must ride in as a "
+            + "query parameter rather than forcing a model per tenant");
+
+        var acmeRows = await acme.Things.AsNoTracking().Select(t => t.Name).ToListAsync();
+        var globexRows = await globex.Things.AsNoTracking().Select(t => t.Name).ToListAsync();
+
+        string[] acmeExpected = ["acme-live"];
+        string[] globexExpected = ["globex-live"];
+        acmeRows.Should().BeEquivalentTo(acmeExpected);
+        globexRows.Should().BeEquivalentTo(globexExpected);
+        acmeRows.Should().NotIntersectWith(globexRows);
+    }
+
+    [Fact]
+    public async Task LiveAccessor_IsReadAtQueryTime_NotAtContextCreation()
+    {
+        await SeedAsync();
+
+        string? tenant = null;
+        await using var context = TenantTestContext.Create(_connection, () => tenant);
+
+        // Created with no tenant, exactly as it would be when the context is materialized before the
+        // resolving middleware has run.
+        (await context.Things.AsNoTracking().CountAsync()).Should().Be(2);
+
+        tenant = Globex;
+
+        var rows = await context.Things.AsNoTracking().Select(t => t.Name).ToListAsync();
+
+        string[] expected = ["globex-live"];
+        rows.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task RepositoryIgnoreQueryFilters_IncludesDeleted_ButKeepsTheTenantFilter()
+    {
+        await SeedAsync();
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+        var repository = new EFReadRepository<TenantThing, int>(acme);
+
+        var rows = await repository.GetAllAsync([], ignoreQueryFilters: true);
+
+        string[] expected = ["acme-live", "acme-deleted"];
+        rows.Select(r => r.Name).Should().BeEquivalentTo(expected,
+            "ignoreQueryFilters means 'include soft-deleted', never 'include other tenants'");
+    }
+
+    [Fact]
+    public async Task NonTenantEntities_AreUnaffected()
+    {
+        await SeedAsync();
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        (await acme.PlainThings.AsNoTracking().CountAsync())
+            .Should().Be(1, "an entity that never carried ITenantEntity gets no Tenant filter");
+    }
+
+    // -- Model shape --
+    [Fact]
+    public void TenantIdProperty_IsRequiredNonUnicodeAndCapped()
+    {
+        using var context = TenantTestContext.Create(_connection);
+
+        var property = context.Model.FindEntityType(typeof(TenantThing))!
+            .FindProperty(ApplicationDbContext.TenantIdPropertyName)!;
+
+        property.IsNullable.Should().BeFalse();
+        property.GetMaxLength().Should().Be(ApplicationDbContext.TenantIdMaxLength);
+        property.IsUnicode().Should().BeFalse();
+    }
+
+    [Fact]
+    public void TenantIdColumn_IsIndexed()
+    {
+        using var context = TenantTestContext.Create(_connection);
+
+        context.Model.FindEntityType(typeof(TenantThing))!
+            .GetIndexes()
+            .Should().Contain(index =>
+                index.Properties.Count == 1
+                && index.Properties[0].Name == ApplicationDbContext.TenantIdPropertyName,
+                "every tenant-scoped read leads with TenantId, so an unindexed column is a scan per query");
+    }
+
+    [Fact]
+    public void OwnedTypes_GetNoFilterOfTheirOwn()
+    {
+        using var context = TenantTestContext.Create(_connection);
+
+        var owned = context.Model.GetEntityTypes().Single(t => t.ClrType == typeof(TenantDetail));
+
+        owned.IsOwned().Should().BeTrue();
+        owned.FindDeclaredQueryFilter(ApplicationDbContext.TenantFilterName).Should().BeNull(
+            "an owned type is queried through its owner and inherits the owner's filter");
+    }
+
+    [Fact]
+    public void BothNamedFilters_AreDeclaredOnATenantOwnedAuditableEntity()
+    {
+        using var context = TenantTestContext.Create(_connection);
+
+        var entityType = context.Model.FindEntityType(typeof(TenantThing))!;
+
+        entityType.FindDeclaredQueryFilter(ApplicationDbContext.TenantFilterName).Should().NotBeNull();
+        entityType.FindDeclaredQueryFilter(ApplicationDbContext.SoftDeleteFilterName).Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Seeds two tenants from a system (untenanted) context: one live row each, plus one
+    /// soft-deleted row for the first tenant.
+    /// </summary>
+    private async Task SeedAsync()
+    {
+        await using var system = TenantTestContext.Create(_connection, tenantAccessor: null);
+
+        var deleted = new TenantThing { Id = 2, TenantId = Acme, Name = "acme-deleted" };
+
+        system.Things.AddRange(
+            new TenantThing { Id = 1, TenantId = Acme, Name = "acme-live" },
+            deleted,
+            new TenantThing { Id = 3, TenantId = Globex, Name = "globex-live" });
+        system.PlainThings.Add(new PlainThing { Id = 1, Name = "plain" });
+        await system.SaveChangesAsync(null);
+
+        deleted.Delete().IsSuccess.Should().BeTrue();
+        await system.SaveChangesAsync(null);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/DbContextFactoryTenantTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/DbContextFactoryTenantTests.cs
@@ -1,0 +1,250 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Services;
+using MMCA.Common.Infrastructure.Settings;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Tenancy;
+
+/// <summary>
+/// Coverage for database-per-tenant routing in the scoped context factory: the override replaces the
+/// connection while keeping the data source key, a tenant without an override stays on the shared
+/// database, and a scope cannot switch tenants under a context already bound to one database.
+/// </summary>
+public sealed class DbContextFactoryTenantTests : IDisposable
+{
+    private const string Acme = "acme";
+    private const string Globex = "globex";
+    private const string AcmeConnection = "DataSource=acme-tenant.db";
+
+    private static readonly DataSourceKey SqliteKey = DataSourceKey.Default(DataSource.Sqlite);
+
+    private readonly SqliteConnection _connection = TenantTestContext.OpenDatabase();
+    private readonly List<ApplicationDbContext> _created = [];
+
+    public void Dispose()
+    {
+        foreach (var context in _created)
+        {
+            context.Dispose();
+        }
+
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public void OverriddenSource_IsCreatedAgainstTheTenantsConnection_WithTheSameKey()
+    {
+        var physicalFactory = PhysicalFactory();
+        var sut = CreateSut(physicalFactory, Acme, TenancyWithAcmeOverride());
+
+        sut.GetDbContext(SqliteKey);
+
+        physicalFactory.Verify(
+            f => f.Create(
+                SqliteKey,
+                It.Is<PhysicalDataSource>(p => p.Key == SqliteKey && p.ConnectionString == AcmeConnection)),
+            Times.Once,
+            "the key is what EF's model cache is keyed on, so only the connection may change");
+        physicalFactory.Verify(f => f.Create(It.IsAny<DataSourceKey>()), Times.Never);
+    }
+
+    [Fact]
+    public void TenantWithoutAnOverride_StaysOnTheSharedDatabase()
+    {
+        var physicalFactory = PhysicalFactory();
+        var sut = CreateSut(physicalFactory, Globex, TenancyWithAcmeOverride());
+
+        sut.GetDbContext(SqliteKey);
+
+        physicalFactory.Verify(f => f.Create(SqliteKey), Times.Once,
+            "a shared-schema tenant is isolated by the query filter, not by its own database");
+        physicalFactory.Verify(
+            f => f.Create(It.IsAny<DataSourceKey>(), It.IsAny<PhysicalDataSource>()), Times.Never);
+    }
+
+    [Fact]
+    public void OverrideOnAnotherEngine_LeavesThisSourceShared()
+    {
+        var tenancy = new TenancySettings();
+        var tenant = new TenantEntrySettings();
+        tenant.DataSources["Default"] = new TenantDataSourceOverrideSettings
+        {
+            SQLServerConnectionString = "Server=acme;Database=acme",
+        };
+        tenancy.Tenants[Acme] = tenant;
+
+        var physicalFactory = PhysicalFactory();
+        var sut = CreateSut(physicalFactory, Acme, tenancy);
+
+        sut.GetDbContext(SqliteKey);
+
+        physicalFactory.Verify(f => f.Create(SqliteKey), Times.Once);
+    }
+
+    [Fact]
+    public void NoTenancyConfigured_UsesTheOriginalCreateOverload()
+    {
+        var physicalFactory = PhysicalFactory();
+        var sut = CreateSut(physicalFactory, tenantId: null, tenancy: null);
+
+        sut.GetDbContext(SqliteKey);
+
+        physicalFactory.Verify(f => f.Create(SqliteKey), Times.Once);
+    }
+
+    [Fact]
+    public void RoutedContext_IsCachedForTheScope()
+    {
+        var physicalFactory = PhysicalFactory();
+        var sut = CreateSut(physicalFactory, Acme, TenancyWithAcmeOverride());
+
+        var first = sut.GetDbContext(SqliteKey);
+        var second = sut.GetDbContext(SqliteKey);
+
+        second.Should().BeSameAs(first);
+        physicalFactory.Verify(
+            f => f.Create(It.IsAny<DataSourceKey>(), It.IsAny<PhysicalDataSource>()), Times.Once);
+    }
+
+    [Fact]
+    public void ChangingTheScopesTenant_AfterARoutedContextWasCreated_Throws()
+    {
+        var tenantContext = new MutableTenantContext(Acme);
+        var sut = CreateSut(PhysicalFactory(), tenantContext, TenancyWithAcmeOverride());
+
+        sut.GetDbContext(SqliteKey);
+        tenantContext.Force(Globex);
+
+        var act = () => sut.GetDbContext(SqliteKey);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*acme*globex*",
+                "the cached context is bound to one physical database for the life of the scope");
+    }
+
+    [Fact]
+    public void ChangingTheScopesTenant_OnASharedSource_IsAllowed()
+    {
+        var tenantContext = new MutableTenantContext(Globex);
+        var sut = CreateSut(PhysicalFactory(), tenantContext, TenancyWithAcmeOverride());
+
+        sut.GetDbContext(SqliteKey);
+        tenantContext.Force("initech");
+
+        var act = () => sut.GetDbContext(SqliteKey);
+
+        act.Should().NotThrow("a shared source is scoped by the live filter, so the tenant may still move");
+    }
+
+    [Fact]
+    public void CreatedContext_ReadsTheTenantLive()
+    {
+        var tenantContext = new MutableTenantContext(null);
+        var sut = CreateSut(PhysicalFactory(), tenantContext, tenancy: null);
+
+        var context = sut.GetDbContext(SqliteKey);
+        context.CurrentTenantId.Should().BeNull();
+
+        tenantContext.Force(Acme);
+
+        context.CurrentTenantId.Should().Be(Acme,
+            "the accessor is read at query time, which is what removes the middleware-ordering hazard");
+    }
+
+    [Fact]
+    public void DefaultedConstructorParameters_StillResolveFromAContainerWithoutTenancy()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(PhysicalFactory().Object);
+        services.AddSingleton(Mock.Of<IEntityDataSourceRegistry>());
+        services.AddSingleton(Resolver());
+        services.AddSingleton(Mock.Of<ICurrentUserService>());
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => ActivatorUtilities.CreateInstance<DbContextFactory>(provider);
+
+        act.Should().NotThrow("the pre-tenancy constructor shape must keep resolving");
+    }
+
+    // ── Scaffolding ──
+    private Mock<IPhysicalDbContextFactory> PhysicalFactory()
+    {
+        var factory = new Mock<IPhysicalDbContextFactory>();
+        factory.Setup(f => f.Create(It.IsAny<DataSourceKey>())).Returns(NewContext);
+        factory.Setup(f => f.Create(It.IsAny<DataSourceKey>(), It.IsAny<PhysicalDataSource>()))
+            .Returns(NewContext);
+        return factory;
+    }
+
+    private ApplicationDbContext NewContext()
+    {
+        var context = TenantTestContext.Create(_connection);
+        _created.Add(context);
+        return context;
+    }
+
+    private static TenancySettings TenancyWithAcmeOverride()
+    {
+        var settings = new TenancySettings();
+        var tenant = new TenantEntrySettings();
+        tenant.DataSources["Default"] = new TenantDataSourceOverrideSettings
+        {
+            SqliteConnectionString = AcmeConnection,
+        };
+        settings.Tenants[Acme] = tenant;
+        return settings;
+    }
+
+    private static IDataSourceResolver Resolver()
+    {
+        var resolver = new Mock<IDataSourceResolver>();
+        resolver.Setup(r => r.GetPhysical(It.IsAny<DataSourceKey>()))
+            .Returns(TestDoubles.TestPhysicalDataSources.Sqlite());
+        return resolver.Object;
+    }
+
+    private static DbContextFactory CreateSut(
+        Mock<IPhysicalDbContextFactory> physicalFactory,
+        string? tenantId,
+        TenancySettings? tenancy)
+    {
+        var tenantContext = new MutableTenantContext(tenantId);
+        return CreateSut(physicalFactory, tenantContext, tenancy);
+    }
+
+    private static DbContextFactory CreateSut(
+        Mock<IPhysicalDbContextFactory> physicalFactory,
+        ITenantContext tenantContext,
+        TenancySettings? tenancy) =>
+        new(
+            physicalFactory.Object,
+            Mock.Of<IEntityDataSourceRegistry>(),
+            Resolver(),
+            Mock.Of<ICurrentUserService>(),
+            tenantContext,
+            tenancy is null ? null : Options.Create(tenancy));
+
+    /// <summary>
+    /// A tenant context a test can move, which the production <see cref="TenantContext"/> refuses to
+    /// do. It is exactly that refusal the factory's guard exists to back up at a second layer.
+    /// </summary>
+    private sealed class MutableTenantContext(string? tenantId) : ITenantContext
+    {
+        public string? TenantId { get; private set; } = tenantId;
+
+        public bool IsResolved => TenantId is not null;
+
+        public void SetTenant(string tenantId) => TenantId = tenantId;
+
+        public void Force(string? value) => TenantId = value;
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantDataSourceTargetTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantDataSourceTargetTests.cs
@@ -1,0 +1,182 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Settings;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Tenancy;
+
+/// <summary>
+/// Coverage for the (source, tenant) expansion the background sweeps run on. A tenant with its own
+/// database has its own outbox, inbox and trail tables, and nothing else opens that database, so
+/// missing a pair means events that are never delivered and rows that are never purged.
+/// </summary>
+public sealed class TenantDataSourceTargetTests
+{
+    private static readonly DataSourceKey Default = DataSourceKey.Default(DataSource.SQLServer);
+    private static readonly DataSourceKey Conference = new(DataSource.SQLServer, "Conference");
+
+    [Fact]
+    public void WithoutTenancy_EveryTargetIsTheSharedDatabase()
+    {
+        var targets = TenantDataSourceTargets.Expand([Default, Conference], settings: null);
+
+        targets.Should().Equal(
+            new TenantDataSourceTarget(Default, null),
+            new TenantDataSourceTarget(Conference, null));
+    }
+
+    [Fact]
+    public void SharedSchemaTenants_AddNoTargets()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = new TenantEntrySettings();
+
+        var targets = TenantDataSourceTargets.Expand([Default], settings);
+
+        targets.Should().ContainSingle("a shared-schema tenant's rows are drained by the shared sweep");
+    }
+
+    [Fact]
+    public void ATenantWithItsOwnDatabase_AddsOnePairPerOverriddenSource()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = Tenant(("Conference", new TenantDataSourceOverrideSettings
+        {
+            SQLServerConnectionString = "Server=acme;Database=acme_conf",
+        }));
+
+        var targets = TenantDataSourceTargets.Expand([Default, Conference], settings);
+
+        targets.Should().Equal(
+            new TenantDataSourceTarget(Default, null),
+            new TenantDataSourceTarget(Conference, null),
+            new TenantDataSourceTarget(Conference, "acme"));
+    }
+
+    [Fact]
+    public void AnOverrideForAnotherEngine_AddsNoPair()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = Tenant(("Default", new TenantDataSourceOverrideSettings
+        {
+            SqliteConnectionString = "DataSource=acme.db",
+        }));
+
+        var targets = TenantDataSourceTargets.Expand([Default], settings);
+
+        targets.Should().ContainSingle("this host's Default source is SQL Server, which the tenant did not override");
+    }
+
+    [Fact]
+    public void AnOverrideForASourceThisHostDoesNotOwn_AddsNoPair()
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = Tenant(("Conference", new TenantDataSourceOverrideSettings
+        {
+            SQLServerConnectionString = "Server=acme;Database=acme_conf",
+        }));
+
+        var targets = TenantDataSourceTargets.Expand([Default], settings);
+
+        targets.Should().ContainSingle("a host only ever drains its own databases");
+    }
+
+    [Fact]
+    public void Target_RendersTheTenantForLogging()
+    {
+        new TenantDataSourceTarget(Default, null).ToString().Should().Be(Default.ToString());
+        new TenantDataSourceTarget(Default, "acme").ToString().Should().Contain("acme");
+    }
+
+    // ── The two background services expose the same expansion ──
+    [Fact]
+    public void OutboxProcessor_EnumeratesThePairs()
+    {
+        var processor = new OutboxProcessor(
+            Mock.Of<IServiceScopeFactory>(),
+            NullLogger<OutboxProcessor>.Instance,
+            Options.Create(new OutboxSettings()),
+            Mock.Of<IOutboxSignal>(),
+            RegistryWith(Default),
+            ResolverFor(Default),
+            TimeProvider.System,
+            Options.Create(TenancyOverriding("Default")));
+
+        processor.GetOutboxTargets().Should().Equal(
+            new TenantDataSourceTarget(Default, null),
+            new TenantDataSourceTarget(Default, "acme"));
+    }
+
+    [Fact]
+    public void OutboxCleanupService_EnumeratesThePairs()
+    {
+        var cleanup = new OutboxCleanupService(
+            Mock.Of<IServiceScopeFactory>(),
+            NullLogger<OutboxCleanupService>.Instance,
+            Options.Create(new OutboxSettings()),
+            Options.Create(new MessageBusSettings()),
+            RegistryWith(Default),
+            ResolverFor(Default),
+            TimeProvider.System,
+            Options.Create(TenancyOverriding("Default")));
+
+        cleanup.GetRelationalTargets().Should().Equal(
+            new TenantDataSourceTarget(Default, null),
+            new TenantDataSourceTarget(Default, "acme"));
+    }
+
+    [Fact]
+    public void OutboxProcessor_WithoutTenancy_EnumeratesSourcesOnly()
+    {
+        var processor = new OutboxProcessor(
+            Mock.Of<IServiceScopeFactory>(),
+            NullLogger<OutboxProcessor>.Instance,
+            Options.Create(new OutboxSettings()),
+            Mock.Of<IOutboxSignal>(),
+            RegistryWith(Default),
+            ResolverFor(Default),
+            TimeProvider.System);
+
+        processor.GetOutboxTargets().Should().Equal(new TenantDataSourceTarget(Default, null));
+    }
+
+    private static TenantEntrySettings Tenant(params (string Source, TenantDataSourceOverrideSettings Override)[] overrides)
+    {
+        var tenant = new TenantEntrySettings();
+        foreach (var (source, settings) in overrides)
+        {
+            tenant.DataSources[source] = settings;
+        }
+
+        return tenant;
+    }
+
+    private static TenancySettings TenancyOverriding(string sourceName)
+    {
+        var settings = new TenancySettings();
+        settings.Tenants["acme"] = Tenant((sourceName, new TenantDataSourceOverrideSettings
+        {
+            SQLServerConnectionString = "Server=acme;Database=acme",
+        }));
+        return settings;
+    }
+
+    private static IEntityDataSourceRegistry RegistryWith(params DataSourceKey[] keys)
+    {
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse()).Returns(keys);
+        return registry.Object;
+    }
+
+    private static IDataSourceResolver ResolverFor(DataSourceKey key)
+    {
+        var resolver = new Mock<IDataSourceResolver>();
+        resolver.Setup(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>())).Returns(key);
+        return resolver.Object;
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantSaveChangesInterceptorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantSaveChangesInterceptorTests.cs
@@ -1,0 +1,213 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Tenancy;
+
+/// <summary>
+/// Coverage for the write side of tenancy: the interceptor stamps inserts, refuses anything that
+/// would cross the tenant boundary, and stays out of the way of entities that never opted in.
+/// </summary>
+public sealed class TenantSaveChangesInterceptorTests : IDisposable
+{
+    private const string Acme = "acme";
+    private const string Globex = "globex";
+
+    private readonly SqliteConnection _connection = TenantTestContext.OpenDatabase();
+
+    public void Dispose() => _connection.Dispose();
+
+    [Fact]
+    public async Task Added_IsStampedWithTheScopesTenant()
+    {
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        var thing = new TenantThing { Id = 1, Name = "new" };
+        acme.Things.Add(thing);
+        await acme.SaveChangesAsync(null);
+
+        thing.TenantId.Should().Be(Acme, "the tenant is the framework's to assign, not the caller's");
+    }
+
+    [Fact]
+    public async Task Added_WithNoResolvedTenantAndNoTenantOnTheEntity_Throws()
+    {
+        await using var system = TenantTestContext.Create(_connection, tenantAccessor: null);
+
+        system.Things.Add(new TenantThing { Id = 1, Name = "orphan" });
+
+        var act = async () => await system.SaveChangesAsync(null);
+
+        (await act.Should().ThrowAsync<CrossTenantWriteException>())
+            .Which.EntityType.Should().Contain(nameof(TenantThing));
+    }
+
+    [Fact]
+    public async Task Added_WithNoResolvedTenantButAnExplicitTenant_IsWrittenAsIs()
+    {
+        await using var system = TenantTestContext.Create(_connection, tenantAccessor: null);
+
+        system.Things.Add(new TenantThing { Id = 1, TenantId = Globex, Name = "seeded" });
+        await system.SaveChangesAsync(null);
+
+        (await system.Things.AsNoTracking().SingleAsync()).TenantId.Should().Be(Globex,
+            "a seeder or a per-tenant job legitimately writes an explicitly tenanted row");
+    }
+
+    [Fact]
+    public async Task Added_ForAnotherTenant_Throws()
+    {
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        acme.Things.Add(new TenantThing { Id = 1, TenantId = Globex, Name = "smuggled" });
+
+        var act = async () => await acme.SaveChangesAsync(null);
+
+        var exception = (await act.Should().ThrowAsync<CrossTenantWriteException>()).Which;
+        exception.CurrentTenantId.Should().Be(Acme);
+        exception.EntityTenantId.Should().Be(Globex);
+    }
+
+    [Fact]
+    public async Task Modified_OfAnotherTenantsRow_Throws()
+    {
+        await SeedAsync(Globex, id: 1, name: "theirs");
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        // Reached past the filter on purpose: this is exactly the caller the write guard exists for.
+        var row = await acme.Things.IgnoreQueryFilters().SingleAsync();
+        row.Name = "hijacked";
+
+        var act = async () => await acme.SaveChangesAsync(null);
+
+        (await act.Should().ThrowAsync<CrossTenantWriteException>())
+            .Which.EntityTenantId.Should().Be(Globex);
+    }
+
+    [Fact]
+    public async Task Deleted_OfAnotherTenantsRow_Throws()
+    {
+        await SeedAsync(Globex, id: 1, name: "theirs");
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        var row = await acme.Things.IgnoreQueryFilters().SingleAsync();
+        acme.Things.Remove(row);
+
+        var act = async () => await acme.SaveChangesAsync(null);
+
+        await act.Should().ThrowAsync<CrossTenantWriteException>();
+    }
+
+    [Fact]
+    public async Task Modified_ReassigningTheTenant_Throws()
+    {
+        await SeedAsync(Acme, id: 1, name: "mine");
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        var row = await acme.Things.SingleAsync();
+        row.TenantId = Globex;
+
+        var act = async () => await acme.SaveChangesAsync(null);
+
+        (await act.Should().ThrowAsync<CrossTenantWriteException>())
+            .Which.EntityTenantId.Should().Be(Globex);
+    }
+
+    [Fact]
+    public async Task Modified_OfOwnRow_Succeeds()
+    {
+        await SeedAsync(Acme, id: 1, name: "mine");
+
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        var row = await acme.Things.SingleAsync();
+        row.Name = "renamed";
+
+        await acme.SaveChangesAsync(null);
+
+        (await acme.Things.AsNoTracking().SingleAsync()).Name.Should().Be("renamed");
+    }
+
+    [Fact]
+    public async Task NonTenantEntities_AreUntouched()
+    {
+        await using var acme = TenantTestContext.Create(_connection, () => Acme);
+
+        acme.PlainThings.Add(new PlainThing { Id = 1, Name = "plain" });
+
+        await acme.SaveChangesAsync(null);
+
+        (await acme.PlainThings.AsNoTracking().CountAsync()).Should().Be(1,
+            "the interceptor is inert for every entity that does not carry ITenantEntity");
+    }
+
+    [Fact]
+    public async Task OwnedValues_AreNotStamped_AndDoNotBlockASystemInsert()
+    {
+        await using var system = TenantTestContext.Create(_connection, tenantAccessor: null);
+
+        system.Things.Add(new TenantThing { Id = 1, TenantId = Acme, Name = "with-detail" });
+
+        var act = async () => await system.SaveChangesAsync(null);
+
+        await act.Should().NotThrowAsync(
+            "an owned value has no independent existence, so its tenant is its owner's and the guard skips it");
+
+        (await system.Things.AsNoTracking().SingleAsync()).Detail.TenantId.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WithoutTheInterceptorRegistered_TheContextStillBuildsAndSaves()
+    {
+        await using var context = TenantTestContext.Create(
+            _connection, tenantAccessor: null, registerTenantInterceptor: false);
+
+        context.Things.Add(new TenantThing { Id = 1, TenantId = Acme, Name = "unguarded" });
+
+        await context.SaveChangesAsync(null);
+
+        (await context.Things.AsNoTracking().CountAsync()).Should().Be(1,
+            "a design-time or directly-constructed context resolves the interceptor with GetService and finds none");
+    }
+
+    [Fact]
+    public async Task AuditTrailRows_RecordTheTenant()
+    {
+        await using var acme = TenantTestContext.Create(
+            _connection, () => Acme, registerTrailInterceptor: true);
+
+        acme.TrailedThings.Add(new TrailedTenantThing { Id = 1, Name = "trailed" });
+        await acme.SaveChangesAsync(null);
+
+        var rows = await acme.TrailRows.AsNoTracking().ToListAsync();
+
+        rows.Should().NotBeEmpty();
+        rows.Should().OnlyContain(row => row.TenantId == Acme,
+            "the trail column exists so a shared trail table can still be read back per tenant");
+    }
+
+    [Fact]
+    public async Task AuditTrailRows_LeaveTheTenantNull_ForASystemSave()
+    {
+        await using var system = TenantTestContext.Create(
+            _connection, tenantAccessor: null, registerTrailInterceptor: true);
+
+        system.TrailedThings.Add(new TrailedTenantThing { Id = 1, TenantId = Acme, Name = "seeded" });
+        await system.SaveChangesAsync(null);
+
+        (await system.TrailRows.AsNoTracking().ToListAsync())
+            .Should().OnlyContain(row => row.TenantId == null);
+    }
+
+    /// <summary>Writes one row for a tenant through a system context, bypassing the write guard.</summary>
+    private async Task SeedAsync(string tenantId, int id, string name)
+    {
+        await using var system = TenantTestContext.Create(_connection, tenantAccessor: null);
+        system.Things.Add(new TenantThing { Id = id, TenantId = tenantId, Name = name });
+        await system.SaveChangesAsync(null);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantTestHarness.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantTestHarness.cs
@@ -1,0 +1,186 @@
+using System.Reflection;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.AuditTrail;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Tenancy;
+
+/// <summary>A tenant-owned, soft-deletable entity: the shape both global filters apply to.</summary>
+public sealed class TenantThing : AuditableBaseEntity<int>, ITenantEntity
+{
+    /// <summary>Gets or sets the owning tenant. Public setter for test seeding only.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>An owned value that also carries the marker, to prove owned types are excluded.</summary>
+    public TenantDetail Detail { get; set; } = new();
+}
+
+/// <summary>An owned type carrying the marker; it must inherit its owner's filter, not get its own.</summary>
+public sealed class TenantDetail : ITenantEntity
+{
+    /// <summary>Gets or sets the owning tenant. Public setter for test seeding only.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Label { get; set; } = string.Empty;
+}
+
+/// <summary>An entity that never opted in to tenancy; nothing tenant-related may touch it.</summary>
+public sealed class PlainThing : AuditableBaseEntity<int>
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>An opted-in entity that is also change-trailed, for the trail's TenantId column.</summary>
+public sealed class TrailedTenantThing : AuditableBaseEntity<int>, ITenantEntity, IAuditedEntity
+{
+    /// <summary>Gets or sets the owning tenant. Public setter for test seeding only.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A context running the real interceptor pipeline and the real named query filters over SQLite, so
+/// the rows a test sees are the rows production would see (the AuditTrailTestHarness pattern).
+/// </summary>
+public sealed class TenantTestContext : ApplicationDbContext
+{
+    private TenantTestContext(DbContextOptions<TenantTestContext> options, IServiceProvider serviceProvider)
+        : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+    {
+    }
+
+    public DbSet<TenantThing> Things => Set<TenantThing>();
+
+    public DbSet<PlainThing> PlainThings => Set<PlainThing>();
+
+    public DbSet<TrailedTenantThing> TrailedThings => Set<TrailedTenantThing>();
+
+    public DbSet<AuditTrailEntry> TrailRows => Set<AuditTrailEntry>();
+
+    internal override bool SupportsOutbox => false;
+
+    /// <summary>
+    /// Creates a context over <paramref name="connection"/> whose tenant is whatever
+    /// <paramref name="tenantAccessor"/> answers at the moment a query or save runs.
+    /// </summary>
+    /// <param name="connection">An already-open SQLite connection; share it to share a database.</param>
+    /// <param name="tenantAccessor">The live tenant accessor, or null for a system context.</param>
+    /// <param name="registerTenantInterceptor">
+    /// False reproduces a container that never registered the tenant interceptor, which must still
+    /// build a context (design time, a directly-constructed test double).
+    /// </param>
+    /// <param name="registerTrailInterceptor">Whether the change trail records this context's saves.</param>
+    /// <returns>The context; the caller owns disposal.</returns>
+    public static TenantTestContext Create(
+        SqliteConnection connection,
+        Func<string?>? tenantAccessor = null,
+        bool registerTenantInterceptor = true,
+        bool registerTrailInterceptor = false)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+        services.AddSingleton(new DomainEventSaveChangesInterceptor(
+            Mock.Of<IDomainEventDispatcher>(),
+            NullLogger<DomainEventSaveChangesInterceptor>.Instance,
+            Mock.Of<IOutboxSignal>()));
+        services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+
+        if (registerTenantInterceptor)
+        {
+            services.AddSingleton(new TenantSaveChangesInterceptor());
+        }
+
+        if (registerTrailInterceptor)
+        {
+            services.AddSingleton(new AuditTrailSaveChangesInterceptor(TimeProvider.System));
+        }
+
+        var options = new DbContextOptionsBuilder<TenantTestContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var context = new TenantTestContext(options, services.BuildServiceProvider())
+        {
+            TenantIdAccessor = tenantAccessor,
+        };
+
+        return context;
+    }
+
+    /// <summary>Opens a fresh in-memory SQLite connection and creates the schema once.</summary>
+    /// <returns>The open connection; the caller owns disposal.</returns>
+    public static SqliteConnection OpenDatabase()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        using var creator = Create(connection);
+        creator.Database.EnsureCreated();
+
+        return connection;
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        modelBuilder.Entity<TenantThing>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.RowVersion).IsConcurrencyToken();
+            entity.OwnsOne(e => e.Detail);
+        });
+
+        modelBuilder.Entity<PlainThing>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.RowVersion).IsConcurrencyToken();
+        });
+
+        modelBuilder.Entity<TrailedTenantThing>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+            entity.Property(e => e.RowVersion).IsConcurrencyToken();
+        });
+
+        // SQLite-portable copy of the production trail mapping (no schema, no filtered indexes).
+        modelBuilder.Entity<AuditTrailEntry>(entity =>
+        {
+            entity.ToTable("AuditTrailEntries");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.EntityType).IsRequired().HasMaxLength(256);
+            entity.Property(e => e.EntityKey).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.PropertyName).HasMaxLength(128);
+            entity.Property(e => e.Operation).IsRequired().HasMaxLength(16);
+            entity.Property(e => e.CorrelationId).HasMaxLength(64);
+            entity.Property(e => e.TenantId).HasMaxLength(64);
+        });
+
+        // The behavior under test: both named global filters, applied exactly as production does.
+        ApplySoftDeleteFilters(modelBuilder);
+        ApplyTenantFilters(modelBuilder);
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/AddScheduledJobsTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/AddScheduledJobsTests.cs
@@ -1,0 +1,136 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Scheduling;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Scheduling;
+
+/// <summary>
+/// Coverage for the scheduler's DI surface: <c>AddScheduledJobs</c> is called once per host and
+/// <c>AddScheduledJob&lt;TJob&gt;</c> any number of times, in any order, and both are idempotent.
+/// </summary>
+public sealed class AddScheduledJobsTests
+{
+    // ── Jobs accumulate across modules ──
+    [Fact]
+    public void AddScheduledJob_TwoDifferentJobs_BothResolve()
+    {
+        var services = new ServiceCollection();
+        services.AddScheduledJob<FirstJob>();
+        services.AddScheduledJob<SecondJob>();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetServices<IScheduledJob>()
+            .Select(job => job.Name)
+            .Should().BeEquivalentTo("first", "second");
+    }
+
+    // ── The same job registered twice is registered once ──
+    [Fact]
+    public void AddScheduledJob_SameJobTwice_RegistersItOnce()
+    {
+        var services = new ServiceCollection();
+        services.AddScheduledJob<FirstJob>();
+        services.AddScheduledJob<FirstJob>();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetServices<IScheduledJob>().Should().ContainSingle();
+        scope.ServiceProvider.GetService<FirstJob>().Should().NotBeNull(
+            "the concrete type is registered too, so a test or an admin endpoint can run the job on demand");
+    }
+
+    // ── The runner is registered exactly once, however many times the host opts in ──
+    [Fact]
+    public void AddScheduledJobs_CalledTwice_RegistersExactlyOneRunner()
+    {
+        var services = new ServiceCollection();
+        services.AddScheduledJobs(EmptyConfiguration());
+        services.AddScheduledJobs(EmptyConfiguration());
+
+        services.Count(d => d.ServiceType == typeof(IHostedService)
+                && d.ImplementationType == typeof(ScheduledJobRunner))
+            .Should().Be(1, "two runners in one process would race for the same job rows");
+    }
+
+    // ── Order-free: jobs before the opt-in, or after it, give the same container ──
+    [Fact]
+    public void AddScheduledJobs_JobsRegisteredBeforeTheOptIn_StillResolve()
+    {
+        var services = new ServiceCollection();
+        services.AddScheduledJob<FirstJob>();
+        services.AddScheduledJobs(EmptyConfiguration());
+        services.AddScheduledJob<SecondJob>();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        scope.ServiceProvider.GetServices<IScheduledJob>().Should().HaveCount(2);
+    }
+
+    // ── Settings binding ──
+    [Fact]
+    public void AddScheduledJobs_BindsTheSchedulerSection()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["Scheduler:Enabled"] = "true",
+                ["Scheduler:PollingIntervalSeconds"] = "45",
+                ["Scheduler:LeaseSeconds"] = "120",
+                ["Scheduler:Jobs:first:Cron"] = "*/2 * * * *",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddScheduledJobs(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<IOptions<SchedulerSettings>>().Value;
+
+        settings.Enabled.Should().BeTrue();
+        settings.PollingIntervalSeconds.Should().Be(45);
+        settings.LeaseSeconds.Should().Be(120);
+        settings.Jobs.Should().ContainKey("first");
+        settings.Jobs["first"].Cron.Should().Be("*/2 * * * *");
+    }
+
+    // ── Defaults ──
+    [Fact]
+    public void SchedulerSettings_Defaults_AreOffWithA30SecondPollAnd300SecondLease()
+    {
+        var settings = new SchedulerSettings();
+
+        settings.Enabled.Should().BeFalse("adopting the framework must never add a table or a loop unasked");
+        settings.PollingIntervalSeconds.Should().Be(30);
+        settings.LeaseSeconds.Should().Be(300);
+        settings.Jobs.Should().BeEmpty();
+    }
+
+    private static IConfiguration EmptyConfiguration() => new ConfigurationBuilder().Build();
+
+    private sealed class FirstJob : IScheduledJob
+    {
+        public string Name => "first";
+
+        public string CronExpression => "0 * * * *";
+
+        public Task ExecuteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class SecondJob : IScheduledJob
+    {
+        public string Name => "second";
+
+        public string CronExpression => "0 0 * * *";
+
+        public Task ExecuteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/CronosNextOccurrenceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/CronosNextOccurrenceTests.cs
@@ -1,0 +1,94 @@
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Scheduling;
+
+namespace MMCA.Common.Infrastructure.Tests.Scheduling;
+
+/// <summary>
+/// Coverage for <see cref="ScheduledJobRunner.TryGetNextOccurrence"/>: the cron grammar the
+/// scheduler exposes, its strictly-after semantics, and the UTC-only clock that keeps a schedule
+/// stable across daylight saving transitions.
+/// </summary>
+public sealed class CronosNextOccurrenceTests
+{
+    [Theory]
+    // Five-minute step from a boundary instant: strictly after, so 00:00 yields 00:05, never 00:00.
+    [InlineData("*/5 * * * *", "2000-01-01T00:00:00Z", "2000-01-01T00:05:00Z")]
+    [InlineData("*/5 * * * *", "2000-01-01T00:01:00Z", "2000-01-01T00:05:00Z")]
+    // Hourly on the hour.
+    [InlineData("0 * * * *", "2000-01-01T00:00:00Z", "2000-01-01T01:00:00Z")]
+    // Daily at 03:00, asked just after it passed: rolls to tomorrow.
+    [InlineData("0 3 * * *", "2000-01-01T03:00:01Z", "2000-01-02T03:00:00Z")]
+    // Mondays at 02:00 (2000-01-01 was a Saturday).
+    [InlineData("0 2 * * 1", "2000-01-01T00:00:00Z", "2000-01-03T02:00:00Z")]
+    // Lists and ranges.
+    [InlineData("0,30 * * * *", "2000-01-01T00:05:00Z", "2000-01-01T00:30:00Z")]
+    [InlineData("0 9-17 * * *", "2000-01-01T00:00:00Z", "2000-01-01T09:00:00Z")]
+    public void TryGetNextOccurrence_ValidExpression_ReturnsTheFirstOccurrenceStrictlyAfter(
+        string cron,
+        string afterUtc,
+        string expectedUtc)
+    {
+        var next = ScheduledJobRunner.TryGetNextOccurrence(cron, ParseUtc(afterUtc), out var error);
+
+        error.Should().BeNull();
+        next.Should().Be(ParseUtc(expectedUtc));
+    }
+
+    // ── UTC semantics: the schedule never doubles, skips, or shifts across a DST transition ──
+    [Fact]
+    public void TryGetNextOccurrence_AcrossAUsDstSpringForward_AdvancesByExactlyOneDay()
+    {
+        // 2000-04-02 02:00 local was the US spring-forward instant. In UTC there is no such hour, so
+        // a daily 03:00 UTC schedule simply advances 24 hours; a local-time scheduler would have had
+        // to decide whether the occurrence existed at all.
+        var next = ScheduledJobRunner.TryGetNextOccurrence("0 3 * * *", ParseUtc("2000-04-01T03:00:01Z"), out var error);
+
+        error.Should().BeNull();
+        next.Should().Be(ParseUtc("2000-04-02T03:00:00Z"));
+    }
+
+    [Fact]
+    public void TryGetNextOccurrence_AcrossAUsDstFallBack_RunsExactlyOnce()
+    {
+        // 2000-10-29 was the US fall-back date, where a local 01:30 happens twice. In UTC the hourly
+        // schedule steps once per hour, so no occurrence is ever executed twice.
+        var next = ScheduledJobRunner.TryGetNextOccurrence("30 * * * *", ParseUtc("2000-10-29T05:30:00Z"), out var error);
+
+        error.Should().BeNull();
+        next.Should().Be(ParseUtc("2000-10-29T06:30:00Z"));
+    }
+
+    [Fact]
+    public void TryGetNextOccurrence_ReturnsUtcKind()
+    {
+        var next = ScheduledJobRunner.TryGetNextOccurrence("0 * * * *", ParseUtc("2000-01-01T00:00:00Z"), out _);
+
+        next.Should().NotBeNull();
+        next!.Value.Kind.Should().Be(DateTimeKind.Utc, "every scheduling timestamp is UTC end to end");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a cron expression")]
+    // Four fields: too few.
+    [InlineData("* * * *")]
+    // Minute out of range.
+    [InlineData("99 * * * *")]
+    public void TryGetNextOccurrence_InvalidOrUnsatisfiableExpression_ReturnsNullWithoutThrowing(string cron)
+    {
+        var next = ScheduledJobRunner.TryGetNextOccurrence(cron, ParseUtc("2000-01-01T00:00:00Z"), out _);
+
+        next.Should().BeNull("an expression the scheduler cannot honor must park the row, never crash the runner");
+    }
+
+    [Fact]
+    public void TryGetNextOccurrence_InvalidExpression_ReportsTheParseError()
+    {
+        ScheduledJobRunner.TryGetNextOccurrence("not a cron expression", ParseUtc("2000-01-01T00:00:00Z"), out var error);
+
+        error.Should().NotBeNullOrWhiteSpace("the message is what lands in LastError for an operator to read");
+    }
+
+    private static DateTime ParseUtc(string value) =>
+        DateTime.Parse(value, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal);
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/ScheduledJobRunnerTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/ScheduledJobRunnerTests.cs
@@ -1,0 +1,437 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Scheduling;
+using MMCA.Common.Infrastructure.Settings;
+using Moq;
+using static MMCA.Common.Infrastructure.Tests.Scheduling.SchedulerTestHarness;
+
+namespace MMCA.Common.Infrastructure.Tests.Scheduling;
+
+/// <summary>
+/// Coverage for <see cref="ScheduledJobRunner"/>: registration sync, the configuration override,
+/// the claim lease, outcome recording, and the missed-run policy. Every test drives the runner over
+/// a <see cref="FakeTimeProvider"/> and an in-memory SQLite <c>ScheduledJobs</c> table, so the
+/// schedule arithmetic is exact rather than timing-dependent.
+/// </summary>
+public sealed class ScheduledJobRunnerTests
+{
+    // Hourly on the hour. From the 00:00:00 epoch the first occurrence AFTER now is 01:00:00.
+    private const string HourlyCron = "0 * * * *";
+
+    // Every five minutes: the first occurrence after the epoch is 00:05:00.
+    private const string FiveMinuteCron = "*/5 * * * *";
+
+    // ── Registration sync: a job seen for the first time gets a row with its first occurrence ──
+    [Fact]
+    public async Task RunCycleAsync_FirstCycle_InsertsRowWithFirstOccurrenceAfterNow()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var job = new DelegateScheduledJob("nightly", HourlyCron);
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        var row = await LoadAsync(context, "nightly");
+        row.Should().NotBeNull();
+        row.CronExpression.Should().Be(HourlyCron);
+        row.NextRunOn.Should().Be(EpochUtc.AddHours(1), "the first occurrence strictly after the current instant");
+        row.LastRunOn.Should().BeNull();
+        row.LastOutcome.Should().BeNull();
+        row.LockedUntil.Should().BeNull();
+        job.ExecutionCount.Should().Be(0, "nothing is due yet");
+    }
+
+    // ── Registration sync: an unchanged schedule is left alone, or nothing would ever fire ──
+    [Fact]
+    public async Task RunCycleAsync_UnchangedCron_DoesNotPushTheScheduleForward()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var job = new DelegateScheduledJob("nightly", HourlyCron);
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromMinutes(30));
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        (await LoadAsync(context, "nightly")).NextRunOn.Should().Be(
+            EpochUtc.AddHours(1),
+            "a cycle that changes nothing must not recompute the next occurrence from the new instant");
+    }
+
+    // ── Registration sync: a schedule changed in code rewrites the row and recomputes ──
+    [Fact]
+    public async Task RunCycleAsync_CronChangedInCode_RewritesExpressionAndRecomputesNextRun()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var settings = EnabledSettings();
+        var (firstRunner, firstScope, _) = CreateRunner(
+            context, settings, timeProvider, new DelegateScheduledJob("nightly", HourlyCron));
+        await using (firstScope)
+        using (firstRunner)
+        {
+            await firstRunner.RunCycleAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Same job name, new compiled-in schedule: the redeployed host must adopt it.
+        var (runner, scopeServices, _) = CreateRunner(
+            context, settings, timeProvider, new DelegateScheduledJob("nightly", FiveMinuteCron));
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        var row = await LoadAsync(context, "nightly");
+        row.CronExpression.Should().Be(FiveMinuteCron);
+        row.NextRunOn.Should().Be(EpochUtc.AddMinutes(5));
+    }
+
+    // ── Registration sync: the configuration override beats the compiled-in default ──
+    [Fact]
+    public async Task RunCycleAsync_ConfigurationOverride_WinsOverTheJobDefault()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var settings = EnabledSettings();
+        settings.Jobs["nightly"] = new ScheduledJobOverrideSettings { Cron = FiveMinuteCron };
+
+        var (runner, scopeServices, _) = CreateRunner(
+            context, settings, timeProvider, new DelegateScheduledJob("nightly", HourlyCron));
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        var row = await LoadAsync(context, "nightly");
+        row.CronExpression.Should().Be(FiveMinuteCron, "the per-job configuration override beats the code default");
+        row.NextRunOn.Should().Be(EpochUtc.AddMinutes(5));
+    }
+
+    // ── Registration sync: a blank override leaves the code default in force ──
+    [Fact]
+    public void ResolveCronExpression_BlankOverride_FallsBackToTheJobDefault()
+    {
+        var settings = EnabledSettings();
+        settings.Jobs["nightly"] = new ScheduledJobOverrideSettings { Cron = "   " };
+
+        ScheduledJobRunner.ResolveCronExpression(settings, new DelegateScheduledJob("nightly", HourlyCron))
+            .Should().Be(HourlyCron);
+    }
+
+    // ── Execution: a due job runs exactly once and its outcome is recorded ──
+    [Fact]
+    public async Task RunCycleAsync_DueJob_ExecutesOnceAndRecordsSucceeded()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        // The job burns two seconds of fake time, so the recorded duration is a real number.
+        var job = new DelegateScheduledJob("nightly", HourlyCron, _ =>
+        {
+            timeProvider.Advance(TimeSpan.FromSeconds(2));
+            return Task.CompletedTask;
+        });
+
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);   // registers, nothing due
+        timeProvider.Advance(TimeSpan.FromHours(1));                          // 01:00:00, the occurrence
+        var earliest = await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        job.ExecutionCount.Should().Be(1, "one occurrence is one execution");
+
+        var row = await LoadAsync(context, "nightly");
+        row.LastOutcome.Should().Be("Succeeded");
+        row.LastError.Should().BeNull();
+        row.LastRunOn.Should().Be(EpochUtc.AddHours(1));
+        row.LastDurationMs.Should().Be(2000);
+        row.NextRunOn.Should().Be(EpochUtc.AddHours(2));
+        row.NextRunOn.Should().BeAfter(EpochUtc.AddHours(1).AddSeconds(2), "the schedule must advance strictly past now");
+        row.LockedUntil.Should().BeNull("the claim is released once the outcome is stamped");
+        row.LockToken.Should().BeNull();
+        earliest.Should().Be(EpochUtc.AddHours(2), "the smart wait targets the next occurrence");
+    }
+
+    // ── Execution: a failing job is recorded, truncated, and still advanced ──
+    [Fact]
+    public async Task RunCycleAsync_FailingJob_RecordsFailedWithTruncatedErrorAndStillAdvances()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var longMessage = new string('x', ScheduledJobRunner.MaxErrorLength + 500);
+        var job = new DelegateScheduledJob("nightly", HourlyCron, _ => throw new InvalidOperationException(longMessage));
+
+        var (runner, scopeServices, logger) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromHours(1));
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        var row = await LoadAsync(context, "nightly");
+        row.LastOutcome.Should().Be("Failed");
+        row.LastError.Should().NotBeNull();
+        row.LastError!.Length.Should().Be(
+            ScheduledJobRunner.MaxErrorLength,
+            "a long exception message is truncated to the column width rather than failing the update");
+        row.NextRunOn.Should().Be(
+            EpochUtc.AddHours(2),
+            "a failure still advances the schedule, so a permanently failing job cannot hot-loop");
+        row.LockedUntil.Should().BeNull();
+        VerifyLogged(logger, LogLevel.Error, "LogJobFailed");
+
+        // A second cycle at the same instant must not re-run it: the row is no longer due.
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+        job.ExecutionCount.Should().Be(1);
+    }
+
+    // ── Lease: a row another replica holds is left alone ──
+    [Fact]
+    public async Task RunCycleAsync_RowUnderAnotherReplicasLease_IsNotClaimed()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var otherReplicaToken = Guid.NewGuid();
+        context.Add(new ScheduledJobEntry
+        {
+            JobName = "nightly",
+            CronExpression = HourlyCron,
+            NextRunOn = EpochUtc,
+            LockedUntil = EpochUtc.AddMinutes(5),
+            LockToken = otherReplicaToken,
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.ChangeTracker.Clear();
+
+        var job = new DelegateScheduledJob("nightly", HourlyCron);
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        job.ExecutionCount.Should().Be(0, "an unexpired lease means another replica owns this occurrence");
+        var row = await LoadAsync(context, "nightly");
+        row.LockToken.Should().Be(otherReplicaToken, "the other replica's claim is untouched");
+        row.NextRunOn.Should().Be(EpochUtc, "the occurrence is still owed, just not to this replica");
+    }
+
+    // ── Lease: a dead replica's expired claim is reclaimed ──
+    [Fact]
+    public async Task RunCycleAsync_ExpiredLease_IsReclaimedAndRun()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        context.Add(new ScheduledJobEntry
+        {
+            JobName = "nightly",
+            CronExpression = HourlyCron,
+            NextRunOn = EpochUtc.AddHours(-1),
+            LockedUntil = EpochUtc.AddMinutes(-5),
+            LockToken = Guid.NewGuid(),
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.ChangeTracker.Clear();
+
+        var job = new DelegateScheduledJob("nightly", HourlyCron);
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        job.ExecutionCount.Should().Be(1, "an expired lease is how a dead replica's work is picked up");
+        var row = await LoadAsync(context, "nightly");
+        row.LastOutcome.Should().Be("Succeeded");
+        row.LockedUntil.Should().BeNull();
+        row.LockToken.Should().BeNull();
+    }
+
+    // ── Missed-run policy: a long outage produces exactly one run, not a catch-up storm ──
+    [Fact]
+    public async Task RunCycleAsync_ClockJumpedPastManyOccurrences_RunsOnceAndAdvancesPastNow()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var job = new DelegateScheduledJob("nightly", HourlyCron);
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider, job);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        // Two full days down: forty-eight hourly occurrences elapsed.
+        timeProvider.Advance(TimeSpan.FromDays(2));
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        job.ExecutionCount.Should().Be(1, "missed occurrences collapse into one run, never a backlog replay");
+
+        var now = EpochUtc.AddDays(2);
+        var row = await LoadAsync(context, "nightly");
+        row.NextRunOn.Should().Be(now.AddHours(1), "the next occurrence is computed from now, not from the missed one");
+        row.NextRunOn.Should().BeAfter(now);
+
+        // And the very next cycle at the same instant runs nothing.
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+        job.ExecutionCount.Should().Be(1);
+    }
+
+    // ── Invalid cron: recorded as Skipped, parked, and the runner survives ──
+    [Fact]
+    public async Task RunCycleAsync_InvalidCronExpression_RecordsSkippedAndNeverRunsTheJob()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var broken = new DelegateScheduledJob("broken", "not a cron expression");
+        var healthy = new DelegateScheduledJob("healthy", FiveMinuteCron);
+        var (runner, scopeServices, logger) = CreateRunner(context, EnabledSettings(), timeProvider, broken, healthy);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromDays(1));
+        await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        var brokenRow = await LoadAsync(context, "broken");
+        brokenRow.LastOutcome.Should().Be("Skipped");
+        brokenRow.LastError.Should().NotBeNullOrWhiteSpace();
+        brokenRow.NextRunOn.Should().Be(DateTime.MaxValue, "an unparsable schedule is parked, never claimed");
+        broken.ExecutionCount.Should().Be(0);
+        VerifyLogged(logger, LogLevel.Error, "LogInvalidCronExpression");
+
+        healthy.ExecutionCount.Should().Be(1, "one bad expression must not stop the other jobs in the host");
+    }
+
+    // ── An unregistered row is recorded as Skipped rather than silently held ──
+    [Fact]
+    public async Task RunCycleAsync_NoRegisteredJobs_DoesNothingAndReportsNoWork()
+    {
+        var timeProvider = new FakeTimeProvider(Epoch);
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = SchedulerTestContext.Create(connection);
+
+        var (runner, scopeServices, _) = CreateRunner(context, EnabledSettings(), timeProvider);
+        await using var scope = scopeServices;
+        using var service = runner;
+
+        var earliest = await runner.RunCycleAsync(TestContext.Current.CancellationToken);
+
+        earliest.Should().BeNull();
+        (await context.Set<ScheduledJobEntry>().CountAsync(TestContext.Current.CancellationToken)).Should().Be(0);
+    }
+
+    // ── Disabled: the runner logs once and never touches the store ──
+    [Fact]
+    public async Task ExecuteAsync_Disabled_LogsOnceAndNeverCreatesAScope()
+    {
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        var logger = new Mock<ILogger<ScheduledJobRunner>>();
+        logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        var resolver = new Mock<IDataSourceResolver>();
+
+        using var runner = new ScheduledJobRunner(
+            scopeFactory.Object,
+            logger.Object,
+            Microsoft.Extensions.Options.Options.Create(new SchedulerSettings()),
+            resolver.Object,
+            new FakeTimeProvider(Epoch));
+
+        await runner.StartAsync(TestContext.Current.CancellationToken);
+        await runner.ExecuteTask!.WaitAsync(TimeSpan.FromSeconds(30), TimeProvider.System);
+        await runner.StopAsync(TestContext.Current.CancellationToken);
+
+        runner.ExecuteTask.IsCompletedSuccessfully.Should().BeTrue("the disabled path returns immediately");
+        scopeFactory.Verify(f => f.CreateScope(), Times.Never);
+        resolver.Verify(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()), Times.Never);
+        VerifyLogged(logger, LogLevel.Information, "LogSchedulerDisabled");
+    }
+
+    // ── Smart wait ──
+    [Fact]
+    public void ComputeWaitTime_NoUpcomingOccurrence_UsesThePollingInterval() =>
+        ScheduledJobRunner.ComputeWaitTime(null, EpochUtc, TimeSpan.FromSeconds(30))
+            .Should().Be(TimeSpan.FromSeconds(30));
+
+    [Fact]
+    public void ComputeWaitTime_OccurrenceSoonerThanTheInterval_SleepsUntilTheOccurrence() =>
+        ScheduledJobRunner.ComputeWaitTime(EpochUtc.AddSeconds(8), EpochUtc, TimeSpan.FromSeconds(30))
+            .Should().Be(TimeSpan.FromSeconds(8));
+
+    [Fact]
+    public void ComputeWaitTime_OccurrenceFurtherOutThanTheInterval_IsCappedAtTheInterval() =>
+        ScheduledJobRunner.ComputeWaitTime(EpochUtc.AddHours(4), EpochUtc, TimeSpan.FromSeconds(30))
+            .Should().Be(TimeSpan.FromSeconds(30));
+
+    [Fact]
+    public void ComputeWaitTime_OverdueOccurrence_IsFlooredSoTheLoopCannotSpin() =>
+        ScheduledJobRunner.ComputeWaitTime(EpochUtc.AddMinutes(-5), EpochUtc, TimeSpan.FromSeconds(30))
+            .Should().Be(TimeSpan.FromSeconds(1));
+
+    private static async Task<ScheduledJobEntry> LoadAsync(
+        MMCA.Common.Infrastructure.Persistence.DbContexts.ApplicationDbContext context,
+        string jobName)
+    {
+        var row = await context.Set<ScheduledJobEntry>().AsNoTracking()
+            .SingleOrDefaultAsync(e => e.JobName == jobName, TestContext.Current.CancellationToken);
+        row.Should().NotBeNull("a row is expected for the job " + jobName);
+        return row;
+    }
+
+    // The LoggerMessage source generator names the EventId after the logging method, and its
+    // LoggerMessageState does not expose the formatted message via ToString(), so the event id is
+    // the stable way to assert THIS specific log entry was written.
+    private static void VerifyLogged(Mock<ILogger<ScheduledJobRunner>> logger, LogLevel level, string eventName) =>
+        logger.Verify(
+            l => l.Log(
+                level,
+                It.Is<EventId>(e => e.Name == eventName),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/SchedulerMetricsTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/SchedulerMetricsTests.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.Metrics;
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Scheduling;
+
+namespace MMCA.Common.Infrastructure.Tests.Scheduling;
+
+/// <summary>
+/// Coverage for <see cref="SchedulerMetrics"/>: the meter name a host registers for export, and the
+/// instrument names, units and tags an operator builds dashboards on. These are a published contract
+/// (the Aspire service defaults add the meter by literal name), so a rename must fail here rather
+/// than silently blank a dashboard.
+/// </summary>
+public sealed class SchedulerMetricsTests
+{
+    [Fact]
+    public void MeterName_MatchesTheNameTheAspireDefaultsRegister() =>
+        SchedulerMetrics.MeterName.Should().Be("MMCA.Common.Scheduler");
+
+    [Fact]
+    public void Instruments_CarryTheirPublishedNamesAndUnits()
+    {
+        SchedulerMetrics.RunCounter.Name.Should().Be("scheduler.job.runs");
+        SchedulerMetrics.RunCounter.Unit.Should().Be("runs");
+
+        SchedulerMetrics.DurationHistogram.Name.Should().Be("scheduler.job.duration");
+        SchedulerMetrics.DurationHistogram.Unit.Should().Be("s");
+
+        SchedulerMetrics.LagHistogram.Name.Should().Be("scheduler.job.lag");
+        SchedulerMetrics.LagHistogram.Unit.Should().Be("s");
+    }
+
+    [Fact]
+    public void Instruments_AllBelongToTheOneSchedulerMeter()
+    {
+        SchedulerMetrics.RunCounter.Meter.Name.Should().Be(SchedulerMetrics.MeterName);
+        SchedulerMetrics.DurationHistogram.Meter.Name.Should().Be(SchedulerMetrics.MeterName);
+        SchedulerMetrics.LagHistogram.Meter.Name.Should().Be(SchedulerMetrics.MeterName);
+    }
+
+    [Fact]
+    public void RunCounter_RecordsTheJobAndOutcomeTags()
+    {
+        // A job name unique to this test: the runner tests record on the same counter, and xUnit runs
+        // test classes in parallel, so the assertion filters to measurements this test produced.
+        const string jobName = "metrics-contract-probe";
+
+        // Touch the instrument BEFORE starting the listener so its static initializer has run: a
+        // listener started first would be handed the instrument while the field it is compared
+        // against is still null.
+        var counter = SchedulerMetrics.RunCounter;
+        var observed = new List<(long Value, string? Job, string? Outcome)>();
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (ReferenceEquals(instrument, counter))
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            string? job = null;
+            string? outcome = null;
+            foreach (KeyValuePair<string, object?> tag in tags)
+            {
+                if (string.Equals(tag.Key, "job", StringComparison.Ordinal))
+                {
+                    job = tag.Value as string;
+                }
+                else if (string.Equals(tag.Key, "outcome", StringComparison.Ordinal))
+                {
+                    outcome = tag.Value as string;
+                }
+            }
+
+            observed.Add((value, job, outcome));
+        });
+        listener.Start();
+
+        counter.Add(
+            1,
+            new KeyValuePair<string, object?>("job", jobName),
+            new KeyValuePair<string, object?>("outcome", "Succeeded"));
+
+        observed.Where(m => string.Equals(m.Job, jobName, StringComparison.Ordinal))
+            .Should().ContainSingle()
+            .Which.Should().Be((1L, jobName, "Succeeded"));
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/SchedulerModelGateTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/SchedulerModelGateTests.cs
@@ -1,0 +1,122 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Scheduling;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Scheduling;
+
+/// <summary>
+/// The <c>ScheduledJobs</c> table is settings-gated: a host that never opted in must get exactly the
+/// model it had before the scheduler shipped, so its migrations never see the table. These tests
+/// build the real <see cref="ApplicationDbContext"/> model under each combination of
+/// <c>Scheduler:Enabled</c> and data source.
+/// </summary>
+public sealed class SchedulerModelGateTests
+{
+    [Fact]
+    public void Model_SchedulerDisabled_DoesNotContainTheJobTable()
+    {
+        using var context = GateTestContext.Create(schedulerEnabled: false, sourceName: DataSourceKey.DefaultName);
+
+        context.Model.FindEntityType(typeof(ScheduledJobEntry)).Should().BeNull(
+            "a host that never called AddScheduledJobs must not gain a table in its next migration");
+    }
+
+    [Fact]
+    public void Model_NoSchedulerSettingsRegisteredAtAll_DoesNotContainTheJobTable()
+    {
+        using var context = GateTestContext.Create(
+            schedulerEnabled: false, sourceName: DataSourceKey.DefaultName, registerSettings: false);
+
+        context.Model.FindEntityType(typeof(ScheduledJobEntry)).Should().BeNull(
+            "the absence of the settings must read as disabled, not fail context construction");
+    }
+
+    [Fact]
+    public void Model_SchedulerEnabledOnTheDefaultSource_ContainsTheJobTable()
+    {
+        using var context = GateTestContext.Create(schedulerEnabled: true, sourceName: DataSourceKey.DefaultName);
+
+        var entityType = context.Model.FindEntityType(typeof(ScheduledJobEntry));
+        entityType.Should().NotBeNull();
+        entityType!.GetTableName().Should().Be("ScheduledJobs");
+        entityType.FindPrimaryKey()!.Properties.Select(p => p.Name).Should().Equal(nameof(ScheduledJobEntry.JobName));
+    }
+
+    [Fact]
+    public void Model_SchedulerEnabledOnANonDefaultSource_DoesNotContainTheJobTable()
+    {
+        using var context = GateTestContext.Create(schedulerEnabled: true, sourceName: "Conference");
+
+        context.Model.FindEntityType(typeof(ScheduledJobEntry)).Should().BeNull(
+            "jobs are host-scoped: the table lives in exactly one database, unlike the per-source outbox");
+    }
+
+    /// <summary>
+    /// A context that runs the real <see cref="ApplicationDbContext.OnModelCreating"/> (and therefore
+    /// the real gate) with a configurable data source and scheduler setting.
+    /// </summary>
+    private sealed class GateTestContext : ApplicationDbContext
+    {
+        private GateTestContext(
+            DbContextOptions<GateTestContext> options,
+            IServiceProvider serviceProvider,
+            PhysicalDataSource physicalDataSource)
+            : base(options, serviceProvider, new NullAssemblyProvider(), physicalDataSource)
+        {
+        }
+
+        public static GateTestContext Create(bool schedulerEnabled, string sourceName, bool registerSettings = true)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(_ =>
+            {
+                var dispatcher = new Mock<IDomainEventDispatcher>();
+                var logger = new Mock<ILogger<DomainEventSaveChangesInterceptor>>();
+                var outboxSignal = new Mock<IOutboxSignal>();
+                return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
+            });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+
+            if (registerSettings)
+            {
+                services.AddSingleton<IOptions<SchedulerSettings>>(
+                    Options.Create(new SchedulerSettings { Enabled = schedulerEnabled }));
+            }
+
+            // EF caches its internal service provider (and with it the built model) per distinct set
+            // of options, and DataSourceModelCacheKeyFactory keys that model by (context type,
+            // source name) only. These tests build the SAME context type against the SAME source
+            // name under different scheduler settings, which in production never happens (the flag is
+            // fixed for the life of a host), so caching must be off here or every case after the
+            // first would silently assert against the first case's model.
+            var options = new DbContextOptionsBuilder<GateTestContext>()
+                .UseSqlite("DataSource=:memory:")
+                .EnableServiceProviderCaching(false)
+                .Options;
+
+            var physical = new PhysicalDataSource(
+                new DataSourceKey(DataSource.Sqlite, sourceName), "DataSource=:memory:", null, "Test");
+
+            return new GateTestContext(options, services.BuildServiceProvider(), physical);
+        }
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/SchedulerTestHarness.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Scheduling/SchedulerTestHarness.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Scheduling;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
+
+namespace MMCA.Common.Infrastructure.Tests.Scheduling;
+
+/// <summary>
+/// Shared scaffolding for the scheduler tests: an in-memory SQLite
+/// <see cref="ApplicationDbContext"/> mapping <see cref="ScheduledJobEntry"/> (the
+/// OutboxCleanupServiceTests harness pattern) plus a <see cref="ScheduledJobRunner"/> wired to it
+/// over a <see cref="FakeTimeProvider"/>.
+/// </summary>
+internal static class SchedulerTestHarness
+{
+    /// <summary>Epoch for every scheduler test, passed explicitly so seeded timestamps read plainly.</summary>
+    public static readonly DateTimeOffset Epoch = new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The <see cref="Epoch"/> as the UTC <see cref="DateTime"/> the runner works in.</summary>
+    public static DateTime EpochUtc => Epoch.UtcDateTime;
+
+    /// <summary>
+    /// Builds a runner over <paramref name="context"/> with <paramref name="jobs"/> registered in the
+    /// scope the runner creates each cycle.
+    /// </summary>
+    public static (ScheduledJobRunner Runner, ServiceProvider ScopeServices, Mock<ILogger<ScheduledJobRunner>> Logger) CreateRunner(
+        ApplicationDbContext context,
+        SchedulerSettings settings,
+        FakeTimeProvider timeProvider,
+        params IScheduledJob[] jobs)
+    {
+        var dbContextFactory = new Mock<IDbContextFactory>();
+        dbContextFactory
+            .Setup(f => f.GetDbContext(It.IsAny<DataSourceKey>()))
+            .Returns(context);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => dbContextFactory.Object);
+        foreach (var job in jobs)
+        {
+            services.AddScoped<IScheduledJob>(_ => job);
+        }
+
+        var scopeServices = services.BuildServiceProvider();
+
+        var logger = new Mock<ILogger<ScheduledJobRunner>>();
+        logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+        var resolver = new Mock<IDataSourceResolver>();
+        resolver
+            .Setup(r => r.ResolveLogical(It.IsAny<DataSource>(), It.IsAny<string>()))
+            .Returns((DataSource engine, string _) => DataSourceKey.Default(engine));
+
+        var runner = new ScheduledJobRunner(
+            scopeServices.GetRequiredService<IServiceScopeFactory>(),
+            logger.Object,
+            Options.Create(settings),
+            resolver.Object,
+            timeProvider);
+
+        return (runner, scopeServices, logger);
+    }
+
+    /// <summary>Scheduler settings with the SQLite harness selected and the scheduler switched on.</summary>
+    public static SchedulerSettings EnabledSettings(int leaseSeconds = 300) => new()
+    {
+        Enabled = true,
+        DataSource = DataSource.Sqlite,
+        LeaseSeconds = leaseSeconds,
+    };
+
+    /// <summary>
+    /// A test <see cref="ApplicationDbContext"/> mapping only <see cref="ScheduledJobEntry"/>,
+    /// SQLite-portable (no schema, no SQL Server index annotations). The production gate that
+    /// decides whether the table is in the model at all is covered separately by
+    /// <c>SchedulerModelGateTests</c>, so this harness maps it unconditionally.
+    /// </summary>
+    public sealed class SchedulerTestContext : ApplicationDbContext
+    {
+        private SchedulerTestContext(DbContextOptions<SchedulerTestContext> options, IServiceProvider serviceProvider)
+            : base(options, serviceProvider, new NullAssemblyProvider(), TestPhysicalDataSources.Sqlite())
+        {
+        }
+
+        public static SchedulerTestContext Create(SqliteConnection connection)
+        {
+            var options = new DbContextOptionsBuilder<SchedulerTestContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var context = new SchedulerTestContext(options, BuildContextServices());
+            context.Database.EnsureCreated();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            ArgumentNullException.ThrowIfNull(modelBuilder);
+            modelBuilder.Entity<ScheduledJobEntry>(entity =>
+            {
+                entity.ToTable("ScheduledJobs");
+                entity.HasKey(e => e.JobName);
+                entity.Property(e => e.JobName).HasMaxLength(128);
+                entity.Property(e => e.CronExpression).IsRequired().HasMaxLength(128);
+                entity.Property(e => e.LastOutcome).HasMaxLength(32);
+                entity.Property(e => e.LastError).HasMaxLength(2048);
+                entity.HasIndex(e => e.NextRunOn);
+            });
+        }
+
+        private static ServiceProvider BuildContextServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new AuditSaveChangesInterceptor(TimeProvider.System));
+            services.AddSingleton(_ =>
+            {
+                var dispatcher = new Mock<IDomainEventDispatcher>();
+                var logger = new Mock<ILogger<DomainEventSaveChangesInterceptor>>();
+                var outboxSignal = new Mock<IOutboxSignal>();
+                return new DomainEventSaveChangesInterceptor(dispatcher.Object, logger.Object, outboxSignal.Object);
+            });
+            services.AddSingleton<IEntityDataSourceRegistry>(new EmptyEntityDataSourceRegistry());
+            return services.BuildServiceProvider();
+        }
+    }
+
+    private sealed class NullAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<Assembly> GetConfigurationAssemblies() => [];
+    }
+}
+
+/// <summary>
+/// A job whose body is supplied by the test. The delegate receives the job instance so a test can
+/// count executions or advance the fake clock from inside the run.
+/// </summary>
+internal sealed class DelegateScheduledJob(string name, string cronExpression, Func<CancellationToken, Task>? body = null)
+    : IScheduledJob
+{
+    public string Name => name;
+
+    public string CronExpression => cronExpression;
+
+    /// <summary>Gets how many times this job has been executed.</summary>
+    public int ExecutionCount { get; private set; }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        ExecutionCount++;
+        if (body is not null)
+        {
+            await body(cancellationToken);
+        }
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/TenantContextTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/TenantContextTests.cs
@@ -1,0 +1,81 @@
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Services;
+
+namespace MMCA.Common.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Coverage for the scoped tenant context invariants: unresolved until told, idempotent for the
+/// value it already holds, and immovable once set.
+/// </summary>
+public sealed class TenantContextTests
+{
+    [Fact]
+    public void NewContext_IsUnresolved()
+    {
+        var sut = new TenantContext();
+
+        sut.TenantId.Should().BeNull();
+        sut.IsResolved.Should().BeFalse("an unresolved tenant is a real state, not a missing value");
+    }
+
+    [Fact]
+    public void SetTenant_ResolvesTheScope()
+    {
+        var sut = new TenantContext();
+
+        sut.SetTenant("acme");
+
+        sut.TenantId.Should().Be("acme");
+        sut.IsResolved.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetTenant_WithTheSameValue_IsIdempotent()
+    {
+        var sut = new TenantContext();
+        sut.SetTenant("acme");
+
+        var act = () => sut.SetTenant("acme");
+
+        act.Should().NotThrow("re-asserting the same tenant on a scope must not be a fight");
+        sut.TenantId.Should().Be("acme");
+    }
+
+    [Fact]
+    public void SetTenant_WithADifferentValue_Throws()
+    {
+        var sut = new TenantContext();
+        sut.SetTenant("acme");
+
+        var act = () => sut.SetTenant("globex");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*acme*globex*",
+                "anything already read in this scope was scoped to the first tenant");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetTenant_WithABlankValue_Throws(string? tenantId)
+    {
+        var sut = new TenantContext();
+
+        var act = () => sut.SetTenant(tenantId!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetTenant_IsCaseSensitive()
+    {
+        var sut = new TenantContext();
+        sut.SetTenant("acme");
+
+        var act = () => sut.SetTenant("ACME");
+
+        act.Should().Throw<InvalidOperationException>(
+            "tenant identifiers are compared ordinally everywhere in the framework, so two casings are two tenants");
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
@@ -882,6 +882,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -921,6 +922,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
@@ -892,6 +892,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -1039,6 +1040,18 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.10",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Http": {

--- a/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/EnumerationSerializationTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/EnumerationSerializationTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AwesomeAssertions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Shared.Tests.ValueObjects;
+
+/// <summary>
+/// Pins the JSON wire contract of the smart enumeration: the member name is the payload, and a
+/// payload that cannot be resolved fails loudly instead of materializing a null member. Both routes
+/// to the converter are covered, the attribute on the concrete type and the factory registered in
+/// <see cref="JsonSerializerOptions.Converters"/>, because System.Text.Json resolves a converter
+/// attribute off the type it is converting without walking base types.
+/// </summary>
+public class EnumerationSerializationTests
+{
+    // ── Round-trip ──
+    [Fact]
+    public void Serialize_WritesTheMemberName()
+    {
+        var json = JsonSerializer.Serialize(Severity.Major);
+
+        json.Should().Be("\"Major\"", "the factory attached to the base class serializes by Name");
+    }
+
+    [Fact]
+    public void Roundtrip_TopLevelMember_ReturnsTheDeclaredInstance()
+    {
+        var json = JsonSerializer.Serialize(Severity.Minor);
+
+        var deserialized = JsonSerializer.Deserialize<Severity>(json);
+
+        deserialized.Should().BeSameAs(Severity.Minor);
+    }
+
+    [Fact]
+    public void Roundtrip_MemberOnAContainer_PreservesTheMember()
+    {
+        var json = JsonSerializer.Serialize(new Alert { Title = "Disk full", Level = Severity.Major });
+
+        var deserialized = JsonSerializer.Deserialize<Alert>(json);
+
+        json.Should().Contain("\"Level\":\"Major\"");
+        deserialized!.Level.Should().BeSameAs(Severity.Major);
+    }
+
+    [Fact]
+    public void Deserialize_NameWithDifferentCasing_ResolvesTheMember()
+    {
+        var deserialized = JsonSerializer.Deserialize<Severity>("\"mAJOR\"");
+
+        deserialized.Should().BeSameAs(Severity.Major, "the converter resolves through the case-insensitive FromName");
+    }
+
+    // ── Factory registered in the options instead of attributed on the type ──
+    [Fact]
+    public void Roundtrip_ThroughAFactoryRegisteredInTheOptions_NeedsNoTypeAttribute()
+    {
+        var options = new JsonSerializerOptions { Converters = { new EnumerationJsonConverterFactory() } };
+
+        var json = JsonSerializer.Serialize(Grade.Pass, options);
+        var deserialized = JsonSerializer.Deserialize<Grade>(json, options);
+
+        json.Should().Be("\"Pass\"");
+        deserialized.Should().BeSameAs(Grade.Pass);
+    }
+
+    [Fact]
+    public void Serialize_WithoutEitherRoute_FallsBackToTheDefaultObjectShape()
+    {
+        var json = JsonSerializer.Serialize(Grade.Fail);
+
+        json.Should().Contain("\"Name\":\"Fail\"",
+            "the documented limitation is real: an unattributed enumeration serialized through unconfigured options uses the default converter");
+    }
+
+    // ── Rejected payloads ──
+    [Fact]
+    public void Deserialize_UnknownName_ThrowsJsonException()
+        => FluentActions.Invoking(() => JsonSerializer.Deserialize<Severity>("\"Catastrophic\""))
+            .Should().Throw<JsonException>();
+
+    [Fact]
+    public void Deserialize_NumericToken_ThrowsJsonException()
+        => FluentActions.Invoking(() => JsonSerializer.Deserialize<Severity>("2"))
+            .Should().Throw<JsonException>(
+                "a non-string token must fail the same way MVC model binding does, not bind by value");
+
+    [Fact]
+    public void Deserialize_ObjectToken_ThrowsJsonException()
+        => FluentActions.Invoking(() => JsonSerializer.Deserialize<Severity>("{\"Name\":\"Major\"}"))
+            .Should().Throw<JsonException>();
+
+    // ── Null handling ──
+    [Fact]
+    public void Deserialize_NullToken_ReturnsNull()
+        => JsonSerializer.Deserialize<Severity>("null").Should().BeNull(
+            "HandleNull stays at its default, so the serializer short-circuits null before the converter runs");
+
+    [Fact]
+    public void Roundtrip_ContainerWithNullMember_KeepsTheMemberNull()
+    {
+        var json = JsonSerializer.Serialize(new Alert { Title = "Nothing to see" });
+
+        var deserialized = JsonSerializer.Deserialize<Alert>(json);
+
+        deserialized!.Level.Should().BeNull();
+    }
+
+    [JsonConverter(typeof(EnumerationJsonConverterFactory))]
+    private sealed class Severity : Enumeration<Severity>
+    {
+        public static readonly Severity Minor = new(1, "Minor");
+        public static readonly Severity Major = new(2, "Major");
+
+        private Severity(int value, string name)
+            : base(value, name)
+        {
+        }
+    }
+
+    private sealed class Grade : Enumeration<Grade>
+    {
+        public static readonly Grade Fail = new(1, "Fail");
+        public static readonly Grade Pass = new(2, "Pass");
+
+        private Grade(int value, string name)
+            : base(value, name)
+        {
+        }
+    }
+
+    private sealed record Alert
+    {
+        public string Title { get; init; } = string.Empty;
+
+        public Severity? Level { get; init; }
+    }
+}

--- a/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/EnumerationTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/ValueObjects/EnumerationTests.cs
@@ -1,0 +1,144 @@
+using AwesomeAssertions;
+using MMCA.Common.Shared.ValueObjects;
+
+namespace MMCA.Common.Shared.Tests.ValueObjects;
+
+/// <summary>
+/// Pins the smart-enumeration contract: reflection-based member discovery, Result-returning lookups,
+/// and type-guarded equality (two enumerations that happen to share an integer value are never equal).
+/// </summary>
+public class EnumerationTests
+{
+    // ── FromValue ──
+    [Fact]
+    public void FromValue_WithDeclaredValue_ReturnsTheDeclaredInstance()
+    {
+        var result = Priority.FromValue(2);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(Priority.Normal, "lookups hand back the interned singleton, not a copy");
+    }
+
+    [Fact]
+    public void FromValue_WithUnknownValue_ReturnsUnknownValueError()
+    {
+        var result = Priority.FromValue(99);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Code == "Enumeration.UnknownValue");
+    }
+
+    // ── FromName ──
+    [Fact]
+    public void FromName_WithDeclaredName_ReturnsTheDeclaredInstance()
+    {
+        var result = Priority.FromName("High");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(Priority.High);
+    }
+
+    [Fact]
+    public void FromName_WithDifferentCasing_ReturnsTheDeclaredInstance()
+    {
+        var result = Priority.FromName("hIGh");
+
+        result.IsSuccess.Should().BeTrue("name lookup is case-insensitive, matching RoleValue");
+        result.Value.Should().BeSameAs(Priority.High);
+    }
+
+    [Fact]
+    public void FromName_WithUnknownName_ReturnsUnknownNameError()
+    {
+        var result = Priority.FromName("Urgent");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().Contain(e => e.Code == "Enumeration.UnknownName");
+    }
+
+    [Fact]
+    public void FromName_WithNull_ReturnsUnknownNameError()
+    {
+        var result = Priority.FromName(null!);
+
+        result.IsFailure.Should().BeTrue("a null name must fail as a lookup miss, not throw");
+        result.Errors.Should().Contain(e => e.Code == "Enumeration.UnknownName");
+    }
+
+    // ── All ──
+    [Fact]
+    public void All_ContainsEveryDeclaredMemberOrderedByValue()
+    {
+        Priority.All.Should().HaveCount(3);
+        Priority.All.Should().ContainInOrder(Priority.Low, Priority.Normal, Priority.High);
+    }
+
+    [Fact]
+    public void All_IsScopedToTheDeclaringEnumeration()
+    {
+        Severity.All.Should().HaveCount(2, "each closed type gets its own lookup tables");
+        Severity.All.Should().ContainInOrder(Severity.Trivial, Severity.Blocking);
+    }
+
+    // ── Equality ──
+    [Fact]
+    public void Equals_SameMember_IsTrue()
+        => Priority.High.Should().Be(Priority.High);
+
+    [Fact]
+    public void Equals_DifferentMembersOfTheSameEnumeration_IsFalse()
+        => Priority.High.Should().NotBe(Priority.Low);
+
+    [Fact]
+    public void Equals_MembersOfDifferentEnumerationsSharingAValue_IsFalse()
+    {
+        Priority.Low.Value.Should().Be(Severity.Trivial.Value, "the two members share an integer value");
+
+        Priority.Low.Equals(Severity.Trivial).Should().BeFalse(
+            "equality is type-guarded, so an integer value alone never makes two enumerations equal");
+    }
+
+    [Fact]
+    public void Equals_NonEnumerationObject_IsFalse()
+        => Priority.Low.Equals("Low").Should().BeFalse();
+
+    [Fact]
+    public void GetHashCode_SameMember_IsStable()
+        => Priority.High.GetHashCode().Should().Be(Priority.High.GetHashCode());
+
+    [Fact]
+    public void GetHashCode_MembersOfDifferentEnumerationsSharingAValue_StayDistinctEntries()
+    {
+        var set = new HashSet<object>(2) { Priority.Low, Severity.Trivial };
+
+        set.Should().HaveCount(2, "the concrete type participates in both equality and hashing");
+    }
+
+    // ── ToString ──
+    [Fact]
+    public void ToString_ReturnsTheMemberName()
+        => Priority.Normal.ToString().Should().Be("Normal");
+
+    private sealed class Priority : Enumeration<Priority>
+    {
+        public static readonly Priority Low = new(1, "Low");
+        public static readonly Priority Normal = new(2, "Normal");
+        public static readonly Priority High = new(3, "High");
+
+        private Priority(int value, string name)
+            : base(value, name)
+        {
+        }
+    }
+
+    private sealed class Severity : Enumeration<Severity>
+    {
+        public static readonly Severity Trivial = new(1, "Trivial");
+        public static readonly Severity Blocking = new(2, "Blocking");
+
+        private Severity(int value, string name)
+            : base(value, name)
+        {
+        }
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Configuration/KeyVaultConfigurationExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Configuration/KeyVaultConfigurationExtensionsTests.cs
@@ -1,0 +1,212 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+
+namespace MMCA.Common.Aspire.Tests.Configuration;
+
+/// <summary>
+/// Guards the configuration gate on <c>AddCommonKeyVaultConfiguration</c>: no <c>KeyVault:Uri</c>
+/// means the host gains no configuration source and takes no Azure dependency at startup, while a
+/// configured URI appends the Key Vault source that later reads the vault.
+/// <para>
+/// No test here touches the network, and the two builder shapes are what keeps that true. The tests
+/// that must NOT add a source (the gate, and the two malformed-configuration cases, which throw
+/// before the source is built) run against a real <see cref="HostApplicationBuilder"/>, because that
+/// is the type a host actually uses. The tests that DO add a source run against a builder double
+/// whose configuration merely collects sources: a real <c>ConfigurationManager</c> builds and loads
+/// every source the instant it is added, and loading the Key Vault source means a live call to the
+/// vault. The double therefore proves the registration without the call, which is exactly the part
+/// this extension is responsible for.
+/// </para>
+/// </summary>
+public sealed class KeyVaultConfigurationExtensionsTests
+{
+    private const string KeyVaultAssemblyName = "Azure.Extensions.AspNetCore.Configuration.Secrets";
+
+    [Fact]
+    public void AddCommonKeyVaultConfiguration_WithoutVaultUri_AddsNoConfigurationSource()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        var configuration = builder.Configuration;
+        var sourceCountBefore = configuration.Sources.Count;
+
+        builder.AddCommonKeyVaultConfiguration();
+
+        configuration.Sources.Count
+            .Should().Be(
+                sourceCountBefore,
+                because: "an unconfigured host must gain no configuration source at all, so local development and tests never reach for a vault at startup");
+
+        configuration.Sources.Any(IsKeyVaultSource)
+            .Should().BeFalse(
+                because: "the gate key is what decides whether the host takes an Azure dependency, and it is absent here");
+    }
+
+    [Fact]
+    public void AddCommonKeyVaultConfiguration_WithVaultUri_AppendsTheKeyVaultConfigurationSource()
+    {
+        var builder = SourceCollectingBuilderWith(new(StringComparer.Ordinal)
+        {
+            ["KeyVault:Uri"] = "https://mmca-tests.vault.azure.net/",
+        });
+
+        builder.AddCommonKeyVaultConfiguration();
+
+        builder.Configuration.Sources
+            .Should().ContainSingle(
+                because: "a configured vault URI must add exactly one configuration source");
+
+        IsKeyVaultSource(builder.Configuration.Sources[^1])
+            .Should().BeTrue(
+                because: "the source has to be the Key Vault one specifically, and it has to be appended last so vault secrets override the file and environment values added before it");
+    }
+
+    [Fact]
+    public void AddCommonKeyVaultConfiguration_WithReloadIntervalMinutes_StillAppendsTheKeyVaultConfigurationSource()
+    {
+        var builder = SourceCollectingBuilderWith(new(StringComparer.Ordinal)
+        {
+            ["KeyVault:Uri"] = "https://mmca-tests.vault.azure.net/",
+            ["KeyVault:ReloadIntervalMinutes"] = "15",
+        });
+
+        builder.AddCommonKeyVaultConfiguration();
+
+        IsKeyVaultSource(builder.Configuration.Sources[^1])
+            .Should().BeTrue(
+                because: "a valid reload interval must be accepted and still produce the vault source; the interval itself is carried on options held by a source type the Azure package keeps internal, so it is not observable from here without reading private state");
+    }
+
+    [Fact]
+    public void AddCommonKeyVaultConfiguration_WithMalformedVaultUri_Throws()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["KeyVault:Uri"] = "not-a-vault-uri",
+        });
+
+        var act = () => builder.AddCommonKeyVaultConfiguration();
+
+        act.Should().Throw<UriFormatException>(
+            because: "a typo in the vault URI must stop the host at startup rather than let it run on whatever configuration it happened to have");
+
+        builder.Configuration.Sources.Any(IsKeyVaultSource)
+            .Should().BeFalse(
+                because: "the URI is validated before the source is constructed, so nothing is added and no vault call is attempted");
+    }
+
+    [Fact]
+    public void AddCommonKeyVaultConfiguration_WithNonPositiveReloadIntervalMinutes_Throws()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["KeyVault:Uri"] = "https://mmca-tests.vault.azure.net/",
+            ["KeyVault:ReloadIntervalMinutes"] = "0",
+        });
+
+        var act = () => builder.AddCommonKeyVaultConfiguration();
+
+        act.Should().Throw<InvalidOperationException>(
+            because: "a reload interval that cannot be honored must fail loudly: quietly falling back to no reload would leave a rotated secret unused until the next restart, and nobody would notice until it mattered")
+            .WithMessage("*KeyVault:ReloadIntervalMinutes*");
+    }
+
+    private static bool IsKeyVaultSource(IConfigurationSource source) =>
+        string.Equals(source.GetType().Assembly.GetName().Name, KeyVaultAssemblyName, StringComparison.Ordinal);
+
+    private static SourceCollectingHostApplicationBuilder SourceCollectingBuilderWith(Dictionary<string, string?> settings) =>
+        new(settings);
+
+    /// <summary>
+    /// A minimal <see cref="IHostApplicationBuilder"/> whose configuration collects sources instead of
+    /// building them, so a Key Vault source can be registered and asserted on without the vault ever
+    /// being contacted. Only the members the extension under test uses are functional.
+    /// </summary>
+    private sealed class SourceCollectingHostApplicationBuilder : IHostApplicationBuilder
+    {
+        public SourceCollectingHostApplicationBuilder(Dictionary<string, string?> settings) =>
+            Configuration = new SourceCollectingConfigurationManager(settings);
+
+        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
+
+        public IConfigurationManager Configuration { get; }
+
+        public IHostEnvironment Environment { get; } = new StubHostEnvironment();
+
+        public ILoggingBuilder Logging { get; } = new StubLoggingBuilder();
+
+        public IMetricsBuilder Metrics { get; } = new StubMetricsBuilder();
+
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public void ConfigureContainer<TContainerBuilder>(
+            IServiceProviderFactory<TContainerBuilder> factory,
+            Action<TContainerBuilder>? configure = null)
+            where TContainerBuilder : notnull =>
+            throw new NotSupportedException("The source-collecting builder double does not build a container.");
+    }
+
+    /// <summary>
+    /// An <see cref="IConfigurationManager"/> that reads its values from a fixed in-memory set and
+    /// appends added sources to a plain list, deliberately never building or loading them.
+    /// </summary>
+    private sealed class SourceCollectingConfigurationManager : IConfigurationManager
+    {
+        private readonly IConfigurationRoot _values;
+
+        public SourceCollectingConfigurationManager(Dictionary<string, string?> settings) =>
+            _values = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        public IList<IConfigurationSource> Sources { get; } = [];
+
+        public string? this[string key]
+        {
+            get => _values[key];
+            set => _values[key] = value;
+        }
+
+        public IConfigurationBuilder Add(IConfigurationSource source)
+        {
+            Sources.Add(source);
+            return this;
+        }
+
+        public IConfigurationRoot Build() => _values;
+
+        public IEnumerable<IConfigurationSection> GetChildren() => _values.GetChildren();
+
+        public IChangeToken GetReloadToken() => _values.GetReloadToken();
+
+        public IConfigurationSection GetSection(string key) => _values.GetSection(key);
+    }
+
+    private sealed class StubHostEnvironment : IHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "MMCA.Common.Aspire.Tests";
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public string EnvironmentName { get; set; } = Environments.Development;
+    }
+
+    private sealed class StubLoggingBuilder : ILoggingBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+    }
+
+    private sealed class StubMetricsBuilder : IMetricsBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
@@ -86,6 +86,14 @@
           "Azure.Core": "1.54.0"
         }
       },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "lcJtcgTkk1gGy59RQhGLJLMyad+zgASMn975PVjMft69q+jjFTo6Nyq5SCtOhPY1WvA0gNI1qYIVN2oikVXDjw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Common": {
         "type": "Transitive",
         "resolved": "12.25.0",
@@ -445,6 +453,7 @@
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
+          "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.1, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.3, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.3, )",
           "Azure.Identity": "[1.21.0, )",
@@ -488,6 +497,16 @@
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
+      "Azure.Extensions.AspNetCore.Configuration.Secrets": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.1, )",
+        "resolved": "1.5.1",
+        "contentHash": "2Io9af/y8GH1jfu//BQrYcwb+MZOJG+au2KCv+ltWM6PBCghbhaDyZWDkYWNWIougZgoHtyKM0CnlGi+9XAu/A==",
+        "dependencies": {
+          "Azure.Core": "1.54.0",
+          "Azure.Security.KeyVault.Secrets": "4.10.0"
         }
       },
       "Azure.Extensions.AspNetCore.DataProtection.Blobs": {

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/EntityControllerBaseExportTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/EntityControllerBaseExportTests.cs
@@ -1,0 +1,430 @@
+using System.Dynamic;
+using System.Globalization;
+using System.Text;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.API.Controllers;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Settings;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Specifications;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.DTOs;
+using Moq;
+using Moq.Language;
+
+namespace MMCA.Common.API.Tests.Controllers;
+
+public sealed class EntityControllerBaseExportTests : IDisposable
+{
+    private static readonly DateTimeOffset ExportInstant = new(2026, 8, 13, 10, 15, 0, TimeSpan.Zero);
+
+    private readonly Mock<IEntityQueryService<ExportTestEntity, ExportTestDTO, int>> _queryServiceMock = new();
+    private readonly Mock<ILogger<EntityControllerBase<ExportTestEntity, ExportTestDTO, int>>> _loggerMock = new();
+    private readonly MemoryStream _body = new();
+
+    private ExportTestController CreateController(int maxPageSize = 500, int maxExportRows = 100_000)
+    {
+        var settingsMock = new Mock<IApplicationSettings>();
+        settingsMock.Setup(s => s.MaxPageSize).Returns(maxPageSize);
+        settingsMock.Setup(s => s.MaxExportRows).Returns(maxExportRows);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(settingsMock.Object);
+        services.AddSingleton<TimeProvider>(new FakeTimeProvider(ExportInstant));
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Response.Body = _body;
+
+        return new ExportTestController(_queryServiceMock.Object, _loggerMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+    }
+
+    public void Dispose() => _body.Dispose();
+
+    private string BodyText() => Encoding.UTF8.GetString(_body.ToArray());
+
+    private static string[] BodyLines(string body) =>
+        body.TrimStart('\uFEFF').Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+    private static PagedCollectionResult<object> Page(IReadOnlyCollection<object> items, int totalItemCount) =>
+        new(items, new PaginationMetadata(totalItemCount, pageSize: items.Count == 0 ? 1 : items.Count, currentPage: 1));
+
+    private static ExportTestDTO Dto(int id, string? name = null, bool isActive = true) =>
+        new() { Id = id, Name = name ?? string.Create(CultureInfo.InvariantCulture, $"Name {id}"), IsActive = isActive, CreatedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+
+    private static ExpandoObject Shaped(params (string Key, object? Value)[] pairs)
+    {
+        IDictionary<string, object?> expando = new ExpandoObject();
+        foreach ((string key, object? value) in pairs)
+        {
+            expando[key] = value;
+        }
+
+        return (ExpandoObject)expando;
+    }
+
+    private ISetupSequentialResult<Task<Result<PagedCollectionResult<object>>>> SetupPages() =>
+        _queryServiceMock.SetupSequence(q => q.GetAllAsync(
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<Specification<ExportTestEntity, int>?>(),
+            It.IsAny<Dictionary<string, (string, string)>?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<int?>(),
+            It.IsAny<int?>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()));
+
+    // ── Page-loop fan-in ──
+    [Fact]
+    public async Task ExportAsync_ThreePages_FansInEveryRow()
+    {
+        SetupPages()
+            .ReturnsAsync(Result.Success(Page([Dto(1), Dto(2)], totalItemCount: 5)))
+            .ReturnsAsync(Result.Success(Page([Dto(3), Dto(4)], totalItemCount: 5)))
+            .ReturnsAsync(Result.Success(Page([Dto(5)], totalItemCount: 5)));
+        ExportTestController sut = CreateController(maxPageSize: 2);
+
+        IActionResult result = await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        result.Should().BeOfType<EmptyResult>(because: "the CSV was written straight to the response body");
+        string[] lines = BodyLines(BodyText());
+        lines.Should().HaveCount(6, because: "one header row plus five data rows across three pages");
+        lines[1].Should().StartWith("1,Name 1");
+        lines[5].Should().StartWith("5,Name 5");
+    }
+
+    [Fact]
+    public async Task ExportAsync_ShortFirstPage_StopsAfterOneQuery()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        _queryServiceMock.Verify(
+            q => q.GetAllAsync(
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<Specification<ExportTestEntity, int>?>(),
+                It.IsAny<Dictionary<string, (string, string)>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a page shorter than the page size is the last page");
+    }
+
+    [Fact]
+    public async Task ExportAsync_PagesThroughIncrementingPageNumbers()
+    {
+        SetupPages()
+            .ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 2)))
+            .ReturnsAsync(Result.Success(Page([Dto(2)], totalItemCount: 2)))
+            .ReturnsAsync(Result.Success(Page([], totalItemCount: 2)));
+        ExportTestController sut = CreateController(maxPageSize: 1);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        foreach (int pageNumber in new[] { 1, 2, 3 })
+        {
+            _queryServiceMock.Verify(
+                q => q.GetAllAsync(
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<Specification<ExportTestEntity, int>?>(),
+                    It.IsAny<Dictionary<string, (string, string)>?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    pageNumber,
+                    1,
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+
+    // ── Truncation ──
+    [Fact]
+    public async Task ExportAsync_AlwaysAdvertisesTheRowLimit()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10, maxExportRows: 7);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        sut.Response.Headers[EntityControllerBase<ExportTestEntity, ExportTestDTO, int>.ExportRowLimitHeaderName]
+            .ToString().Should().Be("7", because: "the ceiling is knowable before the body starts, so it rides in a header");
+    }
+
+    [Fact]
+    public async Task ExportAsync_CapReachedMidPage_AppendsTruncationMarker()
+    {
+        SetupPages()
+            .ReturnsAsync(Result.Success(Page([Dto(1), Dto(2)], totalItemCount: 10)))
+            .ReturnsAsync(Result.Success(Page([Dto(3), Dto(4)], totalItemCount: 10)));
+        ExportTestController sut = CreateController(maxPageSize: 2, maxExportRows: 3);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines(BodyText());
+        lines.Should().HaveCount(5, because: "header plus three data rows plus the truncation marker");
+        lines[^1].Should().Be("# export truncated at 3 rows");
+        sut.Response.Headers[EntityControllerBase<ExportTestEntity, ExportTestDTO, int>.ExportRowLimitHeaderName]
+            .ToString().Should().Be("3");
+    }
+
+    [Fact]
+    public async Task ExportAsync_CapOnPageBoundaryWithMoreRows_AppendsTruncationMarker()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1), Dto(2)], totalItemCount: 9)));
+        ExportTestController sut = CreateController(maxPageSize: 2, maxExportRows: 2);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        BodyLines(BodyText())[^1].Should().Be(
+            "# export truncated at 2 rows",
+            because: "the total says rows were left behind even though the cap fell on a page boundary");
+    }
+
+    [Fact]
+    public async Task ExportAsync_CapOnPageBoundaryWithNoMoreRows_WritesNoMarker()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1), Dto(2)], totalItemCount: 2)));
+        ExportTestController sut = CreateController(maxPageSize: 2, maxExportRows: 2);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        string body = BodyText();
+        body.Should().NotContain("# export truncated", because: "the export is complete, it just happens to end at the cap");
+        BodyLines(body).Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task ExportAsync_WithinTheCap_WritesNoMarker()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10, maxExportRows: 100);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        BodyText().Should().NotContain("# export truncated");
+    }
+
+    // ── Column resolution ──
+    [Fact]
+    public async Task ExportAsync_NoFields_UsesCamelCaseDtoColumns()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1, "Ada")], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines(BodyText());
+        lines[0].Should().Be("id,name,isActive,createdOn", because: "CSV columns must match the JSON property names");
+        lines[1].Should().Be("1,Ada,true,2026-01-01T00:00:00.0000000Z");
+    }
+
+    [Fact]
+    public async Task ExportAsync_WithFields_UsesShapedRowKeys()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page(
+            [Shaped(("id", 1), ("name", "Ada")), Shaped(("id", 2), ("name", "Grace"))],
+            totalItemCount: 2)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(fields: "Id,Name", cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines(BodyText());
+        lines[0].Should().Be("id,name", because: "the query service already shaped the rows to the requested fields");
+        lines[1].Should().Be("1,Ada");
+        lines[2].Should().Be("2,Grace");
+    }
+
+    [Fact]
+    public async Task ExportAsync_EmptyResult_WritesHeaderOnly()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([], totalItemCount: 0)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines(BodyText());
+        lines.Should().ContainSingle(because: "an empty export still names its columns");
+        lines[0].Should().Be("id,name,isActive,createdOn");
+    }
+
+    [Fact]
+    public async Task ExportAsync_EmptyResultWithFields_HeaderIsTheRequestedSubset()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([], totalItemCount: 0)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(fields: "Name,Id", cancellationToken: CancellationToken.None);
+
+        BodyLines(BodyText())[0].Should().Be(
+            "id,name",
+            because: "with no row to read keys from, the columns come from the DTO filtered to the requested fields, in DTO order");
+    }
+
+    // ── Escaping through the endpoint ──
+    [Fact]
+    public async Task ExportAsync_ValuesNeedingEscape_AreQuoted()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1, "Doe, Jane")], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        BodyText().Should().Contain("1,\"Doe, Jane\",true,");
+    }
+
+    [Fact]
+    public async Task ExportAsync_WritesExactlyOneByteOrderMark()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        byte[] bytes = _body.ToArray();
+        Convert.ToHexString(bytes.Take(3).ToArray()).Should().Be("EFBBBF");
+        BodyText().Count(c => c == '\uFEFF').Should().Be(1);
+    }
+
+    // ── Response metadata ──
+    [Fact]
+    public async Task ExportAsync_SetsCsvContentTypeAndAttachmentFileName()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        sut.Response.ContentType.Should().Be("text/csv; charset=utf-8");
+        sut.Response.Headers.ContentDisposition.ToString().Should().Be(
+            "attachment; filename=\"ExportTest-20260813T101500Z.csv\"",
+            because: "the file name is the controller stem plus an invariant UTC timestamp from the time provider");
+    }
+
+    // ── Failures ──
+    [Fact]
+    public async Task ExportAsync_FirstPageFailure_ReturnsProblemDetailsAndWritesNothing()
+    {
+        SetupPages().ReturnsAsync(Result.Failure<PagedCollectionResult<object>>(
+            Error.NotFoundError("Test.NotFound", "Not found")));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        IActionResult result = await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        objectResult.Value.Should().BeOfType<ProblemDetails>();
+        _body.ToArray().Should().BeEmpty(because: "nothing was flushed, so the status line was still ours to set");
+    }
+
+    [Fact]
+    public async Task ExportAsync_LaterPageFailure_AppendsIncompleteMarker()
+    {
+        SetupPages()
+            .ReturnsAsync(Result.Success(Page([Dto(1), Dto(2)], totalItemCount: 10)))
+            .ReturnsAsync(Result.Failure<PagedCollectionResult<object>>(
+                Error.Failure("Test.Failure", "Query blew up")));
+        ExportTestController sut = CreateController(maxPageSize: 2);
+
+        IActionResult result = await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        result.Should().BeOfType<EmptyResult>(because: "the headers were already sent, so Problem Details is no longer reachable");
+        BodyLines(BodyText())[^1].Should().Be("# export incomplete after 2 rows");
+    }
+
+    // ── Query surface pass-through ──
+    [Fact]
+    public async Task ExportAsync_PassesFiltersSortAndIncludesToTheQueryService()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 25);
+        var filters = new Dictionary<string, (string Operator, string Value)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Name"] = ("contains", "ada")
+        };
+
+        await sut.ExportAsync(
+            includeFKs: true,
+            sortColumn: "Name",
+            sortDirection: "desc",
+            fields: null,
+            filters: filters,
+            cancellationToken: CancellationToken.None);
+
+        _queryServiceMock.Verify(
+            q => q.GetAllAsync(
+                true,
+                false,
+                null,
+                filters,
+                "Name",
+                "desc",
+                null,
+                1,
+                25,
+                false,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the export must query exactly what the paged endpoint would, at the max page size");
+    }
+
+    // ── Settings resolution ──
+    [Fact]
+    public async Task ExportAsync_NonPositiveConfiguredCap_FallsBackToTheDefault()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1)], totalItemCount: 1)));
+        ExportTestController sut = CreateController(maxPageSize: 10, maxExportRows: 0);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        sut.Response.Headers[EntityControllerBase<ExportTestEntity, ExportTestDTO, int>.ExportRowLimitHeaderName]
+            .ToString().Should().Be("100000", because: "a cap of zero would serve every caller a header-only file");
+        BodyLines(BodyText()).Should().HaveCount(2);
+    }
+}
+
+public sealed class ExportTestController(
+    IEntityQueryService<ExportTestEntity, ExportTestDTO, int> queryService,
+    ILogger<EntityControllerBase<ExportTestEntity, ExportTestDTO, int>> logger)
+    : EntityControllerBase<ExportTestEntity, ExportTestDTO, int>(queryService, logger);
+
+public sealed class ExportTestEntity : AuditableBaseEntity<int>;
+
+public sealed record ExportTestDTO : IBaseDTO<int>
+{
+    public required int Id { get; init; }
+
+    public string? Name { get; init; }
+
+    public bool IsActive { get; init; }
+
+    public DateTime CreatedOn { get; init; }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Privacy/DataExportControllerBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/Privacy/DataExportControllerBaseTests.cs
@@ -1,0 +1,278 @@
+using System.Reflection;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.Mvc;
+using MMCA.Common.API.Authorization;
+using MMCA.Common.API.Controllers.Privacy;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Application.UseCases;
+using MMCA.Common.Application.Users;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Privacy;
+using Moq;
+
+namespace MMCA.Common.API.Tests.Controllers.Privacy;
+
+/// <summary>
+/// Pins the shipped data-subject export endpoint: the download shape a subject actually receives,
+/// the Problem Details failure path, and the two attributes that are the whole of its security
+/// posture. The attributes are asserted directly because nothing else fails when one is dropped:
+/// the endpoint simply becomes anonymous, or becomes reachable in a host that never enabled it.
+/// </summary>
+public sealed class DataExportControllerBaseTests
+{
+    private static readonly DateTimeOffset GeneratedOn = new(2026, 8, 13, 17, 42, 9, TimeSpan.Zero);
+
+    private readonly Mock<IQueryHandler<TestExportQuery, Result<UserDataExportDTO>>> _handlerMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+
+    [Fact]
+    public async Task ExportAsync_WhenUnauthenticated_ReturnsUnauthorizedProblemDetails()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns((UserIdentifierType?)null);
+        TestDataExportController sut = CreateController();
+
+        IActionResult result = await sut.ExportAsync(userId: 7);
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        objectResult.Value.Should().BeOfType<ProblemDetails>();
+    }
+
+    [Fact]
+    public async Task ExportAsync_WhenHandlerFails_ReturnsProblemDetailsCarryingTheErrors()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(2);
+        _handlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<TestExportQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<UserDataExportDTO>(Error.Forbidden(
+                code: "User.ExportForbidden",
+                message: "You can only export your own account data.",
+                source: "ExportUserDataHandler",
+                target: "UserId")));
+        TestDataExportController sut = CreateController();
+
+        IActionResult result = await sut.ExportAsync(userId: 7);
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        var problemDetails = objectResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status403Forbidden);
+        problemDetails.Extensions.Should().ContainKey("errors");
+    }
+
+    [Fact]
+    public async Task ExportAsync_OnSuccess_ReturnsTheDownloadWithTheDatedFileName()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(7);
+        ArrangeExport(CreateExport());
+        TestDataExportController sut = CreateController();
+
+        IActionResult result = await sut.ExportAsync(userId: 7);
+
+        var fileResult = result.Should().BeOfType<FileContentResult>().Subject;
+        fileResult.ContentType.Should().Be("application/json");
+        fileResult.FileDownloadName.Should().Be("user-data-7-20260813.json",
+            "the file name carries the package's own generated-on date, formatted invariantly");
+    }
+
+    [Fact]
+    public async Task ExportAsync_OnSuccess_WritesABodyThatRoundTripsThePackage()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(7);
+        ArrangeExport(CreateExport());
+        TestDataExportController sut = CreateController();
+
+        IActionResult result = await sut.ExportAsync(userId: 7);
+
+        var fileResult = (FileContentResult)result;
+        var roundTripped = JsonSerializer.Deserialize<UserDataExportDTO>(
+            fileResult.FileContents, JsonSerializerOptions.Web);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.FormatVersion.Should().Be("1.0");
+        roundTripped.UserId.Should().Be(7);
+        roundTripped.GeneratedOn.Should().Be(GeneratedOn);
+        roundTripped.Sections.Should().HaveCount(2);
+        roundTripped.Sections[0].SectionName.Should().Be("Engagement");
+        roundTripped.Sections[0].Available.Should().BeTrue();
+        roundTripped.Sections[1].SectionName.Should().Be("Sales");
+        roundTripped.Sections[1].Available.Should().BeFalse();
+        roundTripped.Sections[1].UnavailableReason.Should().Be("Temporarily unreachable.");
+    }
+
+    [Fact]
+    public async Task ExportAsync_BuildsTheQueryFromTheRouteAndTheAuthenticatedCaller()
+    {
+        _currentUserServiceMock.Setup(s => s.UserId).Returns(2);
+        _currentUserServiceMock.Setup(s => s.Role).Returns("Organizer");
+        TestExportQuery? capturedQuery = null;
+        _handlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<TestExportQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<TestExportQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(Result.Success(CreateExport()));
+        TestDataExportController sut = CreateController();
+
+        await sut.ExportAsync(userId: 7);
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.UserId.Should().Be(7);
+        capturedQuery.CurrentUserId.Should().Be(2);
+        capturedQuery.CurrentUserRole.Should().Be("Organizer");
+    }
+
+    [Fact]
+    public void Controller_RequiresAnAuthenticatedCaller() =>
+        typeof(DataExportControllerBase<TestExportQuery>)
+            .GetCustomAttribute<AuthorizeAttribute>()!.Policy
+            .Should().Be(AuthorizationPolicies.RequireAuthenticated,
+                because: "the handler's ownership check is the second line of defence, not the first");
+
+    [Fact]
+    public void Controller_IsGatedOnThePrivacyDataExportFlag()
+    {
+        var featureGate = typeof(DataExportControllerBase<TestExportQuery>)
+            .GetCustomAttribute<FeatureGateAttribute>();
+
+        featureGate.Should().NotBeNull(
+            because: "the DSAR surface stays off until a host deliberately enables it");
+        featureGate!.Features.Should().Equal(PrivacyFeatures.DataExport);
+    }
+
+    // The gate is an action filter, so a disabled feature is answered by the filter rather than by
+    // the controller. Driven directly here so "off" is a verified 404 (the framework's standard
+    // disabled-feature response: the endpoint does not exist as far as the caller is concerned)
+    // rather than an assumption about the attribute's default behaviour.
+    [Fact]
+    public async Task FeatureGate_WhenTheFlagIsOff_ShortCircuitsWithTheDisabledFeatureResponse()
+    {
+        var featureGate = typeof(DataExportControllerBase<TestExportQuery>)
+            .GetCustomAttribute<FeatureGateAttribute>()!;
+        ActionExecutingContext context = CreateActionExecutingContext(featureEnabled: false);
+
+        await featureGate.OnActionExecutionAsync(
+            context,
+            () => throw new InvalidOperationException("the action must not run when the feature is off"));
+
+        var statusCodeResult = context.Result.Should().BeAssignableTo<StatusCodeResult>().Subject;
+        statusCodeResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task FeatureGate_WhenTheFlagIsOn_LetsTheActionRun()
+    {
+        var featureGate = typeof(DataExportControllerBase<TestExportQuery>)
+            .GetCustomAttribute<FeatureGateAttribute>()!;
+        ActionExecutingContext context = CreateActionExecutingContext(featureEnabled: true);
+        var ran = false;
+
+        await featureGate.OnActionExecutionAsync(
+            context,
+            () =>
+            {
+                ran = true;
+                return Task.FromResult(new ActionExecutedContext(context, [], context.Controller));
+            });
+
+        ran.Should().BeTrue();
+        context.Result.Should().BeNull();
+    }
+
+    private static UserDataExportDTO CreateExport() =>
+        new()
+        {
+            FormatVersion = "1.0",
+            GeneratedOn = GeneratedOn,
+            UserId = 7,
+            Subject = new SubjectSnapshot("jane@example.com", "Attendee"),
+            Sections =
+            [
+                new UserDataExportSectionDTO
+                {
+                    SectionName = "Engagement",
+                    Available = true,
+                    Data = new { Bookmarks = 2 },
+                },
+                new UserDataExportSectionDTO
+                {
+                    SectionName = "Sales",
+                    Available = false,
+                    UnavailableReason = "Temporarily unreachable.",
+                },
+            ],
+        };
+
+    private void ArrangeExport(UserDataExportDTO export) =>
+        _handlerMock
+            .Setup(h => h.HandleAsync(It.IsAny<TestExportQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(export));
+
+    private TestDataExportController CreateController() =>
+        new(_handlerMock.Object, _currentUserServiceMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+    private static ActionExecutingContext CreateActionExecutingContext(bool featureEnabled)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IFeatureManagerSnapshot>(new StubFeatureManager(featureEnabled));
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+
+        return new ActionExecutingContext(
+            new ActionContext(httpContext, new RouteData(), new ControllerActionDescriptor()),
+            [],
+            new Dictionary<string, object?>(StringComparer.Ordinal),
+            controller: new object());
+    }
+
+    private sealed record SubjectSnapshot(string Email, string Role);
+
+    private sealed class StubFeatureManager(bool enabled) : IFeatureManagerSnapshot
+    {
+        public async IAsyncEnumerable<string> GetFeatureNamesAsync()
+        {
+            yield return PrivacyFeatures.DataExport;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        public Task<bool> IsEnabledAsync(string feature) => Task.FromResult(enabled);
+
+        public Task<bool> IsEnabledAsync<TContext>(string feature, TContext context) => Task.FromResult(enabled);
+    }
+}
+
+/// <summary>App-side export query shape, standing in for each app's <c>ExportUserDataQuery</c>.</summary>
+public sealed record TestExportQuery(
+    UserIdentifierType UserId,
+    UserIdentifierType CurrentUserId,
+    string? CurrentUserRole) : IUserOwnedRequest;
+
+/// <summary>
+/// The thin subclass an adopting app writes: route, query type, nothing else.
+/// </summary>
+public sealed class TestDataExportController(
+    IQueryHandler<TestExportQuery, Result<UserDataExportDTO>> exportHandler,
+    ICurrentUserService currentUserService)
+    : DataExportControllerBase<TestExportQuery>(exportHandler, currentUserService)
+{
+    protected override TestExportQuery CreateQuery(
+        UserIdentifierType userId,
+        UserIdentifierType currentUserId,
+        string? currentUserRole) =>
+        new(userId, currentUserId, currentUserRole);
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Export/CsvWriterTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Export/CsvWriterTests.cs
@@ -1,0 +1,194 @@
+using System.Globalization;
+using System.Text;
+using AwesomeAssertions;
+using MMCA.Common.API.Export;
+
+namespace MMCA.Common.API.Tests.Export;
+
+public sealed class CsvWriterTests
+{
+    private static string Write(Action<StringWriter> write)
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        write(writer);
+        return writer.ToString();
+    }
+
+    // ── RFC 4180 quoting ──
+    [Fact]
+    public void WriteRow_PlainValues_AreNotQuoted() =>
+        Write(w => CsvWriter.WriteRow(["alpha", "beta"], w))
+            .Should().Be("alpha,beta\r\n", because: "RFC 4180 quotes only fields that need it");
+
+    [Fact]
+    public void WriteRow_ValueWithComma_IsQuoted() =>
+        Write(w => CsvWriter.WriteRow(["a,b", "c"], w))
+            .Should().Be("\"a,b\",c\r\n", because: "an embedded delimiter would otherwise split the record");
+
+    [Fact]
+    public void WriteRow_ValueWithQuote_IsQuotedAndDoubled() =>
+        Write(w => CsvWriter.WriteRow(["say \"hi\"", "x"], w))
+            .Should().Be("\"say \"\"hi\"\"\",x\r\n", because: "RFC 4180 escapes a quote by doubling it");
+
+    [Fact]
+    public void WriteRow_ValueWithLineFeed_IsQuoted() =>
+        Write(w => CsvWriter.WriteRow(["line1\nline2"], w))
+            .Should().Be("\"line1\nline2\"\r\n", because: "an embedded LF must not terminate the record");
+
+    [Fact]
+    public void WriteRow_ValueWithCarriageReturn_IsQuoted() =>
+        Write(w => CsvWriter.WriteRow(["line1\rline2"], w))
+            .Should().Be("\"line1\rline2\"\r\n", because: "an embedded CR must not terminate the record");
+
+    [Fact]
+    public void WriteRow_ValueWithCrLf_IsQuoted() =>
+        Write(w => CsvWriter.WriteRow(["line1\r\nline2"], w))
+            .Should().Be("\"line1\r\nline2\"\r\n", because: "an embedded record separator must be protected");
+
+    [Fact]
+    public void WriteRow_EmptyCells_ProduceBareDelimiters() =>
+        Write(w => CsvWriter.WriteRow([string.Empty, string.Empty], w))
+            .Should().Be(",\r\n", because: "an empty field needs no quoting");
+
+    [Fact]
+    public void WriteRow_NoCells_WritesOnlyTheLineEnding() =>
+        Write(w => CsvWriter.WriteRow([], w))
+            .Should().Be("\r\n", because: "a record with no fields is still a record");
+
+    // ── Line endings ──
+    [Fact]
+    public void WriteRow_AlwaysTerminatesWithCrLf() =>
+        Write(w =>
+        {
+            CsvWriter.WriteRow(["a"], w);
+            CsvWriter.WriteRow(["b"], w);
+        })
+            .Should().Be("a\r\nb\r\n", because: "RFC 4180 records are CRLF-terminated on every platform");
+
+    [Fact]
+    public void LineEnding_IsCrLf() =>
+        CsvWriter.LineEnding.Should().Be("\r\n");
+
+    // ── Header row ──
+    [Fact]
+    public void WriteHeader_EscapesColumnNamesLikeDataFields() =>
+        Write(w => CsvWriter.WriteHeader(["id", "full,name"], w))
+            .Should().Be("id,\"full,name\"\r\n", because: "a header field follows the same quoting rules");
+
+    // ── Byte order mark ──
+    [Fact]
+    public void WriteByteOrderMark_WritesExactlyOneMark()
+    {
+        var output = Write(w =>
+        {
+            CsvWriter.WriteByteOrderMark(w);
+            CsvWriter.WriteHeader(["id"], w);
+            CsvWriter.WriteRow([1], w);
+        });
+
+        output.Should().StartWith("\uFEFF", because: "Excel needs the BOM to read the file as UTF-8");
+        output.Count(c => c == '\uFEFF').Should().Be(1, because: "a second BOM would show up as a stray column");
+    }
+
+    [Fact]
+    public void Utf8NoPreamble_EmitsNoPreambleOfItsOwn()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new StreamWriter(stream, CsvWriter.Utf8NoPreamble, leaveOpen: true))
+        {
+            CsvWriter.WriteByteOrderMark(writer);
+            CsvWriter.WriteHeader(["id"], writer);
+        }
+
+        byte[] bytes = stream.ToArray();
+
+        Convert.ToHexString(bytes.Take(3).ToArray()).Should().Be("EFBBBF", because: "the explicit BOM is the first thing on the wire");
+        Encoding.UTF8.GetString(bytes).Count(c => c == '\uFEFF')
+            .Should().Be(1, because: "the encoding must not add a preamble on top of the explicit mark");
+    }
+
+    // ── Cell formatting ──
+    [Fact]
+    public void FormatCell_Null_IsEmpty() =>
+        CsvWriter.FormatCell(null).Should().BeEmpty();
+
+    [Fact]
+    public void FormatCell_String_IsVerbatim() =>
+        CsvWriter.FormatCell(" padded ").Should().Be(" padded ", because: "strings are written as given");
+
+    [Theory]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    public void FormatCell_Bool_IsLowercase(bool value, string expected) =>
+        CsvWriter.FormatCell(value).Should().Be(expected, because: "the JSON endpoints emit lowercase booleans");
+
+    [Fact]
+    public void FormatCell_DateTime_IsIso8601RoundTrip()
+    {
+        var value = new DateTime(2026, 8, 13, 14, 30, 15, 250, DateTimeKind.Utc);
+
+        CsvWriter.FormatCell(value).Should().Be("2026-08-13T14:30:15.2500000Z");
+    }
+
+    [Fact]
+    public void FormatCell_DateTimeOffset_IsIso8601RoundTrip()
+    {
+        var value = new DateTimeOffset(2026, 8, 13, 14, 30, 15, TimeSpan.FromHours(-4));
+
+        CsvWriter.FormatCell(value).Should().Be("2026-08-13T14:30:15.0000000-04:00");
+    }
+
+    [Fact]
+    public void FormatCell_Decimal_UsesInvariantCultureRegardlessOfAmbientCulture()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            // de-DE writes 1234,56 and would turn one cell into two.
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            CsvWriter.FormatCell(1234.56m).Should().Be("1234.56");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void FormatCell_DateTime_UsesInvariantCultureRegardlessOfAmbientCulture()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            CsvWriter.FormatCell(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc))
+                .Should().Be("2026-01-02T03:04:05.0000000Z");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void FormatCell_Guid_UsesInvariantFormatting() =>
+        CsvWriter.FormatCell(Guid.Empty).Should().Be("00000000-0000-0000-0000-000000000000");
+
+    [Fact]
+    public void WriteRow_MixedCells_FormatsEachByType() =>
+        Write(w => CsvWriter.WriteRow([1, null, true, "x,y"], w))
+            .Should().Be("1,,true,\"x,y\"\r\n");
+
+    // ── Guard clauses ──
+    [Fact]
+    public void WriteRow_NullWriter_Throws() =>
+        FluentActions.Invoking(() => CsvWriter.WriteRow(["a"], writer: null!))
+            .Should().Throw<ArgumentNullException>();
+
+    [Fact]
+    public void WriteHeader_NullColumns_Throws() =>
+        FluentActions.Invoking(() => CsvWriter.WriteHeader(null!, new StringWriter(CultureInfo.InvariantCulture)))
+            .Should().Throw<ArgumentNullException>();
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Middleware/TenantResolutionMiddlewareTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Middleware/TenantResolutionMiddlewareTests.cs
@@ -1,0 +1,250 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using MMCA.Common.API.Middleware;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Infrastructure.Settings;
+using Moq;
+
+namespace MMCA.Common.API.Tests.Middleware;
+
+/// <summary>
+/// Coverage for tenant resolution at the API edge: the configured strategy order, the fail-closed
+/// rejection, the excluded paths, and the two shapes that must pass every request straight through
+/// (tenancy disabled, and a host that never called <c>AddMultiTenancy</c>).
+/// </summary>
+public sealed class TenantResolutionMiddlewareTests
+{
+    private const string Acme = "acme";
+    private const string Globex = "globex";
+
+    [Fact]
+    public async Task Disabled_PassesThroughWithoutResolving()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: Acme);
+
+        var nextCalled = await InvokeAsync(context, tenantContext, new TenancySettings());
+
+        nextCalled.Should().BeTrue();
+        tenantContext.Verify(t => t.SetTenant(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NoOptionsRegistered_BehavesLikeDisabled()
+    {
+        // A host that never called AddMultiTenancy still resolves IOptions<TenancySettings> to the
+        // framework defaults, which is what makes the unconditional pipeline wiring safe.
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: Acme);
+
+        var nextCalled = await InvokeAsync(context, tenantContext, Options.Create(new TenancySettings()).Value);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        tenantContext.Verify(t => t.SetTenant(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Claim_WinsOverHeader_InTheDefaultOrder()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: Globex, claim: Acme);
+
+        await InvokeAsync(context, tenantContext, Enabled());
+
+        tenantContext.Verify(t => t.SetTenant(Acme), Times.Once,
+            "the claim was signed by the issuer; the header is caller-supplied");
+    }
+
+    [Fact]
+    public async Task Header_IsTheFallback_WhenNoClaimIsPresent()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: Globex);
+
+        await InvokeAsync(context, tenantContext, Enabled());
+
+        tenantContext.Verify(t => t.SetTenant(Globex), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConfiguredOrder_IsHonored()
+    {
+        var settings = Enabled();
+        settings.ResolutionOrder.Add(TenantResolutionStrategy.Header);
+        settings.ResolutionOrder.Add(TenantResolutionStrategy.Claim);
+
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: Globex, claim: Acme);
+
+        await InvokeAsync(context, tenantContext, settings);
+
+        tenantContext.Verify(t => t.SetTenant(Globex), Times.Once);
+    }
+
+    [Fact]
+    public async Task CustomClaimTypeAndHeaderName_AreHonored()
+    {
+        var settings = new TenancySettings { Enabled = true, ClaimType = "org", HeaderName = "X-Org" };
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Org"] = Globex;
+
+        var tenantContext = new Mock<ITenantContext>();
+        await InvokeAsync(context, tenantContext, settings);
+
+        tenantContext.Verify(t => t.SetTenant(Globex), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolvedTenant_IsTrimmed()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: "  acme  ");
+
+        await InvokeAsync(context, tenantContext, Enabled());
+
+        tenantContext.Verify(t => t.SetTenant(Acme), Times.Once);
+    }
+
+    [Fact]
+    public async Task BlankHeader_IsNotATenant()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: "   ");
+
+        await InvokeAsync(context, tenantContext, Enabled());
+
+        tenantContext.Verify(t => t.SetTenant(It.IsAny<string>()), Times.Never);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task RequireTenant_RejectsAnUnresolvedRequest_AsProblemDetails()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = new DefaultHttpContext();
+        ProblemDetailsContext? written = null;
+
+        var nextCalled = await InvokeAsync(
+            context, tenantContext, Enabled(), problem => written = problem);
+
+        nextCalled.Should().BeFalse("failing closed means the request never reaches the application");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        written.Should().NotBeNull();
+        written!.ProblemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        written.ProblemDetails.Title.Should().Be(TenantResolutionMiddleware.UnresolvedTenantTitle);
+        written.ProblemDetails.Detail.Should().Contain("tenant_id").And.Contain("X-Tenant-Id");
+    }
+
+    [Fact]
+    public async Task RequireTenantFalse_LetsAnUnresolvedRequestThrough()
+    {
+        var settings = new TenancySettings { Enabled = true, RequireTenant = false };
+
+        var tenantContext = new Mock<ITenantContext>();
+        var context = new DefaultHttpContext();
+
+        var nextCalled = await InvokeAsync(context, tenantContext, settings);
+
+        nextCalled.Should().BeTrue();
+        tenantContext.Verify(t => t.SetTenant(It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/health/live")]
+    [InlineData("/alive")]
+    [InlineData("/.well-known/jwks.json")]
+    public async Task ExcludedPaths_PassThroughWithoutATenant(string path)
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        var nextCalled = await InvokeAsync(context, tenantContext, Enabled());
+
+        nextCalled.Should().BeTrue("probes and discovery documents must answer before any tenant exists");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        tenantContext.Verify(t => t.SetTenant(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConfiguredExclusions_ReplaceTheDefaults()
+    {
+        var settings = Enabled();
+        settings.ExcludedPathPrefixes.Add("/ping");
+
+        var tenantContext = new Mock<ITenantContext>();
+        var health = new DefaultHttpContext();
+        health.Request.Path = "/health";
+
+        await InvokeAsync(health, tenantContext, settings);
+
+        health.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest,
+            "a configured exclusion list replaces the framework default rather than extending it");
+    }
+
+    [Fact]
+    public async Task NonExcludedPath_WithATenant_ReachesTheApplication()
+    {
+        var tenantContext = new Mock<ITenantContext>();
+        var context = HttpContextWith(header: Acme);
+        context.Request.Path = "/api/tickets";
+
+        var nextCalled = await InvokeAsync(context, tenantContext, Enabled());
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ── Scaffolding ──
+    private static TenancySettings Enabled() => new() { Enabled = true };
+
+    private static DefaultHttpContext HttpContextWith(string? header = null, string? claim = null)
+    {
+        var context = new DefaultHttpContext();
+
+        if (header is not null)
+        {
+            context.Request.Headers["X-Tenant-Id"] = header;
+        }
+
+        if (claim is not null)
+        {
+            context.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("tenant_id", claim)], "test"));
+        }
+
+        return context;
+    }
+
+    private static async Task<bool> InvokeAsync(
+        HttpContext context,
+        Mock<ITenantContext> tenantContext,
+        TenancySettings settings,
+        Action<ProblemDetailsContext>? onProblem = null)
+    {
+        var nextCalled = false;
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService
+            .Setup(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Callback<ProblemDetailsContext>(ctx => onProblem?.Invoke(ctx))
+            .Returns(new ValueTask<bool>(true));
+
+        var sut = new TenantResolutionMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await sut.InvokeAsync(
+            context,
+            tenantContext.Object,
+            Options.Create(settings),
+            problemDetailsService.Object);
+
+        return nextCalled;
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
@@ -1011,6 +1011,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -1232,6 +1233,18 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.10",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
           "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {

--- a/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
@@ -1001,6 +1001,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -1075,6 +1076,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -127,6 +127,14 @@
           "Azure.Core": "1.54.0"
         }
       },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "Transitive",
+        "resolved": "4.10.0",
+        "contentHash": "lcJtcgTkk1gGy59RQhGLJLMyad+zgASMn975PVjMft69q+jjFTo6Nyq5SCtOhPY1WvA0gNI1qYIVN2oikVXDjw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Common": {
         "type": "Transitive",
         "resolved": "12.28.0",
@@ -685,6 +693,7 @@
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
           "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
+          "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.1, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.3, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.3, )",
           "Azure.Identity": "[1.21.0, )",
@@ -812,6 +821,16 @@
         "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "5.2.2"
+        }
+      },
+      "Azure.Extensions.AspNetCore.Configuration.Secrets": {
+        "type": "CentralTransitive",
+        "requested": "[1.5.1, )",
+        "resolved": "1.5.1",
+        "contentHash": "2Io9af/y8GH1jfu//BQrYcwb+MZOJG+au2KCv+ltWM6PBCghbhaDyZWDkYWNWIougZgoHtyKM0CnlGi+9XAu/A==",
+        "dependencies": {
+          "Azure.Core": "1.54.0",
+          "Azure.Security.KeyVault.Secrets": "4.10.0"
         }
       },
       "Azure.Extensions.AspNetCore.DataProtection.Blobs": {

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -730,6 +730,7 @@
           "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.10, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.8.0, )",
           "Microsoft.Extensions.Http.Resilience": "[10.8.0, )",
           "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
@@ -1036,6 +1037,12 @@
           "Microsoft.Data.SqlClient": "6.1.1",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.10"
         }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "RCtCTK3eqKXx8LXqd7B8GjbTkIp4k3EgKeunaCmBJ+WA55Nva83CI2I+wVyp0S9jTG+aT6AYWQbkKOfvFOlmLA=="
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "CentralTransitive",

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -720,6 +720,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "MassTransit": "[8.5.10, )",
           "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
@@ -885,6 +886,12 @@
           "Azure.Core": "1.55.0",
           "Azure.Storage.Common": "12.28.0"
         }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",

--- a/samples/deployment/DEPLOYMENT.md
+++ b/samples/deployment/DEPLOYMENT.md
@@ -35,6 +35,11 @@ az role assignment create --assignee-object-id "$PRINCIPAL" --assignee-principal
 # (az CLI 2.84 may misreport role writes — verify with `az role assignment list`.)
 ```
 
+Step 3 is also the only grant `AddCommonKeyVaultConfiguration()` (MMCA.Common.Aspire) needs: the app opts
+in by setting `KeyVault:Uri` to the vault URI, and the same managed identity reads the secrets as
+configuration. Name the secrets with a double dash where the configuration key has a colon
+(`ConnectionStrings--Default` binds to `ConnectionStrings:Default`).
+
 ## OIDC for the GitHub deploy identity (no stored cloud secret)
 
 CD authenticates to Azure with a **federated credential** — GitHub mints a short-lived OIDC token per


### PR DESCRIPTION
Eight opt-in enterprise capabilities in one release, per the approved wave plan. Everything is inert until a host calls the matching registration extension, so the release itself is non-breaking for hosts that only bump pins (one exception noted below).

## Features
- **Multi-tenancy**: shared-schema named `Tenant` query filter composing with `SoftDelete` (one cached model per source), claim-then-header resolution (fail-closed `RequireTenant`), `TenantSaveChangesInterceptor` write guard, database-per-tenant `DataSources` overrides through the same `DataSourceKey`, outbox/cleanup/audit-retention drained per (source, tenant) pair, per-tenant startup migration pass, tenant-scoped cache decorator keys.
- **Recurring job scheduler**: `IScheduledJob` + Cronos over a claim-leased `ScheduledJobs` store (OutboxProcessor pattern), config cron overrides, OTel meter `MMCA.Common.Scheduler`.
- **Audit trail**: `IAuditedEntity` field-level change history written in the same transaction (outbox precedent), `[Pii]` values stored redacted, retention as the first framework scheduled job, minimal `IAuditTrailReader`.
- **DSAR export**: `ExportUserDataHandlerBase` hoisting the ADC/Store idiom with best-effort `IUserDataExportSection` fan-out; abstract `DataExportControllerBase` (both consumers keep their existing routes).
- **CSV export**: streamed `GET {controller}/export` (RFC 4180, columns match JSON field names, `MaxExportRows` cap with explicit truncation markers); distinct route by design (output cache does not vary by Accept).
- **`Enumeration<T>`** smart-enum base (RoleValue design, name-based JSON, EF converter pair).
- **Key Vault configuration provider**: `AddCommonKeyVaultConfiguration()` gated on `KeyVault:Uri`.
- **HybridCache substrate**: opt-in `AddCommonHybridCache()` under a disjoint `hc:` keyspace (structural fix for the mixed-format class of bug); `ICacheService.GetOrCreateAsync` default member.

## Breaking note
`IPhysicalDbContextFactory` gained abstract `Create(DataSourceKey, PhysicalDataSource)` (per-tenant routing). Custom implementors must add it; all shipped implementations updated. Called out in the CHANGELOG.

## Verification
- Full solution Release build 0 warnings / 0 errors; **3335/3335 tests green** (was 3096 at branch point; +239 wave tests).
- Real-Redis tier ran locally via Testcontainers (14/14) including the unmodified `DistributedCacheService` tests over the scanner extraction.
- The load-bearing tenancy test (two tenants, one cached EF model, disjoint rows) passes.
- MMCA.Helpdesk source-mode canary: builds + 91/91 tests against this branch.
- FACTS `--check` clean; analyzer baseline compare clean; new pins: Cronos 0.13.0, Microsoft.Extensions.Caching.Hybrid 10.8.0, Azure.Extensions.AspNetCore.Configuration.Secrets 1.5.1 (lock files regenerated incl. out-of-slnx).

ADRs 073-078 are drafted on a Website branch and land separately. Consumer sweep (pin bumps + full adoption + migrations) follows the release per ADR-016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a