### PR TITLE
release: v1.150.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+> **Consumer versions skipped deliberately (historical note).** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
+> 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
+> is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so
+> sweeping it alone would have cost two production deploys for no behavioural change; 1.129.0 and
+> 1.130.0 were superseded within the same day by 1.131.0, which the consumers took in one pass per
+> ADR-016. An audit that reports the consumers as "several versions behind" for that window is
+> reading history, not a gap.
+
+## [1.150.0] - 2026-08-14
+
 The enterprise capability wave: eight opt-in features in one release. Everything below is inert
 until a host calls the matching registration extension, so upgrading the pins alone changes no
 behavior.
@@ -67,14 +77,6 @@ behavior.
 - New pins: `Cronos` 0.13.0, `Microsoft.Extensions.Caching.Hybrid` 10.8.0 (10.9.0 skews shared
   Microsoft.Extensions transitives to 10.0.11), `Azure.Extensions.AspNetCore.Configuration.Secrets`
   1.5.1.
-
-> **Consumer versions skipped deliberately.** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
-> 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
-> is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so
-> sweeping it alone would have cost two production deploys for no behavioural change; 1.129.0 and
-> 1.130.0 were superseded within the same day by 1.131.0, which the consumers took in one pass per
-> ADR-016. An audit that reports the consumers as "several versions behind" for that window is
-> reading history, not a gap.
 
 ## [1.149.0] - 2026-08-13
 


### PR DESCRIPTION
Stamps the enterprise-capability-wave CHANGELOG entry (merged in #239) as 1.150.0 dated 2026-08-14. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a