### PR TITLE
feat: export scoping hook + CSV formatter hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,31 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 > ADR-016. An audit that reports the consumers as "several versions behind" for that window is
 > reading history, not a gap.
 
+### Added
+
+- **Row scoping for the generic CSV export.** `EntityControllerBase.GetExportSpecification()` is a
+  new `protected virtual` hook whose result is applied to every page `GET {controller}/export`
+  streams, through the specification parameter `IEntityQueryService.GetAllAsync` already carries for
+  authorization filtering (no Application-layer change). It returns null by default, so a controller
+  that overrides nothing queries unscoped and produces the byte-identical file 1.150.0 produced. A
+  controller whose list endpoints row-scope reads should override it with the same specification,
+  and can then relax the privileged-role gate it put on `/export` as the 1.150.0 interim mitigation:
+  with the specification in force it is the query, not the role, that keeps one caller out of
+  another caller's rows, so an owner can export their own data again.
+
+### Fixed
+
+- **CSV export omits columns it cannot render faithfully.** Binary properties (`byte[]` and
+  `ReadOnlyMemory<byte>`, which covers the ubiquitous `rowVersion` concurrency token) and
+  collection-typed properties used to fill every cell with a type name (`System.Byte[]`, the
+  internal materialized-list type) even though the export deliberately queries with
+  `includeChildren: false`. They now produce no column at all, in both the reflection column path
+  and the shaped `fields=` path. Value objects and other class-typed properties are untouched and
+  still render through their invariant `ToString`. A `fields=` request that names a dropped property
+  now fails with the same `Error.InvalidEntityField` validation failure the JSON endpoints return
+  for an unknown field, before a byte of body is written, rather than silently returning a file
+  missing a column the caller asked for.
+
 ## [1.150.0] - 2026-08-14
 
 The enterprise capability wave: eight opt-in features in one release. Everything below is inert

--- a/Source/Presentation/MMCA.Common.API/Controllers/EntityControllerBase.cs
+++ b/Source/Presentation/MMCA.Common.API/Controllers/EntityControllerBase.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Reflection;
@@ -13,6 +14,7 @@ using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Services;
 using MMCA.Common.Application.Settings;
 using MMCA.Common.Domain.Entities;
+using MMCA.Common.Domain.Specifications;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.DTOs;
 
@@ -202,7 +204,17 @@ public abstract class EntityControllerBase<
     /// </para>
     /// <para>
     /// <b>Child collections.</b> Unlike the paged endpoint this takes no <c>includeChildren</c>: a
-    /// child collection has no faithful representation in a flat CSV cell.
+    /// child collection has no faithful representation in a flat CSV cell. For the same reason the
+    /// column set drops any DTO property that cannot render a faithful scalar cell (binary tokens
+    /// such as <c>rowVersion</c>, and every collection-typed property), so those columns are absent
+    /// rather than filled with a type name. A <c>fields=</c> request that names one of them is a
+    /// validation failure, not a silent omission.
+    /// </para>
+    /// <para>
+    /// <b>Row scoping.</b> The rows queried here are whatever
+    /// <see cref="GetExportSpecification"/> allows. The default returns null, so an export is
+    /// unscoped unless the concrete controller says otherwise; a controller whose list endpoints
+    /// row-scope reads must override that hook.
     /// </para>
     /// </remarks>
     /// <param name="includeFKs">When true, eagerly loads foreign key navigation properties.</param>
@@ -227,6 +239,13 @@ public abstract class EntityControllerBase<
         [ModelBinder(typeof(QueryFilterModelBinder))] Dictionary<string, (string Operator, string Value)>? filters = null,
         CancellationToken cancellationToken = default)
     {
+        var unexportableFieldErrors = ValidateExportFields(fields);
+        if (unexportableFieldErrors is not null)
+            return HandleFailure(unexportableFieldErrors);
+
+        // Resolved once, so every page of the loop is filtered by the same instance.
+        var specification = GetExportSpecification();
+
         var maxExportRows = MaxExportRows;
         var pageSize = Math.Max(1, MaxPageSize);
         var pageNumber = 1;
@@ -246,7 +265,7 @@ public abstract class EntityControllerBase<
                 var result = await QueryService.GetAllAsync(
                     includeFKs: includeFKs,
                     includeChildren: false,
-                    specification: null,
+                    specification: specification,
                     filters: filters,
                     sortColumn: sortColumn,
                     sortDirection: sortDirection,
@@ -445,6 +464,106 @@ public abstract class EntityControllerBase<
     }
 
     /// <summary>
+    /// Gets the specification <see cref="ExportAsync"/> applies to every page it streams. Returns
+    /// <see langword="null"/> by default, which queries unscoped exactly as the endpoint always has.
+    /// </summary>
+    /// <returns>The specification every export page is filtered by, or <see langword="null"/> for an unscoped export.</returns>
+    /// <remarks>
+    /// <para>
+    /// A controller whose list endpoints row-scope reads (an ownership specification, a tenancy
+    /// predicate, anything that decides which rows this caller may see) MUST override this with the
+    /// same specification, so <c>/export</c> shows exactly what the list shows. Leaving it at the
+    /// default on such a controller hands every caller the whole table in one request.
+    /// </para>
+    /// <para>
+    /// A controller that overrides this can then relax any privileged-role gate it put on the export
+    /// as an interim mitigation: with the specification in force it is the query, not the role, that
+    /// keeps one caller out of another caller's rows, and an owner can export their own data again.
+    /// </para>
+    /// <para>
+    /// Called once per request, before the first page, so the same instance filters every page of
+    /// the loop. Return a specification that is safe to reuse across those queries.
+    /// </para>
+    /// </remarks>
+    protected virtual Specification<TEntity, TIdentifierType>? GetExportSpecification() => null;
+
+    /// <summary>
+    /// The DTO property names an export omits, because their values cannot render a faithful scalar
+    /// CSV cell: binary concurrency tokens (<see langword="byte"/>[], <see cref="ReadOnlyMemory{T}"/>
+    /// of bytes) and every collection-typed property except <see langword="string"/>. Computed once
+    /// per closed controller type, since a DTO's shape cannot change at runtime.
+    /// </summary>
+    /// <remarks>
+    /// Value objects and other class-typed properties are deliberately NOT dropped: a record or
+    /// value object has a meaningful invariant <c>ToString</c>, which is exactly the cell a reader
+    /// expects. Only the two categories above render a type name instead of a value.
+    /// </remarks>
+    private static readonly string[] UnexportablePropertyNames =
+    [
+        .. typeof(TEntityDTO)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && !IsExportableType(p.PropertyType))
+            .Select(p => p.Name)
+    ];
+
+    /// <summary>
+    /// <see cref="UnexportablePropertyNames"/> as the camelCase column names a shaped row carries,
+    /// for filtering a resolved column list.
+    /// </summary>
+    private static readonly HashSet<string> UnexportableColumns =
+        [.. UnexportablePropertyNames.Select(JsonNamingPolicy.CamelCase.ConvertName)];
+
+    /// <summary>
+    /// <see cref="UnexportablePropertyNames"/> as a case-insensitive set, for matching the names a
+    /// caller spells in <c>fields=</c>.
+    /// </summary>
+    private static readonly HashSet<string> UnexportableFields =
+        new(UnexportablePropertyNames, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Decides whether a DTO property type can render a faithful scalar CSV cell. See
+    /// <see cref="UnexportablePropertyNames"/> for what the two exclusions buy.
+    /// </summary>
+    /// <param name="type">The declared property type.</param>
+    /// <returns><see langword="true"/> when the property earns a column.</returns>
+    private static bool IsExportableType(Type type) =>
+        type != typeof(byte[])
+        && type != typeof(ReadOnlyMemory<byte>)
+        && (type == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(type));
+
+    /// <summary>Whether a resolved column survives the exclusions in <see cref="UnexportableColumns"/>.</summary>
+    /// <param name="column">The camelCase column name.</param>
+    /// <returns><see langword="true"/> when the column is written.</returns>
+    private static bool IsExportableColumn(string column) => !UnexportableColumns.Contains(column);
+
+    /// <summary>
+    /// Rejects a <c>fields=</c> request that names a property the export cannot render. Answering
+    /// such a request with the column quietly missing would hide the contract from the caller, so it
+    /// fails the same way an unknown field does on the JSON endpoints: an
+    /// <c>Error.InvalidEntityField</c> validation failure, before a single byte of body is written.
+    /// </summary>
+    /// <param name="fields">The requested field projection, or null for all fields.</param>
+    /// <returns>The validation errors, or <see langword="null"/> when the request is clean.</returns>
+    private static List<Error>? ValidateExportFields(string? fields)
+    {
+        if (UnexportableFields.Count == 0)
+            return null;
+
+        List<Error> errors =
+        [
+            .. ParseExportFields(fields)
+                .Where(UnexportableFields.Contains)
+                .Select(field => Error.InvalidEntityField with
+                {
+                    Message = $"Field '{field}' on type '{typeof(TEntityDTO).Name}' cannot be exported to CSV: binary and collection properties have no faithful CSV representation.",
+                    Target = typeof(TEntityDTO).Name
+                })
+        ];
+
+        return errors.Count > 0 ? errors : null;
+    }
+
+    /// <summary>
     /// Sets the response status headers for an export, before the first body byte goes out.
     /// </summary>
     /// <param name="maxExportRows">The row ceiling in force, advertised as <see cref="ExportRowLimitHeaderName"/>.</param>
@@ -505,6 +624,12 @@ public abstract class EntityControllerBase<
     /// DTO's own shape when that page is empty (an export of nothing still owes the caller a header
     /// row naming the columns).
     /// </summary>
+    /// <remarks>
+    /// Both paths drop the columns named in <see cref="UnexportableColumns"/>: the shaped-row path
+    /// filters the row's own keys, the empty-page path filters the DTO's properties by type. A
+    /// dropped property yields no column at all rather than an empty one, so a reader never sees a
+    /// header it cannot trust.
+    /// </remarks>
     /// <param name="items">The first page of rows, typed DTOs or already-shaped dynamic objects.</param>
     /// <param name="fields">The requested field projection, or null for all fields.</param>
     /// <returns>The column names, in output order, as camelCase JSON names.</returns>
@@ -512,7 +637,7 @@ public abstract class EntityControllerBase<
     {
         var first = items.FirstOrDefault();
         if (first is not null)
-            return [.. ShapeExportRow(first, fields).Keys];
+            return [.. ShapeExportRow(first, fields).Keys.Where(IsExportableColumn)];
 
         var requested = ParseExportFields(fields);
 
@@ -522,7 +647,9 @@ public abstract class EntityControllerBase<
         [
             .. typeof(TEntityDTO)
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(p => p.CanRead && (requested.Count == 0 || requested.Contains(p.Name)))
+                .Where(p => p.CanRead
+                    && IsExportableType(p.PropertyType)
+                    && (requested.Count == 0 || requested.Contains(p.Name)))
                 .Select(p => JsonNamingPolicy.CamelCase.ConvertName(p.Name))
         ];
     }

--- a/Tests/Presentation/MMCA.Common.API.Tests/Controllers/EntityControllerBaseExportTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Controllers/EntityControllerBaseExportTests.cs
@@ -1,5 +1,6 @@
 using System.Dynamic;
 using System.Globalization;
+using System.Linq.Expressions;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
@@ -27,7 +28,17 @@ public sealed class EntityControllerBaseExportTests : IDisposable
     private readonly Mock<ILogger<EntityControllerBase<ExportTestEntity, ExportTestDTO, int>>> _loggerMock = new();
     private readonly MemoryStream _body = new();
 
-    private ExportTestController CreateController(int maxPageSize = 500, int maxExportRows = 100_000)
+    private ExportTestController CreateController(int maxPageSize = 500, int maxExportRows = 100_000) =>
+        new(_queryServiceMock.Object, _loggerMock.Object)
+        {
+            ControllerContext = CreateControllerContext(maxPageSize, maxExportRows)
+        };
+
+    /// <summary>
+    /// Builds the request context the export reads its settings, clock and response body from.
+    /// Shared with the scoped-controller tests, which differ only in the controller they construct.
+    /// </summary>
+    private ControllerContext CreateControllerContext(int maxPageSize, int maxExportRows)
     {
         var settingsMock = new Mock<IApplicationSettings>();
         settingsMock.Setup(s => s.MaxPageSize).Returns(maxPageSize);
@@ -44,12 +55,9 @@ public sealed class EntityControllerBaseExportTests : IDisposable
         };
         httpContext.Response.Body = _body;
 
-        return new ExportTestController(_queryServiceMock.Object, _loggerMock.Object)
+        return new ControllerContext
         {
-            ControllerContext = new ControllerContext
-            {
-                HttpContext = httpContext
-            }
+            HttpContext = httpContext
         };
     }
 
@@ -396,6 +404,78 @@ public sealed class EntityControllerBaseExportTests : IDisposable
             "the export must query exactly what the paged endpoint would, at the max page size");
     }
 
+    // ── Scoping hook ──
+    [Fact]
+    public async Task ExportAsync_DefaultHook_QueriesUnscopedAndWritesTheSameBytes()
+    {
+        SetupPages().ReturnsAsync(Result.Success(Page([Dto(1, "Ada"), Dto(2, "Grace")], totalItemCount: 2)));
+        ExportTestController sut = CreateController(maxPageSize: 10);
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        BodyText().Should().Be(
+            "﻿id,name,isActive,createdOn\r\n"
+            + "1,Ada,true,2026-01-01T00:00:00.0000000Z\r\n"
+            + "2,Grace,true,2026-01-01T00:00:00.0000000Z\r\n",
+            because: "a controller that overrides nothing must produce the byte-identical file it produced before the hook existed");
+        _queryServiceMock.Verify(
+            q => q.GetAllAsync(
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                null,
+                It.IsAny<Dictionary<string, (string, string)>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the default hook returns null, which is the unscoped query the endpoint always issued");
+    }
+
+    [Fact]
+    public async Task ExportAsync_OverriddenSpecification_FiltersEveryPage()
+    {
+        var queryService = new SpecificationHonoringQueryService(Enumerable.Range(1, 7));
+        var specification = new InlineSpecification<ExportTestEntity, int>(e => e.Id % 2 == 1);
+        var sut = new ScopedExportTestController(queryService, _loggerMock.Object, specification)
+        {
+            ControllerContext = CreateControllerContext(maxPageSize: 2, maxExportRows: 100)
+        };
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        queryService.SpecificationsSeen.Should().HaveCount(3, because: "four matching rows at two per page take three queries");
+        queryService.SpecificationsSeen.Should().AllSatisfy(
+            seen => seen.Should().BeSameAs(specification),
+            because: "a specification applied only to the first page would leak the rest of the table");
+        string[] lines = BodyLines(BodyText());
+        lines.Should().HaveCount(5, because: "header plus the four odd-numbered rows");
+        lines[1..].Select(line => line.Split(',')[0]).Should().Equal("1", "3", "5", "7");
+    }
+
+    [Fact]
+    public async Task ExportAsync_OverriddenSpecification_TruncationCountsTheFilteredSet()
+    {
+        var queryService = new SpecificationHonoringQueryService(Enumerable.Range(1, 7));
+        var specification = new InlineSpecification<ExportTestEntity, int>(e => e.Id % 2 == 1);
+        var sut = new ScopedExportTestController(queryService, _loggerMock.Object, specification)
+        {
+            ControllerContext = CreateControllerContext(maxPageSize: 2, maxExportRows: 3)
+        };
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines(BodyText());
+        lines.Should().HaveCount(5, because: "header plus three data rows plus the truncation marker");
+        lines[1..4].Should().Equal("1,Name 1,true,2026-01-01T00:00:00.0000000Z", "3,Name 3,true,2026-01-01T00:00:00.0000000Z", "5,Name 5,true,2026-01-01T00:00:00.0000000Z");
+        lines[^1].Should().Be(
+            "# export truncated at 3 rows",
+            because: "the ceiling counts the rows the specification allowed, not the rows the table holds");
+    }
+
     // ── Settings resolution ──
     [Fact]
     public async Task ExportAsync_NonPositiveConfiguredCap_FallsBackToTheDefault()
@@ -416,6 +496,115 @@ public sealed class ExportTestController(
     ILogger<EntityControllerBase<ExportTestEntity, ExportTestDTO, int>> logger)
     : EntityControllerBase<ExportTestEntity, ExportTestDTO, int>(queryService, logger);
 
+/// <summary>
+/// A controller that row-scopes its export, standing in for the consumer controllers whose list
+/// endpoints already filter by ownership.
+/// </summary>
+public sealed class ScopedExportTestController(
+    IEntityQueryService<ExportTestEntity, ExportTestDTO, int> queryService,
+    ILogger<EntityControllerBase<ExportTestEntity, ExportTestDTO, int>> logger,
+    Specification<ExportTestEntity, int>? specification)
+    : EntityControllerBase<ExportTestEntity, ExportTestDTO, int>(queryService, logger)
+{
+    protected override Specification<ExportTestEntity, int>? GetExportSpecification() => specification;
+}
+
+/// <summary>
+/// Query-service stand-in that actually honors the specification it is handed and records every
+/// one it sees, so a test can prove the export scoped EVERY page rather than only the first query.
+/// A Moq sequence cannot show that: it replays the same rows whatever it is asked.
+/// </summary>
+public sealed class SpecificationHonoringQueryService(IEnumerable<int> ids)
+    : IEntityQueryService<ExportTestEntity, ExportTestDTO, int>
+{
+    private readonly List<ExportTestEntity> _rows = [.. ids.Select(id => new ExportTestEntity { Id = id })];
+
+    /// <summary>Gets the specification passed to each page query, in call order.</summary>
+    public List<Specification<ExportTestEntity, int>?> SpecificationsSeen { get; } = [];
+
+    public IEntityDTOMapper<ExportTestEntity, ExportTestDTO, int> DTOMapper => throw new NotSupportedException();
+
+    public Task<Result<PagedCollectionResult<object>>> GetAllAsync(
+        bool includeFKs = false,
+        bool includeChildren = false,
+        Specification<ExportTestEntity, int>? specification = null,
+        Dictionary<string, (string Operator, string Value)>? filters = null,
+        string? sortColumn = null,
+        string? sortDirection = null,
+        string? fields = null,
+        int? pageNumber = null,
+        int? pageSize = null,
+        bool asTracking = false,
+        CancellationToken cancellationToken = default)
+    {
+        SpecificationsSeen.Add(specification);
+
+        List<ExportTestEntity> matching = [.. _rows.Where(row => specification is null || specification.IsSatisfiedBy(row))];
+        int size = Math.Max(1, pageSize ?? matching.Count);
+        int page = Math.Max(1, pageNumber ?? 1);
+
+        IReadOnlyCollection<object> items =
+        [
+            .. matching
+                .Skip((page - 1) * size)
+                .Take(size)
+                .Select(row => (object)new ExportTestDTO
+                {
+                    Id = row.Id,
+                    Name = string.Create(CultureInfo.InvariantCulture, $"Name {row.Id}"),
+                    IsActive = true,
+                    CreatedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                })
+        ];
+
+        return Task.FromResult(Result.Success(
+            new PagedCollectionResult<object>(items, new PaginationMetadata(matching.Count, size, page))));
+    }
+
+    public Task<Result<PagedCollectionResult<object>>> GetAllAsync(
+        bool includeFKs = false,
+        bool includeChildren = false,
+        Specification<ExportTestEntity, int>? specification = null,
+        string? fields = null,
+        bool asTracking = false,
+        CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    public Task<Result<IReadOnlyCollection<BaseLookup<int>>>> GetAllForLookupAsync(
+        string nameProperty,
+        Expression<Func<ExportTestEntity, bool>>? where = null,
+        bool asTracking = false,
+        CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    public Task<Result<ExportTestEntity>> GetEntityByIdAsync(
+        string idValue,
+        string? idField = null,
+        bool includeFKs = false,
+        bool includeChildren = false,
+        Specification<ExportTestEntity, int>? specification = null,
+        string? fields = null,
+        bool asTracking = false,
+        CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    public Task<Result<object>> GetByIdAsync(
+        int id,
+        bool includeFKs = false,
+        bool includeChildren = false,
+        Specification<ExportTestEntity, int>? specification = null,
+        string? fields = null,
+        bool asTracking = false,
+        CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    public Task<bool> ExistsAsync(
+        Expression<Func<ExportTestEntity, bool>> where,
+        bool ignoreQueryFilters = false,
+        CancellationToken cancellationToken = default) => throw new NotSupportedException();
+}
+
+public sealed class ExportShapeTestController(
+    IEntityQueryService<ExportTestEntity, ExportShapeTestDTO, int> queryService,
+    ILogger<EntityControllerBase<ExportTestEntity, ExportShapeTestDTO, int>> logger)
+    : EntityControllerBase<ExportTestEntity, ExportShapeTestDTO, int>(queryService, logger);
+
 public sealed class ExportTestEntity : AuditableBaseEntity<int>;
 
 public sealed record ExportTestDTO : IBaseDTO<int>
@@ -427,4 +616,176 @@ public sealed record ExportTestDTO : IBaseDTO<int>
     public bool IsActive { get; init; }
 
     public DateTime CreatedOn { get; init; }
+}
+
+/// <summary>
+/// A DTO carrying one of each shape the CSV formatter has to decide about: scalars, a binary
+/// concurrency token, a binary memory, a child collection, and a value object.
+/// </summary>
+public sealed record ExportShapeTestDTO : IBaseDTO<int>
+{
+    public required int Id { get; init; }
+
+    public string? Name { get; init; }
+
+    public byte[] RowVersion { get; init; } = [];
+
+    public ReadOnlyMemory<byte> Signature { get; init; }
+
+    public IReadOnlyCollection<string> Comments { get; init; } = [];
+
+    public ExportMoney? Price { get; init; }
+}
+
+/// <summary>A value object with a meaningful invariant string form, which the export must keep.</summary>
+public sealed record ExportMoney(decimal Amount, string Currency)
+{
+    public override string ToString() => string.Create(CultureInfo.InvariantCulture, $"{Amount} {Currency}");
+}
+
+/// <summary>
+/// Covers the column-selection rules: a property whose value cannot render a faithful scalar cell
+/// (a binary token, a child collection) produces no column at all, in either the reflection path or
+/// the shaped <c>fields=</c> path, and naming one explicitly is a validation failure rather than a
+/// silent omission.
+/// </summary>
+public sealed class EntityControllerBaseExportColumnTests : IDisposable
+{
+    private readonly Mock<IEntityQueryService<ExportTestEntity, ExportShapeTestDTO, int>> _queryServiceMock = new();
+    private readonly Mock<ILogger<EntityControllerBase<ExportTestEntity, ExportShapeTestDTO, int>>> _loggerMock = new();
+    private readonly MemoryStream _body = new();
+
+    public void Dispose() => _body.Dispose();
+
+    private ExportShapeTestController CreateController()
+    {
+        var settingsMock = new Mock<IApplicationSettings>();
+        settingsMock.Setup(s => s.MaxPageSize).Returns(10);
+        settingsMock.Setup(s => s.MaxExportRows).Returns(100);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(settingsMock.Object);
+        services.AddSingleton<TimeProvider>(new FakeTimeProvider(new DateTimeOffset(2026, 8, 14, 9, 0, 0, TimeSpan.Zero)));
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Response.Body = _body;
+
+        return new ExportShapeTestController(_queryServiceMock.Object, _loggerMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+    }
+
+    private string[] BodyLines() =>
+        Encoding.UTF8.GetString(_body.ToArray()).TrimStart('﻿').Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+
+    private void SetupPage(IReadOnlyCollection<object> items) =>
+        _queryServiceMock.Setup(q => q.GetAllAsync(
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<Specification<ExportTestEntity, int>?>(),
+                It.IsAny<Dictionary<string, (string, string)>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new PagedCollectionResult<object>(
+                items,
+                new PaginationMetadata(items.Count, pageSize: 10, currentPage: 1))));
+
+    [Fact]
+    public async Task ExportAsync_BinaryAndCollectionProperties_ProduceNoColumns()
+    {
+        SetupPage([
+            new ExportShapeTestDTO
+            {
+                Id = 1,
+                Name = "Ada",
+                RowVersion = [1, 2, 3],
+                Signature = new byte[] { 4, 5 },
+                Comments = ["first", "second"],
+                Price = new ExportMoney(9.5m, "USD")
+            }
+        ]);
+        ExportShapeTestController sut = CreateController();
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines();
+        lines[0].Should().Be(
+            "id,name,price",
+            because: "a rowversion renders its type name and a child collection renders the materialized list type, so neither earns a column");
+        lines[1].Should().Be(
+            "1,Ada,9.5 USD",
+            because: "a value object still renders through its invariant ToString, which is the whole point of dropping only the two unrenderable categories");
+    }
+
+    [Fact]
+    public async Task ExportAsync_EmptyResult_HeaderAlsoDropsThoseColumns()
+    {
+        SetupPage([]);
+        ExportShapeTestController sut = CreateController();
+
+        await sut.ExportAsync(cancellationToken: CancellationToken.None);
+
+        BodyLines().Should().ContainSingle().Which.Should().Be(
+            "id,name,price",
+            because: "the DTO-shape fallback must name the same columns a populated export would");
+    }
+
+    [Fact]
+    public async Task ExportAsync_ShapedRowCarryingADroppedKey_OmitsThatColumn()
+    {
+        IDictionary<string, object?> shaped = new ExpandoObject();
+        shaped["id"] = 1;
+        shaped["rowVersion"] = new byte[] { 1, 2, 3 };
+        shaped["price"] = new ExportMoney(3m, "EUR");
+        SetupPage([(ExpandoObject)shaped]);
+        ExportShapeTestController sut = CreateController();
+
+        await sut.ExportAsync(fields: "Id,Price", cancellationToken: CancellationToken.None);
+
+        string[] lines = BodyLines();
+        lines[0].Should().Be("id,price", because: "the shaped path filters the row's own keys too, not just the reflected properties");
+        lines[1].Should().Be("1,3 EUR");
+    }
+
+    [Fact]
+    public async Task ExportAsync_FieldsNamingADroppedProperty_FailsValidation()
+    {
+        ExportShapeTestController sut = CreateController();
+
+        IActionResult result = await sut.ExportAsync(fields: "Id,rowversion", cancellationToken: CancellationToken.None);
+
+        var objectResult = result as ObjectResult;
+        objectResult.Should().NotBeNull();
+        objectResult!.StatusCode.Should().Be(
+            StatusCodes.Status400BadRequest,
+            because: "an unexportable field is a validation failure, exactly as an unknown field is on the JSON endpoints");
+        objectResult.Value.Should().BeOfType<ProblemDetails>();
+        _body.ToArray().Should().BeEmpty(because: "the request is rejected before the first page is queried");
+        _queryServiceMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ExportAsync_FieldsNamingOnlyExportableProperties_Succeeds()
+    {
+        SetupPage([]);
+        ExportShapeTestController sut = CreateController();
+
+        IActionResult result = await sut.ExportAsync(fields: "Id,Name", cancellationToken: CancellationToken.None);
+
+        result.Should().BeOfType<EmptyResult>(because: "the validation gate only rejects the fields the export cannot render");
+        BodyLines()[0].Should().Be("id,name");
+    }
 }


### PR DESCRIPTION
Implements the approved export-scoping spec (the ADR-078 recorded follow-up from v1.150.0):

- `GetExportSpecification()` virtual hook on `EntityControllerBase` (default null = byte-identical to v1.150.0, pinned by an exact-bytes test), threaded through every page of the export loop so owner-scoped exports become possible.
- CSV formatter drops binary and collection columns in both the reflection and `fields=` paths; explicitly requesting one returns the standard 400 validation shape.
- 8 new tests; full solution 3343/3343; FACTS clean.

Ships as v1.151.0; consumer sweep follows (Store relaxes its admin export gates to ownership specifications; ADC keeps its Forbid gates per the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a