### PR TITLE
fix: bug-hunt remediation (H31 H32 M71 M72 M73 M74 L27 L28 L29 L30 + M84 enabler)

### DIFF
--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
@@ -91,10 +91,20 @@ public interface IEntityQuerier<TEntity, TIdentifierType>
 
     /// <summary>Retrieves entities projected to a different type via a selector expression (translated to SQL).</summary>
     /// <typeparam name="TResult">The projected result type.</typeparam>
+    /// <param name="select">The projection expression.</param>
+    /// <param name="where">Optional filter predicate.</param>
+    /// <param name="asTracking">Whether to track the source entities for changes.</param>
+    /// <param name="ignoreQueryFilters">
+    /// Whether to include soft-deleted rows. It drops the <c>SoftDelete</c> global query filter and
+    /// <b>only</b> that one: the <c>Tenant</c> filter stays in force, so a caller asking for deleted
+    /// rows can never read another tenant's data.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<IReadOnlyCollection<TResult>> GetProjectedAsync<TResult>(
         Expression<Func<TEntity, TResult>> select,
         Expression<Func<TEntity, bool>>? where = null,
         bool asTracking = false,
+        bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves entities as lightweight id/name pairs for lookup scenarios.</summary>

--- a/Source/Core/MMCA.Common.Application/Specifications/CrossSourceSpecification.cs
+++ b/Source/Core/MMCA.Common.Application/Specifications/CrossSourceSpecification.cs
@@ -53,7 +53,7 @@ public static class CrossSourceSpecification
 
         var principalRepository = unitOfWork.GetReadRepository<TPrincipal, TPrincipalId>();
         var matchingKeys = await principalRepository
-            .GetProjectedAsync(p => p.Id, principalPredicate, asTracking: false, cancellationToken)
+            .GetProjectedAsync(p => p.Id, principalPredicate, asTracking: false, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         // Materialize once so the predicate embeds a stable collection EF can translate (IN / ARRAY_CONTAINS).

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Inbox/EfInboxStore.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Inbox/EfInboxStore.cs
@@ -49,13 +49,19 @@ public sealed partial class EfInboxStore(
         }
         catch (DbUpdateException)
         {
-            // A concurrent duplicate delivery already inserted this MessageId (unique index).
-            // Idempotent — treat as processed.
             // The context is cached per data source for the whole scope, so the rejected row must be
             // detached: left Added, every later SaveChangesAsync on this scope would re-attempt the
-            // duplicate insert and fail. Same idiom as DomainEventSaveChangesInterceptor uses when it
+            // failed insert and fail. Same idiom as DomainEventSaveChangesInterceptor uses when it
             // discards an abandoned capture.
             entry.State = EntityState.Detached;
+
+            // Only a concurrent duplicate delivery (the unique index on MessageId) is idempotent and
+            // safe to absorb. Re-query instead of sniffing provider-specific error codes, so the check
+            // holds for SQL Server and SQLite alike. Any other write failure must surface: swallowing
+            // it would ACK a message whose inbox row was never written, hiding the failure from the
+            // broker's redelivery.
+            if (!await AlreadyProcessedAsync(messageId, cancellationToken).ConfigureAwait(false))
+                throw;
 
             LogConcurrentDuplicate(logger, messageId);
         }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepository.cs
@@ -66,11 +66,15 @@ internal class EFReadRepository<TEntity, TIdentifierType>(
         Expression<Func<TEntity, TResult>> select,
         Expression<Func<TEntity, bool>>? where = null,
         bool asTracking = false,
+        bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(select);
 
         var query = asTracking ? Table : TableNoTracking;
+
+        if (ignoreQueryFilters)
+            query = query.IgnoreQueryFilters(SoftDeleteFilterOnly);
 
         if (where is not null)
             query = query.Where(where);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepositoryDecorator.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFReadRepositoryDecorator.cs
@@ -35,9 +35,10 @@ internal class EFReadRepositoryDecorator<TEntity, TIdentifierType>(IReadReposito
         Expression<Func<TEntity, TResult>> select,
         Expression<Func<TEntity, bool>>? where = null,
         bool asTracking = false,
+        bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default) =>
         ProfilingHelper.ProfileAsync(ClassName, nameof(GetProjectedAsync),
-            () => _inner.GetProjectedAsync(select, where, asTracking, cancellationToken));
+            () => _inner.GetProjectedAsync(select, where, asTracking, ignoreQueryFilters, cancellationToken));
 
     public Task<IReadOnlyCollection<BaseLookup<TIdentifierType>>> GetAllForLookupAsync(
         string nameProperty,

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
@@ -48,27 +48,20 @@ internal sealed class EFRepository<TEntity, TIdentifierType>(
     /// via <see cref="Microsoft.EntityFrameworkCore.ChangeTracking.PropertyValues.SetValues(object)"/>
     /// to avoid an "already tracked" exception. Otherwise, <see cref="DbSet{TEntity}.Update"/>
     /// attaches and marks the entity as modified.
-    /// On failure, all pending changes are rolled back to <see cref="EntityState.Unchanged"/>
-    /// to keep the context in a usable state.
     /// </remarks>
     public Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        try
-        {
-            // FindEntry is an O(1) key lookup against the tracker's identity map (and never
-            // falls back to the database), replacing a linear scan of the LocalView.
-            var trackedEntry = Entities.Local.FindEntry(entity.Id);
-            if (trackedEntry is not null)
-                trackedEntry.CurrentValues.SetValues(entity);
-            else
-                Entities.Update(entity);
-            return Task.CompletedTask;
-        }
-        catch (DbUpdateException ex)
-        {
-            throw new DbUpdateException(GetFullErrorTextAndRollbackEntityChanges(ex), ex);
-        }
+
+        // FindEntry is an O(1) key lookup against the tracker's identity map (and never
+        // falls back to the database), replacing a linear scan of the LocalView.
+        var trackedEntry = Entities.Local.FindEntry(entity.Id);
+        if (trackedEntry is not null)
+            trackedEntry.CurrentValues.SetValues(entity);
+        else
+            Entities.Update(entity);
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
@@ -158,37 +151,4 @@ internal sealed class EFRepository<TEntity, TIdentifierType>(
         _context is ApplicationDbContext applicationContext
             ? await applicationContext.SaveChangesAsync(currentUserService?.UserId, cancellationToken).ConfigureAwait(false)
             : await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-    /// <summary>
-    /// Rolls back all Added/Modified entries to Unchanged and persists the reset
-    /// so the context is left in a clean state after a failed update.
-    /// </summary>
-    /// <returns>The full error text from the original or rollback exception.</returns>
-    private string GetFullErrorTextAndRollbackEntityChanges(DbUpdateException exception)
-    {
-        var entries = _context.ChangeTracker.Entries()
-            .Where(e => e.State is EntityState.Added or EntityState.Modified).ToList();
-
-        foreach (var entry in entries)
-        {
-            try
-            {
-                entry.State = EntityState.Unchanged;
-            }
-            catch (InvalidOperationException)
-            {
-                // Entry may be in a state that cannot transition to Unchanged (e.g. keyless).
-            }
-        }
-
-        try
-        {
-            _context.SaveChanges();
-            return exception.ToString();
-        }
-        catch (Exception ex)
-        {
-            return ex.ToString();
-        }
-    }
 }

--- a/Source/Core/MMCA.Common.Shared/Abstractions/PaginationMetadata.cs
+++ b/Source/Core/MMCA.Common.Shared/Abstractions/PaginationMetadata.cs
@@ -76,7 +76,7 @@ public sealed record PaginationMetadata
 
     /// <summary>Gets the 1-based index of the first item on the current page.</summary>
     [IgnoreDataMember]
-    public int FirstRowOnPage => TotalItemCount == 0 || PageSize == 0 ? 0 : (int)((long)(CurrentPage - 1) * PageSize + 1);
+    public int FirstRowOnPage => TotalItemCount == 0 || PageSize == 0 || CurrentPage < 1 ? 0 : (int)((long)(CurrentPage - 1) * PageSize + 1);
 
     /// <summary>Gets the 1-based index of the last item on the current page, clamped to <see cref="TotalItemCount"/>.</summary>
     [IgnoreDataMember]

--- a/Source/Core/MMCA.Common.Shared/Auth/RoleValue.cs
+++ b/Source/Core/MMCA.Common.Shared/Auth/RoleValue.cs
@@ -43,7 +43,7 @@ public abstract class RoleValue
     {
         ArgumentNullException.ThrowIfNull(knownRoles);
 
-        return knownRoles.Contains(role ?? string.Empty)
+        return IsKnown(role, knownRoles)
             ? Result.Success()
             : Result.Failure(Error.Invariant(
                 code: "User.Role.Invalid",
@@ -51,6 +51,18 @@ public abstract class RoleValue
                 source: source,
                 target: nameof(role)));
     }
+
+    /// <summary>
+    /// Case-insensitive membership test that does not depend on how the caller built its set.
+    /// The fast path is the set's own lookup (correct and O(1) for the intended
+    /// <see cref="StringComparer.OrdinalIgnoreCase"/> sets); a miss falls back to an explicit
+    /// case-insensitive scan, so a set built with the default ordinal comparer still validates
+    /// case-insensitively as the contract promises. Role sets hold a handful of entries, so the
+    /// fallback scan is negligible and only ever runs on a miss.
+    /// </summary>
+    private static bool IsKnown(string? role, IReadOnlySet<string> knownRoles) =>
+        knownRoles.Contains(role ?? string.Empty)
+        || knownRoles.Any(k => string.Equals(k, role, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Builds a case-insensitive, frozen lookup of the supplied role instances keyed by their

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/E2ETestBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/E2ETestBase.cs
@@ -39,13 +39,25 @@ public abstract class E2ETestBase : IAsyncLifetime
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);
-        if (E2ETestConfiguration.TracePath is not null)
+
+        // A failed InitializeAsync (context or page creation threw) leaves these null despite the
+        // null! declarations, and the NullReferenceException from disposal then replaced the real
+        // setup error in the run output. StopTracingAsync dereferences the context, so it is guarded
+        // by the same check.
+        if (E2ETestConfiguration.TracePath is not null && _context is not null)
         {
             await StopTracingAsync(E2ETestConfiguration.TracePath).ConfigureAwait(false);
         }
 
-        await Page.CloseAsync().ConfigureAwait(false);
-        await _context.DisposeAsync().ConfigureAwait(false);
+        if (Page is { } page)
+        {
+            await page.CloseAsync().ConfigureAwait(false);
+        }
+
+        if (_context is not null)
+        {
+            await _context.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     // Stops the Playwright trace. When E2E_TRACE names a DIRECTORY (per-test mode), a trace is written

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PlaywrightFixture.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PlaywrightFixture.cs
@@ -31,8 +31,16 @@ public sealed class PlaywrightFixture : IAsyncLifetime
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);
-        await Browser.DisposeAsync().ConfigureAwait(false);
-        Playwright.Dispose();
+
+        // A failed InitializeAsync (no browser binaries, a launch timeout) leaves these null despite
+        // the null! declarations, and the NullReferenceException from disposal then replaced the real
+        // launch error in the run output.
+        if (Browser is { } browser)
+        {
+            await browser.DisposeAsync().ConfigureAwait(false);
+        }
+
+        Playwright?.Dispose();
     }
 }
 

--- a/Source/Presentation/MMCA.Common.API/SessionCookies/CookieSessionRefresher.cs
+++ b/Source/Presentation/MMCA.Common.API/SessionCookies/CookieSessionRefresher.cs
@@ -1,8 +1,10 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using MMCA.Common.Shared.Auth;
 using MMCA.Common.Shared.Concurrency;
 
@@ -46,10 +48,11 @@ public interface ICookieSessionRefresher
 /// rotation-grace cache is re-checked per token after acquiring.
 /// </para>
 /// </summary>
-internal sealed class CookieSessionRefresher(
+internal sealed partial class CookieSessionRefresher(
     IHttpClientFactory httpClientFactory,
     IMemoryCache cache,
-    IWebHostEnvironment environment) : ICookieSessionRefresher
+    IWebHostEnvironment environment,
+    ILogger<CookieSessionRefresher> logger) : ICookieSessionRefresher
 {
     internal const string RefreshClientName = "SessionCookieRefreshClient";
 
@@ -111,27 +114,41 @@ internal sealed class CookieSessionRefresher(
     {
         var client = httpClientFactory.CreateClient(RefreshClientName);
 
-        // CancellationToken.None: once we hold the lock the refresh must complete (and write its cookies)
-        // regardless of whether the triggering request was aborted; the call is short.
-        using var response = await client.PostAsJsonAsync(
-            new Uri("auth/refresh", UriKind.Relative),
-            new RefreshTokenRequest(accessToken, refreshToken),
-            CancellationToken.None).ConfigureAwait(false);
-
-        if (!response.IsSuccessStatusCode)
+        // A transport failure or a malformed body means "no session right now", not a broken request:
+        // this runs during SSR, so an escaping exception turned a signed-in user's navigation into a
+        // 500 instead of an anonymous render. The failure is deliberately NOT cached (only a
+        // successful rotation reaches cache.Set below), so the next navigation retries. A missing
+        // BaseAddress raises InvalidOperationException and is left to propagate: that is a host
+        // configuration error, not a runtime condition.
+        try
         {
+            // CancellationToken.None: once we hold the lock the refresh must complete (and write its cookies)
+            // regardless of whether the triggering request was aborted; the call is short.
+            using var response = await client.PostAsJsonAsync(
+                new Uri("auth/refresh", UriKind.Relative),
+                new RefreshTokenRequest(accessToken, refreshToken),
+                CancellationToken.None).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            var auth = await response.Content.ReadFromJsonAsync<AuthenticationResponse>(CancellationToken.None).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(auth.AccessToken))
+            {
+                return null;
+            }
+
+            // Cache by the OLD refresh token so a slightly-late sibling request gets the same rotated pair.
+            cache.Set(CacheKey(refreshToken), auth, RotationGrace);
+            return auth;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or JsonException or NotSupportedException)
+        {
+            LogRefreshCallFailed(logger, ex);
             return null;
         }
-
-        var auth = await response.Content.ReadFromJsonAsync<AuthenticationResponse>(CancellationToken.None).ConfigureAwait(false);
-        if (string.IsNullOrWhiteSpace(auth.AccessToken))
-        {
-            return null;
-        }
-
-        // Cache by the OLD refresh token so a slightly-late sibling request gets the same rotated pair.
-        cache.Set(CacheKey(refreshToken), auth, RotationGrace);
-        return auth;
     }
 
     private static bool TryReadValidExpiry(string? token, out DateTime expiry)
@@ -170,4 +187,7 @@ internal sealed class CookieSessionRefresher(
     /// concurrency test can pick two refresh tokens that do not land on the same stripe.
     /// </summary>
     internal static string CacheKey(string refreshToken) => $"mmca:session-refresh:{refreshToken}";
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Session cookie refresh call failed; the request renders anonymously and the next navigation retries")]
+    private static partial void LogRefreshCallFailed(ILogger logger, Exception exception);
 }

--- a/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
@@ -10,7 +10,9 @@ namespace MMCA.Common.UI.Maui.Services;
 /// enrolment change), and the raw APIs then throw a platform exception instead of returning
 /// nothing. An unhandled throw here bricks the app on launch until it is reinstalled, so a read
 /// failure degrades to "no token stored" (which <see cref="ITokenStorageService"/> already
-/// documents) and drops the unreadable entry, forcing one clean re-login.
+/// documents) and drops the unreadable entry, forcing one clean re-login. A write failure clears
+/// BOTH entries before it propagates, so the app can never be left holding a stale pair it believes
+/// is current: the outcome of any failed write is the clean signed-out state.
 /// <para>
 /// Register with <c>AddCommonMauiTokenStorage()</c>; the browser-host siblings are
 /// <c>WasmTokenStorageService</c> (MMCA.Common.UI) and <c>ServerTokenStorageService</c>
@@ -31,12 +33,13 @@ public sealed class MauiTokenStorageService : ITokenStorageService
     /// <inheritdoc />
     public async Task SetTokensAsync(string accessToken, string refreshToken)
     {
-        // Refresh first: if it fails the old pair stays coherent. If the access write then fails,
-        // drop both so storage is a clean signed-out state instead of a mismatched pair holding a
-        // new access token against a stale refresh token whose refresh path is already dead.
-        await SetAsync(RefreshTokenKey, refreshToken);
+        // Refresh first, both writes under the SAME guard: whichever one fails, drop both so storage
+        // is a clean signed-out state. A failing refresh write used to escape before the guard was
+        // entered, leaving the OLD pair in place: the app then held a stale access token it believed
+        // was current, and only a manual sign-out cleared it.
         try
         {
+            await SetAsync(RefreshTokenKey, refreshToken);
             await SetAsync(AccessTokenKey, accessToken);
         }
 #pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; rethrown after the cleanup

--- a/Source/Presentation/MMCA.Common.UI/Pages/Auth/Register.razor
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Auth/Register.razor
@@ -1,4 +1,5 @@
 @page "/register"
+@using MMCA.Common.Shared.Abstractions
 @using MMCA.Common.Shared.Auth
 @using MMCA.Common.Shared.ValueObjects
 @using MMCA.Common.UI.Services.Auth
@@ -122,13 +123,20 @@
     private string? _errorMessage;
     private bool _isLoading;
 
-    private Address? BuildAddress()
+    // Null means "no address entered", which is legitimate: the address block is optional. Anything
+    // the user DID type is validated, and an invalid address blocks the registration instead of being
+    // silently dropped (the account used to be created with no address at all).
+    private Result<Address>? BuildAddressResult()
     {
-        if (string.IsNullOrWhiteSpace(_model.AddressLine1))
+        if (string.IsNullOrWhiteSpace(_model.AddressLine1)
+            && string.IsNullOrWhiteSpace(_model.AddressLine2)
+            && string.IsNullOrWhiteSpace(_model.City)
+            && string.IsNullOrWhiteSpace(_model.State)
+            && string.IsNullOrWhiteSpace(_model.ZipCode)
+            && string.IsNullOrWhiteSpace(_model.Country))
             return null;
 
-        var result = Address.Create(_model.AddressLine1, _model.AddressLine2, _model.City, _model.State, _model.ZipCode, _model.Country);
-        return result.IsSuccess ? result.Value : null;
+        return Address.Create(_model.AddressLine1, _model.AddressLine2, _model.City, _model.State, _model.ZipCode, _model.Country);
     }
 
     private async Task HandleRegisterAsync()
@@ -137,12 +145,20 @@
         // EditForm + DataAnnotations before OnValidSubmit fires; this method only handles the call and
         // any server-side failure, surfaced in the form-level MudAlert.
         _errorMessage = null;
+
+        var addressResult = BuildAddressResult();
+        if (addressResult is { IsFailure: true } failedAddress)
+        {
+            _errorMessage = failedAddress.Errors[0].Message;
+            return;
+        }
+
         _isLoading = true;
 
         try
         {
             var result = await AuthService.RegisterAsync(
-                new RegisterRequest(_model.Email, _model.Password, _model.FirstName, _model.LastName, BuildAddress()));
+                new RegisterRequest(_model.Email, _model.Password, _model.FirstName, _model.LastName, addressResult?.Value));
             if (result is not null)
             {
                 Navigation.NavigateTo("/", forceLoad: true);

--- a/Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs
@@ -462,28 +462,31 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
         LoadFailed = false;
         StateHasChanged();
 
-        var filters = ExtractGridFilters(state);
-        additionalFilters?.Invoke(filters);
-
-        var (sortColumn, sortDirection) = ExtractSortParameters(state);
-
-        // First-fetch fallback: when MudDataGrid hasn't yet picked up a SortDefinition
-        // (typical on initial load with a URL-driven sort), use the sort restored from
-        // the query string so the data lands sorted from the very first request.
-        if (string.IsNullOrEmpty(sortColumn) && !string.IsNullOrEmpty(_savedSortColumn))
-        {
-            sortColumn = _savedSortColumn;
-            sortDirection = _savedSortDescending ? "desc" : "asc";
-        }
-
         // Bound the fetch token: during SSR pre-render (CreateFetchCts) it times out so a cold/unreachable
         // backend can't block prerendering — and therefore the page load / navigation — indefinitely (the
         // dominant cause of E2E navigation timeouts). On timeout the fetch throws OperationCanceledException
         // and we return an empty grid; the first INTERACTIVE ServerData call then loads the real data.
         using var fetchCts = CreateFetchCts();
 
+        // Filter and sort extraction run INSIDE the try: the caller's additionalFilters callback is
+        // arbitrary page code, and a throw from it (or from the extraction itself) used to escape
+        // past the finally, stranding IsLoading at true and leaving the grid spinning forever.
         try
         {
+            var filters = ExtractGridFilters(state);
+            additionalFilters?.Invoke(filters);
+
+            var (sortColumn, sortDirection) = ExtractSortParameters(state);
+
+            // First-fetch fallback: when MudDataGrid hasn't yet picked up a SortDefinition
+            // (typical on initial load with a URL-driven sort), use the sort restored from
+            // the query string so the data lands sorted from the very first request.
+            if (string.IsNullOrEmpty(sortColumn) && !string.IsNullOrEmpty(_savedSortColumn))
+            {
+                sortColumn = _savedSortColumn;
+                sortDirection = _savedSortDescending ? "desc" : "asc";
+            }
+
             var (items, totalItems) = await fetchAsync(filters, state.Page + 1, state.PageSize, sortColumn, sortDirection, fetchCts.Token);
             var gridData = new GridData<TDto> { Items = items, TotalItems = totalItems };
             _lastSuccessfulGridData = gridData;
@@ -594,12 +597,23 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
         }
     }
 
+    /// <summary>
+    /// Flattens the grid's filter definitions into the one-filter-per-column shape the fetch
+    /// delegate takes. MudDataGrid lets the user add several filter rows on the SAME column, which
+    /// a dictionary cannot carry, so the newest row wins instead of the projection throwing.
+    /// </summary>
     private static Dictionary<string, (string Operator, string Value)> ExtractGridFilters(GridState<TDto> state) =>
         state.FilterDefinitions?
             .Where(f => !string.IsNullOrWhiteSpace(f.Column?.PropertyName))
+            .GroupBy(f => f.Column!.PropertyName!, StringComparer.Ordinal)
             .ToDictionary(
-                f => f.Column!.PropertyName!,
-                f => (f.Operator ?? string.Empty, f.Value?.ToString() ?? string.Empty)
+                g => g.Key,
+                g =>
+                {
+                    var newest = g.Last();
+                    return (newest.Operator ?? string.Empty, newest.Value?.ToString() ?? string.Empty);
+                },
+                StringComparer.Ordinal
             ) ?? [];
 
     private static (string? SortColumn, string? SortDirection) ExtractSortParameters(GridState<TDto> state)

--- a/Source/Presentation/MMCA.Common.UI/Services/Capabilities/Browser/CapabilitiesJsModule.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Capabilities/Browser/CapabilitiesJsModule.cs
@@ -13,11 +13,10 @@ public sealed class CapabilitiesJsModule : IAsyncDisposable
 {
     private const string ModulePath = "./_content/MMCA.Common.UI/capabilities-interop.js";
 
-    private readonly IJSRuntime _jsRuntime;
-    private IJSObjectReference? _module;
+    private readonly LazyJsModule _module;
 
     /// <summary>Initializes the accessor over the host's <see cref="IJSRuntime"/>.</summary>
-    public CapabilitiesJsModule(IJSRuntime jsRuntime) => _jsRuntime = jsRuntime;
+    public CapabilitiesJsModule(IJSRuntime jsRuntime) => _module = new LazyJsModule(jsRuntime, ModulePath);
 
     /// <summary>
     /// Invokes a module export, returning <see langword="default"/> when JS interop is
@@ -31,10 +30,8 @@ public sealed class CapabilitiesJsModule : IAsyncDisposable
     {
         try
         {
-            _module ??= await _jsRuntime
-                .InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath)
-                .ConfigureAwait(false);
-            return await _module.InvokeAsync<T>(identifier, cancellationToken, args).ConfigureAwait(false);
+            var module = await _module.GetOrImportAsync(cancellationToken).ConfigureAwait(false);
+            return await module.InvokeAsync<T>(identifier, cancellationToken, args).ConfigureAwait(false);
         }
         catch (InvalidOperationException)
         {
@@ -52,20 +49,5 @@ public sealed class CapabilitiesJsModule : IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
-    {
-        if (_module is null)
-        {
-            return;
-        }
-
-        try
-        {
-            await _module.DisposeAsync().ConfigureAwait(false);
-        }
-        catch (JSDisconnectedException)
-        {
-            // Circuit already gone; nothing to release.
-        }
-    }
+    public ValueTask DisposeAsync() => _module.DisposeAsync();
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/LazyJsModule.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/LazyJsModule.cs
@@ -1,0 +1,100 @@
+using Microsoft.JSInterop;
+
+namespace MMCA.Common.UI.Services;
+
+/// <summary>
+/// Single-flight, prerender-safe importer for one JS module, shared by the UI services that own a
+/// <c>_content/MMCA.Common.UI/*.js</c> module. An unguarded <c>_module ??= await import(...)</c>
+/// lets two concurrent callers each start an import; the browser then holds two module instances
+/// and the later assignment leaks the earlier reference (it is never disposed). This class caches
+/// the in-flight import task under a lock so concurrent callers share ONE import, and drops that
+/// task when it fails so a later call retries: an import attempted during SSR prerender must not
+/// poison the module for the rest of the circuit.
+/// </summary>
+/// <remarks>
+/// Callers keep their own exception handling: this class deliberately does not swallow anything on
+/// the import path, so each service can keep its own degradation contract (return default, fall
+/// back to a navigation, no-op). Disposal is guarded, because a torn-down circuit is the normal
+/// end of life for a scoped UI service.
+/// </remarks>
+internal sealed class LazyJsModule(IJSRuntime js, string modulePath) : IAsyncDisposable
+{
+    private readonly Lock _sync = new();
+
+    private Task<IJSObjectReference>? _inFlight;
+    private IJSObjectReference? _module;
+
+    /// <summary>Whether the module has been imported (used to skip work on disposal).</summary>
+    public bool IsImported => _module is not null;
+
+    /// <summary>
+    /// Returns the imported module, importing it on first use. Concurrent callers share one import.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the import call.</param>
+    public async Task<IJSObjectReference> GetOrImportAsync(CancellationToken cancellationToken = default)
+    {
+        if (_module is { } cached)
+        {
+            return cached;
+        }
+
+        // The lock is what makes the import single: ImportAsync reaches its first await
+        // immediately, so nothing slow runs under it.
+        Task<IJSObjectReference> inFlight;
+        lock (_sync)
+        {
+            _inFlight ??= ImportAsync(cancellationToken);
+            inFlight = _inFlight;
+        }
+
+        try
+        {
+            return await inFlight.ConfigureAwait(false);
+        }
+        finally
+        {
+            // Only clear a FAILED task, and only our own: clearing unconditionally could drop a
+            // newer import started after this one completed, splitting the next set of callers.
+            if (!inFlight.IsCompletedSuccessfully)
+            {
+                lock (_sync)
+                {
+                    if (ReferenceEquals(_inFlight, inFlight))
+                    {
+                        _inFlight = null;
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task<IJSObjectReference> ImportAsync(CancellationToken cancellationToken)
+    {
+        var module = await js
+            .InvokeAsync<IJSObjectReference>("import", cancellationToken, modulePath)
+            .ConfigureAwait(false);
+
+        _module = module;
+        return module;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not { } module)
+        {
+            return;
+        }
+
+        _module = null;
+
+        try
+        {
+            await module.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone; nothing to release.
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/ListPageStateService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/ListPageStateService.cs
@@ -55,13 +55,13 @@ public sealed record ListPageState
 /// (via the <c>nav-interop.js</c> module) so state survives circuit teardowns,
 /// <c>forceLoad: true</c> navigations, and the SSR → WASM render-mode transition.
 /// </summary>
-public sealed class ListPageStateService(IJSRuntime js)
+public sealed class ListPageStateService(IJSRuntime js) : IAsyncDisposable
 {
     private const string ModulePath = "./_content/MMCA.Common.UI/nav-interop.js";
     private const string SessionKeyPrefix = "mmca.lps:";
 
     private readonly Dictionary<string, ListPageState> _states = [];
-    private IJSObjectReference? _module;
+    private readonly LazyJsModule _module = new(js, ModulePath);
 
     /// <summary>
     /// Returns the in-memory snapshot for <paramref name="routePath"/>, or
@@ -163,15 +163,9 @@ public sealed class ListPageStateService(IJSRuntime js)
 
     private async ValueTask<IJSObjectReference?> GetModuleAsync()
     {
-        if (_module is not null)
-        {
-            return _module;
-        }
-
         try
         {
-            _module = await js.InvokeAsync<IJSObjectReference>("import", ModulePath).ConfigureAwait(false);
-            return _module;
+            return await _module.GetOrImportAsync().ConfigureAwait(false);
         }
         catch (InvalidOperationException)
         {
@@ -182,4 +176,7 @@ public sealed class ListPageStateService(IJSRuntime js)
             return null;
         }
     }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _module.DisposeAsync();
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/Navigation/NavigationHistoryService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Navigation/NavigationHistoryService.cs
@@ -9,11 +9,11 @@ namespace MMCA.Common.UI.Services.Navigation;
 /// the MAUI hardware-back bridge to perform a real <c>history.back()</c> when an
 /// in-history previous entry exists, falling back to a hard-coded path otherwise.
 /// </summary>
-public sealed class NavigationHistoryService(NavigationManager navigation, IJSRuntime js)
+public sealed class NavigationHistoryService(NavigationManager navigation, IJSRuntime js) : IAsyncDisposable
 {
     private const string ModulePath = "./_content/MMCA.Common.UI/nav-interop.js";
 
-    private IJSObjectReference? _module;
+    private readonly LazyJsModule _module = new(js, ModulePath);
 
     /// <summary>
     /// Returns <see langword="true"/> when the browser history stack contains a
@@ -84,15 +84,9 @@ public sealed class NavigationHistoryService(NavigationManager navigation, IJSRu
 
     private async ValueTask<IJSObjectReference?> GetModuleAsync()
     {
-        if (_module is not null)
-        {
-            return _module;
-        }
-
         try
         {
-            _module = await js.InvokeAsync<IJSObjectReference>("import", ModulePath).ConfigureAwait(false);
-            return _module;
+            return await _module.GetOrImportAsync().ConfigureAwait(false);
         }
         catch (InvalidOperationException)
         {
@@ -103,4 +97,7 @@ public sealed class NavigationHistoryService(NavigationManager navigation, IJSRu
             return null;
         }
     }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _module.DisposeAsync();
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/ThemeService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/ThemeService.cs
@@ -16,7 +16,7 @@ namespace MMCA.Common.UI.Services;
 public sealed class ThemeService(IJSRuntime jsRuntime) : IAsyncDisposable
 {
     private const string ModulePath = "./_content/MMCA.Common.UI/theme.js";
-    private IJSObjectReference? _module;
+    private readonly LazyJsModule _module = new(jsRuntime, ModulePath);
 
     /// <summary>Whether dark mode is currently active.</summary>
     public bool IsDarkMode { get; private set; }
@@ -61,22 +61,8 @@ public sealed class ThemeService(IJSRuntime jsRuntime) : IAsyncDisposable
     /// <summary>Flips between light and dark, persisting the new value.</summary>
     public Task ToggleAsync() => SetDarkModeAsync(!IsDarkMode);
 
-    private async Task<IJSObjectReference> GetModuleAsync() =>
-        _module ??= await jsRuntime.InvokeAsync<IJSObjectReference>("import", ModulePath);
+    private Task<IJSObjectReference> GetModuleAsync() => _module.GetOrImportAsync();
 
     /// <inheritdoc/>
-    public async ValueTask DisposeAsync()
-    {
-        if (_module is not null)
-        {
-            try
-            {
-                await _module.DisposeAsync();
-            }
-            catch (JSDisconnectedException)
-            {
-                // The circuit is already gone (page closed); nothing to dispose.
-            }
-        }
-    }
+    public ValueTask DisposeAsync() => _module.DisposeAsync();
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Specifications/CrossSourceSpecificationTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Specifications/CrossSourceSpecificationTests.cs
@@ -32,6 +32,7 @@ public sealed class CrossSourceSpecificationTests
                 It.IsAny<Expression<Func<Principal, int>>>(),
                 It.IsAny<Expression<Func<Principal, bool>>>(),
                 false,
+                false,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(matchingPrincipalKeys);
 

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFReadRepositoryDecoratorAdditionalTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFReadRepositoryDecoratorAdditionalTests.cs
@@ -45,6 +45,7 @@ public sealed class EFReadRepositoryDecoratorAdditionalTests
                 It.IsAny<Expression<Func<FakeEntity, string>>>(),
                 It.IsAny<Expression<Func<FakeEntity, bool>>>(),
                 false,
+                false,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(projected);
 

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFReadRepositoryProjectedFilterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EFReadRepositoryProjectedFilterTests.cs
@@ -1,0 +1,108 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Persistence.Repositories;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Pins the <c>ignoreQueryFilters</c> flag on <c>GetProjectedAsync</c> against a real database with
+/// the production NAMED soft-delete filter. Without the flag a projection could never reach a
+/// soft-deleted row, so any caller needing deleted rows (an admin restore screen, a GDPR export)
+/// had to abandon the projection and load whole entities.
+/// </summary>
+public sealed class EFReadRepositoryProjectedFilterTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly NamedSoftDeleteTestDbContext _context;
+    private readonly EFReadRepository<ProjectedTestEntity, int> _sut;
+
+    public EFReadRepositoryProjectedFilterTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NamedSoftDeleteTestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new NamedSoftDeleteTestDbContext(options);
+        _context.Database.EnsureCreated();
+        _sut = new EFReadRepository<ProjectedTestEntity, int>(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task GetProjectedAsync_WithIgnoreQueryFilters_ReturnsSoftDeletedRow()
+    {
+        await SeedSoftDeletedAsync();
+
+        var result = await _sut.GetProjectedAsync(e => e.Name, ignoreQueryFilters: true);
+
+        result.Should().ContainSingle().Which.Should().Be("Deleted");
+    }
+
+    [Fact]
+    public async Task GetProjectedAsync_WithoutIgnoreQueryFilters_SkipsSoftDeletedRow()
+    {
+        await SeedSoftDeletedAsync();
+
+        var result = await _sut.GetProjectedAsync(e => e.Name);
+
+        result.Should().BeEmpty("the soft-delete filter applies unless the caller opts out");
+    }
+
+    [Fact]
+    public async Task GetProjectedAsync_WithIgnoreQueryFilters_StillHonorsTheWherePredicate()
+    {
+        await SeedSoftDeletedAsync();
+        _context.Add(new ProjectedTestEntity { Id = 2, Name = "Live" });
+        await _context.SaveChangesAsync();
+
+        var result = await _sut.GetProjectedAsync(
+            select: e => e.Name,
+            where: e => e.Id == 1,
+            ignoreQueryFilters: true);
+
+        result.Should().ContainSingle().Which.Should().Be("Deleted");
+    }
+
+    private async Task SeedSoftDeletedAsync()
+    {
+        var entity = new ProjectedTestEntity { Id = 1, Name = "Deleted" };
+        _context.Add(entity);
+        await _context.SaveChangesAsync();
+
+        entity.Delete().IsSuccess.Should().BeTrue();
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+    }
+
+    /// <summary>An entity with the production soft-delete flag, mapped with the matching named filter.</summary>
+    public sealed class ProjectedTestEntity : AuditableBaseEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class NamedSoftDeleteTestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<ProjectedTestEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.Property(e => e.Name);
+                b.Ignore(e => e.RowVersion);
+
+                // The NAME matters: the repository drops this filter by name so the Tenant filter survives.
+                b.HasQueryFilter(ApplicationDbContext.SoftDeleteFilterName, e => !e.IsDeleted);
+            });
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Inbox/EfInboxStoreTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Inbox/EfInboxStoreTests.cs
@@ -128,6 +128,22 @@ public sealed class EfInboxStoreTests : IDisposable
         (await _contextA.Set<InboxMessage>().CountAsync(m => m.MessageId == duplicated)).Should().Be(1);
     }
 
+    [Fact]
+    public async Task NonDuplicateWriteFailure_IsRethrown_AndNothingIsRecorded()
+    {
+        // A write that fails for a reason OTHER than the unique index (here the NOT NULL EventType
+        // column) must surface: swallowing it would ACK a message whose inbox row was never written,
+        // so the broker never redelivers and the message is lost.
+        var store = CreateStore(_contextA);
+        var messageId = Guid.NewGuid();
+
+        var failing = async () => await store.MarkProcessedAsync(messageId, null!, CancellationToken.None);
+        await failing.Should().ThrowAsync<DbUpdateException>();
+
+        (await store.AlreadyProcessedAsync(messageId, CancellationToken.None)).Should().BeFalse(
+            "the row was never written, so the message must stay eligible for redelivery");
+    }
+
     private static EfInboxStore CreateStore(ApplicationDbContext context)
     {
         var factory = new Mock<IDbContextFactory>();

--- a/Tests/Core/MMCA.Common.Shared.Tests/Abstractions/PaginationMetadataTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Abstractions/PaginationMetadataTests.cs
@@ -57,6 +57,15 @@ public class PaginationMetadataTests
         metadata.FirstRowOnPage.Should().Be(0);
     }
 
+    [Fact]
+    public void FirstRowOnPage_WithCurrentPageZero_ReturnsZero()
+    {
+        // CurrentPage is 1-based, but 0 is a legal value (the parameterless constructor uses it, and
+        // any deserialized payload can carry it), which made the arithmetic produce a negative row.
+        var metadata = new PaginationMetadata(100, 10, 0);
+        metadata.FirstRowOnPage.Should().Be(0);
+    }
+
     // ── LastRowOnPage ──
     [Fact]
     public void LastRowOnPage_FullPage_ReturnsPageBoundary()

--- a/Tests/Core/MMCA.Common.Shared.Tests/Auth/RoleValueTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Auth/RoleValueTests.cs
@@ -1,0 +1,73 @@
+using AwesomeAssertions;
+using MMCA.Common.Shared.Auth;
+
+namespace MMCA.Common.Shared.Tests.Auth;
+
+/// <summary>
+/// Pins the documented contract of <see cref="RoleValue.Validate"/>: role comparison is
+/// case-insensitive regardless of the comparer the caller's set was built with. A set built with
+/// the default ordinal comparer (the natural result of a collection expression or
+/// <c>ToHashSet()</c> without a comparer) used to reject a correctly-spelled role that differed
+/// only in casing.
+/// </summary>
+public sealed class RoleValueTests
+{
+    private const string Source = nameof(RoleValueTests);
+
+    [Fact]
+    public void Validate_WithDefaultComparerSet_MatchesRoleCaseInsensitively()
+    {
+        // A default-comparer set: ordinal, so "admin" is not "Admin" to the set's own lookup.
+        var knownRoles = new HashSet<string> { RoleNames.Admin, RoleNames.Customer };
+
+        var result = RoleValue.Validate("admin", knownRoles, Source);
+
+        result.IsSuccess.Should().BeTrue(
+            "role comparison is case-insensitive whatever comparer the caller's set carries");
+    }
+
+    [Fact]
+    public void Validate_WithOrdinalIgnoreCaseSet_MatchesRoleCaseInsensitively()
+    {
+        var knownRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { RoleNames.Admin };
+
+        RoleValue.Validate("ADMIN", knownRoles, Source).IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithExactRole_Succeeds()
+    {
+        var knownRoles = new HashSet<string> { RoleNames.Organizer, RoleNames.Attendee };
+
+        RoleValue.Validate(RoleNames.Organizer, knownRoles, Source).IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithUnknownRole_FailsWithInvariantCode()
+    {
+        var knownRoles = new HashSet<string> { RoleNames.Admin };
+
+        var result = RoleValue.Validate("Wizard", knownRoles, Source);
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle();
+        result.Errors[0].Code.Should().Be("User.Role.Invalid");
+        result.Errors[0].Source.Should().Be(Source);
+    }
+
+    [Fact]
+    public void Validate_WithNullRole_Fails()
+    {
+        var knownRoles = new HashSet<string> { RoleNames.Admin };
+
+        RoleValue.Validate(null!, knownRoles, Source).IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithNullKnownRoles_Throws()
+    {
+        var act = () => RoleValue.Validate(RoleNames.Admin, null!, Source);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/SessionCookies/CookieSessionRefresherTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/SessionCookies/CookieSessionRefresherTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.API.SessionCookies;
 using MMCA.Common.Shared.Auth;
 using MMCA.Common.Shared.Concurrency;
@@ -138,6 +139,56 @@ public sealed class CookieSessionRefresherTests
 
         result.Should().NotBeNull();
         result!.Value.AccessToken.Should().Be("new-access");
+    }
+
+    // ── Transport and payload failures ──
+    // These run during SSR: an escaping exception turned a signed-in user's navigation into a 500
+    // instead of an anonymous render.
+    [Fact]
+    public async Task GetOrRefreshAsync_WhenRefreshCallThrows_ReturnsNullWithoutThrowing()
+    {
+        string expired = CreateJwt(DateTime.UtcNow.AddMinutes(-5));
+        using var harness = CreateSut(_ => throw new HttpRequestException("connection refused"));
+        var context = CreateContext(accessToken: expired, refreshToken: "old-refresh");
+
+        SessionTokenResult? result = null;
+        Func<Task> act = async () => result = await harness.Sut.GetOrRefreshAsync(context);
+
+        await act.Should().NotThrowAsync("a transport failure means no session, not a broken request");
+        result.Should().BeNull();
+        context.Response.Headers.SetCookie.Count.Should().Be(0);
+        context.Items.Should().NotContainKey(CookieTokenReader.FreshAccessTokenItemKey);
+    }
+
+    [Fact]
+    public async Task GetOrRefreshAsync_WhenRefreshReturnsMalformedSuccessBody_ReturnsNullWithoutThrowing()
+    {
+        string expired = CreateJwt(DateTime.UtcNow.AddMinutes(-5));
+        using var harness = CreateSut(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{ not json at all", System.Text.Encoding.UTF8, "application/json"),
+        });
+        var context = CreateContext(accessToken: expired, refreshToken: "old-refresh");
+
+        SessionTokenResult? result = null;
+        Func<Task> act = async () => result = await harness.Sut.GetOrRefreshAsync(context);
+
+        await act.Should().NotThrowAsync();
+        result.Should().BeNull();
+        context.Response.Headers.SetCookie.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetOrRefreshAsync_AfterAFailedRefresh_RetriesOnTheNextCall()
+    {
+        // Only a successful rotation is cached, so a failure must not stick to the refresh token.
+        string expired = CreateJwt(DateTime.UtcNow.AddMinutes(-5));
+        using var harness = CreateSut(_ => throw new HttpRequestException("connection refused"));
+
+        await harness.Sut.GetOrRefreshAsync(CreateContext(accessToken: expired, refreshToken: "old-refresh"));
+        await harness.Sut.GetOrRefreshAsync(CreateContext(accessToken: expired, refreshToken: "old-refresh"));
+
+        harness.Handler.CallCount.Should().Be(2, "a failed refresh is never cached");
     }
 
     // ── Rotation-grace single flight ──
@@ -291,7 +342,11 @@ public sealed class CookieSessionRefresherTests
             _cache = new MemoryCache(new MemoryCacheOptions());
             var environment = new Mock<IWebHostEnvironment>();
             environment.SetupGet(x => x.EnvironmentName).Returns(Environments.Production);
-            Sut = new CookieSessionRefresher(new StubHttpClientFactory(Handler), _cache, environment.Object);
+            Sut = new CookieSessionRefresher(
+                new StubHttpClientFactory(Handler),
+                _cache,
+                environment.Object,
+                NullLogger<CookieSessionRefresher>.Instance);
         }
 
         public CookieSessionRefresher Sut { get; }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Auth/RegisterFormTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Auth/RegisterFormTests.cs
@@ -36,4 +36,48 @@ public sealed class RegisterFormTests : BunitTestBase
             x => x.RegisterAsync(It.IsAny<RegisterRequest>(), It.IsAny<CancellationToken>()),
             Times.Never());
     }
+
+    [Fact]
+    public void SubmittingWithAnInvalidAddress_ShowsTheAddressError_AndDoesNotRegister()
+    {
+        // The optional address block used to be built with Address.Create and its failure discarded,
+        // so a partially-filled address silently created an account with NO address at all. Anything
+        // the user typed is now validated, and the failure blocks the submit.
+        var cut = RenderUnderTest<Register>(_ => { });
+        FillRequiredFields(cut);
+
+        // City entered, address line 1 left blank: an address the value object refuses to build.
+        // The address fields are not Immediate, so they commit on change rather than on input.
+        cut.Find("input[autocomplete='address-level2']").Change("Atlanta");
+
+        cut.ClickButtonByText("Create Account");
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Address Line 1 cannot be empty"));
+        _auth.Verify(
+            x => x.RegisterAsync(It.IsAny<RegisterRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+    }
+
+    [Fact]
+    public void SubmittingWithNoAddressAtAll_StillRegisters()
+    {
+        // The address block is optional: an untouched block must still register, with a null address.
+        var cut = RenderUnderTest<Register>(_ => { });
+        FillRequiredFields(cut);
+
+        cut.ClickButtonByText("Create Account");
+
+        cut.WaitForAssertion(() => _auth.Verify(
+            x => x.RegisterAsync(It.Is<RegisterRequest>(r => r.Address == null), It.IsAny<CancellationToken>()),
+            Times.Once()));
+    }
+
+    private static void FillRequiredFields(IRenderedComponent<Register> cut)
+    {
+        cut.Find("input[autocomplete='given-name']").Input("Ada");
+        cut.Find("input[autocomplete='family-name']").Input("Lovelace");
+        cut.Find("input[autocomplete='email']").Input("ada@example.com");
+        cut.FindAll("input[autocomplete='new-password']")[0].Input("Str0ng!Passw0rd");
+        cut.FindAll("input[autocomplete='new-password']")[1].Input("Str0ng!Passw0rd");
+    }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
@@ -32,7 +32,9 @@ public sealed class DataGridListPageBaseTests : BunitTestBase
         SetRendererInfo(new RendererInfo("Server", isInteractive: true));
     }
 
-    private sealed record WidgetRow(int Id, string Name);
+    // Public so Moq can proxy MudBlazor's Column&lt;WidgetRow&gt; over it (Castle cannot subclass a
+    // generic type closed over an inaccessible argument).
+    public sealed record WidgetRow(int Id, string Name);
 
     private sealed class TestGridPage : DataGridListPageBase<WidgetRow>
     {
@@ -128,6 +130,88 @@ public sealed class DataGridListPageBaseTests : BunitTestBase
 
         seenFilters.Should().NotBeNull();
         seenFilters!.Should().ContainKey("search").WhoseValue.Should().Be(("contains", "blue"));
+    }
+
+    private static IFilterDefinition<WidgetRow> Filter(string propertyName, string @operator, string value)
+    {
+        var column = new Mock<Column<WidgetRow>>();
+        column.Setup(c => c.PropertyName).Returns(propertyName);
+
+        var definition = new Mock<IFilterDefinition<WidgetRow>>();
+        definition.SetupGet(f => f.Column).Returns(column.Object);
+        definition.SetupGet(f => f.Operator).Returns(@operator);
+        definition.SetupGet(f => f.Value).Returns(value);
+        return definition.Object;
+    }
+
+    // == Grid filter extraction ==
+    [Fact]
+    public async Task LoadServerDataAsync_TranslatesGridFiltersIntoTheFetchDictionary()
+    {
+        var cut = Render<TestGridPage>();
+        Dictionary<string, (string Operator, string Value)>? seenFilters = null;
+        cut.Instance.Fetch = (filters, _, _, _, _, _) =>
+        {
+            seenFilters = filters;
+            return Task.FromResult<(IReadOnlyList<WidgetRow> Items, int TotalItems)>(([], 0));
+        };
+
+        var state = State(page: 0, pageSize: 10);
+        state.FilterDefinitions = [Filter("Name", "contains", "blue")];
+
+        await LoadOnDispatcherAsync(cut, state);
+
+        seenFilters.Should().NotBeNull();
+        seenFilters!.Should().ContainKey("Name").WhoseValue.Should().Be(("contains", "blue"));
+    }
+
+    [Fact]
+    public async Task LoadServerDataAsync_WithTwoFiltersOnTheSameColumn_KeepsTheNewestAndStillLoads()
+    {
+        // MudDataGrid lets the user add a second filter row on a column that is already filtered.
+        // The fetch contract carries one filter per column, so the projection used to throw
+        // ArgumentException ("an item with the same key has already been added") BEFORE the try
+        // block, stranding IsLoading at true and leaving the grid spinning forever.
+        var cut = Render<TestGridPage>();
+        Dictionary<string, (string Operator, string Value)>? seenFilters = null;
+        cut.Instance.Fetch = (filters, _, _, _, _, _) =>
+        {
+            seenFilters = filters;
+            return Task.FromResult<(IReadOnlyList<WidgetRow> Items, int TotalItems)>(([], 0));
+        };
+
+        var state = State(page: 0, pageSize: 10);
+        state.FilterDefinitions =
+        [
+            Filter("Name", "contains", "blue"),
+            Filter("Name", "equals", "green")
+        ];
+
+        var act = async () => await LoadOnDispatcherAsync(cut, state);
+
+        await act.Should().NotThrowAsync();
+        seenFilters.Should().NotBeNull();
+        seenFilters!.Should().ContainKey("Name").WhoseValue.Should().Be(("equals", "green"),
+            "the newest filter row wins when a column carries more than one");
+        cut.Instance.LoadingNow.Should().BeFalse("the loading flag must always be reset");
+    }
+
+    [Fact]
+    public async Task LoadServerDataAsync_WhenAdditionalFiltersCallbackThrows_ReportsAndResetsLoading()
+    {
+        // The callback is arbitrary page code; a throw from it used to escape past the finally.
+        var cut = Render<TestGridPage>();
+
+        var data = await LoadOnDispatcherAsync(
+            cut,
+            State(page: 0, pageSize: 10),
+            additionalFilters: _ => throw new InvalidOperationException("bad filter"));
+
+        data.Items.Should().BeEmpty();
+        cut.Instance.LoadingNow.Should().BeFalse();
+        _snackbar.Verify(
+            s => s.Add(It.IsAny<string>(), Severity.Error, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            Times.Once);
     }
 
     // == State persistence: in-memory service + URL mirror ==

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/LazyJsModuleTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/LazyJsModuleTests.cs
@@ -1,0 +1,114 @@
+using AwesomeAssertions;
+using Microsoft.JSInterop;
+using MMCA.Common.UI.Services;
+using Moq;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// Pins the single-flight contract of <see cref="LazyJsModule"/>, the helper the UI services delegate
+/// their <c>import()</c> to. An unguarded <c>_module ??= await import(...)</c> lets two concurrent
+/// callers each start an import: the browser holds two module instances and the later assignment
+/// leaks the earlier reference, which is then never disposed.
+/// </summary>
+public sealed class LazyJsModuleTests
+{
+    private const string ModulePath = "./_content/MMCA.Common.UI/probe.js";
+
+    [Fact]
+    public async Task ConcurrentCallers_ShareOneImport_AndGetTheSameModule()
+    {
+        var gate = new TaskCompletionSource<IJSObjectReference>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var module = Mock.Of<IJSObjectReference>();
+        var js = new Mock<IJSRuntime>();
+        js.Setup(r => r.InvokeAsync<IJSObjectReference>("import", It.IsAny<CancellationToken>(), It.IsAny<object?[]>()))
+            .Returns(new ValueTask<IJSObjectReference>(gate.Task));
+
+        var sut = new LazyJsModule(js.Object, ModulePath);
+
+        var first = sut.GetOrImportAsync();
+        var second = sut.GetOrImportAsync();
+        gate.SetResult(module);
+
+        var results = await Task.WhenAll(first, second);
+
+        results[0].Should().BeSameAs(module);
+        results[1].Should().BeSameAs(module, "both callers must observe the one imported module");
+        js.Verify(
+            r => r.InvokeAsync<IJSObjectReference>("import", It.IsAny<CancellationToken>(), It.IsAny<object?[]>()),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task AfterTheImportIsCached_NoFurtherImportIsIssued()
+    {
+        var module = Mock.Of<IJSObjectReference>();
+        var js = new Mock<IJSRuntime>();
+        js.Setup(r => r.InvokeAsync<IJSObjectReference>("import", It.IsAny<CancellationToken>(), It.IsAny<object?[]>()))
+            .Returns(new ValueTask<IJSObjectReference>(module));
+
+        var sut = new LazyJsModule(js.Object, ModulePath);
+
+        (await sut.GetOrImportAsync()).Should().BeSameAs(module);
+        (await sut.GetOrImportAsync()).Should().BeSameAs(module);
+
+        js.Verify(
+            r => r.InvokeAsync<IJSObjectReference>("import", It.IsAny<CancellationToken>(), It.IsAny<object?[]>()),
+            Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task AFailedImport_IsNotCached_AndTheNextCallRetries()
+    {
+        // A prerender-time import throws InvalidOperationException. Caching that failed task would
+        // leave the module permanently unavailable for the rest of the circuit.
+        var module = Mock.Of<IJSObjectReference>();
+        var js = new Mock<IJSRuntime>();
+        var attempts = 0;
+        js.Setup(r => r.InvokeAsync<IJSObjectReference>("import", It.IsAny<CancellationToken>(), It.IsAny<object?[]>()))
+            .Returns(() =>
+            {
+                attempts++;
+                return attempts == 1
+                    ? ValueTask.FromException<IJSObjectReference>(new InvalidOperationException("JS interop unavailable"))
+                    : new ValueTask<IJSObjectReference>(module);
+            });
+
+        var sut = new LazyJsModule(js.Object, ModulePath);
+
+        var failing = async () => await sut.GetOrImportAsync();
+        await failing.Should().ThrowAsync<InvalidOperationException>();
+
+        (await sut.GetOrImportAsync()).Should().BeSameAs(module, "a later call must retry the import");
+        attempts.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ReleasesTheModule_AndToleratesADisconnectedCircuit()
+    {
+        var module = new Mock<IJSObjectReference>();
+        module.Setup(m => m.DisposeAsync()).Throws(new JSDisconnectedException("circuit gone"));
+        var js = new Mock<IJSRuntime>();
+        js.Setup(r => r.InvokeAsync<IJSObjectReference>("import", It.IsAny<CancellationToken>(), It.IsAny<object?[]>()))
+            .Returns(new ValueTask<IJSObjectReference>(module.Object));
+
+        var sut = new LazyJsModule(js.Object, ModulePath);
+        await sut.GetOrImportAsync();
+
+        var dispose = async () => await sut.DisposeAsync();
+
+        await dispose.Should().NotThrowAsync();
+        module.Verify(m => m.DisposeAsync(), Times.Once());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithoutAnImport_DoesNothing()
+    {
+        var js = new Mock<IJSRuntime>();
+        var sut = new LazyJsModule(js.Object, ModulePath);
+
+        await sut.DisposeAsync();
+
+        js.VerifyNoOtherCalls();
+    }
+}


### PR DESCRIPTION
Ten verified bug-hunt findings plus one enabler API, landed in four commits (core, UI, API, compile-verified). Every headline fix is revert-proved: the fix hunk was temporarily reverted and the new test confirmed failing before the fix was restored.

## Findings

- **H31** `DataGridListPageBase`: two filter rows on the same column threw `ArgumentException` from the filter projection, and that throw happened before the `try`, so the `finally` never ran and the grid stayed stuck on `IsLoading`. Extraction is now duplicate-tolerant (newest row wins) and both the extraction and the `additionalFilters` callback run inside the `try`. Pre-fix the new test failed with the filters never reaching the fetch; the callback-throws test failed with `InvalidOperationException` escaping.
- **H32** `CookieSessionRefresher.CallRefreshAsync`: a transport failure or a malformed 2xx body escaped during SSR, turning a signed-in user's navigation into a 500. Now catches `HttpRequestException`/`OperationCanceledException`/`JsonException`/`NotSupportedException`, logs a warning, returns null. `InvalidOperationException` (missing `BaseAddress`, a host configuration error) still propagates. Failures are never cached, so the next navigation retries.
- **M71** `EfInboxStore.MarkProcessedAsync` swallowed EVERY `DbUpdateException`. It now detaches the rejected entry, re-queries the inbox, and only absorbs a genuine concurrent duplicate; any other write failure rethrows. Engine-agnostic (no provider error-code sniffing), so it holds for SQLite and SQL Server alike.
- **M72** adds `LazyJsModule`, a single-flight JS module importer, and delegates the four services that each raced an unguarded `_module ??= await import(...)` (`CapabilitiesJsModule`, `ThemeService`, `NavigationHistoryService`, `ListPageStateService`). Concurrent callers now share one import instead of leaking an undisposed duplicate module reference, and a failed import is not cached so a prerender-time failure is retried. `NavigationHistoryService` and `ListPageStateService` gain `IAsyncDisposable` so their module is released.
- **M73** `Register`: the optional address block was built with `Address.Create` and its failure silently discarded, so a partially-filled address created an account with no address at all. The address is validated before the call and any failure is surfaced in the form-level alert.
- **M74** `MauiTokenStorageService.SetTokensAsync`: a failing refresh-token write escaped before the guard was entered, leaving the OLD pair in secure storage. Both writes are now under the same guard.
- **L27** removes the unreachable `DbUpdateException` catch in `EFRepository.UpdateAsync` (the guarded block only touches the change tracker, which throws `InvalidOperationException`) and its sole-caller helper `GetFullErrorTextAndRollbackEntityChanges`.
- **L28** `PlaywrightFixture` / `E2ETestBase` disposal guards their `null!` fields: a failed `InitializeAsync` used to produce a `NullReferenceException` that replaced the real setup error in the run output.
- **L29** `PaginationMetadata.FirstRowOnPage` returned a negative row index when `CurrentPage` was 0 (pre-fix the new test observed -9).
- **L30** `RoleValue.Validate` promised case-insensitive matching but delegated to the caller's set comparer, so a default-ordinal set rejected a correctly-cased-differently role. The set lookup stays the fast path; a miss falls back to an explicit case-insensitive scan.

## Behavior changes for the release notes

1. **H32**: a refresh-endpoint outage now renders the page anonymously instead of returning 500.
2. **M71**: a non-duplicate inbox write failure is no longer silently ACKed; the message is redelivered by the broker.
3. **M73**: registration now BLOCKS on an invalid address instead of dropping it. The "did the user enter an address" gate widened from "address line 1 filled" to "any address field filled", so a user who fills only City now gets a validation error rather than a silently address-less account.
4. **M74**: a double write failure forces a clean re-login instead of leaving a stale token pair.
5. **H31**: a duplicate-column filter is now last-wins rather than a hard failure.

## M84 enabler and consumer sweep note

`GetProjectedAsync` gains an `ignoreQueryFilters` flag in sibling position (before the cancellation token, default `false`), applied with the exact `GetAllAsync` idiom so it drops ONLY the named `SoftDelete` filter and leaves `Tenant` in force. Additive, but **source-breaking** for callers that pass the cancellation token as the 4th positional argument and for 4-argument Moq setups of `GetProjectedAsync` in consumer test suites. The in-repo caller (`CrossSourceSpecification`) and the two in-repo Moq setups are fixed here; ADC and Store need the same sweep when they take the next version bump.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors.
- `dotnet test --solution MMCA.Common.slnx -c Release`: 3367 passed, 0 failed.
- Out-of-slnx Release builds green: `MMCA.Common.UI.Maui` (net10.0-windows and net10.0-android), `MMCA.Common.Testing.E2E`, `MMCA.Common.UI.Gallery`, `MMCA.Common.UI.E2E.Tests`, `MMCA.Common.Infrastructure.Redis.Tests`.
- `build/facts -- . --check`: FACTS.md up to date (no packages added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaJvsoQ8J8Ffipqr5wvj1a
