### PR TITLE
§11: versioned ciphertext envelope and key ring in EncryptedStringConverter

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Encryption/EncryptedStringConverter.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Encryption/EncryptedStringConverter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -31,87 +32,208 @@ namespace MMCA.Common.Infrastructure.Persistence.Encryption;
 /// </para>
 /// <para>
 /// <b>Key management:</b> The encryption key should be stored securely (e.g., Azure Key Vault,
-/// user-secrets, or environment variables) — never hardcoded. The key must be exactly 32 bytes
+/// user-secrets, or environment variables): never hardcoded. Every key must be exactly 32 bytes
 /// (256 bits) for AES-256. Use <see cref="GenerateKey"/> to create a new key.
 /// </para>
 /// <para>
-/// <b>Storage format:</b> The encrypted value is stored as a Base64 string containing the nonce
-/// (12 bytes) + ciphertext + authentication tag (16 bytes). This is transparent to application code.
+/// <b>Storage format:</b> The encrypted value is stored as a Base64 string containing the key
+/// version (1 byte) + nonce (12 bytes) + ciphertext + authentication tag (16 bytes). This is
+/// transparent to application code. The version byte is also passed to AES-GCM as associated
+/// data, so it is covered by the authentication tag: rewriting the version byte of a stored
+/// value fails decryption instead of silently selecting a different key.
+/// </para>
+/// <para>
+/// <b>Key ring and rotation:</b> A converter can be constructed over a whole ring of versioned
+/// keys, with one of them nominated as current. Writes always use the current version; reads
+/// resolve their key from the version byte in the stored value itself. Rotation is therefore a
+/// four-step, zero-downtime operation:
+/// <list type="number">
+///   <item>add the new key to the ring under a new version and make that version current, keeping
+///   the old versions registered;</item>
+///   <item>deploy: new writes carry the new version byte, existing rows keep decrypting under
+///   their original version;</item>
+///   <item>re-encrypt the existing rows in the background at your own pace (load an entity and
+///   save it, which rewrites the column under the current version);</item>
+///   <item>once no row carries the old version, drop that entry from the ring.</item>
+/// </list>
+/// A value whose version is not registered fails with a <see cref="CryptographicException"/>
+/// rather than decrypting to garbage.
+/// </para>
+/// <para>
+/// <b>Stateless and context-free by design:</b> the converter holds only the frozen key ring
+/// captured at construction, and version resolution is data-driven from the stored envelope.
+/// It never consults the <c>DbContext</c>, the current user, or any ambient scope, because a
+/// value converter runs inside the provider's materialization path and has no access to them.
+/// That also makes per-tenant or per-request key selection deliberately out of scope here: those
+/// need a <c>SaveChanges</c> interceptor or application-layer encryption above EF Core, where the
+/// request context is still reachable.
 /// </para>
 /// </summary>
 public sealed class EncryptedStringConverter : ValueConverter<string, string>
 {
+    /// <summary>Key version prefix size in bytes.</summary>
+    private const int VersionSize = 1;
+
     /// <summary>AES-GCM nonce size in bytes (96 bits, NIST recommended).</summary>
     private const int NonceSize = 12;
 
     /// <summary>AES-GCM authentication tag size in bytes (128 bits).</summary>
     private const int TagSize = 16;
 
+    /// <summary>Required key size in bytes (256 bits).</summary>
+    private const int KeySize = 32;
+
+    /// <summary>Key version assigned to the single-key constructor.</summary>
+    private const byte DefaultKeyVersion = 1;
+
     /// <summary>
-    /// Initializes a new instance of the <see cref="EncryptedStringConverter"/> class.
+    /// Initializes a new instance of the <see cref="EncryptedStringConverter"/> class over a
+    /// single key, registered as version <c>1</c> and used for all writes.
     /// </summary>
     /// <param name="encryptionKey">A 32-byte (256-bit) AES encryption key.</param>
     public EncryptedStringConverter(byte[] encryptionKey)
-        : base(
-            plaintext => Encrypt(plaintext, encryptionKey),
-            ciphertext => Decrypt(ciphertext, encryptionKey))
+        : this(CreateSingleKeyRing(encryptionKey), DefaultKeyVersion)
     {
-        ArgumentNullException.ThrowIfNull(encryptionKey);
-        if (encryptionKey.Length != 32)
-        {
-            throw new ArgumentException(
-                $"Encryption key must be exactly 32 bytes (256 bits). Received {encryptionKey.Length} bytes.",
-                nameof(encryptionKey));
-        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EncryptedStringConverter"/> class over a ring
+    /// of versioned keys. Writes use <paramref name="currentKeyVersion"/>; reads resolve their key
+    /// from the version byte stored with the value, so older versions stay readable while they
+    /// remain in the ring.
+    /// </summary>
+    /// <param name="keyRing">Key version to 32-byte (256-bit) AES key. Copied defensively, so
+    /// later mutation of the supplied dictionary does not affect this converter.</param>
+    /// <param name="currentKeyVersion">The version used to encrypt new values. Must be present
+    /// in <paramref name="keyRing"/>.</param>
+    public EncryptedStringConverter(IReadOnlyDictionary<byte, byte[]> keyRing, byte currentKeyVersion)
+        : this(ValidateAndFreeze(keyRing, currentKeyVersion), currentKeyVersion)
+    {
+    }
+
+    private EncryptedStringConverter(FrozenDictionary<byte, byte[]> keyRing, byte currentKeyVersion)
+        : base(
+            plaintext => Encrypt(plaintext, keyRing, currentKeyVersion),
+            ciphertext => Decrypt(ciphertext, keyRing))
+    {
     }
 
     /// <summary>
     /// Generates a cryptographically random 256-bit AES key suitable for use with this converter.
     /// </summary>
     /// <returns>A 32-byte random key.</returns>
-    public static byte[] GenerateKey() => RandomNumberGenerator.GetBytes(32);
+    public static byte[] GenerateKey() => RandomNumberGenerator.GetBytes(KeySize);
 
-    private static string Encrypt(string plaintext, byte[] key)
+    private static Dictionary<byte, byte[]> CreateSingleKeyRing(byte[] encryptionKey)
+    {
+        ArgumentNullException.ThrowIfNull(encryptionKey);
+        if (encryptionKey.Length != KeySize)
+        {
+            throw new ArgumentException(
+                $"Encryption key must be exactly 32 bytes (256 bits). Received {encryptionKey.Length} bytes.",
+                nameof(encryptionKey));
+        }
+
+        return new Dictionary<byte, byte[]>(1) { [DefaultKeyVersion] = encryptionKey };
+    }
+
+    /// <summary>
+    /// Validates a caller-supplied key ring and returns an immutable copy of it. The copy is what
+    /// the conversion delegates capture, so mutating the original dictionary afterwards cannot
+    /// change which keys this converter uses. Key material itself is kept by reference, matching
+    /// the single-key constructor.
+    /// </summary>
+    private static FrozenDictionary<byte, byte[]> ValidateAndFreeze(
+        IReadOnlyDictionary<byte, byte[]> keyRing,
+        byte currentKeyVersion)
+    {
+        ArgumentNullException.ThrowIfNull(keyRing);
+
+        if (keyRing.Count == 0)
+        {
+            throw new ArgumentException("Key ring must contain at least one key.", nameof(keyRing));
+        }
+
+        foreach (var entry in keyRing)
+        {
+            if (entry.Value is null)
+            {
+                throw new ArgumentException(
+                    $"Key ring entry for version {entry.Key} is null. Every key must be exactly 32 bytes (256 bits).",
+                    nameof(keyRing));
+            }
+
+            if (entry.Value.Length != KeySize)
+            {
+                throw new ArgumentException(
+                    $"Key ring entry for version {entry.Key} must be exactly 32 bytes (256 bits). Received {entry.Value.Length} bytes.",
+                    nameof(keyRing));
+            }
+        }
+
+        if (!keyRing.ContainsKey(currentKeyVersion))
+        {
+            throw new ArgumentException(
+                $"Key ring does not contain the current key version {currentKeyVersion}.",
+                nameof(keyRing));
+        }
+
+        return keyRing.ToFrozenDictionary();
+    }
+
+    private static string Encrypt(string plaintext, FrozenDictionary<byte, byte[]> keyRing, byte keyVersion)
     {
         if (string.IsNullOrEmpty(plaintext))
             return plaintext;
+
+        // Validated at construction, so the current version is always present.
+        var key = keyRing[keyVersion];
 
         var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
         var nonce = RandomNumberGenerator.GetBytes(NonceSize);
         var ciphertext = new byte[plaintextBytes.Length];
         var tag = new byte[TagSize];
 
-        using var aes = new AesGcm(key, TagSize);
-        aes.Encrypt(nonce, plaintextBytes, ciphertext, tag);
+        // The version byte travels as associated data, so the tag authenticates it.
+        ReadOnlySpan<byte> associatedData = [keyVersion];
 
-        // Format: [nonce (12)] [ciphertext (N)] [tag (16)]
-        var result = new byte[NonceSize + ciphertext.Length + TagSize];
-        nonce.CopyTo(result, 0);
-        ciphertext.CopyTo(result, NonceSize);
-        tag.CopyTo(result, NonceSize + ciphertext.Length);
+        using var aes = new AesGcm(key, TagSize);
+        aes.Encrypt(nonce, plaintextBytes, ciphertext, tag, associatedData);
+
+        // Format: [key version (1)] [nonce (12)] [ciphertext (N)] [tag (16)]
+        var result = new byte[VersionSize + NonceSize + ciphertext.Length + TagSize];
+        result[0] = keyVersion;
+        nonce.CopyTo(result, VersionSize);
+        ciphertext.CopyTo(result, VersionSize + NonceSize);
+        tag.CopyTo(result, VersionSize + NonceSize + ciphertext.Length);
 
         return Convert.ToBase64String(result);
     }
 
-    private static string Decrypt(string encoded, byte[] key)
+    private static string Decrypt(string encoded, FrozenDictionary<byte, byte[]> keyRing)
     {
         if (string.IsNullOrEmpty(encoded))
             return encoded;
 
         var combined = Convert.FromBase64String(encoded);
 
-        if (combined.Length < NonceSize + TagSize)
-            throw new CryptographicException("Encrypted value is too short to contain a valid nonce and tag.");
+        if (combined.Length < VersionSize + NonceSize + TagSize)
+            throw new CryptographicException("Encrypted value is too short to contain a valid key version, nonce and tag.");
 
-        var nonce = combined.AsSpan(0, NonceSize);
-        var ciphertextLength = combined.Length - NonceSize - TagSize;
-        var ciphertext = combined.AsSpan(NonceSize, ciphertextLength);
-        var tag = combined.AsSpan(NonceSize + ciphertextLength, TagSize);
+        var keyVersion = combined[0];
+        if (!keyRing.TryGetValue(keyVersion, out var key))
+            throw new CryptographicException($"No key registered for key version {keyVersion}.");
+
+        var nonce = combined.AsSpan(VersionSize, NonceSize);
+        var ciphertextLength = combined.Length - VersionSize - NonceSize - TagSize;
+        var ciphertext = combined.AsSpan(VersionSize + NonceSize, ciphertextLength);
+        var tag = combined.AsSpan(VersionSize + NonceSize + ciphertextLength, TagSize);
+        var associatedData = combined.AsSpan(0, VersionSize);
 
         var plaintext = new byte[ciphertextLength];
 
         using var aes = new AesGcm(key, TagSize);
-        aes.Decrypt(nonce, ciphertext, tag, plaintext);
+        aes.Decrypt(nonce, ciphertext, tag, plaintext, associatedData);
 
         return Encoding.UTF8.GetString(plaintext);
     }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EncryptedStringConverterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/EncryptedStringConverterTests.cs
@@ -111,8 +111,8 @@ public sealed class EncryptedStringConverterTests
         var converter = new EncryptedStringConverter(key);
         var decrypt = converter.ConvertFromProviderExpression.Compile();
 
-        // 10 bytes total is too short for nonce (12) + tag (16)
-        string shortCipher = Convert.ToBase64String(new byte[10]);
+        // 28 bytes total is too short for version (1) + nonce (12) + tag (16)
+        string shortCipher = Convert.ToBase64String(new byte[28]);
 
         FluentActions.Invoking(() => decrypt(shortCipher))
             .Should().Throw<System.Security.Cryptography.CryptographicException>();
@@ -138,5 +138,161 @@ public sealed class EncryptedStringConverterTests
         string decrypted = decrypt(encrypted);
 
         decrypted.Should().Be(unicodeText);
+    }
+
+    // \u2500\u2500 Single-key constructor stamps version 1 \u2500\u2500
+    [Fact]
+    public void Encrypt_SingleKeyConstructor_StampsKeyVersionOne()
+    {
+        byte[] key = EncryptedStringConverter.GenerateKey();
+        var converter = new EncryptedStringConverter(key);
+
+        string encrypted = converter.ConvertToProviderExpression.Compile()("versioned");
+
+        Convert.FromBase64String(encrypted)[0].Should().Be(1);
+    }
+
+    // \u2500\u2500 Key ring roundtrip \u2500\u2500
+    [Fact]
+    public void EncryptThenDecrypt_KeyRingConstructor_RoundTrips()
+    {
+        var keyRing = new Dictionary<byte, byte[]>
+        {
+            [1] = EncryptedStringConverter.GenerateKey(),
+            [2] = EncryptedStringConverter.GenerateKey(),
+        };
+        var converter = new EncryptedStringConverter(keyRing, currentKeyVersion: 2);
+
+        const string plaintext = "ring-roundtrip";
+        string encrypted = converter.ConvertToProviderExpression.Compile()(plaintext);
+        string decrypted = converter.ConvertFromProviderExpression.Compile()(encrypted);
+
+        decrypted.Should().Be(plaintext);
+    }
+
+    // \u2500\u2500 Rotation: old ciphertext stays readable, new writes use the new version \u2500\u2500
+    [Fact]
+    public void Rotation_OldCiphertextRemainsReadable_AndNewWritesUseNewVersion()
+    {
+        byte[] keyV1 = EncryptedStringConverter.GenerateKey();
+        byte[] keyV2 = EncryptedStringConverter.GenerateKey();
+
+        var beforeRotation = new EncryptedStringConverter(
+            new Dictionary<byte, byte[]> { [1] = keyV1 },
+            currentKeyVersion: 1);
+
+        const string plaintext = "written-before-rotation";
+        string legacyCipher = beforeRotation.ConvertToProviderExpression.Compile()(plaintext);
+        Convert.FromBase64String(legacyCipher)[0].Should().Be(1);
+
+        var afterRotation = new EncryptedStringConverter(
+            new Dictionary<byte, byte[]> { [1] = keyV1, [2] = keyV2 },
+            currentKeyVersion: 2);
+        var encryptAfter = afterRotation.ConvertToProviderExpression.Compile();
+        var decryptAfter = afterRotation.ConvertFromProviderExpression.Compile();
+
+        decryptAfter(legacyCipher).Should().Be(plaintext);
+
+        const string freshText = "written-after-rotation";
+        string freshCipher = encryptAfter(freshText);
+
+        Convert.FromBase64String(freshCipher)[0].Should().Be(2);
+        decryptAfter(freshCipher).Should().Be(freshText);
+    }
+
+    // \u2500\u2500 Unknown key version \u2500\u2500
+    [Fact]
+    public void Decrypt_KeyVersionNotInRing_ThrowsCryptographicException()
+    {
+        byte[] keyV1 = EncryptedStringConverter.GenerateKey();
+
+        var writer = new EncryptedStringConverter(
+            new Dictionary<byte, byte[]> { [1] = keyV1 },
+            currentKeyVersion: 1);
+        string encrypted = writer.ConvertToProviderExpression.Compile()("orphaned-version");
+
+        var reader = new EncryptedStringConverter(
+            new Dictionary<byte, byte[]> { [2] = EncryptedStringConverter.GenerateKey() },
+            currentKeyVersion: 2);
+        var decrypt = reader.ConvertFromProviderExpression.Compile();
+
+        FluentActions.Invoking(() => decrypt(encrypted))
+            .Should().Throw<System.Security.Cryptography.CryptographicException>()
+            .WithMessage("*key version 1*");
+    }
+
+    // \u2500\u2500 Version byte is authenticated (AAD), so retagging it fails even under the same key \u2500\u2500
+    [Fact]
+    public void Decrypt_TamperedVersionByte_ThrowsCryptographicException()
+    {
+        byte[] sharedKey = EncryptedStringConverter.GenerateKey();
+        var converter = new EncryptedStringConverter(
+            new Dictionary<byte, byte[]> { [1] = sharedKey, [2] = sharedKey },
+            currentKeyVersion: 1);
+        var decrypt = converter.ConvertFromProviderExpression.Compile();
+
+        byte[] stored = Convert.FromBase64String(
+            converter.ConvertToProviderExpression.Compile()("tamper-me"));
+        stored[0] = 2;
+
+        FluentActions.Invoking(() => decrypt(Convert.ToBase64String(stored)))
+            .Should().Throw<System.Security.Cryptography.CryptographicException>();
+    }
+
+    // \u2500\u2500 Ring validation: null ring \u2500\u2500
+    [Fact]
+    public void Constructor_WithNullKeyRing_ThrowsArgumentNullException() =>
+        FluentActions.Invoking(() => new EncryptedStringConverter(null!, currentKeyVersion: 1))
+            .Should().Throw<ArgumentNullException>();
+
+    // \u2500\u2500 Ring validation: empty ring \u2500\u2500
+    [Fact]
+    public void Constructor_WithEmptyKeyRing_ThrowsArgumentException() =>
+        FluentActions.Invoking(() => new EncryptedStringConverter(
+                new Dictionary<byte, byte[]>(),
+                currentKeyVersion: 1))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*at least one key*");
+
+    // \u2500\u2500 Ring validation: current version missing \u2500\u2500
+    [Fact]
+    public void Constructor_WithCurrentVersionMissingFromRing_ThrowsArgumentException() =>
+        FluentActions.Invoking(() => new EncryptedStringConverter(
+                new Dictionary<byte, byte[]> { [1] = EncryptedStringConverter.GenerateKey() },
+                currentKeyVersion: 3))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*current key version 3*");
+
+    // \u2500\u2500 Ring validation: wrong key length \u2500\u2500
+    [Fact]
+    public void Constructor_WithKeyRingEntryOfInvalidLength_ThrowsArgumentException() =>
+        FluentActions.Invoking(() => new EncryptedStringConverter(
+                new Dictionary<byte, byte[]>
+                {
+                    [1] = EncryptedStringConverter.GenerateKey(),
+                    [2] = new byte[16],
+                },
+                currentKeyVersion: 1))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("*32 bytes*");
+
+    // \u2500\u2500 Defensive copy: mutating the caller's dictionary does not affect the converter \u2500\u2500
+    [Fact]
+    public void Constructor_KeyRingIsCopiedDefensively_CallerMutationHasNoEffect()
+    {
+        byte[] keyV1 = EncryptedStringConverter.GenerateKey();
+        var keyRing = new Dictionary<byte, byte[]> { [1] = keyV1 };
+        var converter = new EncryptedStringConverter(keyRing, currentKeyVersion: 1);
+
+        const string plaintext = "immune-to-mutation";
+        string encrypted = converter.ConvertToProviderExpression.Compile()(plaintext);
+
+        keyRing[1] = EncryptedStringConverter.GenerateKey();
+        keyRing[2] = EncryptedStringConverter.GenerateKey();
+        keyRing.Remove(1);
+
+        string decrypted = converter.ConvertFromProviderExpression.Compile()(encrypted);
+
+        decrypted.Should().Be(plaintext);
     }
 }


### PR DESCRIPTION
## What changed

`EncryptedStringConverter` now writes a **versioned ciphertext envelope** and can be constructed over a **key ring** instead of a single key.

New stored format (the only format, no legacy-decode path):

```
Base64( [keyVersion(1)] [nonce(12)] [ciphertext(N)] [tag(16)] )
```

Public API:

```csharp
public EncryptedStringConverter(byte[] encryptionKey)                                        // unchanged semantics
public EncryptedStringConverter(IReadOnlyDictionary<byte, byte[]> keyRing, byte currentKeyVersion)  // new
public static byte[] GenerateKey()                                                           // unchanged
```

The single-key constructor is now sugar for a one-entry ring at version 1, with its null and 32-byte validation (and messages) unchanged. The ring constructor validates (not null, not empty, contains the current version, every key exactly 32 bytes) and freezes a copy via a private validate-and-freeze helper, chained through `: this(...)` so the delegates handed to the `ValueConverter` base capture the frozen copy: mutating the caller's dictionary afterwards cannot change which keys the converter uses. Key material itself is kept by reference, matching the previous single-key behavior.

Writes always use the current version. Reads resolve their key from the version byte in the stored value, so the converter stays stateless and context-free: version resolution is data-driven from the envelope, never from the `DbContext`, which a value converter cannot reach. An unregistered version fails with `CryptographicException` rather than decrypting to garbage. Per-tenant or per-request key selection remains deliberately out of scope for a value converter (that needs an interceptor or application-layer encryption).

## Why now

The converter has **zero production adopters** (ADR-037 records it as latent), so the storage format was still free to change with no migration and no dual-read path. Adding the version byte later, once rows exist, would have cost a legacy-decode branch permanently.

## The AAD detail

The version byte is not merely a prefix: it is passed to `AesGcm.Encrypt`/`Decrypt` as the `associatedData` argument, so it is authenticated by the GCM tag without being encrypted. Rewriting the version byte of a stored value therefore fails the tag check instead of silently redirecting decryption to a different key in the ring. A test proves this by registering the **same** key under two versions, encrypting under version 1, flipping the stored byte to 2, and asserting the throw: without AAD binding that value would have decrypted cleanly.

## Test coverage

`EncryptedStringConverterTests` goes from 11 to 21 tests. Existing round-trip, key-generation, validation, empty-passthrough and Unicode tests keep passing; the too-short guard was retuned to the new 29-byte minimum (1 + 12 + 16). Added:

- `Encrypt_SingleKeyConstructor_StampsKeyVersionOne`
- `EncryptThenDecrypt_KeyRingConstructor_RoundTrips`
- `Rotation_OldCiphertextRemainsReadable_AndNewWritesUseNewVersion` (encrypt under a current-version-1 converter, read it back through a `{1,2}` ring at current version 2, and assert the first stored byte of a new write is 2)
- `Decrypt_KeyVersionNotInRing_ThrowsCryptographicException`
- `Decrypt_TamperedVersionByte_ThrowsCryptographicException` (the AAD proof above)
- `Constructor_WithNullKeyRing_ThrowsArgumentNullException`
- `Constructor_WithEmptyKeyRing_ThrowsArgumentException`
- `Constructor_WithCurrentVersionMissingFromRing_ThrowsArgumentException`
- `Constructor_WithKeyRingEntryOfInvalidLength_ThrowsArgumentException`
- `Constructor_KeyRingIsCopiedDefensively_CallerMutationHasNoEffect`

Local verification: `dotnet build MMCA.Common.slnx -c Release` clean (0 warnings, 0 errors), Infrastructure tests 1012/1012, Architecture fitness tests 73/73, FACTS drift gate clean (no regeneration needed). No package changes, so no lock-file movement. `FrozenDictionary` comes from the BCL (`System.Collections.Frozen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwnaQjfkHbHqoMm4Pec3oE
