### PR TITLE
feat: name each source's outcome on an ambiguous multi-source commit

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -492,7 +492,10 @@ public sealed class DbContextFactory(
     /// <para>
     /// <b>Limitation, multiple physical sources:</b> commits are sequential, so a commit failure on
     /// source #2 leaves source #1 already committed. The ambiguity is then a partial commit rather
-    /// than an unknown one, and the caller's replay is what reconciles it. A witness row (a marker
+    /// than an unknown one, and the caller's replay is what reconciles it. The thrown
+    /// <see cref="TransactionCommitAmbiguousException"/> names each source's outcome (committed,
+    /// ambiguous, or rolled back) so that partial state is observable rather than inferred. A
+    /// witness row (a marker
     /// written inside each source's transaction that a replay can read to learn what landed) would
     /// close this; it is deliberately not built here, since a single transactional source, the case
     /// every host runs today, needs none.
@@ -519,7 +522,7 @@ public sealed class DbContextFactory(
             ?? GetDbContext(DataSource.SQLServer);
 
         var attempt = 0;
-        Exception? commitFailure = null;
+        TransactionCommitAmbiguousException? commitFailure = null;
         var strategy = context.Database.CreateExecutionStrategy();
 
         var outcome = await strategy.ExecuteAsync(async ct =>
@@ -537,7 +540,7 @@ public sealed class DbContextFactory(
         // error would still be retried; returning normally is the only way to guarantee the
         // delegate is not re-entered after a commit whose outcome is unknown.
         if (commitFailure is not null)
-            throw new TransactionCommitAmbiguousException(commitFailure);
+            throw commitFailure;
 
         return outcome;
     }
@@ -550,7 +553,7 @@ public sealed class DbContextFactory(
     /// failure is RETURNED rather than thrown so the execution strategy sees a completed attempt
     /// and cannot re-run the operation against a commit that may already be durable.
     /// </returns>
-    private async Task<(TResult Value, Exception? CommitFailure)> RunTransactionalAttemptAsync<TResult>(
+    private async Task<(TResult Value, TransactionCommitAmbiguousException? CommitFailure)> RunTransactionalAttemptAsync<TResult>(
         Func<CancellationToken, Task<TResult>> operation,
         CancellationToken cancellationToken)
     {
@@ -608,21 +611,47 @@ public sealed class DbContextFactory(
     }
 
     /// <summary>
-    /// Commits every enlisted context, returning the failure instead of throwing it.
+    /// Commits every enlisted context in turn, returning the failure instead of throwing it and
+    /// recording what each physical source did. Commits are sequential and independent (no
+    /// two-phase commit), so a failure part-way through leaves earlier sources durable; naming them
+    /// is what makes the partial state observable to the caller who owns the replay.
     /// </summary>
-    /// <returns><see langword="null"/> on success, otherwise the exception the commit raised.</returns>
-    private Exception? TryCommit()
+    /// <returns>
+    /// <see langword="null"/> on success, otherwise the ambiguity carrying the provider's failure
+    /// and the per-source outcome.
+    /// </returns>
+    private TransactionCommitAmbiguousException? TryCommit()
     {
-        try
+        _transactionActive = false;
+
+        // Snapshot before committing anything: this order IS the commit order, so the entries past
+        // the failing one are exactly what AbandonAfterCommitFailure rolls back.
+        var enlisted = _dbContexts
+            .Where(entry => SupportsTransactions(entry.Value) && HasActiveTransaction(entry.Value))
+            .Select(entry => (Source: entry.Key.ToString(), Context: entry.Value))
+            .ToArray();
+
+        var committed = new List<string>(enlisted.Length);
+
+        for (var index = 0; index < enlisted.Length; index++)
         {
-            CommitTransaction();
-            return null;
+            var (source, context) = enlisted[index];
+
+            try
+            {
+                context.Database.CommitTransaction();
+            }
+            catch (Exception ex)
+            {
+                var rolledBack = enlisted[(index + 1)..].Select(entry => entry.Source).ToArray();
+                AbandonAfterCommitFailure();
+                return new TransactionCommitAmbiguousException(ex, committed, source, rolledBack);
+            }
+
+            committed.Add(source);
         }
-        catch (Exception ex)
-        {
-            AbandonAfterCommitFailure();
-            return ex;
-        }
+
+        return null;
     }
 
     /// <summary>

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/TransactionCommitAmbiguousException.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/TransactionCommitAmbiguousException.cs
@@ -44,4 +44,76 @@ public sealed class TransactionCommitAmbiguousException : Exception
     /// <param name="innerException">The commit failure reported by the provider.</param>
     public TransactionCommitAmbiguousException(Exception innerException)
         : base(DefaultMessage, innerException) { }
+
+    /// <summary>
+    /// Initializes a new instance carrying <paramref name="innerException"/> plus the outcome of
+    /// every physical source the failed commit touched. The message is the default ambiguity text
+    /// followed by a per-source outcome sentence; groups with no sources are left out of it.
+    /// </summary>
+    /// <param name="innerException">The commit failure reported by the provider.</param>
+    /// <param name="committedSources">The sources whose commit had already succeeded.</param>
+    /// <param name="ambiguousSource">The source whose commit threw, or <see langword="null"/> when none is known.</param>
+    /// <param name="rolledBackSources">The sources still uncommitted when the failure hit.</param>
+    public TransactionCommitAmbiguousException(
+        Exception innerException,
+        IReadOnlyList<string> committedSources,
+        string? ambiguousSource,
+        IReadOnlyList<string> rolledBackSources)
+        : base(
+            ComposeMessage(committedSources ?? [], ambiguousSource, rolledBackSources ?? []),
+            innerException)
+    {
+        CommittedSources = committedSources ?? [];
+        AmbiguousSource = ambiguousSource;
+        RolledBackSources = rolledBackSources ?? [];
+    }
+
+    /// <summary>
+    /// The physical sources whose commit succeeded before the failure. Commits are sequential and
+    /// independent (no two-phase commit), so these are durable: the ambiguity is a PARTIAL commit,
+    /// and reconciling it means replaying only what the remaining sources owed.
+    /// </summary>
+    public IReadOnlyList<string> CommittedSources { get; } = [];
+
+    /// <summary>
+    /// The physical source whose commit threw, or <see langword="null"/> when the failure could not
+    /// be attributed to one source. Its outcome alone is unknowable: the database may have applied
+    /// the transaction and lost only the acknowledgement. With a single transactional source, the
+    /// case every host runs today, this source IS the whole outcome and the other two groups are
+    /// empty.
+    /// </summary>
+    public string? AmbiguousSource { get; }
+
+    /// <summary>
+    /// The physical sources still uncommitted when the failure hit, rolled back on a best-effort
+    /// basis. Best-effort is literal: a rollback that itself throws (a zombied transaction, a lost
+    /// connection) is swallowed and the transaction abandoned to the server, which ends it when the
+    /// connection is reclaimed. A source listed here therefore wrote nothing that survives.
+    /// </summary>
+    public IReadOnlyList<string> RolledBackSources { get; } = [];
+
+    /// <summary>
+    /// Appends the per-source outcome sentence to the default ambiguity message, skipping any group
+    /// with nothing in it so a single-source failure reads as one clause rather than three.
+    /// </summary>
+    private static string ComposeMessage(
+        IReadOnlyList<string> committedSources,
+        string? ambiguousSource,
+        IReadOnlyList<string> rolledBackSources)
+    {
+        var groups = new List<string>(3);
+
+        if (committedSources.Count > 0)
+            groups.Add("committed [" + string.Join(", ", committedSources) + "]");
+
+        if (!string.IsNullOrWhiteSpace(ambiguousSource))
+            groups.Add("ambiguous [" + ambiguousSource + "]");
+
+        if (rolledBackSources.Count > 0)
+            groups.Add("rolled back [" + string.Join(", ", rolledBackSources) + "]");
+
+        return groups.Count == 0
+            ? DefaultMessage
+            : DefaultMessage + " Per-source outcome: " + string.Join("; ", groups) + ".";
+    }
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryCommitAmbiguityTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryCommitAmbiguityTests.cs
@@ -38,8 +38,7 @@ public sealed class DbContextFactoryCommitAmbiguityTests : IDisposable
 
     public DbContextFactoryCommitAmbiguityTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        _connection = OpenConnection();
         _dbContext = CommitFailingDbContext.Create(_connection, _dispatcherMock.Object);
 
         var physicalFactory = new Mock<IPhysicalDbContextFactory>();
@@ -87,6 +86,14 @@ public sealed class DbContextFactoryCommitAmbiguityTests : IDisposable
         attempts.Should().Be(
             1,
             "a retry would re-run every write of an operation whose commit may already be durable");
+
+        thrown.And.CommittedSources.Should().BeEmpty(
+            "nothing was committed ahead of the only source, so no part of the write is known durable");
+        thrown.And.AmbiguousSource.Should().Be(
+            DataSourceKey.Default(DataSource.SQLServer).ToString(),
+            "with one transactional source the whole outcome is that source's outcome");
+        thrown.And.RolledBackSources.Should().BeEmpty(
+            "there was no later source left holding an open transaction");
     }
 
     // ── Nothing is delivered in-process for a commit nobody can vouch for ──
@@ -150,6 +157,91 @@ public sealed class DbContextFactoryCommitAmbiguityTests : IDisposable
         attempts.Should().Be(
             4,
             "one attempt plus the strategy's three retries; only the commit phase opts out of this");
+    }
+
+    // ── Sequential commits: the exception names what landed, what is unknowable, and what did not ──
+    [Fact]
+    public async Task ExecuteInTransactionAsync_SecondSourceCommitFails_ReportsEachSourceOutcome()
+    {
+        // The default SQL Server key comes first deliberately: ExecuteInTransactionAsync materializes
+        // it to obtain an execution strategy, which makes it the first entry and so the first commit.
+        var productsKey = DataSourceKey.Default(DataSource.SQLServer);
+        var ordersKey = new DataSourceKey(DataSource.SQLServer, "Orders");
+        var auditKey = new DataSourceKey(DataSource.SQLServer, "Audit");
+
+        await using var productsConnection = OpenConnection();
+        await using var ordersConnection = OpenConnection();
+        await using var auditConnection = OpenConnection();
+
+        var products = CommitFailingDbContext.Create(productsConnection, _dispatcherMock.Object);
+        var orders = CommitFailingDbContext.Create(ordersConnection, _dispatcherMock.Object);
+        var audit = CommitFailingDbContext.Create(auditConnection, _dispatcherMock.Object);
+
+        var lostAcknowledgement = new TimeoutException("commit acknowledgement lost");
+        orders.FailCommitWith = lostAcknowledgement;
+
+        var physicalFactory = new Mock<IPhysicalDbContextFactory>();
+        physicalFactory.Setup(f => f.Create(productsKey)).Returns(products);
+        physicalFactory.Setup(f => f.Create(ordersKey)).Returns(orders);
+        physicalFactory.Setup(f => f.Create(auditKey)).Returns(audit);
+
+        var registry = new Mock<IEntityDataSourceRegistry>();
+        registry.Setup(r => r.GetPhysicalSourcesInUse()).Returns([]);
+
+        await using var sut = new DbContextFactory(
+            physicalFactory.Object,
+            registry.Object,
+            Mock.Of<IDataSourceResolver>(),
+            Mock.Of<ICurrentUserService>());
+
+        var act = async () => await sut.ExecuteInTransactionAsync<Result>(
+            async ct =>
+            {
+                // Touch order is enlistment order, which is commit order.
+                sut.GetDbContext(productsKey).Set<TestAggregate>().Add(CreateAggregateWithEvent());
+                sut.GetDbContext(ordersKey).Set<TestAggregate>().Add(CreateAggregateWithEvent());
+                sut.GetDbContext(auditKey).Set<TestAggregate>().Add(CreateAggregateWithEvent());
+                await sut.SaveChangesAsync(ct);
+                return Result.Success();
+            });
+
+        var thrown = await act.Should().ThrowAsync<TransactionCommitAmbiguousException>();
+
+        thrown.And.InnerException.Should().BeSameAs(
+            lostAcknowledgement,
+            "the provider's failure stays the diagnostic payload under the outcome map");
+        thrown.And.CommittedSources.Should().ContainSingle()
+            .Which.Should().Be(
+                productsKey.ToString(),
+                "the first source committed before the failure and is durable");
+        thrown.And.AmbiguousSource.Should().Be(
+            ordersKey.ToString(),
+            "the source whose commit threw is the one nobody can vouch for");
+        thrown.And.RolledBackSources.Should().ContainSingle()
+            .Which.Should().Be(
+                auditKey.ToString(),
+                "a source never reached by the sequential commit wrote nothing that survives");
+        thrown.And.Message.Should()
+            .Contain("committed [" + productsKey.ToString() + "]")
+            .And.Contain("ambiguous [" + ordersKey.ToString() + "]")
+            .And.Contain("rolled back [" + auditKey.ToString() + "]",
+                "the partial state has to be readable straight off the message in a log");
+
+        audit.Database.CurrentTransaction.Should().BeNull(
+            "the sources past the failure are rolled back before the ambiguity surfaces");
+        (await products.Set<TestAggregate>().AsNoTracking().CountAsync()).Should().Be(
+            1,
+            "there is no two-phase commit, so an already-committed source stays committed");
+        (await audit.Set<TestAggregate>().AsNoTracking().CountAsync()).Should().Be(
+            0,
+            "the rolled-back source is the half of the partial commit that did not land");
+    }
+
+    private static SqliteConnection OpenConnection()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        return connection;
     }
 
     private static TestAggregate CreateAggregateWithEvent()


### PR DESCRIPTION
## What

`TransactionCommitAmbiguousException` now carries a per-source outcome map: `CommittedSources`, `AmbiguousSource`, and `RolledBackSources`, appended to the exception message (e.g. `Per-source outcome: committed [SQLServer/Default]; ambiguous [SQLServer/Orders]; rolled back [SQLServer/Audit].`). `DbContextFactory.TryCommit` commits each enlisted context itself and records what landed before the failure, what threw, and what was still open.

## Why

With multiple physical sources, commits are sequential and best-effort (no two-phase commit): a commit failure on source #2 leaves source #1 durable. Until now the thrown exception carried only the inner provider error, so nobody could tell which sources committed and which rolled back; diagnosing a partial commit meant database archaeology. This makes the partial state observable straight off the exception, without changing the trade-off itself (the witness-row idea stays deliberately unbuilt, per the existing remark on `ExecuteInTransactionAsync`).

## Notes

- Additive only: all four existing constructors and every public interface member are untouched; `CommitTransaction()` / `RollbackTransaction()` keep their behavior.
- The commit failure still surfaces OUTSIDE the execution strategy, so a possibly-durable commit is never retried; that load-bearing path is unchanged and still pinned by the existing tests.
- Single-source hosts (every production host today) report the one source as the ambiguous outcome, with the other two groups empty.

## Tests

- New: `ExecuteInTransactionAsync_SecondSourceCommitFails_ReportsEachSourceOutcome`, three SQLite-backed sources with the middle commit armed to fail; asserts the outcome partition, message clauses, inner-exception identity, and that the first source's write is durable while the third's is not.
- Extended the existing single-source ambiguity test with the new property assertions.
- Full `MMCA.Common.Infrastructure.Tests`: 1013/1013 green; Release build warning-free; FACTS drift gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCd1wonXVhuiF3ukkchXWB