### PR TITLE
fix(notifications): stop the bell badge and inbox going stale after a push

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationBell.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationBell.razor.cs
@@ -8,9 +8,17 @@ namespace MMCA.Common.UI.Components.Notifications;
 
 /// <summary>
 /// Code-behind for the notification bell: renders the unread badge from the scoped
-/// <see cref="NotificationState"/>, and the first rendered instance registers as the single active
-/// poller (periodic + on-navigation refresh) so duplicate bell placements never duplicate API calls.
+/// <see cref="NotificationState"/>, and one instance at a time holds the single active-poller slot
+/// (periodic + on-navigation refresh) so duplicate bell placements never duplicate API calls.
 /// </summary>
+/// <remarks>
+/// Hosts commonly render the bell twice (a desktop app bar and a mobile nav) inside
+/// <c>&lt;AuthorizeView&gt;</c>, which tears the children down and rebuilds them on every
+/// authentication-state change, including a routine access-token refresh. Registration is therefore
+/// strictly symmetric (every instance unregisters on dispose, whether or not it was polling) and the
+/// surviving instance takes the slot over through <see cref="NotificationState.OnPollerSlotFreed"/>,
+/// so the circuit never ends up with a badge that no one refreshes.
+/// </remarks>
 public partial class NotificationBell : IDisposable
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
@@ -34,17 +42,60 @@ public partial class NotificationBell : IDisposable
 
         State.OnChange += HandleStateChanged;
         State.OnRefreshRequested += HandleRefreshRequested;
+        State.OnPollerSlotFreed += HandlePollerSlotFreed;
 
-        // Only the first instance registers as the active poller to prevent
-        // duplicate API calls when NotificationBell renders in multiple DOM locations.
-        _isActivePoller = State.TryRegisterPoller();
-        if (_isActivePoller)
+        // Only the slot holder polls, so duplicate bell placements do not duplicate API calls.
+        if (State.TryRegisterPoller(this))
         {
-            NavigationManager.LocationChanged += OnLocationChanged;
-            await RefreshUnreadCountAsync();
+            await BecomeActivePollerAsync();
+        }
+    }
 
-            _pollTimer = new PeriodicTimer(PollInterval);
-            _ = PollLoopAsync();
+    /// <summary>
+    /// Starts this instance's polling once it holds the slot: an immediate authoritative refresh,
+    /// then the periodic timer and the on-navigation refresh. Runs on the renderer's synchronization
+    /// context (first render, or marshalled by <see cref="TryTakeOverPollingAsync"/>), which is what
+    /// makes the <see cref="_isActivePoller"/> double-start guard sufficient.
+    /// </summary>
+    private async Task BecomeActivePollerAsync()
+    {
+        if (_disposed || _isActivePoller)
+        {
+            return;
+        }
+
+        _isActivePoller = true;
+        NavigationManager.LocationChanged += OnLocationChanged;
+        await RefreshUnreadCountAsync();
+
+        _pollTimer = new PeriodicTimer(PollInterval);
+        _ = PollLoopAsync();
+    }
+
+    // Event-handler signature; the takeover task observes its own failures internally, so the
+    // explicit discard is safe and avoids the async-void crash-the-process mode (VSTHRD100).
+    private void HandlePollerSlotFreed(object? sender, EventArgs e) =>
+        _ = TryTakeOverPollingAsync();
+
+    /// <summary>
+    /// Claims the freed slot and starts polling. Raised synchronously from the disposing bell's
+    /// thread, so the actual start is marshalled onto this component's renderer.
+    /// </summary>
+    private async Task TryTakeOverPollingAsync()
+    {
+        if (_disposed || _isActivePoller || !State.TryRegisterPoller(this))
+        {
+            return;
+        }
+
+        try
+        {
+            await InvokeAsync(BecomeActivePollerAsync);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed during the dispatch: hand the slot straight back so another bell can claim it.
+            State.UnregisterPoller(this);
         }
     }
 
@@ -85,12 +136,19 @@ public partial class NotificationBell : IDisposable
 
         try
         {
-            int count = await InboxService.GetUnreadCountAsync(_cts.Token);
+            int? count = await InboxService.GetUnreadCountAsync(_cts.Token);
+            if (count is null)
+            {
+                // The authoritative count is unknown (expired session, transient failure). Leave the
+                // badge exactly as it is: zeroing it here is what used to erase a push increment.
+                return;
+            }
+
             if (!_disposed)
             {
                 await InvokeAsync(() =>
                 {
-                    State.SetUnreadCount(count);
+                    State.SetUnreadCount(count.Value);
                     StateHasChanged();
                 });
             }
@@ -105,7 +163,7 @@ public partial class NotificationBell : IDisposable
         }
         catch
         {
-            // Network or deserialization error — badge stays at current value
+            // Network or deserialization error - badge stays at current value
         }
     }
 
@@ -141,12 +199,13 @@ public partial class NotificationBell : IDisposable
         _disposed = true;
         State.OnChange -= HandleStateChanged;
         State.OnRefreshRequested -= HandleRefreshRequested;
+        State.OnPollerSlotFreed -= HandlePollerSlotFreed;
+        NavigationManager.LocationChanged -= OnLocationChanged;
 
-        if (_isActivePoller)
-        {
-            NavigationManager.LocationChanged -= OnLocationChanged;
-            State.UnregisterPoller();
-        }
+        // Unconditional, and the slot is only released when this instance actually holds it: a bell
+        // that claimed the slot but was torn down before it started polling still frees it, and a
+        // bell that never held it cannot evict the live poller.
+        State.UnregisterPoller(this);
 
         _pollTimer?.Dispose();
         _cts.Cancel();

--- a/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationInbox.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationInbox.razor.cs
@@ -36,6 +36,9 @@ public partial class NotificationInbox : IDisposable
     private int _currentPage = 1;
     private int _totalPages = 1;
 
+    /// <summary>A push arrived while a load was in flight and still owes the list one reload.</summary>
+    private bool _refreshPending;
+
     protected override async Task OnInitializedAsync()
     {
         // Breadcrumbs are built here (not in a field initializer) so the injected localizer is
@@ -63,10 +66,16 @@ public partial class NotificationInbox : IDisposable
 
     private async Task RefreshFromPushAsync()
     {
-        // Coalesce overlapping refreshes: the toast and bell badge still signal the push,
-        // and the next push or navigation reconciles the list.
-        if (_disposed || IsLoading)
+        if (_disposed)
         {
+            return;
+        }
+
+        if (IsLoading)
+        {
+            // Never drop the push: the in-flight load drains this flag when it completes, so
+            // overlapping pushes coalesce into exactly one trailing reload instead of vanishing.
+            _refreshPending = true;
             return;
         }
 
@@ -102,6 +111,15 @@ public partial class NotificationInbox : IDisposable
         {
             IsLoading = false;
         }
+
+        // Trailing reload for any push that arrived while the load above was in flight. The flag is
+        // cleared first, so a push arriving during THIS reload queues one more and no further:
+        // recursion is bounded by the pushes actually received, never self-sustaining.
+        if (_refreshPending && !_disposed)
+        {
+            _refreshPending = false;
+            await RefreshFromPushAsync();
+        }
     }
 
     private async Task OnPageChangedAsync(int page)
@@ -124,9 +142,12 @@ public partial class NotificationInbox : IDisposable
                 _notifications[index] = notification with { IsRead = true, ReadOn = DateTime.UtcNow };
             }
 
-            // Refresh the unread count
-            int count = await InboxService.GetUnreadCountAsync(_cts.Token);
-            NotificationState.SetUnreadCount(count);
+            // Refresh the unread count; a null count means "unknown", so the badge keeps its value.
+            int? count = await InboxService.GetUnreadCountAsync(_cts.Token);
+            if (count is not null)
+            {
+                NotificationState.SetUnreadCount(count.Value);
+            }
         }
         catch (OperationCanceledException)
         {

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -1,5 +1,17 @@
 #nullable enable
+*REMOVED*MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.NotificationInboxService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Notifications.INotificationScopeProvider! scopeProvider) -> void
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.TryRegisterPoller() -> bool
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.UnregisterPoller() -> void
 MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.get -> string!
 MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.init -> void
 MMCA.Common.UI.Components.MmcaThemeProviders.Theme.get -> MudBlazor.MudTheme!
 MMCA.Common.UI.Components.MmcaThemeProviders.Theme.set -> void
+MMCA.Common.UI.Services.AuthenticatedServiceBase.CreateClientWithToken(string! accessToken) -> System.Net.Http.HttpClient!
+MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int?>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int?>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.NotificationInboxService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Notifications.INotificationScopeProvider! scopeProvider, MMCA.Common.UI.Services.Auth.ITokenRefresher? tokenRefresher = null) -> void
+MMCA.Common.UI.Services.Notifications.NotificationState.OnPollerSlotFreed -> System.EventHandler?
+MMCA.Common.UI.Services.Notifications.NotificationState.TryRegisterPoller(object! owner) -> bool
+MMCA.Common.UI.Services.Notifications.NotificationState.UnregisterPoller(object! owner) -> void

--- a/Source/Presentation/MMCA.Common.UI/Services/AuthenticatedServiceBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/AuthenticatedServiceBase.cs
@@ -32,6 +32,8 @@ public abstract class AuthenticatedServiceBase(
                 + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000)));
 #pragma warning restore S2245
 
+    private const string ApiClientName = "APIClient";
+
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
     private readonly ITokenStorageService _tokenStorageService = tokenStorageService ?? throw new ArgumentNullException(nameof(tokenStorageService));
 
@@ -56,7 +58,7 @@ public abstract class AuthenticatedServiceBase(
     /// </summary>
     protected async Task<HttpClient> CreateAuthenticatedClientAsync()
     {
-        var httpClient = _httpClientFactory.CreateClient("APIClient");
+        var httpClient = _httpClientFactory.CreateClient(ApiClientName);
 
         try
         {
@@ -72,6 +74,23 @@ public abstract class AuthenticatedServiceBase(
             // JS interop not available during SSR prerender: proceed without token
         }
 
+        return httpClient;
+    }
+
+    /// <summary>
+    /// Creates an APIClient carrying an explicit bearer token rather than the one currently held by
+    /// <see cref="Auth.ITokenStorageService"/>. Used to replay a request the API answered
+    /// <c>401 Unauthorized</c> with a token acquired straight from
+    /// <see cref="Auth.ITokenRefresher"/>: the stored token still looks fresh by the client clock,
+    /// so re-reading storage would just resend the token the server has already rejected.
+    /// </summary>
+    /// <param name="accessToken">The freshly acquired access token.</param>
+    protected HttpClient CreateClientWithToken(string accessToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+
+        var httpClient = _httpClientFactory.CreateClient(ApiClientName);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         return httpClient;
     }
 

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/INotificationInboxUIService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/INotificationInboxUIService.cs
@@ -11,8 +11,14 @@ public interface INotificationInboxUIService
     /// <summary>Gets the current user's notification inbox with pagination.</summary>
     Task<PagedCollectionResult<UserNotificationDTO>?> GetInboxAsync(int pageNumber = 1, int pageSize = 20, CancellationToken cancellationToken = default);
 
-    /// <summary>Gets the count of unread notifications for the current user.</summary>
-    Task<int> GetUnreadCountAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets the count of unread notifications for the current user, or <see langword="null"/> when
+    /// the count could not be established (expired session, transient failure). Callers must treat
+    /// <see langword="null"/> as "unknown" and leave the displayed count untouched: reporting zero
+    /// would erase a badge that a real-time push had just incremented.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    Task<int?> GetUnreadCountAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Marks a single notification as read.</summary>
     Task MarkReadAsync(UserNotificationIdentifierType id, CancellationToken cancellationToken = default);

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationInboxService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationInboxService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net;
 using System.Net.Http.Json;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.Notifications.UserNotifications;
@@ -12,10 +13,23 @@ namespace MMCA.Common.UI.Services.Notifications;
 /// <see cref="INotificationScopeProvider"/>, so the inbox, the badge and a bulk mark-read all agree
 /// on which notifications the user is looking at.
 /// </summary>
+/// <remarks>
+/// The two reads go through <see cref="SendReadWithAuthRefreshAsync"/>: a badge poll or an inbox load
+/// that lands on an access token the server has already rejected gets one forced token refresh and a
+/// replay, instead of surfacing as an empty inbox or a blanked badge.
+/// </remarks>
+/// <param name="httpClientFactory">Factory for the named APIClient.</param>
+/// <param name="tokenStorageService">Circuit-scoped access-token storage.</param>
+/// <param name="scopeProvider">Resolves the application's current notification scope.</param>
+/// <param name="tokenRefresher">
+/// Optional: acquires a fresh access token after a 401. Hosts that register no refresher simply skip
+/// the retry (the read then reports failure rather than a fabricated empty result).
+/// </param>
 public sealed class NotificationInboxService(
     IHttpClientFactory httpClientFactory,
     ITokenStorageService tokenStorageService,
-    INotificationScopeProvider scopeProvider)
+    INotificationScopeProvider scopeProvider,
+    ITokenRefresher? tokenRefresher = null)
     : AuthenticatedServiceBase(httpClientFactory, tokenStorageService), INotificationInboxUIService
 {
     private const string Endpoint = "notifications/inbox";
@@ -27,11 +41,12 @@ public sealed class NotificationInboxService(
         CancellationToken cancellationToken = default)
     {
         string scopeQuery = await ScopeQueryAsync("&", cancellationToken);
-        using HttpClient httpClient = await CreateAuthenticatedClientAsync();
-        var url = string.Create(CultureInfo.InvariantCulture, $"{Endpoint}?pageNumber={pageNumber}&pageSize={pageSize}{scopeQuery}");
+        var url = new Uri(
+            string.Create(CultureInfo.InvariantCulture, $"{Endpoint}?pageNumber={pageNumber}&pageSize={pageSize}{scopeQuery}"),
+            UriKind.Relative);
 
-        HttpResponseMessage response = await RetryPolicy
-            .ExecuteAsync(() => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken));
+        using HttpResponseMessage response = await SendReadWithAuthRefreshAsync(
+            (client, ct) => client.GetAsync(url, ct), cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -44,18 +59,19 @@ public sealed class NotificationInboxService(
     }
 
     /// <inheritdoc />
-    public async Task<int> GetUnreadCountAsync(CancellationToken cancellationToken = default)
+    public async Task<int?> GetUnreadCountAsync(CancellationToken cancellationToken = default)
     {
         string scopeQuery = await ScopeQueryAsync("?", cancellationToken);
-        using HttpClient httpClient = await CreateAuthenticatedClientAsync();
-        var url = $"{Endpoint}/unread-count{scopeQuery}";
+        var url = new Uri($"{Endpoint}/unread-count{scopeQuery}", UriKind.Relative);
 
-        HttpResponseMessage response = await RetryPolicy
-            .ExecuteAsync(() => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken));
+        using HttpResponseMessage response = await SendReadWithAuthRefreshAsync(
+            (client, ct) => client.GetAsync(url, ct), cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
-            return 0;
+            // Unknown, deliberately NOT zero: reporting zero here let a rejected token or a transient
+            // failure erase a badge that a real-time push had just incremented.
+            return null;
         }
 
         return await response.Content.ReadFromJsonAsync<int>(cancellationToken);
@@ -93,6 +109,63 @@ public sealed class NotificationInboxService(
         {
             await ServiceExceptionHelper.ThrowIfDomainExceptionAsync(response, cancellationToken);
             response.EnsureSuccessStatusCode();
+        }
+    }
+
+    /// <summary>
+    /// Runs one idempotent read under the shared retry policy and, when the API answers
+    /// <c>401 Unauthorized</c>, makes a single attempt to acquire a fresh access token and replay it.
+    /// </summary>
+    /// <remarks>
+    /// Only the reads use this: they are safe to replay, whereas a mark-read PUT is left with the
+    /// existing single-shot behaviour. The response content is fully buffered before the send task
+    /// completes, so the caller can still read it after the client that produced it is disposed.
+    /// </remarks>
+    /// <param name="send">Issues the request on the supplied client.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    private async Task<HttpResponseMessage> SendReadWithAuthRefreshAsync(
+        Func<HttpClient, CancellationToken, Task<HttpResponseMessage>> send,
+        CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response;
+        using (HttpClient httpClient = await CreateAuthenticatedClientAsync())
+        {
+            response = await RetryPolicy.ExecuteAsync(() => send(httpClient, cancellationToken));
+        }
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized || tokenRefresher is null)
+        {
+            return response;
+        }
+
+        string? refreshedToken = await TryAcquireRefreshedTokenAsync(cancellationToken);
+        if (refreshedToken is null)
+        {
+            return response;
+        }
+
+        response.Dispose();
+
+        using HttpClient retryClient = CreateClientWithToken(refreshedToken);
+        return await RetryPolicy.ExecuteAsync(() => send(retryClient, cancellationToken));
+    }
+
+    /// <summary>
+    /// Forces one access-token re-acquisition, returning <see langword="null"/> when the session can
+    /// no longer be refreshed or when the host cannot refresh from here (SSR prerender).
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    private async Task<string?> TryAcquireRefreshedTokenAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            string? token = await tokenRefresher!.AcquireAccessTokenAsync(cancellationToken);
+            return string.IsNullOrWhiteSpace(token) ? null : token;
+        }
+        catch (InvalidOperationException)
+        {
+            // JS interop not available during SSR prerender: no refresh is possible here.
+            return null;
         }
     }
 

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationState.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationState.cs
@@ -7,7 +7,15 @@ namespace MMCA.Common.UI.Services.Notifications;
 /// </summary>
 public sealed class NotificationState
 {
-    private int _pollerCount;
+    private readonly Lock _pollerSync = new();
+
+    /// <summary>
+    /// The component that currently holds the single active-poller slot, or <see langword="null"/>
+    /// when the slot is free. An owner reference (rather than a counter) is what makes register and
+    /// unregister symmetric: a counter leaks one increment per teardown that never unregisters, and
+    /// once it leaks no bell can ever win the slot again for the life of the circuit.
+    /// </summary>
+    private object? _pollerOwner;
 
     /// <summary>Gets the current unread notification count.</summary>
     public int UnreadCount { get; private set; }
@@ -20,6 +28,13 @@ public sealed class NotificationState
     /// Subscribers (e.g., <c>NotificationBell</c>) use this to fetch the authoritative count.
     /// </summary>
     public event EventHandler? OnRefreshRequested;
+
+    /// <summary>
+    /// Raised when the active-poller slot becomes free. A surviving <c>NotificationBell</c> uses this
+    /// to take over polling when the bell that held the slot is torn down (the desktop and mobile
+    /// placements are rebuilt independently whenever the authentication state changes).
+    /// </summary>
+    public event EventHandler? OnPollerSlotFreed;
 
     /// <summary>Sets the unread count to an absolute value (e.g., after fetching from API).</summary>
     public void SetUnreadCount(int count)
@@ -44,12 +59,50 @@ public sealed class NotificationState
     public void RequestRefresh() => OnRefreshRequested?.Invoke(this, EventArgs.Empty);
 
     /// <summary>
-    /// Registers a poller instance. Returns <see langword="true"/> if this is the first (active) poller,
-    /// meaning it should start polling. Subsequent callers receive <see langword="false"/> and should skip polling.
-    /// Used to prevent duplicate API polling when <c>NotificationBell</c> renders in multiple DOM locations.
+    /// Claims the single active-poller slot for <paramref name="owner"/>. Returns
+    /// <see langword="true"/> when the caller now holds the slot (including a caller that already
+    /// held it, so the call is idempotent) and should poll; <see langword="false"/> when another
+    /// owner holds it, which is how duplicate <c>NotificationBell</c> placements avoid double-polling.
     /// </summary>
-    public bool TryRegisterPoller() => Interlocked.Increment(ref _pollerCount) == 1;
+    /// <param name="owner">The claiming component instance.</param>
+    public bool TryRegisterPoller(object owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
 
-    /// <summary>Unregisters a poller instance so the next <c>NotificationBell</c> to register can become the active poller.</summary>
-    public void UnregisterPoller() => Interlocked.Decrement(ref _pollerCount);
+        lock (_pollerSync)
+        {
+            if (_pollerOwner is not null && !ReferenceEquals(_pollerOwner, owner))
+            {
+                return false;
+            }
+
+            _pollerOwner = owner;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Releases the active-poller slot, but only when <paramref name="owner"/> is the component that
+    /// holds it, so a non-owner disposing cannot evict the live poller. Freeing the slot raises
+    /// <see cref="OnPollerSlotFreed"/> so a surviving bell can take polling over.
+    /// </summary>
+    /// <param name="owner">The component releasing the slot.</param>
+    public void UnregisterPoller(object owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+
+        lock (_pollerSync)
+        {
+            if (!ReferenceEquals(_pollerOwner, owner))
+            {
+                return;
+            }
+
+            _pollerOwner = null;
+        }
+
+        // Raised outside the lock: a subscriber claims the slot from its handler, which would
+        // otherwise re-enter the lock on the disposing component's thread.
+        OnPollerSlotFreed?.Invoke(this, EventArgs.Empty);
+    }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/Stubs/StubNotificationInboxUIService.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/Stubs/StubNotificationInboxUIService.cs
@@ -31,7 +31,7 @@ internal sealed class StubNotificationInboxUIService : INotificationInboxUIServi
             new PagedCollectionResult<UserNotificationDTO>(items, new PaginationMetadata(items.Length, pageSize, pageNumber)));
     }
 
-    public Task<int> GetUnreadCountAsync(CancellationToken cancellationToken = default) => Task.FromResult(3);
+    public Task<int?> GetUnreadCountAsync(CancellationToken cancellationToken = default) => Task.FromResult<int?>(3);
 
     public Task MarkReadAsync(UserNotificationIdentifierType id, CancellationToken cancellationToken = default)
         => Task.CompletedTask;

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationBellTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationBellTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.UI.Components.Notifications;
 using MMCA.Common.UI.Services.Notifications;
@@ -9,8 +10,40 @@ using Moq;
 namespace MMCA.Common.UI.Tests.Components;
 
 /// <summary>
-/// bUnit tests for <see cref="NotificationBell"/> — badge count, navigation on click, reaction to
-/// shared-state changes, and the single-active-poller registration that prevents duplicate polling.
+/// Host that renders the bell in the two placements a real layout uses (desktop app bar and mobile
+/// nav), each independently removable, so a test can tear one down the way an
+/// <c>&lt;AuthorizeView&gt;</c> rebuild does. Keys keep the diff from reusing one instance for the other slot.
+/// </summary>
+internal sealed class NotificationBellHost : ComponentBase
+{
+    [Parameter] public bool ShowFirst { get; set; } = true;
+
+    [Parameter] public bool ShowSecond { get; set; } = true;
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (ShowFirst)
+        {
+            builder.OpenComponent<NotificationBell>(0);
+            builder.SetKey("first");
+            builder.CloseComponent();
+        }
+
+        if (ShowSecond)
+        {
+            builder.OpenComponent<NotificationBell>(1);
+            builder.SetKey("second");
+            builder.CloseComponent();
+        }
+    }
+}
+
+/// <summary>
+/// bUnit tests for <see cref="NotificationBell"/>: badge count, navigation on click, reaction to
+/// shared-state changes, and the single-active-poller protocol (symmetric registration, takeover by a
+/// surviving bell, and leaving the badge alone when the count cannot be established).
 /// </summary>
 public sealed class NotificationBellTests : BunitTestBase
 {
@@ -23,10 +56,13 @@ public sealed class NotificationBellTests : BunitTestBase
         Services.AddSingleton(_inbox.Object);
     }
 
+    private void CountIs(int? count) =>
+        _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(count);
+
     [Fact]
     public void RendersUnreadCount_FromService()
     {
-        _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(5);
+        CountIs(5);
 
         var cut = RenderUnderTest<NotificationBell>(_ => { });
 
@@ -36,7 +72,7 @@ public sealed class NotificationBellTests : BunitTestBase
     [Fact]
     public void ClickingBell_NavigatesToInbox()
     {
-        _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        CountIs(0);
         var nav = Services.GetRequiredService<NavigationManager>();
 
         var cut = RenderUnderTest<NotificationBell>(_ => { });
@@ -48,7 +84,7 @@ public sealed class NotificationBellTests : BunitTestBase
     [Fact]
     public void WhenSharedStateChanges_BadgeReflectsNewCount()
     {
-        _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        CountIs(0);
 
         var cut = RenderUnderTest<NotificationBell>(_ => { });
         // SetUnreadCount raises OnChange; the bell's handler marshals StateHasChanged onto the renderer.
@@ -60,15 +96,65 @@ public sealed class NotificationBellTests : BunitTestBase
     [Fact]
     public void OnlyTheFirstBell_BecomesActivePoller()
     {
-        _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        CountIs(0);
 
         var cut = RenderUnderTest<NotificationBell>(_ => { });
         // Wait until first-render registration + the initial API refresh have run.
         cut.WaitForAssertion(() =>
             _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce()));
 
-        // The bell holds the single active-poller slot, so a second registration is rejected.
-        _state.TryRegisterPoller().Should().BeFalse();
-        _state.UnregisterPoller();
+        // The bell holds the single active-poller slot, so another claimant is rejected.
+        _state.TryRegisterPoller(new object()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DisposingTheBell_AlwaysReleasesThePollerSlot()
+    {
+        // The staleness regression: the slot leaked on every teardown, after which no bell ever
+        // polled again for the life of the circuit.
+        CountIs(0);
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        await cut.WaitForAssertionAsync(() =>
+            _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce()));
+
+        await DisposeComponentsAsync();
+
+        _state.TryRegisterPoller(new object()).Should().BeTrue("a disposed bell must hand the slot back");
+    }
+
+    [Fact]
+    public void WhenTheActiveBellIsTornDown_TheSurvivingBellTakesOverPolling()
+    {
+        CountIs(0);
+
+        var cut = RenderUnderTest<NotificationBellHost>(_ => { });
+        cut.WaitForAssertion(() =>
+            _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), Times.Once()));
+
+        // Tear down the placement that holds the slot, exactly as an AuthorizeView rebuild does.
+        cut.Render(p => p.Add(x => x.ShowFirst, false));
+
+        // The survivor claims the freed slot and refreshes the badge immediately.
+        cut.WaitForAssertion(() =>
+            _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), Times.Exactly(2)));
+        _state.TryRegisterPoller(new object()).Should()
+            .BeFalse("the surviving bell should now hold the active-poller slot");
+    }
+
+    [Fact]
+    public void WhenTheCountIsUnavailable_TheBadgeKeepsItsValue()
+    {
+        // A null count means "unknown" (expired session, transient failure). Zeroing the badge here
+        // is what erased the increment a real-time push had just applied.
+        CountIs(null);
+        _state.SetUnreadCount(4);
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        cut.WaitForAssertion(() =>
+            _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce()));
+
+        _state.UnreadCount.Should().Be(4);
+        cut.Markup.Should().Contain("4");
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Notifications/NotificationInboxTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Notifications/NotificationInboxTests.cs
@@ -109,6 +109,29 @@ public sealed class NotificationInboxTests : BunitTestBase
     }
 
     [Fact]
+    public async Task WhenRefreshRequestedDuringAnInFlightLoad_RunsExactlyOneTrailingReload()
+    {
+        // The push used to be dropped outright whenever a load was already running, which left the
+        // inbox showing stale contents until the next navigation.
+        var firstLoad = new TaskCompletionSource<PagedCollectionResult<UserNotificationDTO>?>();
+        _inbox
+            .SetupSequence(x => x.GetInboxAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(firstLoad.Task)
+            .ReturnsAsync(Inbox(Unread(1), Unread(2)));
+
+        var cut = RenderUnderTest<NotificationInbox>(_ => { });
+
+        // Raised on the renderer, so the page observes the push while IsLoading is still true.
+        await cut.InvokeAsync(_state.RequestRefresh);
+        firstLoad.SetResult(Inbox(Unread(1)));
+
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("Notice 2"));
+        _inbox.Verify(
+            x => x.GetInboxAsync(1, It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task WhenRefreshRequestedAfterDispose_DoesNotReload()
     {
         _inbox

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationInboxServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationInboxServiceTests.cs
@@ -15,7 +15,8 @@ namespace MMCA.Common.UI.Tests.Services.Notifications;
 /// <summary>
 /// Verifies <see cref="NotificationInboxService"/>: the inbox REST contract (paged GET, unread-count
 /// GET, per-item and bulk mark-read PUTs) on the named APIClient with the stored bearer token, plus
-/// the failure shapes (domain ProblemDetails re-thrown, unread-count degrading to zero).
+/// the failure shapes (domain ProblemDetails re-thrown, a 401 refresh-and-replay on the reads, and an
+/// unestablished unread count reported as null rather than zero).
 /// Failure-path responses use 4xx codes only; 5xx would engage the class-level Polly retry backoff.
 /// </summary>
 public sealed class NotificationInboxServiceTests
@@ -30,16 +31,33 @@ public sealed class NotificationInboxServiceTests
 
     private static (NotificationInboxService Sut, Mocks Mocks) CreateSut(
         Func<HttpRequestMessage, HttpResponseMessage> responder,
-        string? scopeKey = null)
+        string? scopeKey = null,
+        ITokenRefresher? tokenRefresher = null)
     {
         var handler = new StubHttpMessageHandler(responder);
         var factory = new StubHttpClientFactory(handler);
         var tokenStorage = new Mock<ITokenStorageService>();
         tokenStorage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync("stored-access-token");
         return (
-            new NotificationInboxService(factory, tokenStorage.Object, new StubScopeProvider(scopeKey)),
+            new NotificationInboxService(factory, tokenStorage.Object, new StubScopeProvider(scopeKey), tokenRefresher),
             new Mocks(handler, factory));
     }
+
+    /// <summary>A refresher that hands back <paramref name="token"/> (null = the session is gone).</summary>
+    private static ITokenRefresher Refresher(string? token)
+    {
+        var refresher = new Mock<ITokenRefresher>();
+        refresher.Setup(r => r.AcquireAccessTokenAsync(It.IsAny<CancellationToken>())).ReturnsAsync(token);
+        return refresher.Object;
+    }
+
+    /// <summary>Answers 401 until the caller presents <paramref name="acceptedToken"/>.</summary>
+    private static Func<HttpRequestMessage, HttpResponseMessage> AcceptingOnly(
+        string acceptedToken,
+        Func<HttpResponseMessage> onAccepted) =>
+        request => request.Headers.Authorization?.Parameter == acceptedToken
+            ? onAccepted()
+            : new HttpResponseMessage(HttpStatusCode.Unauthorized);
 
     private static UserNotificationDTO Notification(int id, bool isRead = false) => new()
     {
@@ -112,14 +130,70 @@ public sealed class NotificationInboxServiceTests
     }
 
     [Fact]
-    public async Task GetUnreadCountAsync_OnFailure_ReturnsZeroWithoutThrowing()
+    public async Task GetUnreadCountAsync_OnFailure_ReturnsNullWithoutThrowing()
     {
-        // The badge must never break the page; any failure degrades to "no unread notifications".
-        var (sut, _) = CreateSut(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        // The badge must never break the page, but "unknown" is not "zero": reporting zero erased a
+        // badge that a real-time push had just incremented.
+        var (sut, mocks) = CreateSut(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
 
         var result = await sut.GetUnreadCountAsync(TestContext.Current.CancellationToken);
 
-        result.Should().Be(0);
+        result.Should().BeNull();
+        mocks.Handler.CallCount.Should().Be(1, "only a 401 is worth replaying");
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_On401_RefreshesTheTokenAndReplaysTheRead()
+    {
+        var (sut, mocks) = CreateSut(
+            AcceptingOnly("refreshed-access-token", () => StubHttpMessageHandler.CreateResponse(HttpStatusCode.OK, "7")),
+            tokenRefresher: Refresher("refreshed-access-token"));
+
+        var result = await sut.GetUnreadCountAsync(TestContext.Current.CancellationToken);
+
+        result.Should().Be(7);
+        mocks.Handler.CallCount.Should().Be(2);
+        mocks.Handler.LastRequest.Authorization!.Parameter.Should().Be("refreshed-access-token");
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_WhenTheRefreshedTokenIsAlsoRejected_ReturnsNullNotZero()
+    {
+        var (sut, mocks) = CreateSut(
+            _ => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            tokenRefresher: Refresher("refreshed-access-token"));
+
+        var result = await sut.GetUnreadCountAsync(TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+        mocks.Handler.CallCount.Should().Be(2, "the read is replayed exactly once, never in a loop");
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_WhenTheSessionCannotBeRefreshed_ReturnsNullWithoutReplaying()
+    {
+        var (sut, mocks) = CreateSut(
+            _ => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            tokenRefresher: Refresher(null));
+
+        var result = await sut.GetUnreadCountAsync(TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+        mocks.Handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetInboxAsync_On401_RefreshesTheTokenAndReplaysTheRead()
+    {
+        var (sut, mocks) = CreateSut(
+            AcceptingOnly("refreshed-access-token", () => InboxResponse(Notification(1))),
+            tokenRefresher: Refresher("refreshed-access-token"));
+
+        var result = await sut.GetInboxAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.Items.Should().HaveCount(1);
+        mocks.Handler.CallCount.Should().Be(2);
     }
 
     // == MarkReadAsync ==

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationStateTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationStateTests.cs
@@ -84,31 +84,93 @@ public sealed class NotificationStateTests
     }
 
     // == Poller registration ==
+    // The slot is owner-based rather than counted: a counter leaked one increment per teardown that
+    // never unregistered, and after the first leak no bell could ever win the slot again.
     [Fact]
-    public void TryRegisterPoller_FirstCallerBecomesActive_SubsequentCallersDoNot()
+    public void TryRegisterPoller_FirstOwnerClaimsSlot_SecondOwnerRejected()
     {
-        _sut.TryRegisterPoller().Should().BeTrue("the first bell instance should start polling");
-        _sut.TryRegisterPoller().Should().BeFalse("duplicate bell renders must not double-poll");
+        var first = new object();
+        var second = new object();
+
+        _sut.TryRegisterPoller(first).Should().BeTrue("the first bell instance should start polling");
+        _sut.TryRegisterPoller(second).Should().BeFalse("duplicate bell renders must not double-poll");
     }
 
     [Fact]
-    public void TryRegisterPoller_AfterAllPollersUnregister_NextCallerBecomesActive()
+    public void TryRegisterPoller_SameOwnerTwice_StillHoldsTheSlot()
     {
-        _sut.TryRegisterPoller();
-        _sut.UnregisterPoller();
+        var owner = new object();
 
-        _sut.TryRegisterPoller().Should().BeTrue();
+        _sut.TryRegisterPoller(owner).Should().BeTrue();
+        _sut.TryRegisterPoller(owner).Should().BeTrue("re-claiming by the holder is idempotent");
     }
 
     [Fact]
-    public void TryRegisterPoller_WhileAnotherPollerRemainsRegistered_ReturnsFalse()
+    public void UnregisterPoller_ByTheOwner_FreesSlotAndRaisesOnPollerSlotFreed()
     {
-        // Two bells registered, one leaves: the survivor is still counted, so a newcomer must not
-        // become a second active poller.
-        _sut.TryRegisterPoller();
-        _sut.TryRegisterPoller();
-        _sut.UnregisterPoller();
+        var owner = new object();
+        var freed = 0;
+        _sut.OnPollerSlotFreed += (_, _) => freed++;
+        _sut.TryRegisterPoller(owner);
 
-        _sut.TryRegisterPoller().Should().BeFalse();
+        _sut.UnregisterPoller(owner);
+
+        freed.Should().Be(1);
+        _sut.TryRegisterPoller(new object()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnregisterPoller_ByANonOwner_LeavesTheSlotHeld()
+    {
+        var owner = new object();
+        var stranger = new object();
+        var freed = 0;
+        _sut.TryRegisterPoller(owner);
+        _sut.OnPollerSlotFreed += (_, _) => freed++;
+
+        _sut.UnregisterPoller(stranger);
+
+        freed.Should().Be(0);
+        _sut.TryRegisterPoller(new object()).Should().BeFalse("the live poller must not be evicted by a non-owner");
+    }
+
+    [Fact]
+    public void UnregisterPoller_WhenSlotIsFree_DoesNotRaiseOnPollerSlotFreed()
+    {
+        var freed = 0;
+        _sut.OnPollerSlotFreed += (_, _) => freed++;
+
+        _sut.UnregisterPoller(new object());
+
+        freed.Should().Be(0);
+    }
+
+    [Fact]
+    public void TwoOwnersTornDownAndRebuilt_LeavesTheSlotClaimable()
+    {
+        // The regression: two bells inside <AuthorizeView> are torn down and rebuilt on every
+        // authentication-state change (every access-token refresh). Each cycle must end with the
+        // slot claimable, not leaked.
+        for (var cycle = 0; cycle < 3; cycle++)
+        {
+            var desktop = new object();
+            var mobile = new object();
+
+            _sut.TryRegisterPoller(desktop).Should().BeTrue();
+            _sut.TryRegisterPoller(mobile).Should().BeFalse();
+
+            _sut.UnregisterPoller(desktop);
+            _sut.UnregisterPoller(mobile);
+        }
+
+        _sut.TryRegisterPoller(new object()).Should().BeTrue("no teardown cycle may leak the slot");
+    }
+
+    [Fact]
+    public void TryRegisterPoller_WithNullOwner_Throws()
+    {
+        var act = () => _sut.TryRegisterPoller(null!);
+
+        act.Should().Throw<ArgumentNullException>();
     }
 }


### PR DESCRIPTION
## Problem

In a consuming app, when a push notification arrives the snackbar shows but the bell unread badge and the Notifications inbox stay stale until logout/login.

## Root causes and fixes

### 1. Poller-slot leak (primary)

`NotificationState` counted pollers with an unconditional `Interlocked.Increment` (first caller wins), while `NotificationBell` only decremented inside `if (_isActivePoller)`. Hosts render two bells at once (desktop app bar + mobile nav), both inside `<AuthorizeView>`, which tears children down and rebuilds them on every `AuthenticationStateChanged` (raised on every access-token refresh). Each cycle leaked +1, after which no bell could ever win the slot again for the life of the scoped `NotificationState`: no initial `RefreshUnreadCountAsync`, no 30s `PeriodicTimer` poll, no `LocationChanged` refresh. The snackbar kept working because `NotificationListener` is a separate component.

Fix: the counter is replaced by an owner-based slot. `TryRegisterPoller(object owner)` claims a free slot (idempotent for the holder), `UnregisterPoller(object owner)` frees it only when that owner holds it, and freeing raises the new `OnPollerSlotFreed` event (outside the lock). `NotificationBell` now unregisters unconditionally on dispose and non-active bells take the slot over on `OnPollerSlotFreed`, marshalling the start onto their own renderer and reusing one `BecomeActivePollerAsync` path for both first-render and takeover.

### 2. A 401 collapsed the count to zero

`NotificationInboxService.GetUnreadCountAsync` returned `0` on any non-success including 401, and the Polly policy only retries 5xx/408/429. With a token the server has already rejected, a push bumped the badge optimistically and the follow-up refresh erased it.

Fix: both reads go through a 401 refresh-and-replay (one forced `ITokenRefresher.AcquireAccessTokenAsync`, then the request is replayed with that token; `GetInboxAsync` benefits too). The refresher is an optional constructor dependency, so a host that registers none simply skips the retry. The contract becomes `Task<int?>` where `null` means "unknown": `NotificationBell` and the inbox page now leave the displayed count untouched instead of zeroing it.

### 3. Dropped inbox refresh

`NotificationInbox.RefreshFromPushAsync` returned silently when `IsLoading` was already true, dropping the push-triggered reload. It now sets a pending flag and the in-flight load drains exactly one trailing reload when it completes (overlapping pushes coalesce; the recursion is bounded by pushes actually received).

## Public API

Baselined in `PublicAPI.Unshipped.txt` (RS0016/RS0017 are error-severity gates):

- `NotificationState.TryRegisterPoller(object)` / `UnregisterPoller(object)` replace the parameterless pair; new `OnPollerSlotFreed` event.
- `INotificationInboxUIService.GetUnreadCountAsync` returns `Task<int?>`.
- `NotificationInboxService` gains an optional `ITokenRefresher` parameter.
- `AuthenticatedServiceBase` gains `protected HttpClient CreateClientWithToken(string)` (purely additive; the existing constructor is untouched, so the ADC/Store services deriving from it are unaffected).

No consumer repo references the changed poller or unread-count members.

## Tests

12 new/rewritten tests across four files:

- `NotificationStateTests`: claim/free symmetry, idempotent re-claim, owner-mismatch does not free, the slot-freed event, a three-cycle two-owner teardown/rebuild sequence ending claimable, null-owner guard.
- `NotificationBellTests`: dispose always releases the slot, a surviving bell takes over polling when the active one is torn down (new keyed two-placement host component), an unavailable count leaves the badge untouched.
- `NotificationInboxServiceTests`: 401 refresh + replay succeeds (both reads), a persistently rejected session returns null and replays exactly once, an unrefreshable session returns null without replaying, non-401 failures return null.
- `NotificationInboxTests`: a push during an in-flight load runs exactly one trailing reload.

Verification: `dotnet build MMCA.Common.slnx` Debug and Release both clean (0 warnings, warnings-as-errors), `dotnet test --solution MMCA.Common.slnx` 3740/3740 passed, out-of-slnx UI.Gallery and UI.E2E.Tests build clean, FACTS drift gate up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013G5LXsQC9639YshGTeZghs
