### PR TITLE
feat: named-step middleware edge pipeline with fitness function (ADR-079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Added
+
+- **Named-step HTTP edge pipeline.** The shared middleware pipeline that `UseCommonMiddlewarePipeline()`
+  applies is now modeled as an ordered list of named steps rather than a straight-line method body:
+  `MiddlewarePipelineStepNames` (one constant per step), `MiddlewarePipelineStep` (name plus the
+  delegate that registers the step), and `MiddlewarePipelineBuilder` (`CreateDefault()` seeding the
+  18 framework steps, `StepNames`, and `Build()`). The order is data now, so it can be asserted
+  without starting a host.
+- **Scoped extension point: `UseCommonMiddlewarePipeline(Action<MiddlewarePipelineBuilder> configure)`.**
+  A host can `InsertBefore`, `InsertAfter`, `Replace`, or `Remove` steps by name instead of the
+  previous all-or-nothing choice between the framework pipeline and composing its own. Unknown
+  anchors and duplicate step names throw `ArgumentException`.
+- **Startup-validated invariants.** `Build()` runs before any step is applied and throws
+  `InvalidOperationException` naming the violated invariant when the pre-forwarded capture is not
+  immediately before `UseForwardedHeaders`, authentication is not immediately before tenant
+  resolution, authentication does not precede the rate limiter (ADR-019), or forwarded headers do
+  not precede the HTTPS redirect. An invariant binds only when both of the steps it names are
+  present, so removing a whole capability stays legal.
+- **`MiddlewarePipelineOrderTestsBase` (MMCA.Common.Testing).** The edge counterpart of
+  `DecoratorPipelineOrderTestsBase`: two facts that assert the step order matches the documented one
+  and that `Build()` raises no invariant. Subclass it with an empty body for a host on the default
+  pipeline, or override `Configure`/`ExpectedStepNames` for a host that customizes it. No database
+  and no `WebApplication`, so it runs in the fast unit tier.
+
+### Changed
+
+- `MMCA.Common.Testing` now depends on `MMCA.Common.API` (same lockstep version) so the new test base
+  can see the pipeline builder.
+- `UseCommonMiddlewarePipeline()` keeps its signature and behavior exactly: it delegates to the
+  validated default step list, applying the same middleware in the same order under the same
+  conditionals. No host code changes.
+
 > **Consumer versions skipped deliberately (historical note).** MMCA.ADC, MMCA.Store and MMCA.Helpdesk went from
 > 1.127.0 straight to 1.131.0 on 2026-07-28. They never pinned 1.128.0, 1.129.0 or 1.130.0, and that
 > is intentional, not drift. 1.128.0 was distribution-only (assemblies byte-identical to 1.127.0), so

--- a/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
+++ b/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
@@ -39,6 +39,9 @@
          DecoratorPipelineOrderTestsBase resolves ICommandHandler/IQueryHandler pipelines, so this
          package depends on MMCA.Common.Application (same lockstep version when packed). -->
     <ProjectReference Include="..\..\Core\MMCA.Common.Application\MMCA.Common.Application.csproj" />
+    <!-- MiddlewarePipelineOrderTestsBase asserts the order of the shared HTTP edge pipeline, whose
+         builder and step names live in MMCA.Common.API (same lockstep version when packed). -->
+    <ProjectReference Include="..\..\Presentation\MMCA.Common.API\MMCA.Common.API.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />

--- a/Source/Hosting/MMCA.Common.Testing/MiddlewarePipelineOrderTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing/MiddlewarePipelineOrderTestsBase.cs
@@ -1,0 +1,85 @@
+using AwesomeAssertions;
+using MMCA.Common.API.Startup;
+using Xunit;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Opt-in fitness function for the shared HTTP edge pipeline that <c>UseCommonMiddlewarePipeline</c>
+/// applies: seeds <see cref="MiddlewarePipelineBuilder.CreateDefault"/>, applies the host's own
+/// <see cref="Configure"/> customization if it has one, and asserts the resulting step order is
+/// exactly the documented pipeline. It is the edge counterpart of
+/// <see cref="DecoratorPipelineOrderTestsBase{TCommand, TCommandResult, TQuery, TQueryResult}"/>:
+/// several adjacencies are load-bearing (pre-forwarded capture immediately before
+/// <c>UseForwardedHeaders</c>, authentication immediately before tenant resolution, authentication
+/// before the rate limiter per ADR-019, forwarded headers before the HTTPS redirect), and a reorder
+/// that breaks one of them fails at runtime in ways that look like configuration bugs: an
+/// unreachable <c>jwks_uri</c>, a tenant that never resolves, a per-user rate cap that never
+/// engages. This base turns each of those into a test failure instead.
+/// <para>
+/// Subclass it with an empty body for a host that calls the zero-argument overload. A host that
+/// customizes the pipeline overrides <see cref="Configure"/> with the same delegate its
+/// <c>Program.cs</c> passes, and <see cref="ExpectedStepNames"/> with the order it expects.
+/// </para>
+/// <para>
+/// No <c>WebApplication</c> is built: the steps are pure data until they are applied, so this runs
+/// in the fast unit tier with no database and no host.
+/// </para>
+/// </summary>
+public abstract class MiddlewarePipelineOrderTestsBase
+{
+    /// <summary>
+    /// The host's pipeline customization, or null when it calls the zero-argument
+    /// <c>UseCommonMiddlewarePipeline()</c> overload (the default).
+    /// </summary>
+    protected virtual Action<MiddlewarePipelineBuilder>? Configure => null;
+
+    /// <summary>The expected step order, outermost first (the framework default pipeline).</summary>
+    protected virtual IReadOnlyList<string> ExpectedStepNames =>
+    [
+        MiddlewarePipelineStepNames.ExceptionHandler,
+        MiddlewarePipelineStepNames.CorrelationId,
+        MiddlewarePipelineStepNames.RequestLocalization,
+        MiddlewarePipelineStepNames.PreForwardedCapture,
+        MiddlewarePipelineStepNames.ForwardedHeaders,
+        MiddlewarePipelineStepNames.HttpsRedirection,
+        MiddlewarePipelineStepNames.ResponseCompression,
+        MiddlewarePipelineStepNames.Routing,
+        MiddlewarePipelineStepNames.Cors,
+        MiddlewarePipelineStepNames.Authentication,
+        MiddlewarePipelineStepNames.TenantResolution,
+        MiddlewarePipelineStepNames.RateLimiting,
+        MiddlewarePipelineStepNames.SoftDeletedUserFilter,
+        MiddlewarePipelineStepNames.Authorization,
+        MiddlewarePipelineStepNames.OutputCache,
+        MiddlewarePipelineStepNames.JwksEndpoint,
+        MiddlewarePipelineStepNames.OidcDiscoveryEndpoint,
+        MiddlewarePipelineStepNames.Controllers,
+    ];
+
+    [Fact]
+    public void EdgePipeline_OrdersSteps_InDocumentedOrder()
+    {
+        var builder = CreateBuilder();
+
+        builder.StepNames.Should().Equal(ExpectedStepNames,
+            because: "the edge pipeline must run in exactly the documented order, outermost first: the pre-forwarded capture has to sit immediately before UseForwardedHeaders for jwks_uri to stay reachable, tenant resolution immediately after authentication so the claim strategy sees HttpContext.User, and the rate limiter after authentication per ADR-019 so the per-user cap engages");
+    }
+
+    [Fact]
+    public void EdgePipeline_SatisfiesLoadBearingInvariants()
+    {
+        var builder = CreateBuilder();
+        var build = () => builder.Build();
+
+        build.Should().NotThrow(
+            because: "Build() re-checks the load-bearing adjacencies at startup, so a pipeline that fails here would have thrown while the host was starting");
+    }
+
+    private MiddlewarePipelineBuilder CreateBuilder()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        Configure?.Invoke(builder);
+        return builder;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase
+MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.EdgePipeline_OrdersSteps_InDocumentedOrder() -> void
+MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.EdgePipeline_SatisfiesLoadBearingInvariants() -> void
+MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.MiddlewarePipelineOrderTestsBase() -> void
+virtual MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.Configure.get -> System.Action<MMCA.Common.API.Startup.MiddlewarePipelineBuilder!>?
+virtual MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.ExpectedStepNames.get -> System.Collections.Generic.IReadOnlyList<string!>!

--- a/Source/Hosting/MMCA.Common.Testing/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing/packages.lock.json
@@ -161,14 +161,57 @@
           "xunit.v3.common": "[4.0.0]"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.2.1",
+        "contentHash": "jMBztsVim+rYVrkNY23dMuOjTGXGQ9+je1xb3i17KgUof7OcBZtMMDduEWoCQ52SpTlYqKsuzgJyUMCMOFCBfg=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.2.1",
+        "contentHash": "XaVOKS4AV6a6JdFsiuyLkNwU0ilWhUK2U71mBEXJsgi5AGpo24UkfZ4KUhpRGpuMmQNrugS7yxCIscGcnujdFA==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.2.1"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.50.0",
-        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.ClientModel": "1.8.0",
-          "System.Memory.Data": "8.0.1"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Azure.Core.Amqp": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "AY1ZM4WwLBb9L2WwQoWs7wS2XKYg83tp3yVVdgySdebGN0FuIszuEqCy3Nhv6qHpbkjx/NGuOTsUbF/oNGBgwA==",
+        "dependencies": {
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "System.Memory.Data": "1.0.2"
+        }
+      },
+      "Azure.Messaging.ServiceBus": {
+        "type": "Transitive",
+        "resolved": "7.20.1",
+        "contentHash": "DxCkedWPQuiXrIyFcriOhsQcZmDZW+j9d55Ev4nnK3yjMUFjlVe4Hj37fuZTJlNhC3P+7EumqBTt33R6DfOxGA==",
+        "dependencies": {
+          "Azure.Core": "1.46.2",
+          "Azure.Core.Amqp": "1.3.1",
+          "Microsoft.Azure.Amqp": "2.7.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -243,20 +286,51 @@
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
       },
+      "MassTransit.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.5.10",
+        "contentHash": "nZnm2YNH+NcVwY6yC114sJy8J9LtKdFjfKUm/A5HfmzOlZ8ksjgHaPBg5XCG1VAqKDRDFnaudIcesVultKJD7g=="
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "2.5.302",
+        "contentHash": "PTHQHbMJzx1VtUUCpnvPavD7o5X9s2dAJ4uQHAP2kBCwJKICpPTZq0qxzbB4/6iJJiIxem8zlxyfldGAx1SjSQ=="
+      },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Transitive",
         "resolved": "10.0.11",
         "contentHash": "IVGNbZVxLuL80y7cmXYfhIFoTGneHkp4D7xXarYe6V/wjo8/2qiSLUwWax1/h2eHtJ3Y5cuqmtpOyWMnXIsUMA=="
       },
+      "Microsoft.Azure.Amqp": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "gm/AEakujttMzrDhZ5QpRz3fICVkYDn/oDG9SmxDP+J7R8JDBXYU9WWG7hr6wQy40mY+wjUF0yUGXDPRDRNJwQ=="
+      },
+      "Microsoft.Azure.Cosmos": {
+        "type": "Transitive",
+        "resolved": "3.61.0",
+        "contentHash": "o0lhN2nrkC2xidy0lhjnojwqgp/N6GOXAr34xQrU5Scs8MmNG9cwG6MtRJSVTWQYW3gm9Ava3pmVbuuTVQyuYg==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.HashCode": "1.1.0",
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
       },
       "Microsoft.Bcl.Cryptography": {
         "type": "Transitive",
         "resolved": "10.0.2",
         "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
+      },
+      "Microsoft.Bcl.HashCode": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "J2G1k+u5unBV+aYcwxo94ip16Rkp65pgWFb0R6zwJipzWNMgvqlWeuI7/+R+e8bob66LnSG+llLJ+z8wI94cHg=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -268,10 +342,113 @@
         "resolved": "6.0.2",
         "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "hubA20AGenQ4Sx0ElWaPpB8DISjXpdx463+1zOGRslsT0e/t/06ITv+pHsop8CcJ0d8PZLfgnT7juCDVD79Dkw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "VOSGU8en6HZJs8t7UMFN+9vGcRgVOOn6fA44Ngcg2NyvJ3P1KE94iAb0XzaVaGhXGtt+qaM/VtEn0/hzluQJeg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "6auJR+9+9VunznKfH7WGrHMrnrmA0F7JZ22EXzwXvVhjfnbu9Xq7NSIWaOf3KJsOanM2qf5ajJ2JR5TlcPZTLA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Bv7X4wSSnzCQED9WYXKJ8fwgyvKwf0xZM1GO8xkf6CF9zl+UBnvjxmcPnokJRy0JKjc1SlHSzzhx1HcL4jitTQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "grznnTJgEYxaWpdKAsTzg6j+89jHgCXWYp+QGtlX5O92+w/VuhWM6JLPYb+uw8M9VhGUvOTsO76dYOy9vNPd5Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "ywTQKt32xnVhCzjEQAqFufpEyXkOUfvW/EC/s4xnS8Xaor2xXE+TMUyzhgACqXtZEU5IR95y94RDzHto55Fx7w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
+          "Microsoft.Extensions.DependencyModel": "10.0.11",
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "BX45SeAjP6sz9Djg6Gm0/IruBuWkyUKxtr4pn9sLAuprnuRn+VBPZVH2XxpzbaT7cVCPim3+Dkijl6yhLHjBOw=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "tuSqNuiJxlln43sZ8c1EDA4WXit1eX4foGadylXso3DnMVc+DtKfaNEwvHuiFXfPsEUZ6Z3GnF0Bfk9vvOsE4Q=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "hO/IpudHBl+EMXm1Ag8+7ersCN7VuiR6ech1+cVk8I+o7ssPRKdTozIAO4HGPt49G/lY6lo7G2kY5Q00biMHew=="
+      },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.11",
         "contentHash": "PJPtFYsZ+r+uz9qqXWUTEyKeJ1EiBGIJtqavkg9ZXijjGSFAk4Fgi5sqIxj+uAyLZwEKgexDUQXhWhvU6l3+og=="
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "Cyp36W6/XHD6sSDnbc6Ss7M+qOcjrer400Dx4Tfkb5OHcKV6bp9uMqZ4Y8PAoSwTfS8a/3lB9xCF+CLf0JGUig=="
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "jxxGX3bUe0ZZFtkMaigIJG44aGK6toE0EFhQwPYfTGLHw4EgXgceO8+RAdXZakK4BezpeDhR//6cxqmtae0I9Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Telemetry": "10.9.0"
+        }
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "LXMTKZGNzs3fsjKytTVeIEdp+yssJon7PW3VbxERZeqALA2Za/AQzt2h6K64PZ2NzgfFnX4rCJp6aTe+ocX83A==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.9.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.9.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "RpV3VzPa1YoHqvE2Q4uOuVjioVJhLOhaz4FXIE3XAEvla4qujnM+wFB7QnTAmIJxlg7lbBslkIHJQzpI8yHDQQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.9.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.9.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.9.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "rCyM64XvBNi2IY/5noMVsJjt22zVmnI+8tGrb6JnPRW/75Nyv9Hi+7gkxb7zQcR0+2mzS1sAqPXz2PsdHZCqHg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.9.0"
+        }
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
@@ -292,10 +469,10 @@
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
         "type": "Transitive",
-        "resolved": "4.78.0",
-        "contentHash": "DYU9o+DrDQuyZxeq91GBA9eNqBvA3ZMkLzQpF7L9dTk6FcIBM1y1IHXWqiKXTvptPF7CZE59upbyUoa+FJ5eiA==",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
         "dependencies": {
-          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client": "4.83.1",
           "System.Security.Cryptography.ProtectedData": "4.5.0"
         }
       },
@@ -351,6 +528,11 @@
           "Microsoft.IdentityModel.Logging": "8.22.0"
         }
       },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.6.3",
+        "contentHash": "N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA=="
+      },
       "Microsoft.SqlServer.Server": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -369,10 +551,67 @@
         "resolved": "4.5.4",
         "contentHash": "f8ckFm/xTS8C2Bn4BdVc94dNvg+tRfk0e4XFaETOqRi6r0PUOyn3Z9jTQCVpB3R1pP5WiRsEIrqqxux95BVpTA=="
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.16",
+        "contentHash": "nonu9l0YrZH6krVYbskBjE7uG0VMAnvOQ9PU+RmzUsy+++vHkqzzCkHRoP877OiA3iRTxJyNDLfpcU8hrJ3/YQ=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "RabbitMQ.Client": {
+        "type": "Transitive",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg=="
+      },
       "SharpZipLib": {
         "type": "Transitive",
         "resolved": "1.4.2",
         "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SQLite": {
+        "type": "Transitive",
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
+      },
+      "SQLitePCLRaw.config.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
+        "dependencies": {
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "3.0.5"
+        }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
@@ -381,10 +620,10 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.8.0",
-        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
         "dependencies": {
-          "System.Memory.Data": "8.0.1"
+          "System.Memory.Data": "10.0.3"
         }
       },
       "System.Configuration.ConfigurationManager": {
@@ -395,10 +634,15 @@
           "System.Security.Cryptography.ProtectedData": "9.0.11"
         }
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
@@ -429,6 +673,23 @@
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
+      "mmca.common.api": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.2.1, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.2.1, )",
+          "Asp.Versioning.OpenApi": "[10.2.2, )",
+          "AspNet.Security.OAuth.GitHub": "[10.0.0, )",
+          "MMCA.Common.Application": "[1.0.0, )",
+          "MMCA.Common.Infrastructure": "[1.0.0, )",
+          "Microsoft.AspNetCore.Authentication.Google": "[10.0.11, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.11, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.11, )",
+          "Microsoft.FeatureManagement.AspNetCore": "[4.6.0, )",
+          "Microsoft.OpenApi": "[2.12.0, )",
+          "Scalar.AspNetCore": "[2.16.20, )"
+        }
+      },
       "mmca.common.application": {
         "type": "Project",
         "dependencies": {
@@ -446,19 +707,93 @@
           "MMCA.Common.Shared": "[1.0.0, )"
         }
       },
+      "mmca.common.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
+          "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
+          "MMCA.Common.Application": "[1.0.0, )",
+          "MassTransit": "[8.5.10, )",
+          "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
+          "MassTransit.RabbitMQ": "[8.5.10, )",
+          "MessagePack": "[2.5.302, )",
+          "Microsoft.AspNetCore.SignalR.StackExchangeRedis": "[10.0.11, )",
+          "Microsoft.Azure.NotificationHubs": "[4.2.0, )",
+          "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.11, )",
+          "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.11, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.11, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.9.0, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
+          "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
+          "Polly.Core": "[8.7.0, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StackExchange.Redis": "[2.13.17, )"
+        }
+      },
       "mmca.common.shared": {
         "type": "Project"
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.1, )",
+        "resolved": "10.2.1",
+        "contentHash": "fMzUraYZOAobKQn2PffrgPsULbCWFeWroYRYndPasxPsiQl1+i8x5qYRuMYZAbzDrBnymPUMBxT2gZG2PwbkcQ==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.2.1"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.1, )",
+        "resolved": "10.2.1",
+        "contentHash": "Tv1megkpUy+3FN9yfVJKIcYMLXTe5CPs4zftBxGaZhADJe6h9CJZ2Okh5cG4PoE7wzHTef+AK++8IuZta3Ppog==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.2.1"
+        }
+      },
+      "Asp.Versioning.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.2, )",
+        "resolved": "10.2.2",
+        "contentHash": "pY5nhVFGuMBBbzN3v0oW6Pn4NQR8AxZuuWWkDxkWOxHp5rtCSvpphaWDgWeZ59z3yuTI45pPHit1+0d8oDcRsg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc.ApiExplorer": "10.2.1",
+          "Microsoft.AspNetCore.OpenApi": "10.0.10",
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
+        }
+      },
+      "AspNet.Security.OAuth.GitHub": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "PbOrAso/hlCS2p3YHHq94C5W/6851xyMT8ZEkAc3eGQNlsu3Siwu/D98nzCKyOKmB+KNu9MirWpmO66PmEIexQ=="
       },
       "Azure.Identity": {
         "type": "CentralTransitive",
         "requested": "[1.21.0, )",
-        "resolved": "1.17.1",
-        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.78.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
+          "Azure.Core": "1.53.0"
         }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.29.1, )",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",
@@ -469,6 +804,144 @@
           "FluentValidation": "12.1.1"
         }
       },
+      "MassTransit": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "TGi34UA8RftBIpYCHEdoIP5uSu2/pLWZRen4RUcg4CV1nr8MmCZMuFYjzvXXUyFcj0ZuRQxZZNhG7fB5/raSOg==",
+        "dependencies": {
+          "MassTransit.Abstractions": "8.5.10"
+        }
+      },
+      "MassTransit.Azure.ServiceBus.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "pXA+Vk/VB+s/0PeL4iht3q3VzxirbLNuSWnDDvEIFBfQdZpY28ZD/l2+6PTcVj6KvJH9nkqzlI7mnMw2pEYKPQ==",
+        "dependencies": {
+          "Azure.Identity": "1.21.0",
+          "Azure.Messaging.ServiceBus": "7.20.1",
+          "MassTransit": "8.5.10"
+        }
+      },
+      "MassTransit.RabbitMQ": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "5aQGpJpeqRhRv+htkXfi6MfWu0dj/4Lcf1c6h2J3tYZClupGklqB1ixlP3IRdZExrH9BI/60uYoxR+7pg3s1oQ==",
+        "dependencies": {
+          "MassTransit": "8.5.10",
+          "RabbitMQ.Client": "7.2.1"
+        }
+      },
+      "MessagePack": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.302, )",
+        "resolved": "2.5.302",
+        "contentHash": "5DZsKli4dMEpm/glcMAheuO8/IesfaTskbfsuvgnQwWFKS5FN7Z6yNx+5F+UW94E+9N2qt8Zs63/XVzpLsElgA==",
+        "dependencies": {
+          "MessagePack.Annotations": "2.5.302",
+          "Microsoft.NET.StringTools": "17.6.3"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Google": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "v/OZld8HxGa5hudLWiChuCf5asMrE36n19sR1RK5cC65SGJoYvQAcwnz3yoAOLDSw90PYc3hgFCh1FW83sakUg=="
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "R/1EATnPLU+gRfB6lwVkMcymmyAY5ppBBdRN/5lhNEiT3xP1sWccuSFkU/f1lQvN/WgRq5Vn8AhCdE3fqgsL/w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "bo7fagrKzIkwBTnzYXwPSqkV/JLALw22QYSwVnizsrHkiV7txWmIrsWxm8Qe3uRTZbxnykBUOnnC3ZavGtlqRg==",
+        "dependencies": {
+          "MessagePack": "2.5.302",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
+      "Microsoft.Azure.NotificationHubs": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "LOCxFB/sB1frfuXjecdDRDKEHkH+I1qKRatS5NyWIgYhpKhIcAlPNIJajcwLgQBShckdc3hMG9E+75CnL3qDhQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Cosmos": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "Bx8MAu44K23LK7UQvG+iwkYcgHIUnd/G1cFeQX5sk9JzNO9E1fZebGWfLjfk90ii08MUilMmP5wcDOSlkJwFqw==",
+        "dependencies": {
+          "Microsoft.Azure.Cosmos": "3.61.0",
+          "Microsoft.EntityFrameworkCore": "10.0.11",
+          "Newtonsoft.Json": "13.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "jc7iVrhQyInR3loraMESfEFaFOtQOB1mRKHjX6QYC9o7YDbfMNbAPnIwlpffnFwhXd6/27FKaaV+sWSoLd4F1g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.11",
+          "Microsoft.Extensions.DependencyModel": "10.0.11",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.12",
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "LClSs5cNN6za2Uk7IeH7RAP4Qe5EMXxFsD9i53ncPx21TVg04IEjoFyxvvsSNkq2/Ux9HyJsJ2qEO8Tl7Gcrrg==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.6",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "D0tHRbUCliInxTfPgN9K6RxrCVaWu9kyIT66vbIJ/YwA6BV2xa8vTqoE3JQXA2Rf2vRdgd29+HR6Ay6KmzDslw=="
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "loWrGc0mZt6N91IV+PZQeNU4uvb2vHdKgU9pUo8i2SGix9edTNCVhwzBp3gWJeaXeoPMph6F9xXcXF4W2ePpRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.9.0",
+          "Microsoft.Extensions.Resilience": "10.9.0"
+        }
+      },
+      "Microsoft.FeatureManagement.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "+0G11gpuGqggJ7nrB7jL/oT4bsRVqnM5q6+qgC5sO2oW4JWymXoUAkDNsuLsMB9La9Ota248x8dwhoL2erImwQ==",
+        "dependencies": {
+          "Microsoft.FeatureManagement": "4.6.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.12.0, )",
+        "resolved": "2.12.0",
+        "contentHash": "0xB/be+f6qYOhvQPUrVsLrau+fkowYv6gt9RIkajMhwT7sZnqtcA797yW3bS5kgSje+AQW4xZgyLnW641YFioQ=="
+      },
       "MiniProfiler.AspNetCore.Mvc": {
         "type": "CentralTransitive",
         "requested": "[4.5.4, )",
@@ -478,6 +951,28 @@
           "MiniProfiler.AspNetCore": "4.5.4"
         }
       },
+      "MiniProfiler.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.4, )",
+        "resolved": "4.5.4",
+        "contentHash": "SSOuBYtNbM8AMmsYMP6Edr7iBfVYzswVt/yoIDboBRLLUgkA4SyROCJuTTtZ8eJSzlNuq5DIR+BLCCcigaV/vw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.11",
+          "MiniProfiler.Shared": "4.5.4"
+        }
+      },
+      "Polly.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.7.0, )",
+        "resolved": "8.7.0",
+        "contentHash": "BS2t+nsBer16PIebCEPNBK5fgMisADQyRCd7K+BgkMWpFmSaiYE+rVVNpFhGRqUkJmNSLmw0uCNzHHWfgml28Q=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.16.20, )",
+        "resolved": "2.16.20",
+        "contentHash": "pSmyME4FCnYocbLmn9lmAUTVVSEPb5E6noqRcmJYpO65eaum68gw17yMORbeckW+gMksiL04m+zXoTxOKv0+kQ=="
+      },
       "Scrutor": {
         "type": "CentralTransitive",
         "requested": "[7.0.0, )",
@@ -485,6 +980,32 @@
         "contentHash": "wHWaroody48jnlLoq/REwUltIFLxplXyHTP+sttrc8P7+jkiVqf38afDidJNv4qgD/6zz2NKOYg06xLZ1bG7wQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "10.0.0"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.5, )",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
+        "dependencies": {
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.13.17, )",
+        "resolved": "2.13.17",
+        "contentHash": "P7o7ZDBAmBrOLQEw8Pt44iIA08ioj48smRxn4Jp6yzCu6P3DOSU6lj7f+IOtN3pPvSgC9YufvM92ycukEEBCYQ==",
+        "dependencies": {
+          "Pipelines.Sockets.Unofficial": "2.2.16",
+          "System.IO.Hashing": "10.0.2"
         }
       },
       "System.Linq.Dynamic.Core": {

--- a/Source/Presentation/MMCA.Common.API/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.API/PublicAPI.Unshipped.txt
@@ -1,1 +1,44 @@
 #nullable enable
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder.Build() -> System.Collections.Generic.IReadOnlyList<MMCA.Common.API.Startup.MiddlewarePipelineStep!>!
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder.InsertAfter(string! anchor, MMCA.Common.API.Startup.MiddlewarePipelineStep! step) -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder.InsertBefore(string! anchor, MMCA.Common.API.Startup.MiddlewarePipelineStep! step) -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder.Remove(string! name) -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder.Replace(string! name, MMCA.Common.API.Startup.MiddlewarePipelineStep! step) -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
+MMCA.Common.API.Startup.MiddlewarePipelineBuilder.StepNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+MMCA.Common.API.Startup.MiddlewarePipelineStep
+MMCA.Common.API.Startup.MiddlewarePipelineStep.<Clone>$() -> MMCA.Common.API.Startup.MiddlewarePipelineStep!
+MMCA.Common.API.Startup.MiddlewarePipelineStep.Configure.get -> System.Action<Microsoft.AspNetCore.Builder.WebApplication!>!
+MMCA.Common.API.Startup.MiddlewarePipelineStep.Configure.init -> void
+MMCA.Common.API.Startup.MiddlewarePipelineStep.Deconstruct(out string! Name, out System.Action<Microsoft.AspNetCore.Builder.WebApplication!>! Configure) -> void
+MMCA.Common.API.Startup.MiddlewarePipelineStep.Equals(MMCA.Common.API.Startup.MiddlewarePipelineStep? other) -> bool
+MMCA.Common.API.Startup.MiddlewarePipelineStep.MiddlewarePipelineStep(string! Name, System.Action<Microsoft.AspNetCore.Builder.WebApplication!>! Configure) -> void
+MMCA.Common.API.Startup.MiddlewarePipelineStep.Name.get -> string!
+MMCA.Common.API.Startup.MiddlewarePipelineStep.Name.init -> void
+MMCA.Common.API.Startup.MiddlewarePipelineStepNames
+MMCA.Common.API.Startup.WebApplicationExtensions.extension(Microsoft.AspNetCore.Builder.WebApplication!).UseCommonMiddlewarePipeline(System.Action<MMCA.Common.API.Startup.MiddlewarePipelineBuilder!>! configure) -> Microsoft.AspNetCore.Builder.WebApplication!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Authentication = "Authentication" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Authorization = "Authorization" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Controllers = "Controllers" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.CorrelationId = "CorrelationId" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Cors = "Cors" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.ExceptionHandler = "ExceptionHandler" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.ForwardedHeaders = "ForwardedHeaders" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.HttpsRedirection = "HttpsRedirection" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.JwksEndpoint = "JwksEndpoint" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.OidcDiscoveryEndpoint = "OidcDiscoveryEndpoint" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.OutputCache = "OutputCache" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.PreForwardedCapture = "PreForwardedCapture" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.RateLimiting = "RateLimiting" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.RequestLocalization = "RequestLocalization" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.ResponseCompression = "ResponseCompression" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Routing = "Routing" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.SoftDeletedUserFilter = "SoftDeletedUserFilter" -> string!
+const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.TenantResolution = "TenantResolution" -> string!
+override MMCA.Common.API.Startup.MiddlewarePipelineStep.Equals(object? obj) -> bool
+override MMCA.Common.API.Startup.MiddlewarePipelineStep.GetHashCode() -> int
+override MMCA.Common.API.Startup.MiddlewarePipelineStep.ToString() -> string!
+static MMCA.Common.API.Startup.MiddlewarePipelineBuilder.CreateDefault() -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
+static MMCA.Common.API.Startup.MiddlewarePipelineStep.operator !=(MMCA.Common.API.Startup.MiddlewarePipelineStep? left, MMCA.Common.API.Startup.MiddlewarePipelineStep? right) -> bool
+static MMCA.Common.API.Startup.MiddlewarePipelineStep.operator ==(MMCA.Common.API.Startup.MiddlewarePipelineStep? left, MMCA.Common.API.Startup.MiddlewarePipelineStep? right) -> bool
+static MMCA.Common.API.Startup.WebApplicationExtensions.UseCommonMiddlewarePipeline(this Microsoft.AspNetCore.Builder.WebApplication! app, System.Action<MMCA.Common.API.Startup.MiddlewarePipelineBuilder!>! configure) -> Microsoft.AspNetCore.Builder.WebApplication!

--- a/Source/Presentation/MMCA.Common.API/Startup/MiddlewarePipelineBuilder.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/MiddlewarePipelineBuilder.cs
@@ -1,0 +1,343 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Hosting;
+using MMCA.Common.API.Middleware;
+
+namespace MMCA.Common.API.Startup;
+
+/// <summary>
+/// Builds the ordered list of named steps that <c>UseCommonMiddlewarePipeline</c> applies to a
+/// <see cref="WebApplication"/>. <see cref="CreateDefault"/> seeds the framework pipeline; a host
+/// then inserts, replaces, or removes steps by name and <see cref="Build"/> re-checks the
+/// load-bearing adjacencies, so a customized pipeline fails at startup rather than misordering
+/// silently.
+/// </summary>
+public sealed class MiddlewarePipelineBuilder
+{
+    private readonly List<MiddlewarePipelineStep> _steps;
+
+    private MiddlewarePipelineBuilder(List<MiddlewarePipelineStep> steps) => _steps = steps;
+
+    /// <summary>
+    /// The names of the steps currently in the pipeline, in the order they will be applied.
+    /// </summary>
+    public IReadOnlyList<string> StepNames => [.. _steps.Select(step => step.Name)];
+
+    /// <summary>
+    /// Creates a builder seeded with the framework's default edge pipeline, in the order documented
+    /// on <see cref="MiddlewarePipelineStepNames"/>.
+    /// </summary>
+    /// <returns>A builder holding the default steps.</returns>
+    public static MiddlewarePipelineBuilder CreateDefault() =>
+        new(
+        [
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.ExceptionHandler,
+                static app => app.UseExceptionHandler()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.CorrelationId,
+                static app => app.UseMiddleware<CorrelationIdMiddleware>()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.RequestLocalization,
+                // Set CurrentUICulture for the request (ADR-027) so edge error localization and any
+                // culture-aware formatting run under the caller's culture. The UI forwards the active
+                // culture as Accept-Language (the default providers include that header + the cookie).
+                static app => app.UseCommonRequestLocalization()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.PreForwardedCapture,
+                // Capture the actual transport scheme + host before UseForwardedHeaders rewrites
+                // Request.Scheme and Request.Host from the X-Forwarded-* headers. The OIDC discovery
+                // endpoint needs the original values for jwks_uri: internal services fetch JWKS
+                // over cleartext HTTP using the Aspire-resolved DNS name, but envoy/DCP forwards
+                // X-Forwarded-Proto: https and X-Forwarded-Host pointing at the canonical
+                // launchSettings URL (e.g. localhost:56003) which the caller cannot reach.
+                static app => app.Use(static (context, next) =>
+                {
+                    context.Items[WebApplicationExtensions.PreForwardedSchemeKey] = context.Request.Scheme;
+                    context.Items[WebApplicationExtensions.PreForwardedHostKey] = context.Request.Host.Value;
+                    return next(context);
+                })),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.ForwardedHeaders,
+                static app =>
+                {
+                    var forwardedHeadersOptions = new ForwardedHeadersOptions
+                    {
+                        ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
+                    };
+
+                    // Cloud reverse proxies (Azure Container Apps, AWS ALB, etc.) use internal
+                    // IPs that are not in the default KnownProxies/KnownNetworks allow-lists.
+                    // Clear them so forwarded headers are trusted regardless of proxy IP.
+                    forwardedHeadersOptions.KnownProxies.Clear();
+                    forwardedHeadersOptions.KnownIPNetworks.Clear();
+
+                    app.UseForwardedHeaders(forwardedHeadersOptions);
+                }),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.HttpsRedirection,
+                // HTTPS redirect runs for browser/REST traffic only. gRPC clients use HTTP/2
+                // cleartext (h2c) on the HTTP endpoint of extracted services: Aspire's project-
+                // resource service discovery doesn't reliably expose an https key, so the resolver
+                // hands out the http URL. Issuing a 307 redirect on those requests breaks the gRPC
+                // call (the client retries against HTTPS, which then has its own issues). Skip
+                // HTTPS redirect for any request whose Content-Type starts with "application/grpc".
+                static app => app.UseWhen(
+                    ctx => !(ctx.Request.ContentType?.StartsWith("application/grpc", StringComparison.OrdinalIgnoreCase) ?? false),
+                    builder => builder.UseHttpsRedirection())),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.ResponseCompression,
+                static app => app.UseResponseCompression()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.Routing,
+                static app => app.UseRouting()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.Cors,
+                static app => app.UseCors(app.Environment.IsDevelopment()
+                    ? WebApplicationBuilderExtensions.CorsPolicyAllowAll
+                    : WebApplicationBuilderExtensions.CorsPolicyAllowSpecificOrigins)),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.Authentication,
+                static app => app.UseAuthentication()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.TenantResolution,
+                // Immediately after authentication, and that order is load-bearing: the claim strategy
+                // reads HttpContext.User, which carries the token's claims only once authentication has
+                // run. Registered unconditionally and inert unless the host called AddMultiTenancy and
+                // set Tenancy:Enabled (the SoftDeletedUserMiddleware precedent).
+                static app => app.UseMiddleware<TenantResolutionMiddleware>()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.RateLimiting,
+                // Rate limiting runs AFTER authentication on purpose (ADR-019): GlobalRateLimitPartition
+                // partitions by the authenticated principal and routes anonymous traffic down a NoLimiter
+                // branch, so HttpContext.User must already be populated here, otherwise every request
+                // looks anonymous and the per-user cap never engages.
+                static app => app.UseRateLimiter()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.SoftDeletedUserFilter,
+                static app => app.UseMiddleware<SoftDeletedUserMiddleware>()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.Authorization,
+                static app => app.UseAuthorization()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.OutputCache,
+                static app => app.UseOutputCache()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.JwksEndpoint,
+                // Always-mapped JWKS + OIDC discovery endpoints. Returns an empty key set
+                // (JWKS) or 404 (OIDC discovery) when the Identity service's RSA publishing
+                // is not configured, so non-Identity services incur no behavior change.
+                // Identity services flip JwksSettings.Enabled = true and provide RsaPublicKeyPem
+                // to publish their signing key for downstream services to fetch via AddForwardedJwtBearer.
+                static app => app.MapJwksEndpoint()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.OidcDiscoveryEndpoint,
+                static app => app.MapOidcDiscoveryEndpoint()),
+
+            new MiddlewarePipelineStep(
+                MiddlewarePipelineStepNames.Controllers,
+                static app => app.MapControllers()),
+        ]);
+
+    /// <summary>Inserts <paramref name="step"/> immediately before the step named <paramref name="anchor"/>.</summary>
+    /// <param name="anchor">The name of the existing step to insert before.</param>
+    /// <param name="step">The step to insert.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// No step is named <paramref name="anchor"/>, or a step already carries
+    /// <paramref name="step"/>'s name.
+    /// </exception>
+    public MiddlewarePipelineBuilder InsertBefore(string anchor, MiddlewarePipelineStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        var index = RequireIndexOf(anchor, nameof(anchor));
+        RequireUniqueName(step.Name, nameof(step));
+        _steps.Insert(index, step);
+        return this;
+    }
+
+    /// <summary>Inserts <paramref name="step"/> immediately after the step named <paramref name="anchor"/>.</summary>
+    /// <param name="anchor">The name of the existing step to insert after.</param>
+    /// <param name="step">The step to insert.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// No step is named <paramref name="anchor"/>, or a step already carries
+    /// <paramref name="step"/>'s name.
+    /// </exception>
+    public MiddlewarePipelineBuilder InsertAfter(string anchor, MiddlewarePipelineStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        var index = RequireIndexOf(anchor, nameof(anchor));
+        RequireUniqueName(step.Name, nameof(step));
+        _steps.Insert(index + 1, step);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the step named <paramref name="name"/> with <paramref name="step"/>, keeping its
+    /// position. The replacement may carry a different name.
+    /// </summary>
+    /// <param name="name">The name of the existing step to replace.</param>
+    /// <param name="step">The replacement step.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// No step is named <paramref name="name"/>, or another step already carries
+    /// <paramref name="step"/>'s name.
+    /// </exception>
+    public MiddlewarePipelineBuilder Replace(string name, MiddlewarePipelineStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        var index = RequireIndexOf(name, nameof(name));
+
+        if (_steps.Exists(existing => !string.Equals(existing.Name, name, StringComparison.Ordinal)
+            && string.Equals(existing.Name, step.Name, StringComparison.Ordinal)))
+        {
+            throw new ArgumentException(
+                $"A middleware pipeline step named '{step.Name}' already exists. Step names must be unique.",
+                nameof(step));
+        }
+
+        _steps[index] = step;
+        return this;
+    }
+
+    /// <summary>Removes the step named <paramref name="name"/>.</summary>
+    /// <param name="name">The name of the step to remove.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">No step is named <paramref name="name"/>.</exception>
+    public MiddlewarePipelineBuilder Remove(string name)
+    {
+        var index = RequireIndexOf(name, nameof(name));
+        _steps.RemoveAt(index);
+        return this;
+    }
+
+    /// <summary>
+    /// Validates the load-bearing adjacencies and returns the ordered steps. An invariant binds only
+    /// when both of the steps it names are still present, so a host that drops a whole capability
+    /// (both members of a pair) stays legal. The invariants are:
+    /// <list type="bullet">
+    /// <item><description>
+    /// <c>PreForwardedCapture</c> runs immediately before <c>ForwardedHeaders</c>: the captured
+    /// pre-forwarded scheme and host are only faithful if nothing rewrites the request between the
+    /// capture and the <c>X-Forwarded-*</c> rewrite.
+    /// </description></item>
+    /// <item><description>
+    /// <c>Authentication</c> runs immediately before <c>TenantResolution</c>: the tenant claim
+    /// strategy reads <c>HttpContext.User</c>.
+    /// </description></item>
+    /// <item><description>
+    /// <c>Authentication</c> runs before <c>RateLimiting</c> (ADR-019): the global partition keys on
+    /// the authenticated principal, so an unauthenticated pipeline sees every request as anonymous.
+    /// </description></item>
+    /// <item><description>
+    /// <c>ForwardedHeaders</c> runs before <c>HttpsRedirection</c>: the redirect decision must see
+    /// the proxy-reported scheme, not the internal one.
+    /// </description></item>
+    /// </list>
+    /// </summary>
+    /// <returns>The validated steps, in the order they are to be applied.</returns>
+    /// <exception cref="InvalidOperationException">An invariant is violated; the message names it.</exception>
+    public IReadOnlyList<MiddlewarePipelineStep> Build()
+    {
+        RequireImmediatelyBefore(
+            MiddlewarePipelineStepNames.PreForwardedCapture,
+            MiddlewarePipelineStepNames.ForwardedHeaders,
+            "the captured pre-forwarded scheme and host are only faithful if nothing rewrites the request between the capture and the X-Forwarded-* rewrite");
+
+        RequireImmediatelyBefore(
+            MiddlewarePipelineStepNames.Authentication,
+            MiddlewarePipelineStepNames.TenantResolution,
+            "the tenant claim strategy reads HttpContext.User, which carries the token's claims only once authentication has run");
+
+        RequirePrecedes(
+            MiddlewarePipelineStepNames.Authentication,
+            MiddlewarePipelineStepNames.RateLimiting,
+            "GlobalRateLimitPartition keys on the authenticated principal (ADR-019); without authentication first, every request looks anonymous and the per-user cap never engages");
+
+        RequirePrecedes(
+            MiddlewarePipelineStepNames.ForwardedHeaders,
+            MiddlewarePipelineStepNames.HttpsRedirection,
+            "the redirect decision must see the proxy-reported scheme from X-Forwarded-Proto, not the internal transport scheme");
+
+        return [.. _steps];
+    }
+
+    private int IndexOf(string name) =>
+        _steps.FindIndex(step => string.Equals(step.Name, name, StringComparison.Ordinal));
+
+    private int RequireIndexOf(string name, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("A middleware pipeline step name is required.", parameterName);
+        }
+
+        var index = IndexOf(name);
+
+        if (index < 0)
+        {
+            throw new ArgumentException(
+                $"No middleware pipeline step named '{name}' exists. Known steps: {string.Join(", ", StepNames)}.",
+                parameterName);
+        }
+
+        return index;
+    }
+
+    private void RequireUniqueName(string name, string parameterName)
+    {
+        if (IndexOf(name) >= 0)
+        {
+            throw new ArgumentException(
+                $"A middleware pipeline step named '{name}' already exists. Step names must be unique.",
+                parameterName);
+        }
+    }
+
+    private void RequireImmediatelyBefore(string first, string second, string rationale)
+    {
+        var firstIndex = IndexOf(first);
+        var secondIndex = IndexOf(second);
+
+        // The invariant binds only when both steps are present: removing a whole capability is legal.
+        if (firstIndex < 0 || secondIndex < 0 || secondIndex == firstIndex + 1)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Middleware pipeline invariant violated: '{first}' must run immediately before '{second}' ({rationale}). Current order: {string.Join(" -> ", StepNames)}.");
+    }
+
+    private void RequirePrecedes(string first, string second, string rationale)
+    {
+        var firstIndex = IndexOf(first);
+        var secondIndex = IndexOf(second);
+
+        // The invariant binds only when both steps are present: removing a whole capability is legal.
+        if (firstIndex < 0 || secondIndex < 0 || firstIndex < secondIndex)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Middleware pipeline invariant violated: '{first}' must run before '{second}' ({rationale}). Current order: {string.Join(" -> ", StepNames)}.");
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/MiddlewarePipelineStep.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/MiddlewarePipelineStep.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace MMCA.Common.API.Startup;
+
+/// <summary>
+/// One named step of the shared HTTP edge pipeline: a stable identifier plus the delegate that
+/// registers the step's middleware on the application. Steps are pure data until
+/// <c>UseCommonMiddlewarePipeline</c> runs them in order, which is what makes the pipeline order
+/// testable without a running host.
+/// </summary>
+/// <param name="Name">
+/// The step's identifier, used as the anchor for <see cref="MiddlewarePipelineBuilder"/> mutations.
+/// Framework steps use the constants on <see cref="MiddlewarePipelineStepNames"/>; a host adding its
+/// own step supplies its own name, which must be unique within the pipeline.
+/// </param>
+/// <param name="Configure">
+/// Registers the step's middleware on the application. Invoked exactly once, in pipeline order, at
+/// the point <c>UseCommonMiddlewarePipeline</c> is called, so anything the delegate reads from the
+/// host (configuration, environment) is evaluated at configure time.
+/// </param>
+public sealed record MiddlewarePipelineStep(string Name, Action<WebApplication> Configure)
+{
+    /// <summary>
+    /// The step's identifier, used as the anchor for <see cref="MiddlewarePipelineBuilder"/>
+    /// mutations. Never null, empty, or whitespace.
+    /// </summary>
+    public string Name { get; init; } = Validated(Name);
+
+    /// <summary>Registers the step's middleware on the application. Never null.</summary>
+    public Action<WebApplication> Configure { get; init; } = Validated(Configure);
+
+    private static string Validated(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return name;
+    }
+
+    private static Action<WebApplication> Validated(Action<WebApplication> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        return configure;
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/MiddlewarePipelineStepNames.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/MiddlewarePipelineStepNames.cs
@@ -1,0 +1,75 @@
+namespace MMCA.Common.API.Startup;
+
+/// <summary>
+/// The well-known names of the steps that make up the shared HTTP edge pipeline built by
+/// <see cref="MiddlewarePipelineBuilder.CreateDefault"/> and applied by
+/// <c>UseCommonMiddlewarePipeline</c>. A host customizing the pipeline addresses steps by these
+/// names, so they are part of the public contract: renaming one is a breaking change.
+/// <para>
+/// The declaration order below is the runtime order of the default pipeline. Several adjacencies
+/// are load-bearing and are re-checked by <see cref="MiddlewarePipelineBuilder.Build"/>; see the
+/// invariant list documented there.
+/// </para>
+/// </summary>
+public static class MiddlewarePipelineStepNames
+{
+    /// <summary>The framework exception handler (<c>UseExceptionHandler</c>), outermost step.</summary>
+    public const string ExceptionHandler = "ExceptionHandler";
+
+    /// <summary>Correlation-id capture and propagation (<c>CorrelationIdMiddleware</c>).</summary>
+    public const string CorrelationId = "CorrelationId";
+
+    /// <summary>Per-request culture resolution (<c>UseCommonRequestLocalization</c>, ADR-027).</summary>
+    public const string RequestLocalization = "RequestLocalization";
+
+    /// <summary>
+    /// Captures the transport scheme and host as the connection saw them, before the forwarded
+    /// headers rewrite them. Must run immediately before <see cref="ForwardedHeaders"/>.
+    /// </summary>
+    public const string PreForwardedCapture = "PreForwardedCapture";
+
+    /// <summary>Applies <c>X-Forwarded-For/Proto/Host</c> (<c>UseForwardedHeaders</c>).</summary>
+    public const string ForwardedHeaders = "ForwardedHeaders";
+
+    /// <summary>HTTPS redirection for non-gRPC traffic (<c>UseHttpsRedirection</c> under a <c>UseWhen</c>).</summary>
+    public const string HttpsRedirection = "HttpsRedirection";
+
+    /// <summary>Response compression (<c>UseResponseCompression</c>).</summary>
+    public const string ResponseCompression = "ResponseCompression";
+
+    /// <summary>Endpoint routing (<c>UseRouting</c>).</summary>
+    public const string Routing = "Routing";
+
+    /// <summary>CORS policy selection (<c>UseCors</c>); the policy depends on the environment.</summary>
+    public const string Cors = "Cors";
+
+    /// <summary>Authentication (<c>UseAuthentication</c>); populates <c>HttpContext.User</c>.</summary>
+    public const string Authentication = "Authentication";
+
+    /// <summary>
+    /// Tenant resolution (<c>TenantResolutionMiddleware</c>). Must run immediately after
+    /// <see cref="Authentication"/>: the claim strategy reads <c>HttpContext.User</c>.
+    /// </summary>
+    public const string TenantResolution = "TenantResolution";
+
+    /// <summary>Global rate limiter (<c>UseRateLimiter</c>); must run after <see cref="Authentication"/> (ADR-019).</summary>
+    public const string RateLimiting = "RateLimiting";
+
+    /// <summary>Rejects requests from soft-deleted users (<c>SoftDeletedUserMiddleware</c>).</summary>
+    public const string SoftDeletedUserFilter = "SoftDeletedUserFilter";
+
+    /// <summary>Authorization (<c>UseAuthorization</c>).</summary>
+    public const string Authorization = "Authorization";
+
+    /// <summary>Output caching (<c>UseOutputCache</c>).</summary>
+    public const string OutputCache = "OutputCache";
+
+    /// <summary>Maps <c>/.well-known/jwks.json</c> (<c>MapJwksEndpoint</c>).</summary>
+    public const string JwksEndpoint = "JwksEndpoint";
+
+    /// <summary>Maps <c>/.well-known/openid-configuration</c> (<c>MapOidcDiscoveryEndpoint</c>).</summary>
+    public const string OidcDiscoveryEndpoint = "OidcDiscoveryEndpoint";
+
+    /// <summary>Maps the attribute-routed controllers (<c>MapControllers</c>), innermost step.</summary>
+    public const string Controllers = "Controllers";
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/SignalRExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/SignalRExtensions.cs
@@ -16,7 +16,7 @@ public static class SignalRExtensions
         /// <summary>
         /// Maps the <see cref="NotificationHub"/> endpoint using the path configured in
         /// <see cref="PushNotificationSettings"/>. This should be called after
-        /// <see cref="WebApplicationExtensions.UseCommonMiddlewarePipeline"/>.
+        /// <c>WebApplicationExtensions.UseCommonMiddlewarePipeline</c>.
         /// No-ops gracefully when push notification settings are not registered.
         /// </summary>
         public WebApplication MapNotificationHub()

--- a/Source/Presentation/MMCA.Common.API/Startup/WebApplicationExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/WebApplicationExtensions.cs
@@ -1,10 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Hosting;
-using MMCA.Common.API.Middleware;
 using MMCA.Common.Shared.Globalization;
 
 namespace MMCA.Common.API.Startup;
@@ -37,95 +35,35 @@ public static class WebApplicationExtensions
     extension(WebApplication app)
     {
         /// <summary>
-        /// Configures the standard MMCA middleware pipeline in the correct order:
-        /// exception handling → correlation ID → forwarded headers → HTTPS →
-        /// response compression → routing → CORS → auth → tenant resolution →
-        /// rate limiting → soft-delete user filter → authorization → output cache → controllers.
+        /// Configures the standard MMCA middleware pipeline. The order is the contract and it is
+        /// data, not prose: the steps are the defaults of
+        /// <see cref="MiddlewarePipelineBuilder.CreateDefault"/>, named in application order by
+        /// <see cref="MiddlewarePipelineStepNames"/> and frozen by the
+        /// <c>MiddlewarePipelineOrderTestsBase</c> fitness function. Use the
+        /// <c>UseCommonMiddlewarePipeline(Action&lt;MiddlewarePipelineBuilder&gt;)</c>
+        /// overload to customize them.
         /// </summary>
-        public WebApplication UseCommonMiddlewarePipeline()
+        public WebApplication UseCommonMiddlewarePipeline() => ApplyPipeline(app, configure: null);
+
+        /// <summary>
+        /// Configures the standard MMCA middleware pipeline after letting the host adjust it: the
+        /// default steps are seeded first, <paramref name="configure"/> may insert, replace, or
+        /// remove steps by name, and the load-bearing adjacencies are re-checked before anything is
+        /// applied (see <see cref="MiddlewarePipelineBuilder.Build"/>), so a misordered pipeline
+        /// fails at startup instead of at the first misrouted request.
+        /// </summary>
+        /// <param name="configure">Adjusts the seeded default pipeline. Runs before any step is applied.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="configure"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">The customized pipeline violates an invariant.</exception>
+        public WebApplication UseCommonMiddlewarePipeline(Action<MiddlewarePipelineBuilder> configure)
         {
-            app.UseExceptionHandler();
-            app.UseMiddleware<CorrelationIdMiddleware>();
-
-            // Set CurrentUICulture for the request (ADR-027) so edge error localization and any
-            // culture-aware formatting run under the caller's culture. The UI forwards the active
-            // culture as Accept-Language (the default providers include that header + the cookie).
-            app.UseCommonRequestLocalization();
-
-            var forwardedHeadersOptions = new ForwardedHeadersOptions
-            {
-                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
-            };
-
-            // Cloud reverse proxies (Azure Container Apps, AWS ALB, etc.) use internal
-            // IPs that are not in the default KnownProxies/KnownNetworks allow-lists.
-            // Clear them so forwarded headers are trusted regardless of proxy IP.
-            forwardedHeadersOptions.KnownProxies.Clear();
-            forwardedHeadersOptions.KnownIPNetworks.Clear();
-
-            // Capture the actual transport scheme + host before UseForwardedHeaders rewrites
-            // Request.Scheme and Request.Host from the X-Forwarded-* headers. The OIDC discovery
-            // endpoint needs the original values for jwks_uri — internal services fetch JWKS
-            // over cleartext HTTP using the Aspire-resolved DNS name, but envoy/DCP forwards
-            // X-Forwarded-Proto: https and X-Forwarded-Host pointing at the canonical
-            // launchSettings URL (e.g. localhost:56003) which the caller cannot reach.
-            app.Use(static (context, next) =>
-            {
-                context.Items[PreForwardedSchemeKey] = context.Request.Scheme;
-                context.Items[PreForwardedHostKey] = context.Request.Host.Value;
-                return next(context);
-            });
-
-            app.UseForwardedHeaders(forwardedHeadersOptions);
-
-            // HTTPS redirect runs for browser/REST traffic only. gRPC clients use HTTP/2
-            // cleartext (h2c) on the HTTP endpoint of extracted services — Aspire's project-
-            // resource service discovery doesn't reliably expose an https key, so the resolver
-            // hands out the http URL. Issuing a 307 redirect on those requests breaks the gRPC
-            // call (the client retries against HTTPS, which then has its own issues). Skip
-            // HTTPS redirect for any request whose Content-Type starts with "application/grpc".
-            app.UseWhen(
-                ctx => !(ctx.Request.ContentType?.StartsWith("application/grpc", StringComparison.OrdinalIgnoreCase) ?? false),
-                builder => builder.UseHttpsRedirection());
-
-            app.UseResponseCompression();
-            app.UseRouting();
-            app.UseCors(app.Environment.IsDevelopment()
-                ? WebApplicationBuilderExtensions.CorsPolicyAllowAll
-                : WebApplicationBuilderExtensions.CorsPolicyAllowSpecificOrigins);
-            app.UseAuthentication();
-
-            // Immediately after authentication, and that order is load-bearing: the claim strategy
-            // reads HttpContext.User, which carries the token's claims only once authentication has
-            // run. Registered unconditionally and inert unless the host called AddMultiTenancy and
-            // set Tenancy:Enabled (the SoftDeletedUserMiddleware precedent).
-            app.UseMiddleware<TenantResolutionMiddleware>();
-
-            // Rate limiting runs AFTER authentication on purpose (ADR-019): GlobalRateLimitPartition
-            // partitions by the authenticated principal and routes anonymous traffic down a NoLimiter
-            // branch, so HttpContext.User must already be populated here — otherwise every request
-            // looks anonymous and the per-user cap never engages.
-            app.UseRateLimiter();
-            app.UseMiddleware<SoftDeletedUserMiddleware>();
-            app.UseAuthorization();
-            app.UseOutputCache();
-
-            // Always-mapped JWKS + OIDC discovery endpoints. Returns an empty key set
-            // (JWKS) or 404 (OIDC discovery) when the Identity service's RSA publishing
-            // is not configured, so non-Identity services incur no behavior change.
-            // Identity services flip JwksSettings.Enabled = true and provide RsaPublicKeyPem
-            // to publish their signing key for downstream services to fetch via AddForwardedJwtBearer.
-            app.MapJwksEndpoint();
-            app.MapOidcDiscoveryEndpoint();
-
-            app.MapControllers();
-
-            return app;
+            ArgumentNullException.ThrowIfNull(configure);
+            return ApplyPipeline(app, configure);
         }
 
         /// <summary>
         /// Adds <c>RequestLocalization</c> for the framework's supported cultures
-        /// (<see cref="SupportedCultures"/>, ADR-027). Wired into <see cref="UseCommonMiddlewarePipeline"/>
+        /// (<see cref="SupportedCultures"/>, ADR-027). Wired into <c>UseCommonMiddlewarePipeline</c>
         /// for REST/gRPC service hosts; Blazor UI hosts call this explicitly before <c>MapRazorComponents</c>
         /// so SSR prerender runs under the right culture. The default providers resolve culture from the
         /// query string, the ASP.NET culture cookie, then the <c>Accept-Language</c> header.
@@ -190,5 +128,23 @@ public static class WebApplicationExtensions
 
             return app;
         }
+    }
+
+    /// <summary>
+    /// Seeds the default steps, lets the host adjust them, validates the load-bearing adjacencies,
+    /// then applies every step in order. Both <c>UseCommonMiddlewarePipeline</c> overloads route
+    /// through here, so the zero-argument path is exactly the validated default pipeline.
+    /// </summary>
+    private static WebApplication ApplyPipeline(WebApplication app, Action<MiddlewarePipelineBuilder>? configure)
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        configure?.Invoke(builder);
+
+        foreach (var step in builder.Build())
+        {
+            step.Configure(app);
+        }
+
+        return app;
     }
 }

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/MiddlewarePipelineOrderTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/MiddlewarePipelineOrderTests.cs
@@ -1,0 +1,10 @@
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Exercises <see cref="MiddlewarePipelineOrderTestsBase"/> against the framework's own default edge
+/// pipeline, the one every service host gets from the zero-argument
+/// <c>UseCommonMiddlewarePipeline()</c> overload. No host here customizes the pipeline, so nothing
+/// is overridden: this is the Common-side conformance instance of the fitness function the
+/// downstream repos subclass the same way.
+/// </summary>
+public sealed class MiddlewarePipelineOrderTests : MiddlewarePipelineOrderTestsBase;

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
@@ -65,14 +65,62 @@
           "xunit.v3.mtp-v2": "[4.0.0]"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.2.1",
+        "contentHash": "jMBztsVim+rYVrkNY23dMuOjTGXGQ9+je1xb3i17KgUof7OcBZtMMDduEWoCQ52SpTlYqKsuzgJyUMCMOFCBfg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.2.1",
+        "contentHash": "XaVOKS4AV6a6JdFsiuyLkNwU0ilWhUK2U71mBEXJsgi5AGpo24UkfZ4KUhpRGpuMmQNrugS7yxCIscGcnujdFA==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.2.1"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.50.0",
-        "contentHash": "GBNKZEhdIbTXxedvD3R7I/yDVFX9jJJEz02kCziFSJxspSQ5RMHc3GktulJ1s7+ffXaXD7kMgrtdQTaggyInLw==",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.ClientModel": "1.8.0",
-          "System.Memory.Data": "8.0.1"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Azure.Core.Amqp": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "AY1ZM4WwLBb9L2WwQoWs7wS2XKYg83tp3yVVdgySdebGN0FuIszuEqCy3Nhv6qHpbkjx/NGuOTsUbF/oNGBgwA==",
+        "dependencies": {
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "System.Memory.Data": "1.0.2"
+        }
+      },
+      "Azure.Messaging.ServiceBus": {
+        "type": "Transitive",
+        "resolved": "7.20.1",
+        "contentHash": "DxCkedWPQuiXrIyFcriOhsQcZmDZW+j9d55Ev4nnK3yjMUFjlVe4Hj37fuZTJlNhC3P+7EumqBTt33R6DfOxGA==",
+        "dependencies": {
+          "Azure.Core": "1.46.2",
+          "Azure.Core.Amqp": "1.3.1",
+          "Microsoft.Azure.Amqp": "2.7.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -154,6 +202,16 @@
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
       },
+      "MassTransit.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.5.10",
+        "contentHash": "nZnm2YNH+NcVwY6yC114sJy8J9LtKdFjfKUm/A5HfmzOlZ8ksjgHaPBg5XCG1VAqKDRDFnaudIcesVultKJD7g=="
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "2.5.302",
+        "contentHash": "PTHQHbMJzx1VtUUCpnvPavD7o5X9s2dAJ4uQHAP2kBCwJKICpPTZq0qxzbB4/6iJJiIxem8zlxyfldGAx1SjSQ=="
+      },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
         "resolved": "2.23.0",
@@ -164,15 +222,36 @@
         "resolved": "10.0.11",
         "contentHash": "IVGNbZVxLuL80y7cmXYfhIFoTGneHkp4D7xXarYe6V/wjo8/2qiSLUwWax1/h2eHtJ3Y5cuqmtpOyWMnXIsUMA=="
       },
+      "Microsoft.Azure.Amqp": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "gm/AEakujttMzrDhZ5QpRz3fICVkYDn/oDG9SmxDP+J7R8JDBXYU9WWG7hr6wQy40mY+wjUF0yUGXDPRDRNJwQ=="
+      },
+      "Microsoft.Azure.Cosmos": {
+        "type": "Transitive",
+        "resolved": "3.61.0",
+        "contentHash": "o0lhN2nrkC2xidy0lhjnojwqgp/N6GOXAr34xQrU5Scs8MmNG9cwG6MtRJSVTWQYW3gm9Ava3pmVbuuTVQyuYg==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.HashCode": "1.1.0",
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
       },
       "Microsoft.Bcl.Cryptography": {
         "type": "Transitive",
         "resolved": "10.0.2",
         "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
+      },
+      "Microsoft.Bcl.HashCode": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "J2G1k+u5unBV+aYcwxo94ip16Rkp65pgWFb0R6zwJipzWNMgvqlWeuI7/+R+e8bob66LnSG+llLJ+z8wI94cHg=="
       },
       "Microsoft.Bcl.TimeProvider": {
         "type": "Transitive",
@@ -184,24 +263,97 @@
         "resolved": "6.0.2",
         "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "hubA20AGenQ4Sx0ElWaPpB8DISjXpdx463+1zOGRslsT0e/t/06ITv+pHsop8CcJ0d8PZLfgnT7juCDVD79Dkw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "VOSGU8en6HZJs8t7UMFN+9vGcRgVOOn6fA44Ngcg2NyvJ3P1KE94iAb0XzaVaGhXGtt+qaM/VtEn0/hzluQJeg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "6auJR+9+9VunznKfH7WGrHMrnrmA0F7JZ22EXzwXvVhjfnbu9Xq7NSIWaOf3KJsOanM2qf5ajJ2JR5TlcPZTLA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Bv7X4wSSnzCQED9WYXKJ8fwgyvKwf0xZM1GO8xkf6CF9zl+UBnvjxmcPnokJRy0JKjc1SlHSzzhx1HcL4jitTQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "grznnTJgEYxaWpdKAsTzg6j+89jHgCXWYp+QGtlX5O92+w/VuhWM6JLPYb+uw8M9VhGUvOTsO76dYOy9vNPd5Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "ywTQKt32xnVhCzjEQAqFufpEyXkOUfvW/EC/s4xnS8Xaor2xXE+TMUyzhgACqXtZEU5IR95y94RDzHto55Fx7w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyModel": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "BX45SeAjP6sz9Djg6Gm0/IruBuWkyUKxtr4pn9sLAuprnuRn+VBPZVH2XxpzbaT7cVCPim3+Dkijl6yhLHjBOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "PRv1SPyrgl/ullMF6eKDuEULRkTc10fVcnWvzFhqIMDA3m5f91znKH9ZNsKZBgu4xVc4ulNt7TEXyyt0rdlB3g==",
+        "resolved": "10.0.11",
+        "contentHash": "vUl798SmruTqqlt/xH2gDk3tJlhk6k3HdOXAHirlRfbNKDym4g/kRpUL9S4sl6F6FsOTOMW+ZsDapqlZMOOiEw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "9.0.11"
+          "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "9.0.11",
-        "contentHash": "J77oUeVZXdMoiUiCPkL4v13KrNRuMQnSHHw78cTh/2ZidyiMFm8jhu49OUKvNydMUX8ZcuM5g8uohW18YaglMw==",
+        "resolved": "10.0.11",
+        "contentHash": "el1g0mBEbDBGY2bT9mcSfrTWO8QlPdq2nOCnvQugioOFwHV+bVBMeiakoI0dNOdj8d6Hi9K6HY2xzRUWJiDR3w==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "9.0.11",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.11",
-          "Microsoft.Extensions.Options": "9.0.11",
-          "Microsoft.Extensions.Primitives": "9.0.11"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "tuSqNuiJxlln43sZ8c1EDA4WXit1eX4foGadylXso3DnMVc+DtKfaNEwvHuiFXfPsEUZ6Z3GnF0Bfk9vvOsE4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.ObjectPool": "10.0.11"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -276,6 +428,14 @@
         "resolved": "10.0.11",
         "contentHash": "/a1aJz4m7ylhEDf25ugQChLQoN5XwoGjWw/BoR/ZWWKsO1v4DdJElS1uyngahz4B/eOzjFk1KNTkarRLE5wsIg=="
       },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "hO/IpudHBl+EMXm1Ag8+7ersCN7VuiR6ech1+cVk8I+o7ssPRKdTozIAO4HGPt49G/lY6lo7G2kY5Q00biMHew==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11"
+        }
+      },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.11",
@@ -299,6 +459,30 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
           "Microsoft.Extensions.Options": "10.0.11"
         }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "Cyp36W6/XHD6sSDnbc6Ss7M+qOcjrer400Dx4Tfkb5OHcKV6bp9uMqZ4Y8PAoSwTfS8a/3lB9xCF+CLf0JGUig==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "4x6y2Uy+g9Ou93eBCVkG/3JCwnc2AMKhrE1iuEhXT/MzNN7co/Zt6yL+q1Srt0CnOe3iLX+sVqpJI4ZGlOPfug==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
@@ -362,6 +546,15 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.11",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "jxxGX3bUe0ZZFtkMaigIJG44aGK6toE0EFhQwPYfTGLHw4EgXgceO8+RAdXZakK4BezpeDhR//6cxqmtae0I9Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Telemetry": "10.9.0"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -443,6 +636,11 @@
           "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "p76ztQFROBOlHgdV1vXfmTjRyu073Av7ZlsiLR93ka6+nzkLCeV2ONXq0DO/BGf71REqGW29Uy/20fzQHAjB7Q=="
+      },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
         "resolved": "10.0.11",
@@ -469,6 +667,42 @@
         "resolved": "10.0.11",
         "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
       },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "LXMTKZGNzs3fsjKytTVeIEdp+yssJon7PW3VbxERZeqALA2Za/AQzt2h6K64PZ2NzgfFnX4rCJp6aTe+ocX83A==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.9.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.9.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "RpV3VzPa1YoHqvE2Q4uOuVjioVJhLOhaz4FXIE3XAEvla4qujnM+wFB7QnTAmIJxlg7lbBslkIHJQzpI8yHDQQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.9.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.9.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.11",
+          "Microsoft.Extensions.ObjectPool": "10.0.11",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.9.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "rCyM64XvBNi2IY/5noMVsJjt22zVmnI+8tGrb6JnPRW/75Nyv9Hi+7gkxb7zQcR0+2mzS1sAqPXz2PsdHZCqHg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.9.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.ObjectPool": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
         "resolved": "4.84.2",
@@ -488,10 +722,10 @@
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
         "type": "Transitive",
-        "resolved": "4.78.0",
-        "contentHash": "DYU9o+DrDQuyZxeq91GBA9eNqBvA3ZMkLzQpF7L9dTk6FcIBM1y1IHXWqiKXTvptPF7CZE59upbyUoa+FJ5eiA==",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
         "dependencies": {
-          "Microsoft.Identity.Client": "4.78.0",
+          "Microsoft.Identity.Client": "4.83.1",
           "System.Security.Cryptography.ProtectedData": "4.5.0"
         }
       },
@@ -547,6 +781,11 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Microsoft.IdentityModel.Logging": "8.22.0"
         }
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.6.3",
+        "contentHash": "N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA=="
       },
       "Microsoft.SqlServer.Server": {
         "type": "Transitive",
@@ -604,10 +843,73 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.16",
+        "contentHash": "nonu9l0YrZH6krVYbskBjE7uG0VMAnvOQ9PU+RmzUsy+++vHkqzzCkHRoP877OiA3iRTxJyNDLfpcU8hrJ3/YQ=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "RabbitMQ.Client": {
+        "type": "Transitive",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
+        "dependencies": {
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
       "SharpZipLib": {
         "type": "Transitive",
         "resolved": "1.4.2",
         "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SQLite": {
+        "type": "Transitive",
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
+      },
+      "SQLitePCLRaw.config.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
+        "dependencies": {
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "3.0.5"
+        }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
@@ -616,11 +918,13 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.8.0",
-        "contentHash": "AqRzhn0v29GGGLj/Z6gKq4lGNtvPHT4nHdG5PDJh9IfVjv/nYUVmX11hwwws1vDFeIAzrvmn0dPu8IjLtu6fAw==",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "System.Memory.Data": "8.0.1"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
         }
       },
       "System.Configuration.ConfigurationManager": {
@@ -637,10 +941,15 @@
         "resolved": "10.0.11",
         "contentHash": "QTXEoQBzz00SFWbo7nAg1Ogd4f99lwqcO9uAJ7MYSLEUR28f6As32QktrqG2Fr9cfAfd1GjLyGYspE7Ipj7P6w=="
       },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg=="
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -656,6 +965,11 @@
         "type": "Transitive",
         "resolved": "9.0.11",
         "contentHash": "s8yUYuYYu+PAwvBdhLG1KyrGrk9gkYeuPxfAsXsTqqWyepwSyEw8hAaflW4nO98NG52YpYI1am2+9o+79h2RtQ=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "Testcontainers": {
         "type": "Transitive",
@@ -729,6 +1043,23 @@
           "xunit.v3.runner.common": "[4.0.0]"
         }
       },
+      "mmca.common.api": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.2.1, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.2.1, )",
+          "Asp.Versioning.OpenApi": "[10.2.2, )",
+          "AspNet.Security.OAuth.GitHub": "[10.0.0, )",
+          "MMCA.Common.Application": "[1.0.0, )",
+          "MMCA.Common.Infrastructure": "[1.0.0, )",
+          "Microsoft.AspNetCore.Authentication.Google": "[10.0.11, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.11, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.11, )",
+          "Microsoft.FeatureManagement.AspNetCore": "[4.6.0, )",
+          "Microsoft.OpenApi": "[2.12.0, )",
+          "Scalar.AspNetCore": "[2.16.20, )"
+        }
+      },
       "mmca.common.application": {
         "type": "Project",
         "dependencies": {
@@ -746,6 +1077,31 @@
           "MMCA.Common.Shared": "[1.0.0, )"
         }
       },
+      "mmca.common.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
+          "Azure.Storage.Blobs": "[12.29.1, )",
+          "Cronos": "[0.13.0, )",
+          "MMCA.Common.Application": "[1.0.0, )",
+          "MassTransit": "[8.5.10, )",
+          "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
+          "MassTransit.RabbitMQ": "[8.5.10, )",
+          "MessagePack": "[2.5.302, )",
+          "Microsoft.AspNetCore.SignalR.StackExchangeRedis": "[10.0.11, )",
+          "Microsoft.Azure.NotificationHubs": "[4.2.0, )",
+          "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.11, )",
+          "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.11, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.11, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.9.0, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
+          "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
+          "Polly.Core": "[8.7.0, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StackExchange.Redis": "[2.13.17, )"
+        }
+      },
       "mmca.common.shared": {
         "type": "Project"
       },
@@ -753,6 +1109,7 @@
         "type": "Project",
         "dependencies": {
           "AwesomeAssertions": "[9.5.0, )",
+          "MMCA.Common.API": "[1.0.0, )",
           "MMCA.Common.Application": "[1.0.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.11, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.11, )",
@@ -767,16 +1124,65 @@
           "xunit.v3.extensibility.core": "[4.0.0, )"
         }
       },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.1, )",
+        "resolved": "10.2.1",
+        "contentHash": "fMzUraYZOAobKQn2PffrgPsULbCWFeWroYRYndPasxPsiQl1+i8x5qYRuMYZAbzDrBnymPUMBxT2gZG2PwbkcQ==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.2.1"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.1, )",
+        "resolved": "10.2.1",
+        "contentHash": "Tv1megkpUy+3FN9yfVJKIcYMLXTe5CPs4zftBxGaZhADJe6h9CJZ2Okh5cG4PoE7wzHTef+AK++8IuZta3Ppog==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.2.1"
+        }
+      },
+      "Asp.Versioning.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.2, )",
+        "resolved": "10.2.2",
+        "contentHash": "pY5nhVFGuMBBbzN3v0oW6Pn4NQR8AxZuuWWkDxkWOxHp5rtCSvpphaWDgWeZ59z3yuTI45pPHit1+0d8oDcRsg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc.ApiExplorer": "10.2.1",
+          "Microsoft.AspNetCore.OpenApi": "10.0.10",
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
+        }
+      },
+      "AspNet.Security.OAuth.GitHub": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "PbOrAso/hlCS2p3YHHq94C5W/6851xyMT8ZEkAc3eGQNlsu3Siwu/D98nzCKyOKmB+KNu9MirWpmO66PmEIexQ=="
+      },
       "Azure.Identity": {
         "type": "CentralTransitive",
         "requested": "[1.21.0, )",
-        "resolved": "1.17.1",
-        "contentHash": "MSZkBrctcpiGxs9Cvr2VKKoN6qFLZlP3I6xuCWJ9iTgitI5Rgxtk5gfOSpXPZE3+CJmZ/mnqpQyGyjawFn5Vvg==",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
         "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.78.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.78.0"
+          "Azure.Core": "1.53.0"
         }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.29.1, )",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
       },
       "FluentValidation.DependencyInjectionExtensions": {
         "type": "CentralTransitive",
@@ -787,6 +1193,57 @@
           "FluentValidation": "12.1.1",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
         }
+      },
+      "MassTransit": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "TGi34UA8RftBIpYCHEdoIP5uSu2/pLWZRen4RUcg4CV1nr8MmCZMuFYjzvXXUyFcj0ZuRQxZZNhG7fB5/raSOg==",
+        "dependencies": {
+          "MassTransit.Abstractions": "8.5.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "MassTransit.Azure.ServiceBus.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "pXA+Vk/VB+s/0PeL4iht3q3VzxirbLNuSWnDDvEIFBfQdZpY28ZD/l2+6PTcVj6KvJH9nkqzlI7mnMw2pEYKPQ==",
+        "dependencies": {
+          "Azure.Identity": "1.21.0",
+          "Azure.Messaging.ServiceBus": "7.20.1",
+          "MassTransit": "8.5.10"
+        }
+      },
+      "MassTransit.RabbitMQ": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "5aQGpJpeqRhRv+htkXfi6MfWu0dj/4Lcf1c6h2J3tYZClupGklqB1ixlP3IRdZExrH9BI/60uYoxR+7pg3s1oQ==",
+        "dependencies": {
+          "MassTransit": "8.5.10",
+          "RabbitMQ.Client": "7.2.1"
+        }
+      },
+      "MessagePack": {
+        "type": "CentralTransitive",
+        "requested": "[2.5.302, )",
+        "resolved": "2.5.302",
+        "contentHash": "5DZsKli4dMEpm/glcMAheuO8/IesfaTskbfsuvgnQwWFKS5FN7Z6yNx+5F+UW94E+9N2qt8Zs63/XVzpLsElgA==",
+        "dependencies": {
+          "MessagePack.Annotations": "2.5.302",
+          "Microsoft.NET.StringTools": "17.6.3"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Google": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "v/OZld8HxGa5hudLWiChuCf5asMrE36n19sR1RK5cC65SGJoYvQAcwnz3yoAOLDSw90PYc3hgFCh1FW83sakUg=="
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",
@@ -808,6 +1265,36 @@
           "Microsoft.Extensions.Hosting": "10.0.11"
         }
       },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "R/1EATnPLU+gRfB6lwVkMcymmyAY5ppBBdRN/5lhNEiT3xP1sWccuSFkU/f1lQvN/WgRq5Vn8AhCdE3fqgsL/w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "bo7fagrKzIkwBTnzYXwPSqkV/JLALw22QYSwVnizsrHkiV7txWmIrsWxm8Qe3uRTZbxnykBUOnnC3ZavGtlqRg==",
+        "dependencies": {
+          "MessagePack": "2.5.302",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
+      "Microsoft.Azure.NotificationHubs": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "LOCxFB/sB1frfuXjecdDRDKEHkH+I1qKRatS5NyWIgYhpKhIcAlPNIJajcwLgQBShckdc3hMG9E+75CnL3qDhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "6.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
       "Microsoft.Data.SqlClient": {
         "type": "CentralTransitive",
         "requested": "[6.1.6, )",
@@ -826,6 +1313,59 @@
           "System.Configuration.ConfigurationManager": "9.0.11",
           "System.IdentityModel.Tokens.Jwt": "7.7.1",
           "System.Security.Cryptography.Pkcs": "9.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Cosmos": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "Bx8MAu44K23LK7UQvG+iwkYcgHIUnd/G1cFeQX5sk9JzNO9E1fZebGWfLjfk90ii08MUilMmP5wcDOSlkJwFqw==",
+        "dependencies": {
+          "Microsoft.Azure.Cosmos": "3.61.0",
+          "Microsoft.EntityFrameworkCore": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Newtonsoft.Json": "13.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "jc7iVrhQyInR3loraMESfEFaFOtQOB1mRKHjX6QYC9o7YDbfMNbAPnIwlpffnFwhXd6/27FKaaV+sWSoLd4F1g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyModel": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.12",
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "LClSs5cNN6za2Uk7IeH7RAP4Qe5EMXxFsD9i53ncPx21TVg04IEjoFyxvvsSNkq2/Ux9HyJsJ2qEO8Tl7Gcrrg==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.6",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "D0tHRbUCliInxTfPgN9K6RxrCVaWu9kyIT66vbIJ/YwA6BV2xa8vTqoE3JQXA2Rf2vRdgd29+HR6Ay6KmzDslw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -849,6 +1389,31 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11"
         }
       },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "ujx8RvcKzkxPFBguwgiygbwWVHVK0P7HFlNJ6I0JBRb28tzwe42jixBoA+dGmqG9IHepPVcm04vv2IDnU93ekA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "loWrGc0mZt6N91IV+PZQeNU4uvb2vHdKgU9pUo8i2SGix9edTNCVhwzBp3gWJeaXeoPMph6F9xXcXF4W2ePpRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.9.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.11",
+          "Microsoft.Extensions.Resilience": "10.9.0"
+        }
+      },
       "Microsoft.FeatureManagement": {
         "type": "CentralTransitive",
         "requested": "[4.6.0, )",
@@ -862,6 +1427,21 @@
           "Microsoft.Extensions.Logging": "8.0.1"
         }
       },
+      "Microsoft.FeatureManagement.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "+0G11gpuGqggJ7nrB7jL/oT4bsRVqnM5q6+qgC5sO2oW4JWymXoUAkDNsuLsMB9La9Ota248x8dwhoL2erImwQ==",
+        "dependencies": {
+          "Microsoft.FeatureManagement": "4.6.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.12.0, )",
+        "resolved": "2.12.0",
+        "contentHash": "0xB/be+f6qYOhvQPUrVsLrau+fkowYv6gt9RIkajMhwT7sZnqtcA797yW3bS5kgSje+AQW4xZgyLnW641YFioQ=="
+      },
       "MiniProfiler.AspNetCore.Mvc": {
         "type": "CentralTransitive",
         "requested": "[4.5.4, )",
@@ -871,11 +1451,33 @@
           "MiniProfiler.AspNetCore": "4.5.4"
         }
       },
+      "MiniProfiler.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.4, )",
+        "resolved": "4.5.4",
+        "contentHash": "SSOuBYtNbM8AMmsYMP6Edr7iBfVYzswVt/yoIDboBRLLUgkA4SyROCJuTTtZ8eJSzlNuq5DIR+BLCCcigaV/vw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.11",
+          "MiniProfiler.Shared": "4.5.4"
+        }
+      },
+      "Polly.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.7.0, )",
+        "resolved": "8.7.0",
+        "contentHash": "BS2t+nsBer16PIebCEPNBK5fgMisADQyRCd7K+BgkMWpFmSaiYE+rVVNpFhGRqUkJmNSLmw0uCNzHHWfgml28Q=="
+      },
       "Respawn": {
         "type": "CentralTransitive",
         "requested": "[7.0.0, )",
         "resolved": "7.0.0",
         "contentHash": "AyWlducZGOnmlEVz4PaL3Qv8wcY3ClPZS9CrlDnSVahGd/E9tTEgSFiC8yoV/F6o6P6IYm8xnHFa/vmWT8tfcw=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.16.20, )",
+        "resolved": "2.16.20",
+        "contentHash": "pSmyME4FCnYocbLmn9lmAUTVVSEPb5E6noqRcmJYpO65eaum68gw17yMORbeckW+gMksiL04m+zXoTxOKv0+kQ=="
       },
       "Scrutor": {
         "type": "CentralTransitive",
@@ -887,6 +1489,22 @@
           "Microsoft.Extensions.DependencyModel": "10.0.0"
         }
       },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.5, )",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
+        "dependencies": {
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
+        }
+      },
       "SSH.NET": {
         "type": "CentralTransitive",
         "requested": "[2026.0.0, )",
@@ -895,6 +1513,17 @@
         "dependencies": {
           "BouncyCastle.Cryptography": "2.7.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.13.17, )",
+        "resolved": "2.13.17",
+        "contentHash": "P7o7ZDBAmBrOLQEw8Pt44iIA08ioj48smRxn4Jp6yzCu6P3DOSU6lj7f+IOtN3pPvSgC9YufvM92ycukEEBCYQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.16",
+          "System.IO.Hashing": "10.0.2"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/Presentation/MMCA.Common.API.Tests/Startup/MiddlewarePipelineBuilderTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Startup/MiddlewarePipelineBuilderTests.cs
@@ -1,0 +1,273 @@
+using AwesomeAssertions;
+using MMCA.Common.API.Startup;
+
+namespace MMCA.Common.API.Tests.Startup;
+
+/// <summary>
+/// Unit tests for the named-step edge pipeline builder: the default order, the insert/replace/remove
+/// operations a host uses to customize it, and the load-bearing invariants
+/// <see cref="MiddlewarePipelineBuilder.Build"/> re-checks so a customized pipeline fails at startup
+/// rather than misrouting at runtime.
+/// </summary>
+public sealed class MiddlewarePipelineBuilderTests
+{
+    private static readonly string[] DefaultOrder =
+    [
+        MiddlewarePipelineStepNames.ExceptionHandler,
+        MiddlewarePipelineStepNames.CorrelationId,
+        MiddlewarePipelineStepNames.RequestLocalization,
+        MiddlewarePipelineStepNames.PreForwardedCapture,
+        MiddlewarePipelineStepNames.ForwardedHeaders,
+        MiddlewarePipelineStepNames.HttpsRedirection,
+        MiddlewarePipelineStepNames.ResponseCompression,
+        MiddlewarePipelineStepNames.Routing,
+        MiddlewarePipelineStepNames.Cors,
+        MiddlewarePipelineStepNames.Authentication,
+        MiddlewarePipelineStepNames.TenantResolution,
+        MiddlewarePipelineStepNames.RateLimiting,
+        MiddlewarePipelineStepNames.SoftDeletedUserFilter,
+        MiddlewarePipelineStepNames.Authorization,
+        MiddlewarePipelineStepNames.OutputCache,
+        MiddlewarePipelineStepNames.JwksEndpoint,
+        MiddlewarePipelineStepNames.OidcDiscoveryEndpoint,
+        MiddlewarePipelineStepNames.Controllers,
+    ];
+
+    // ── Defaults ──
+    [Fact]
+    public void CreateDefault_SeedsTheDocumentedStepOrder() =>
+        MiddlewarePipelineBuilder.CreateDefault().StepNames.Should().Equal(DefaultOrder);
+
+    [Fact]
+    public void CreateDefault_BuildsWithoutViolatingAnyInvariant() =>
+        MiddlewarePipelineBuilder.CreateDefault().Build().Select(step => step.Name).Should().Equal(DefaultOrder);
+
+    [Fact]
+    public void CreateDefault_ReturnsAnIndependentBuilderEachCall()
+    {
+        var first = MiddlewarePipelineBuilder.CreateDefault().Remove(MiddlewarePipelineStepNames.OutputCache);
+
+        first.StepNames.Should().NotContain(MiddlewarePipelineStepNames.OutputCache);
+        MiddlewarePipelineBuilder.CreateDefault().StepNames.Should().Contain(MiddlewarePipelineStepNames.OutputCache);
+    }
+
+    // ── Mutation operations ──
+    [Fact]
+    public void InsertBefore_PlacesTheStepImmediatelyBeforeTheAnchor()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .InsertBefore(MiddlewarePipelineStepNames.Routing, Step("Tracing"));
+
+        builder.StepNames.Should().ContainInConsecutiveOrder(
+            MiddlewarePipelineStepNames.ResponseCompression, "Tracing", MiddlewarePipelineStepNames.Routing);
+    }
+
+    [Fact]
+    public void InsertAfter_PlacesTheStepImmediatelyAfterTheAnchor()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .InsertAfter(MiddlewarePipelineStepNames.Routing, Step("Tracing"));
+
+        builder.StepNames.Should().ContainInConsecutiveOrder(
+            MiddlewarePipelineStepNames.Routing, "Tracing", MiddlewarePipelineStepNames.Cors);
+    }
+
+    [Fact]
+    public void Replace_SwapsTheStepAndKeepsItsPosition()
+    {
+        var replaced = false;
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .Replace(MiddlewarePipelineStepNames.ResponseCompression, new MiddlewarePipelineStep("BrotliOnly", _ => replaced = true));
+
+        builder.StepNames.Should().ContainInConsecutiveOrder(
+            MiddlewarePipelineStepNames.HttpsRedirection, "BrotliOnly", MiddlewarePipelineStepNames.Routing);
+        builder.StepNames.Should().NotContain(MiddlewarePipelineStepNames.ResponseCompression);
+        replaced.Should().BeFalse(because: "the step delegate runs only when the pipeline is applied to an application");
+    }
+
+    [Fact]
+    public void Replace_KeepingTheSameName_IsAllowed()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .Replace(MiddlewarePipelineStepNames.OutputCache, Step(MiddlewarePipelineStepNames.OutputCache));
+
+        builder.StepNames.Should().Equal(DefaultOrder);
+    }
+
+    [Fact]
+    public void Remove_DropsTheStep()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault().Remove(MiddlewarePipelineStepNames.OutputCache);
+
+        builder.StepNames.Should().NotContain(MiddlewarePipelineStepNames.OutputCache);
+        builder.StepNames.Should().HaveCount(DefaultOrder.Length - 1);
+    }
+
+    [Fact]
+    public void MutationOperations_ReturnTheSameBuilder_ForChaining()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+
+        builder.InsertAfter(MiddlewarePipelineStepNames.Routing, Step("Tracing")).Should().BeSameAs(builder);
+        builder.Remove("Tracing").Should().BeSameAs(builder);
+    }
+
+    // ── Unknown anchors and duplicate names ──
+    [Theory]
+    [InlineData("Nope")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void InsertBefore_WithUnknownAnchor_Throws(string unknownAnchor)
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var insert = () => builder.InsertBefore(unknownAnchor, Step("Tracing"));
+
+        insert.Should().Throw<ArgumentException>().WithParameterName("anchor");
+    }
+
+    [Fact]
+    public void InsertAfter_WithUnknownAnchor_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var insert = () => builder.InsertAfter("Nope", Step("Tracing"));
+
+        insert.Should().Throw<ArgumentException>().WithParameterName("anchor");
+    }
+
+    [Fact]
+    public void Replace_WithUnknownName_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var replace = () => builder.Replace("Nope", Step("Tracing"));
+
+        replace.Should().Throw<ArgumentException>().WithParameterName("name");
+    }
+
+    [Fact]
+    public void Remove_WithUnknownName_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var remove = () => builder.Remove("Nope");
+
+        remove.Should().Throw<ArgumentException>().WithParameterName("name");
+    }
+
+    [Fact]
+    public void InsertBefore_WithDuplicateStepName_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var insert = () => builder.InsertBefore(
+            MiddlewarePipelineStepNames.Routing, Step(MiddlewarePipelineStepNames.Cors));
+
+        insert.Should().Throw<ArgumentException>().WithParameterName("step");
+    }
+
+    [Fact]
+    public void InsertAfter_WithDuplicateStepName_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var insert = () => builder.InsertAfter(
+            MiddlewarePipelineStepNames.Routing, Step(MiddlewarePipelineStepNames.Cors));
+
+        insert.Should().Throw<ArgumentException>().WithParameterName("step");
+    }
+
+    [Fact]
+    public void Replace_WithAnotherStepsName_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var replace = () => builder.Replace(
+            MiddlewarePipelineStepNames.OutputCache, Step(MiddlewarePipelineStepNames.Cors));
+
+        replace.Should().Throw<ArgumentException>().WithParameterName("step");
+    }
+
+    [Fact]
+    public void MiddlewarePipelineStep_RejectsABlankNameAndANullDelegate()
+    {
+        var blankName = () => new MiddlewarePipelineStep(" ", static _ => { });
+        var nullConfigure = () => new MiddlewarePipelineStep("Tracing", null!);
+
+        blankName.Should().Throw<ArgumentException>();
+        nullConfigure.Should().Throw<ArgumentNullException>();
+    }
+
+    // ── Invariants ──
+    [Fact]
+    public void Build_WhenPreForwardedCaptureIsNotImmediatelyBeforeForwardedHeaders_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .InsertBefore(MiddlewarePipelineStepNames.ForwardedHeaders, Step("Intruder"));
+        var build = () => builder.Build();
+
+        build.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*'{MiddlewarePipelineStepNames.PreForwardedCapture}' must run immediately before '{MiddlewarePipelineStepNames.ForwardedHeaders}'*");
+    }
+
+    [Fact]
+    public void Build_WhenAuthenticationIsNotImmediatelyBeforeTenantResolution_Throws()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .InsertAfter(MiddlewarePipelineStepNames.Authentication, Step("Intruder"));
+        var build = () => builder.Build();
+
+        build.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*'{MiddlewarePipelineStepNames.Authentication}' must run immediately before '{MiddlewarePipelineStepNames.TenantResolution}'*");
+    }
+
+    [Fact]
+    public void Build_WhenAuthenticationDoesNotPrecedeRateLimiting_Throws()
+    {
+        // Move authentication (and the tenant resolution that must stay glued to it) after the limiter.
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .Remove(MiddlewarePipelineStepNames.Authentication)
+            .Remove(MiddlewarePipelineStepNames.TenantResolution)
+            .InsertAfter(MiddlewarePipelineStepNames.RateLimiting, Step(MiddlewarePipelineStepNames.TenantResolution))
+            .InsertBefore(MiddlewarePipelineStepNames.TenantResolution, Step(MiddlewarePipelineStepNames.Authentication));
+        var build = () => builder.Build();
+
+        build.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*'{MiddlewarePipelineStepNames.Authentication}' must run before '{MiddlewarePipelineStepNames.RateLimiting}'*");
+    }
+
+    [Fact]
+    public void Build_WhenForwardedHeadersDoesNotPrecedeHttpsRedirection_Throws()
+    {
+        // Move the HTTPS redirect ahead of the capture/forwarded-headers pair, keeping that pair adjacent.
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .Remove(MiddlewarePipelineStepNames.HttpsRedirection)
+            .InsertBefore(MiddlewarePipelineStepNames.PreForwardedCapture, Step(MiddlewarePipelineStepNames.HttpsRedirection));
+        var build = () => builder.Build();
+
+        build.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*'{MiddlewarePipelineStepNames.ForwardedHeaders}' must run before '{MiddlewarePipelineStepNames.HttpsRedirection}'*");
+    }
+
+    [Fact]
+    public void Build_WhenBothMembersOfAGuardedPairAreRemoved_Succeeds()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault()
+            .Remove(MiddlewarePipelineStepNames.PreForwardedCapture)
+            .Remove(MiddlewarePipelineStepNames.ForwardedHeaders)
+            .Remove(MiddlewarePipelineStepNames.Authentication)
+            .Remove(MiddlewarePipelineStepNames.TenantResolution)
+            .Remove(MiddlewarePipelineStepNames.RateLimiting);
+        var build = () => builder.Build();
+
+        build.Should().NotThrow(
+            because: "an invariant binds only when both of the steps it names are present, so dropping a whole capability stays legal");
+    }
+
+    [Fact]
+    public void Build_ReturnsAnImmutableSnapshotOfTheSteps()
+    {
+        var builder = MiddlewarePipelineBuilder.CreateDefault();
+        var steps = builder.Build();
+
+        builder.Remove(MiddlewarePipelineStepNames.OutputCache);
+
+        steps.Select(step => step.Name).Should().Equal(DefaultOrder);
+    }
+
+    private static MiddlewarePipelineStep Step(string name) => new(name, static _ => { });
+}


### PR DESCRIPTION
## Summary

Retires the two costs ADR-079 records for `UseCommonMiddlewarePipeline()`: nothing froze the edge order, and the escape hatch was all-or-nothing.

- **The order is data.** `MiddlewarePipelineBuilder.CreateDefault()` seeds the 18 named steps (`MiddlewarePipelineStepNames`), each carrying its original body and ordering comment verbatim. A new `UseCommonMiddlewarePipeline(Action<MiddlewarePipelineBuilder>)` overload lets a host `InsertBefore`/`InsertAfter`/`Replace`/`Remove` by step name; `Build()` re-validates the four load-bearing adjacencies (pre-forwarded capture immediately before forwarded headers, authentication immediately before tenant resolution, authentication before the rate limiter per ADR-019, forwarded headers before the HTTPS redirect) so a misordered pipeline fails at startup, not at the first misrouted request. An invariant binds only when both of its steps are present.
- **The order is frozen.** `MiddlewarePipelineOrderTestsBase` in `MMCA.Common.Testing` is the edge counterpart of `DecoratorPipelineOrderTestsBase`: it asserts the documented step sequence (plus invariant validation) and is subclassed in Common's own test pass. Consumer repos subclass it in their Architecture.Tests projects after the next release.
- **Zero behavior change on the default path.** The zero-arg overload keeps its exact signature and applies the same middleware in the same order with the same conditionals; no host code changes.

`MMCA.Common.Testing` now references `MMCA.Common.API` (needed to see the builder type); packages stay lockstep so consumers are unaffected.

## Test plan

- Full `dotnet test --solution MMCA.Common.slnx -c Release`: 3767/3767 pass.
- 25 new builder tests (order, mutation ops, unknown anchor, duplicate names, each invariant violation, removing a whole guarded pair stays legal) + the sealed conformance subclass.
- Negative check performed: swapping two steps in `CreateDefault()` turned `EdgePipeline_OrdersSteps_InDocumentedOrder` red; reverted.
- FACTS drift gate clean (the base lives in `MMCA.Common.Testing`, outside the counted `Testing.Architecture` set, matching the decorator precedent).

Follow-ups (separate PRs): ADR-079 revision + Article 07 update in their own repos; consumer subclasses ride the next release sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013G5LXsQC9639YshGTeZghs