### PR TITLE
release: v1.158.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
-## [Unreleased]
+## [1.158.0] - 2026-08-21
 
 ### Added
 


### PR DESCRIPTION
Retitles the Unreleased CHANGELOG section for v1.158.0: the named-step middleware edge pipeline (order as data, scoped configure overload with startup-validated invariants, MiddlewarePipelineOrderTestsBase fitness function; ADR-079 revision). Source landed in #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013G5LXsQC9639YshGTeZghs