### PR TITLE
feat: event upcaster registration extension point (ADR-010 follow-up, ADR-090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [Unreleased]
+
+### Added
+
+- **Event upcaster registration extension point (ADR-010, ADR-090).** The consumer-side half of the
+  event-schema versioning policy now ships as a mechanism instead of a convention:
+  `IEventUpcaster<TSource, TTarget>` (a pure payload mapping from a retired integration-event
+  contract to its successor) plus `services.AddEventUpcaster<TSource, TTarget, TUpcaster>()`.
+  Upcasters accumulate across modules into an `IEventUpcasterRegistry` that follows chains
+  (V1 to V2 to V3) to the terminal contract and preserves `MessageId` and `DateOccurred` across
+  every hop, so inbox deduplication keys stay stable by construction. Misconfiguration (duplicate
+  source types, self-maps, cycles) fails at host startup with the offending types named, not on the
+  first message.
+- **Both delivery paths honor registered upcasters.** In-process (monolith) dispatch upcasts inside
+  `DomainEventDispatcher` before selecting integration handlers, which also covers outbox rows
+  written before an upgrade. Broker hosts drain a retired contract with
+  `RegisterUpcastedIntegrationEventConsumer<TOld>()`, a dedicated MassTransit consumer that upcasts
+  to the terminal type and dispatches its handlers; handlers are written once, against the newest
+  contract only.
+- **Two new event fitness functions** in `MMCA.Common.Testing.Architecture`, inherited automatically
+  by every `EventConventionTestsBase` subclass: no two upcasters may share a source type, and an
+  upcaster's target must declare a strictly higher `SchemaVersion` than its source.
+
 ## [1.158.0] - 2026-08-21
 
 ### Added

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-08-21 (framework v1.158.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-08-22 (framework v1.158.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -41,10 +41,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **104 test methods across 36 abstract `*TestsBase` classes**, shipped once in the
+- **106 test methods across 36 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **99** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **105** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Core/MMCA.Common.Application/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Application/DependencyInjection.cs
@@ -10,6 +10,7 @@ using MMCA.Common.Application.UseCases;
 using MMCA.Common.Application.UseCases.Decorators;
 using MMCA.Common.Application.Users.UseCases.ExportUserData;
 using MMCA.Common.Application.Validation;
+using MMCA.Common.Domain.Interfaces;
 using MMCA.Common.Shared.Abstractions;
 
 namespace MMCA.Common.Application;
@@ -31,6 +32,13 @@ public static class DependencyInjection
             services.TryAddSingleton<IApplicationSettings>(sp => sp.GetRequiredService<IOptions<ApplicationSettings>>().Value);
 
             services.TryAddSingleton<IDomainEventDispatcher, DomainEventDispatcher>();
+
+            // Composed view of every AddEventUpcaster registration. Always registered: with no
+            // upcasters it is an empty registry whose operations are identity, and both delivery paths
+            // (this dispatcher and the broker-side UpcastingIntegrationEventConsumer) can then depend
+            // on it unconditionally (ADR-090).
+            services.TryAddSingleton<IEventUpcasterRegistry, EventUpcasterRegistry>();
+
             services.TryAddSingleton<INavigationMetadataProvider, NavigationMetadataProvider>();
             services.TryAddSingleton<IEntityQueryPipeline, EntityQueryPipeline>();
 
@@ -234,6 +242,50 @@ public static class DependencyInjection
         {
             services.TryAddScoped<TSection>();
             services.TryAddEnumerable(ServiceDescriptor.Scoped<IUserDataExportSection, TSection>());
+            return services;
+        }
+
+        /// <summary>
+        /// Registers one <see cref="IEventUpcaster{TSource, TTarget}"/> implementation, so a message
+        /// still published (or still queued) as the retired contract <typeparamref name="TSource"/> is
+        /// delivered to the handlers written against its successor <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The retired event contract.</typeparam>
+        /// <typeparam name="TTarget">The successor event contract. Must declare a higher <c>SchemaVersion</c>.</typeparam>
+        /// <typeparam name="TUpcaster">The upcaster implementation.</typeparam>
+        /// <returns>The service collection for chaining.</returns>
+        /// <remarks>
+        /// <para>
+        /// ADR-010 makes a breaking event-shape change a NEW event type plus a consumer-side upcaster;
+        /// this is the registration extension point for that policy (ADR-090). Registrations accumulate
+        /// through <c>TryAddEnumerable</c>, the same idiom as <see cref="AddUserDataExportSection{TSection}"/>
+        /// and the scheduled-job registry, and the same type registered twice is added once.
+        /// </para>
+        /// <para>
+        /// <b>Singleton</b>, because upcasters are pure functions over an event instance, matching the
+        /// handler lifetimes they feed. <typeparamref name="TSource"/> and <typeparamref name="TTarget"/>
+        /// are named explicitly so the compiler checks the shape at the registration site instead of
+        /// leaving a mismatch to fail at runtime.
+        /// </para>
+        /// <para>
+        /// Chains compose: registering V1 to V2 and V2 to V3 delivers a V1 message to the V3 handler.
+        /// Registering two upcasters for one source, mapping a type onto itself, or forming a cycle
+        /// fails the host at startup with an exception naming the offenders.
+        /// </para>
+        /// <para>
+        /// A monolith host needs only this call. A host that also consumes the retired contract over a
+        /// broker adds <c>x.RegisterUpcastedIntegrationEventConsumer&lt;TSource&gt;()</c> beside its
+        /// <c>x.RegisterIntegrationEventConsumer&lt;TTarget&gt;()</c>. Once every producer publishes the
+        /// successor and the queues have drained, delete the upcaster, both registrations and
+        /// eventually the retired type.
+        /// </para>
+        /// </remarks>
+        public IServiceCollection AddEventUpcaster<TSource, TTarget, TUpcaster>()
+            where TSource : class, IIntegrationEvent
+            where TTarget : class, IIntegrationEvent
+            where TUpcaster : class, IEventUpcaster<TSource, TTarget>
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IEventUpcaster, TUpcaster>());
             return services;
         }
 

--- a/Source/Core/MMCA.Common.Application/Interfaces/IEventUpcaster.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/IEventUpcaster.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics.CodeAnalysis;
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Application.Interfaces;
+
+/// <summary>
+/// Non-generic view of an event upcaster: converts one retired integration-event contract into its
+/// successor. The framework resolves every registration through this interface (the registry indexes
+/// by <see cref="SourceType"/> and walks chains by <see cref="TargetType"/>); application code
+/// implements the typed <see cref="IEventUpcaster{TSource, TTarget}"/> instead, which supplies these
+/// members as default interface implementations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ADR-010 makes a breaking event-shape change (a renamed, removed or retyped field) a NEW event
+/// type plus a consumer-side upcaster, never a silent reshape of an existing type. ADR-090 is the
+/// registration extension point: <c>services.AddEventUpcaster&lt;TOld, TNew, TUpcaster&gt;()</c> for
+/// the in-process path, plus <c>x.RegisterUpcastedIntegrationEventConsumer&lt;TOld&gt;()</c> when the
+/// retired contract still arrives over a broker.
+/// </para>
+/// <para>
+/// <b>Map payload fields only.</b> The framework preserves the envelope: after every hop the registry
+/// stamps <c>MessageId</c> and <c>DateOccurred</c> from the pre-hop instance onto the upcasted one, so
+/// inbox deduplication keeps working on the id the producer published. An upcaster that copies them
+/// itself is harmless (the stamp is idempotent), and one that forgets is still correct.
+/// </para>
+/// </remarks>
+public interface IEventUpcaster
+{
+    /// <summary>Gets the retired event contract this upcaster reads.</summary>
+    Type SourceType { get; }
+
+    /// <summary>Gets the successor event contract this upcaster produces.</summary>
+    Type TargetType { get; }
+
+    /// <summary>
+    /// Converts an instance of <see cref="SourceType"/> into an instance of <see cref="TargetType"/>.
+    /// </summary>
+    /// <param name="integrationEvent">The event to convert. Must be an instance of <see cref="SourceType"/>.</param>
+    /// <returns>The upcasted event.</returns>
+    IIntegrationEvent Upcast(IIntegrationEvent integrationEvent);
+}
+
+/// <summary>
+/// Converts the retired integration-event contract <typeparamref name="TSource"/> into its successor
+/// <typeparamref name="TTarget"/>, so handlers are written once against the newest contract while
+/// older messages (queued at the broker, or sitting unprocessed in an outbox written before the
+/// upgrade) keep being delivered.
+/// </summary>
+/// <typeparam name="TSource">The retired event contract.</typeparam>
+/// <typeparam name="TTarget">The successor event contract. Must declare a higher <c>SchemaVersion</c>.</typeparam>
+/// <remarks>
+/// <para>
+/// Implementations are pure functions and are registered as singletons:
+/// <c>services.AddEventUpcaster&lt;ProductVariantChanged, ProductVariantChangedV2, ProductVariantChangedUpcaster&gt;()</c>.
+/// Chains compose: registering V1 to V2 and V2 to V3 delivers a V1 message to the V3 handler.
+/// </para>
+/// <para>
+/// Map payload fields only. The registry preserves <c>MessageId</c> and <c>DateOccurred</c> across
+/// every hop, so consumer-side inbox deduplication stays keyed on the id the producer published.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Design",
+    "CA1033:Interface methods should be callable by child types",
+    Justification = "A default interface implementation of an inherited member can only be written as an explicit implementation; there is no non-explicit form. Implementers supply the typed Upcast overload and the framework consumes SourceType/TargetType through the IEventUpcaster interface, which is how the registry indexes them.")]
+public interface IEventUpcaster<in TSource, out TTarget> : IEventUpcaster
+    where TSource : class, IIntegrationEvent
+    where TTarget : class, IIntegrationEvent
+{
+    /// <inheritdoc />
+    Type IEventUpcaster.SourceType => typeof(TSource);
+
+    /// <inheritdoc />
+    Type IEventUpcaster.TargetType => typeof(TTarget);
+
+    /// <summary>
+    /// Converts <paramref name="integrationEvent"/> into the successor contract.
+    /// </summary>
+    /// <param name="integrationEvent">The retired-contract event to convert.</param>
+    /// <returns>The upcasted event. Never <see langword="null"/>.</returns>
+    TTarget Upcast(TSource integrationEvent);
+
+    /// <inheritdoc />
+    IIntegrationEvent IEventUpcaster.Upcast(IIntegrationEvent integrationEvent) =>
+        Upcast((TSource)integrationEvent);
+}

--- a/Source/Core/MMCA.Common.Application/Interfaces/IEventUpcasterRegistry.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/IEventUpcasterRegistry.cs
@@ -1,0 +1,49 @@
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Application.Interfaces;
+
+/// <summary>
+/// The composed view of every registered <see cref="IEventUpcaster"/>: resolves the terminal (newest)
+/// contract for a retired event type and converts an instance to it, walking the whole chain when
+/// several versions are registered (V1 to V2 to V3).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a singleton by <c>AddApplication()</c> and consumed by both delivery paths: the
+/// in-process <c>DomainEventDispatcher</c> and the broker-side
+/// <c>UpcastingIntegrationEventConsumer&lt;TEvent&gt;</c>. A host that registers no upcaster gets an
+/// empty registry whose methods are identity operations (ADR-090).
+/// </para>
+/// <para>
+/// The implementation validates the registration graph in its constructor (duplicate source, a
+/// source mapped onto itself, or a cycle throw <see cref="InvalidOperationException"/> naming the
+/// offenders), and an internal startup validator resolves it at host start so a misconfiguration
+/// fails the host rather than the first message.
+/// </para>
+/// </remarks>
+public interface IEventUpcasterRegistry
+{
+    /// <summary>
+    /// Returns whether any upcaster claims <paramref name="eventType"/> as its source contract.
+    /// </summary>
+    /// <param name="eventType">The event type to probe.</param>
+    /// <returns><see langword="true"/> when a registered upcaster reads this type.</returns>
+    bool HasUpcasterFor(Type eventType);
+
+    /// <summary>
+    /// Resolves the terminal (newest) contract <paramref name="eventType"/> upcasts to, following the
+    /// whole chain. Returns <paramref name="eventType"/> itself when no upcaster claims it.
+    /// </summary>
+    /// <param name="eventType">The event type to resolve.</param>
+    /// <returns>The terminal event type.</returns>
+    Type ResolveTerminalType(Type eventType);
+
+    /// <summary>
+    /// Upcasts <paramref name="integrationEvent"/> to its terminal contract, applying every hop in
+    /// the chain and preserving the envelope (<c>MessageId</c>, <c>DateOccurred</c>) at each one.
+    /// Returns the original instance when no upcaster claims its type.
+    /// </summary>
+    /// <param name="integrationEvent">The event to upcast.</param>
+    /// <returns>The terminal-contract instance.</returns>
+    IIntegrationEvent UpcastToTerminal(IIntegrationEvent integrationEvent);
+}

--- a/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
@@ -1,1 +1,18 @@
 #nullable enable
+MMCA.Common.Application.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddEventUpcaster<TSource, TTarget, TUpcaster>() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.Application.Interfaces.IEventUpcaster
+MMCA.Common.Application.Interfaces.IEventUpcaster.SourceType.get -> System.Type!
+MMCA.Common.Application.Interfaces.IEventUpcaster.TargetType.get -> System.Type!
+MMCA.Common.Application.Interfaces.IEventUpcaster.Upcast(MMCA.Common.Domain.Interfaces.IIntegrationEvent! integrationEvent) -> MMCA.Common.Domain.Interfaces.IIntegrationEvent!
+MMCA.Common.Application.Interfaces.IEventUpcaster<TSource, TTarget>
+MMCA.Common.Application.Interfaces.IEventUpcaster<TSource, TTarget>.Upcast(TSource! integrationEvent) -> TTarget!
+MMCA.Common.Application.Interfaces.IEventUpcasterRegistry
+MMCA.Common.Application.Interfaces.IEventUpcasterRegistry.HasUpcasterFor(System.Type! eventType) -> bool
+MMCA.Common.Application.Interfaces.IEventUpcasterRegistry.ResolveTerminalType(System.Type! eventType) -> System.Type!
+MMCA.Common.Application.Interfaces.IEventUpcasterRegistry.UpcastToTerminal(MMCA.Common.Domain.Interfaces.IIntegrationEvent! integrationEvent) -> MMCA.Common.Domain.Interfaces.IIntegrationEvent!
+MMCA.Common.Application.Services.EventUpcasterRegistry
+MMCA.Common.Application.Services.EventUpcasterRegistry.EventUpcasterRegistry(System.Collections.Generic.IEnumerable<MMCA.Common.Application.Interfaces.IEventUpcaster!>! upcasters) -> void
+MMCA.Common.Application.Services.EventUpcasterRegistry.HasUpcasterFor(System.Type! eventType) -> bool
+MMCA.Common.Application.Services.EventUpcasterRegistry.ResolveTerminalType(System.Type! eventType) -> System.Type!
+MMCA.Common.Application.Services.EventUpcasterRegistry.UpcastToTerminal(MMCA.Common.Domain.Interfaces.IIntegrationEvent! integrationEvent) -> MMCA.Common.Domain.Interfaces.IIntegrationEvent!
+static MMCA.Common.Application.DependencyInjection.AddEventUpcaster<TSource, TTarget, TUpcaster>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/Source/Core/MMCA.Common.Application/Services/DomainEventDispatcher.cs
+++ b/Source/Core/MMCA.Common.Application/Services/DomainEventDispatcher.cs
@@ -12,10 +12,25 @@ namespace MMCA.Common.Application.Services;
 /// and integration events to all registered <see cref="IIntegrationEventHandler{T}"/> instances.
 /// Uses compiled expression trees cached per event type to avoid repeated reflection
 /// when invoking the generic <c>HandleAsync</c> method on each handler.
+/// <para>
+/// The integration branch runs the event through <see cref="IEventUpcasterRegistry"/> first, so a
+/// retired contract reaches the handlers written against its successor (ADR-090). That also covers
+/// outbox rows written before an upgrade, which deserialize back into the old type. The
+/// <see cref="IDomainEventHandler{T}"/> branch is deliberately untouched: intra-module handlers keep
+/// receiving the original type and instance.
+/// </para>
 /// </summary>
 public sealed class DomainEventDispatcher(IServiceProvider serviceProvider, ILogger<DomainEventDispatcher> logger) : IDomainEventDispatcher
 {
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+
+    /// <summary>
+    /// The upcaster registry, resolved on first use and cached. <c>GetService</c> rather than
+    /// <c>GetRequiredService</c>: this dispatcher is constructed directly in tests and in bare
+    /// providers that never called <c>AddApplication()</c>, and no registry simply means no upcasting.
+    /// </summary>
+    private readonly Lazy<IEventUpcasterRegistry?> _upcasterRegistry =
+        new(serviceProvider.GetService<IEventUpcasterRegistry>);
 
     /// <summary>
     /// Caches the closed handler interface type and its compiled invoker keyed by
@@ -40,8 +55,14 @@ public sealed class DomainEventDispatcher(IServiceProvider serviceProvider, ILog
             await DispatchToHandlersAsync(eventType, typeof(IDomainEventHandler<>), domainEvent, cancellationToken).ConfigureAwait(false);
 
             // If the event also implements IIntegrationEvent, dispatch to IIntegrationEventHandler<T> (cross-module handlers).
-            if (domainEvent is IIntegrationEvent)
-                await DispatchToHandlersAsync(eventType, typeof(IIntegrationEventHandler<>), domainEvent, cancellationToken).ConfigureAwait(false);
+            // A registered upcaster chain converts a retired contract to its terminal successor first,
+            // so the handlers are the ones written against the newest type.
+            if (domainEvent is IIntegrationEvent integrationEvent)
+            {
+                var terminalEvent = _upcasterRegistry.Value?.UpcastToTerminal(integrationEvent) ?? integrationEvent;
+
+                await DispatchToHandlersAsync(terminalEvent.GetType(), typeof(IIntegrationEventHandler<>), terminalEvent, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/Source/Core/MMCA.Common.Application/Services/EventUpcasterRegistry.cs
+++ b/Source/Core/MMCA.Common.Application/Services/EventUpcasterRegistry.cs
@@ -1,0 +1,187 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Application.Services;
+
+/// <summary>
+/// Default <see cref="IEventUpcasterRegistry"/>: indexes every registered <see cref="IEventUpcaster"/>
+/// by its source contract, precomputes the terminal type of each chain, and preserves the event
+/// envelope across hops.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Validation is constructor-time.</b> Two upcasters claiming the same source, an upcaster mapping
+/// a type onto itself, or a chain that forms a cycle are all programming errors, so they throw
+/// <see cref="InvalidOperationException"/> naming the offenders rather than returning a
+/// <c>Result</c> (the permission-registry precedent). The chain graph is static once DI is built, so
+/// terminal types are resolved once here instead of per message.
+/// </para>
+/// <para>
+/// <b>Envelope preservation is the registry's job, not the author's.</b> After each hop
+/// <c>MessageId</c> and <c>DateOccurred</c> are stamped from the pre-hop instance onto the upcasted
+/// one through cached <see cref="PropertyInfo"/> handles (both are <c>init</c>-only on
+/// <c>BaseDomainEvent</c>, which reflection can still set). That keeps consumer-side inbox
+/// deduplication keyed on the id the producer published, by construction: upcasters map payload
+/// fields only, and one that copies the envelope itself simply gets the same values written twice.
+/// </para>
+/// </remarks>
+public sealed class EventUpcasterRegistry : IEventUpcasterRegistry
+{
+    /// <summary>
+    /// Caches the writable envelope properties per upcast target type. Keyed by the runtime type of
+    /// the instance an upcaster produced, so a chain pays the reflection lookup once per contract.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Type, (PropertyInfo? MessageId, PropertyInfo? DateOccurred)> EnvelopeProperties = new();
+
+    private readonly Dictionary<Type, IEventUpcaster> _bySourceType;
+    private readonly Dictionary<Type, Type> _terminalTypes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventUpcasterRegistry"/> class and validates the
+    /// registration graph.
+    /// </summary>
+    /// <param name="upcasters">Every upcaster registered through <c>AddEventUpcaster</c>.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when two upcasters claim the same source type, an upcaster maps a type onto itself, or
+    /// the chain forms a cycle. The message names the offending types.
+    /// </exception>
+    public EventUpcasterRegistry(IEnumerable<IEventUpcaster> upcasters)
+    {
+        ArgumentNullException.ThrowIfNull(upcasters);
+
+        _bySourceType = [];
+        var offenders = new List<string>();
+
+        foreach (var upcaster in upcasters)
+        {
+            if (upcaster.SourceType == upcaster.TargetType)
+            {
+                offenders.Add($"{Describe(upcaster)} maps {Describe(upcaster.SourceType)} onto itself");
+                continue;
+            }
+
+            if (_bySourceType.TryGetValue(upcaster.SourceType, out var existing))
+            {
+                offenders.Add($"{Describe(upcaster.SourceType)} is claimed by both {Describe(existing)} and {Describe(upcaster)}");
+                continue;
+            }
+
+            _bySourceType.Add(upcaster.SourceType, upcaster);
+        }
+
+        if (offenders.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Invalid event upcaster registration: " + string.Join("; ", offenders)
+                + ". Exactly one upcaster may claim a source contract, and it must produce a different one.");
+        }
+
+        _terminalTypes = BuildTerminalTypes(_bySourceType);
+    }
+
+    /// <inheritdoc />
+    public bool HasUpcasterFor(Type eventType)
+    {
+        ArgumentNullException.ThrowIfNull(eventType);
+
+        return _bySourceType.ContainsKey(eventType);
+    }
+
+    /// <inheritdoc />
+    public Type ResolveTerminalType(Type eventType)
+    {
+        ArgumentNullException.ThrowIfNull(eventType);
+
+        return _terminalTypes.TryGetValue(eventType, out var terminalType) ? terminalType : eventType;
+    }
+
+    /// <inheritdoc />
+    public IIntegrationEvent UpcastToTerminal(IIntegrationEvent integrationEvent)
+    {
+        ArgumentNullException.ThrowIfNull(integrationEvent);
+
+        var current = integrationEvent;
+        var currentType = integrationEvent.GetType();
+
+        // The walk advances by the upcaster's DECLARED target type, not the runtime type of what it
+        // returned, so the constructor's acyclicity check is what bounds this loop.
+        while (_bySourceType.TryGetValue(currentType, out var upcaster))
+        {
+            var upcasted = upcaster.Upcast(current)
+                ?? throw new InvalidOperationException(
+                    $"{Describe(upcaster)} returned null upcasting {Describe(currentType)}; an upcaster must always produce an instance.");
+
+            PreserveEnvelope(current, upcasted);
+
+            current = upcasted;
+            currentType = upcaster.TargetType;
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Resolves the terminal type of every registered chain up front, failing on a cycle. The graph is
+    /// functional (the constructor already rejected duplicate sources), so a repeated type on a walk
+    /// is a cycle rather than a diamond.
+    /// </summary>
+    /// <param name="bySourceType">The validated source-to-upcaster index.</param>
+    /// <returns>A source-type to terminal-type map.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a chain forms a cycle.</exception>
+    private static Dictionary<Type, Type> BuildTerminalTypes(Dictionary<Type, IEventUpcaster> bySourceType)
+    {
+        var terminalTypes = new Dictionary<Type, Type>();
+
+        foreach (var sourceType in bySourceType.Keys)
+        {
+            var visited = new HashSet<Type> { sourceType };
+            var chain = new List<Type> { sourceType };
+            var currentType = sourceType;
+
+            while (bySourceType.TryGetValue(currentType, out var upcaster))
+            {
+                currentType = upcaster.TargetType;
+                chain.Add(currentType);
+
+                if (!visited.Add(currentType))
+                {
+                    throw new InvalidOperationException(
+                        "Invalid event upcaster registration: the chain forms a cycle ("
+                        + string.Join(" -> ", chain.Select(Describe))
+                        + "). Upcasting must move forward to a newer contract and terminate.");
+                }
+            }
+
+            terminalTypes.Add(sourceType, currentType);
+        }
+
+        return terminalTypes;
+    }
+
+    /// <summary>
+    /// Stamps the envelope of <paramref name="source"/> onto <paramref name="target"/> so the upcasted
+    /// instance keeps the identity the producer published.
+    /// </summary>
+    /// <param name="source">The pre-hop instance.</param>
+    /// <param name="target">The instance the upcaster produced.</param>
+    private static void PreserveEnvelope(IIntegrationEvent source, IIntegrationEvent target)
+    {
+        var (messageId, dateOccurred) = EnvelopeProperties.GetOrAdd(
+            target.GetType(),
+            static type => (
+                Writable(type.GetProperty(nameof(IDomainEvent.MessageId), BindingFlags.Public | BindingFlags.Instance)),
+                Writable(type.GetProperty(nameof(IDomainEvent.DateOccurred), BindingFlags.Public | BindingFlags.Instance))));
+
+        messageId?.SetValue(target, source.MessageId);
+        dateOccurred?.SetValue(target, source.DateOccurred);
+    }
+
+    private static PropertyInfo? Writable(PropertyInfo? property) =>
+        property is { CanWrite: true } ? property : null;
+
+    private static string Describe(IEventUpcaster upcaster) => Describe(upcaster.GetType());
+
+    private static string Describe(Type type) => type.FullName ?? type.Name;
+}

--- a/Source/Core/MMCA.Common.Domain/DomainEvents/BaseIntegrationEvent.cs
+++ b/Source/Core/MMCA.Common.Domain/DomainEvents/BaseIntegrationEvent.cs
@@ -18,6 +18,16 @@ public abstract record class BaseIntegrationEvent : BaseDomainEvent, IIntegratio
     /// upcaster — never a silent reshape of an existing type. Concrete events bump it by overriding:
     /// <c>public override int SchemaVersion =&gt; 2;</c>. Declaring this <see langword="virtual"/> with a
     /// default keeps adding the member a non-breaking change for every existing event (they stay v1).
+    /// <para>
+    /// The upcaster is a registration, not a convention (ADR-090): the module registers
+    /// <c>services.AddEventUpcaster&lt;FooV1, FooV2, FooUpcaster&gt;()</c>, and a host that also receives
+    /// the retired contract over a broker adds
+    /// <c>x.RegisterUpcastedIntegrationEventConsumer&lt;FooV1&gt;()</c> beside its
+    /// <c>x.RegisterIntegrationEventConsumer&lt;FooV2&gt;()</c>. Handlers are then written once, against
+    /// the newest contract; the framework preserves <c>MessageId</c> and <c>DateOccurred</c> across
+    /// every hop, so inbox deduplication is unaffected. A fitness function requires the upcast target
+    /// to declare a HIGHER <c>SchemaVersion</c> than its source.
+    /// </para>
     /// </summary>
     public virtual int SchemaVersion => 1;
 }

--- a/Source/Core/MMCA.Common.Domain/IntegrationEvents/OutputCacheEvictionRequested.cs
+++ b/Source/Core/MMCA.Common.Domain/IntegrationEvents/OutputCacheEvictionRequested.cs
@@ -17,7 +17,11 @@ namespace MMCA.Common.Domain.IntegrationEvents;
 /// else. Every host that consumes it must be able to deserialize it forever, so treat any change as
 /// a versioning decision (ADR-010): additive optional fields keep <c>SchemaVersion</c> at 1, and a
 /// rename, removal or retype requires a new event type plus a consumer-side upcaster, never a
-/// silent reshape.
+/// silent reshape. That upcaster is registered with
+/// <c>services.AddEventUpcaster&lt;OutputCacheEvictionRequested, OutputCacheEvictionRequestedV2, ...&gt;()</c>,
+/// and every host still receiving the old contract over a broker adds
+/// <c>x.RegisterUpcastedIntegrationEventConsumer&lt;OutputCacheEvictionRequested&gt;()</c> until the
+/// queues drain (ADR-090).
 /// </para>
 /// </summary>
 public sealed record class OutputCacheEvictionRequested : BaseIntegrationEvent

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -147,6 +147,13 @@ public static class DependencyInjection
                 .ValidateOnStart();
             services.TryAddSingleton<IJwksProvider, RsaJwksProvider>();
 
+            // Fails the host at start on a bad event-upcaster registration graph (duplicate source,
+            // self-map, cycle) instead of dead-lettering the first retired-contract message.
+            // TryAddEnumerable, not AddHostedService: two modules calling AddInfrastructure must not
+            // run the same validation twice.
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IHostedService, EventUpcasterStartupValidator>());
+
             services.TryAddSingleton<Persistence.Outbox.IOutboxSignal, Persistence.Outbox.OutboxSignal>();
             services.AddHostedService<Persistence.Outbox.OutboxProcessor>();
             services.AddHostedService<Persistence.Outbox.OutboxCleanupService>();

--- a/Source/Core/MMCA.Common.Infrastructure/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Infrastructure/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+MMCA.Common.Infrastructure.Services.IntegrationEventConsumerExtensions.extension(MassTransit.IBusRegistrationConfigurator!).RegisterUpcastedIntegrationEventConsumer<TEvent>(bool registerFaultConsumer = true) -> MassTransit.IBusRegistrationConfigurator!
+MMCA.Common.Infrastructure.Services.UpcastingIntegrationEventConsumer<TEvent>
+MMCA.Common.Infrastructure.Services.UpcastingIntegrationEventConsumer<TEvent>.Consume(MassTransit.ConsumeContext<TEvent!>! context) -> System.Threading.Tasks.Task!
+MMCA.Common.Infrastructure.Services.UpcastingIntegrationEventConsumer<TEvent>.UpcastingIntegrationEventConsumer(MMCA.Common.Application.Interfaces.IEventUpcasterRegistry! upcasters, System.IServiceProvider! serviceProvider, MMCA.Common.Infrastructure.Persistence.Inbox.IInboxStore! inbox, Microsoft.Extensions.Logging.ILogger<MMCA.Common.Infrastructure.Services.UpcastingIntegrationEventConsumer<TEvent!>!>! logger) -> void
+static MMCA.Common.Infrastructure.Services.IntegrationEventConsumerExtensions.RegisterUpcastedIntegrationEventConsumer<TEvent>(this MassTransit.IBusRegistrationConfigurator! x, bool registerFaultConsumer = true) -> MassTransit.IBusRegistrationConfigurator!

--- a/Source/Core/MMCA.Common.Infrastructure/Services/EventUpcasterStartupValidator.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/EventUpcasterStartupValidator.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Infrastructure.Services;
+
+/// <summary>
+/// Forces the event-upcaster registration graph to be validated at host start rather than on the
+/// first message. <see cref="IEventUpcasterRegistry"/>'s implementation validates in its constructor
+/// (duplicate source, a type mapped onto itself, a cycle), so simply resolving it is the check: a
+/// misconfigured host fails to start with an exception naming the offenders, instead of dead-lettering
+/// events hours later.
+/// <para>
+/// Registered by <c>AddInfrastructure</c> through <c>TryAddEnumerable</c>, so several modules calling
+/// it do not run the validation several times. A host with no upcasters resolves an empty registry and
+/// this costs one no-op call (ADR-090).
+/// </para>
+/// </summary>
+/// <param name="upcasters">The registry whose construction performs the validation.</param>
+internal sealed class EventUpcasterStartupValidator(IEventUpcasterRegistry upcasters) : IHostedService
+{
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Reading one member keeps the injected registry load-bearing: the work happened in its
+        // constructor, and this call is what makes the dependency impossible to elide.
+        _ = upcasters.ResolveTerminalType(typeof(IIntegrationEvent));
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/Source/Core/MMCA.Common.Infrastructure/Services/IntegrationEventConsumerExtensions.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/IntegrationEventConsumerExtensions.cs
@@ -50,6 +50,46 @@ public static class IntegrationEventConsumerExtensions
         }
 
         /// <summary>
+        /// Registers a MassTransit consumer for a RETIRED contract <typeparamref name="TEvent"/> that
+        /// upcasts each message to its terminal successor and delegates to the
+        /// <see cref="MMCA.Common.Application.Interfaces.IIntegrationEventHandler{T}"/> implementations
+        /// registered for THAT contract. Use it while the old type is still being published or is still
+        /// sitting in a queue, so handlers only ever have to exist for the newest contract (ADR-090).
+        /// <para>
+        /// Pair it with <c>services.AddEventUpcaster&lt;TEvent, TNew, TUpcaster&gt;()</c>, which supplies
+        /// the conversion, and with a plain
+        /// <c>RegisterIntegrationEventConsumer&lt;TNew&gt;()</c> for the current contract. Do NOT also
+        /// register the plain consumer for <typeparamref name="TEvent"/>: two consumers on one event
+        /// compete for the same queue and would run the handlers twice.
+        /// </para>
+        /// <para>
+        /// With no upcaster registered for <typeparamref name="TEvent"/> this degrades to ordinary
+        /// handler dispatch on the original type, so the registration is safe to add before the
+        /// upcaster exists and safe to leave in place for one release after it is deleted. Once the
+        /// queues have drained, remove this call, the upcaster, and eventually the retired type.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TEvent">The retired integration event type to drain.</typeparam>
+        /// <param name="registerFaultConsumer">
+        /// Whether to also register <see cref="FaultIntegrationEventConsumer{TEvent}"/> for this event.
+        /// Same meaning as on <c>RegisterIntegrationEventConsumer&lt;TEvent&gt;</c>; defaults to
+        /// <see langword="true"/>.
+        /// </param>
+        public IBusRegistrationConfigurator RegisterUpcastedIntegrationEventConsumer<TEvent>(
+            bool registerFaultConsumer = true)
+            where TEvent : class, IIntegrationEvent
+        {
+            x.AddConsumer<UpcastingIntegrationEventConsumer<TEvent>>();
+
+            if (registerFaultConsumer)
+            {
+                x.AddConsumer<FaultIntegrationEventConsumer<TEvent>>();
+            }
+
+            return x;
+        }
+
+        /// <summary>
         /// Registers the consumer for <see cref="OutputCacheEvictionRequested"/>, the framework's
         /// cross-service output-cache eviction broadcast. Shorthand for
         /// <c>RegisterIntegrationEventConsumer&lt;OutputCacheEvictionRequested&gt;()</c>, named so the

--- a/Source/Core/MMCA.Common.Infrastructure/Services/UpcastingIntegrationEventConsumer.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/UpcastingIntegrationEventConsumer.cs
@@ -1,0 +1,167 @@
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Domain.Interfaces;
+using MMCA.Common.Infrastructure.Persistence.Inbox;
+
+namespace MMCA.Common.Infrastructure.Services;
+
+/// <summary>
+/// Draining consumer for a RETIRED integration-event contract: binds the broker queue to
+/// <typeparamref name="TEvent"/>, upcasts each message to its terminal contract through
+/// <see cref="IEventUpcasterRegistry"/>, and invokes the handlers registered for THAT contract.
+/// <para>
+/// It exists so handlers are written once, against the newest event type, while producers that still
+/// publish the old one (and messages already queued at the upgrade) keep being delivered. Register it
+/// per retired type through <c>RegisterUpcastedIntegrationEventConsumer&lt;TEvent&gt;</c>; the current
+/// contract keeps using the plain <see cref="IntegrationEventConsumer{TEvent}"/>. Do NOT register both
+/// consumers for the same type: they would compete for one queue and run the handlers twice.
+/// </para>
+/// <para>
+/// Deduplication stays keyed on the ORIGINAL message id: the registry preserves the envelope across
+/// every upcast hop, so a redelivery of the same broker message is recognised whatever contract the
+/// handlers ultimately see. With no upcaster registered for <typeparamref name="TEvent"/> this
+/// degrades to plain handler dispatch on the original type (ADR-090).
+/// </para>
+/// </summary>
+/// <typeparam name="TEvent">The retired integration event type this queue is bound to.</typeparam>
+public sealed partial class UpcastingIntegrationEventConsumer<TEvent>(
+    IEventUpcasterRegistry upcasters,
+    IServiceProvider serviceProvider,
+    IInboxStore inbox,
+    ILogger<UpcastingIntegrationEventConsumer<TEvent>> logger) : IConsumer<TEvent>
+    where TEvent : class, IIntegrationEvent
+{
+    /// <summary>
+    /// Caches the closed handler interface and its compiled invoker per terminal event type. The
+    /// terminal type is only known at runtime (it depends on which upcasters the host registered), so
+    /// handler resolution is non-generic; the compiled expression keeps reflection off the per-message
+    /// path exactly as <c>DomainEventDispatcher</c> does for the in-process path.
+    /// </summary>
+    private static readonly ConcurrentDictionary<
+        Type,
+        (Type ClosedHandlerType, Func<object, object, CancellationToken, Task> Invoker)> DispatchCache = new();
+
+    /// <inheritdoc />
+    public async Task Consume(ConsumeContext<TEvent> context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var integrationEvent = context.Message;
+
+        // Dedup on the ORIGINAL message id, before any upcasting: the envelope survives every hop, so
+        // this is the same id a plain IntegrationEventConsumer<TEvent> would have recorded.
+        var messageId = integrationEvent.MessageId;
+
+        if (await inbox.AlreadyProcessedAsync(messageId, context.CancellationToken).ConfigureAwait(false))
+        {
+            LogDuplicateSkipped(logger, typeof(TEvent).Name, messageId);
+            return;
+        }
+
+        if (!upcasters.HasUpcasterFor(typeof(TEvent)))
+        {
+            // Degrade path: the host registered this consumer but no upcaster for the type, so the
+            // registry returns the instance untouched and the handlers for TEvent run as usual.
+            LogNoUpcaster(logger, typeof(TEvent).Name);
+        }
+
+        var terminalEvent = upcasters.UpcastToTerminal(integrationEvent);
+        var terminalType = terminalEvent.GetType();
+
+        if (terminalType != typeof(TEvent))
+        {
+            LogUpcasted(logger, typeof(TEvent).Name, terminalType.Name, messageId);
+        }
+
+        var (closedHandlerType, invoker) = DispatchCache.GetOrAdd(
+            terminalType,
+            static eventType => (
+                typeof(IIntegrationEventHandler<>).MakeGenericType(eventType),
+                BuildInvoker(eventType)));
+
+        var handlerCount = 0;
+
+        foreach (var handler in serviceProvider.GetServices(closedHandlerType))
+        {
+            if (handler is null)
+            {
+                continue;
+            }
+
+            handlerCount++;
+
+            try
+            {
+                await invoker(handler, terminalEvent, context.CancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Rethrow so MassTransit applies the UseMessageRetry policy configured in
+                // ConfigureBrokerTransport before the message is dead-lettered. Logging here gives
+                // operators visibility into which handler failed without losing the exception.
+                LogHandlerFailure(logger, ex, terminalType.Name, handler.GetType().FullName ?? "<unknown>");
+                throw;
+            }
+        }
+
+        if (handlerCount == 0)
+        {
+            // No handler registered for the terminal contract in this process. Returning normally lets
+            // MassTransit ack the message; the broker will not retry.
+            LogNoHandlers(logger, terminalType.Name, typeof(TEvent).Name);
+        }
+
+        // Record processing AFTER handlers succeed so a handler failure (which rethrows above) leaves
+        // the message un-recorded and eligible for MassTransit redelivery.
+        await inbox.MarkProcessedAsync(messageId, typeof(TEvent).Name, context.CancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds a compiled delegate that invokes <c>HandleAsync</c> on
+    /// <c>IIntegrationEventHandler&lt;TTerminal&gt;</c> without boxing or reflection at call time. The
+    /// expression tree casts the <see langword="object"/> parameters to their concrete types, then
+    /// calls the strongly-typed method directly.
+    /// </summary>
+    /// <param name="eventType">The terminal event type to build the invoker for.</param>
+    /// <returns>A delegate that accepts (handler, event, cancellationToken) as objects.</returns>
+    private static Func<object, object, CancellationToken, Task> BuildInvoker(Type eventType)
+    {
+        var closedHandlerType = typeof(IIntegrationEventHandler<>).MakeGenericType(eventType);
+        var method = closedHandlerType.GetMethod("HandleAsync")
+            ?? throw new InvalidOperationException($"HandleAsync method not found on {closedHandlerType.Name}");
+
+        // Build: (object handler, object integrationEvent, CancellationToken ct) =>
+        //     ((IIntegrationEventHandler<TEvent>)handler).HandleAsync((TEvent)integrationEvent, ct)
+        var handlerParam = Expression.Parameter(typeof(object), "handler");
+        var eventParam = Expression.Parameter(typeof(object), "integrationEvent");
+        var ctParam = Expression.Parameter(typeof(CancellationToken), "ct");
+
+        var call = Expression.Call(
+            Expression.Convert(handlerParam, closedHandlerType),
+            method,
+            Expression.Convert(eventParam, eventType),
+            ctParam);
+
+        return Expression.Lambda<Func<object, object, CancellationToken, Task>>(
+            call, handlerParam, eventParam, ctParam).Compile();
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Integration event {EventType} (message {MessageId}) already processed, skipping (idempotent inbox)")]
+    private static partial void LogDuplicateSkipped(ILogger logger, string eventType, Guid messageId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Upcasted broker message {MessageId} from retired contract {EventType} to {TerminalEventType}")]
+    private static partial void LogUpcasted(ILogger logger, string eventType, string terminalEventType, Guid messageId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "No IEventUpcaster registered for {EventType}; UpcastingIntegrationEventConsumer is dispatching to handlers of the original contract")]
+    private static partial void LogNoUpcaster(ILogger logger, string eventType);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "No IIntegrationEventHandler<{TerminalEventType}> registered in this process for upcasted {EventType}, broker message acked without action")]
+    private static partial void LogNoHandlers(ILogger logger, string terminalEventType, string eventType);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Integration event handler {HandlerType} failed for {EventType}; MassTransit will apply the configured retry policy before dead-lettering")]
+    private static partial void LogHandlerFailure(ILogger logger, Exception ex, string eventType, string handlerType);
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Upcasters.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Upcasters.cs
@@ -1,0 +1,107 @@
+using System.Runtime.CompilerServices;
+
+namespace MMCA.Common.Testing.Architecture;
+
+public static partial class ArchitectureRules
+{
+    /// <summary>
+    /// No two event upcasters claim the same source contract (ADR-090). The upcast chain has to be a
+    /// function: with two upcasters reading one type, which handler sees the message would depend on
+    /// DI registration order.
+    /// </summary>
+    public static void EventUpcastersHaveUniqueSourceTypes(IArchitectureMap map)
+    {
+        var violations = EventUpcasters(map)
+            .GroupBy(u => u.Source)
+            .Where(g => g.Skip(1).Any())
+            .Select(g => $"  - {Describe(g.Key)} is upcast by {string.Join(", ", g.Select(u => Describe(u.Upcaster)).Order(StringComparer.Ordinal))}: exactly one upcaster may claim a source contract");
+
+        ArchitectureAssert.NoViolations(violations,
+            "an integration event may have at most one upcaster reading it, otherwise the contract a handler receives depends on DI registration order (ADR-090)");
+    }
+
+    /// <summary>
+    /// Every event upcaster moves FORWARD: the target contract declares a higher <c>SchemaVersion</c>
+    /// than the source (ADR-010 plus ADR-090). A target at the same or a lower version means the new
+    /// type is not actually a successor, and the chain can never be reasoned about as a version ladder.
+    /// </summary>
+    public static void EventUpcastersIncreaseSchemaVersion(IArchitectureMap map)
+    {
+        var violations = new List<string>();
+
+        foreach (var (upcaster, source, target) in EventUpcasters(map))
+        {
+            var sourceVersion = SchemaVersionOf(source);
+            var targetVersion = SchemaVersionOf(target);
+
+            // A missing or non-int SchemaVersion is the business of
+            // IntegrationEventsDeclareSchemaVersion; this rule only judges the ordering.
+            if (sourceVersion is null || targetVersion is null)
+            {
+                continue;
+            }
+
+            if (targetVersion <= sourceVersion)
+            {
+                violations.Add(
+                    $"  - {Describe(upcaster)} upcasts {source.Name} (SchemaVersion {sourceVersion}) to {target.Name} (SchemaVersion {targetVersion}): the target must declare a HIGHER SchemaVersion");
+            }
+        }
+
+        ArchitectureAssert.NoViolations(violations,
+            "an upcaster converts a retired contract into its successor, so the target must declare a higher SchemaVersion than the source (ADR-010, ADR-090)");
+    }
+
+    /// <summary>
+    /// Enumerates the event upcasters the map OWNS, scoped exactly like the integration events
+    /// themselves: a module-bearing (consumer) map scans only module assemblies, while the framework's
+    /// own module-less map scans every layer.
+    /// </summary>
+    private static IEnumerable<(Type Upcaster, Type Source, Type Target)> EventUpcasters(IArchitectureMap map)
+    {
+        var includeFrameworkLayers = map.ModuleNames.Count == 0;
+        return map.Layers
+            .Where(l => includeFrameworkLayers || l.Module.Length > 0)
+            .Select(l => l.Assembly)
+            .Distinct()
+            .SelectMany(a => a.ConcreteClasses)
+            .Where(t => !t.ContainsGenericParameters)
+            .Select(t => (Upcaster: t, Contract: UpcasterContract(t)))
+            .Where(x => x.Contract is not null)
+            .Select(x => (
+                x.Upcaster,
+                Source: x.Contract!.GetGenericArguments()[0],
+                Target: x.Contract!.GetGenericArguments()[1]));
+    }
+
+    /// <summary>
+    /// Matches <c>IEventUpcaster&lt;TSource, TTarget&gt;</c> by name and arity, so the rule library
+    /// keeps its no-compile-dependency idiom.
+    /// </summary>
+    private static Type? UpcasterContract(Type type) =>
+        type.GetInterfaces().FirstOrDefault(i =>
+            i.IsGenericType && string.Equals(i.Name, "IEventUpcaster`2", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Reads the declared <c>SchemaVersion</c> off an event contract without running a constructor:
+    /// the property is a get-only virtual returning a literal, so an uninitialized instance answers
+    /// correctly and no event needs a parameterless factory just to be inspected.
+    /// </summary>
+    private static int? SchemaVersionOf(Type eventType)
+    {
+        if (eventType.IsAbstract || eventType.IsInterface || eventType.ContainsGenericParameters)
+        {
+            return null;
+        }
+
+        var property = eventType.GetProperty("SchemaVersion", BindingFlags.Public | BindingFlags.Instance);
+        if (property?.PropertyType != typeof(int) || !property.CanRead)
+        {
+            return null;
+        }
+
+        return property.GetValue(RuntimeHelpers.GetUninitializedObject(eventType)) as int?;
+    }
+
+    private static string Describe(Type type) => type.FullName ?? type.Name;
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/EventConventionTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/EventConventionTestsBase.cs
@@ -3,7 +3,8 @@ namespace MMCA.Common.Testing.Architecture;
 /// <summary>
 /// Integration-event convention fitness functions (ADR-010): every concrete integration event inherits
 /// <c>BaseIntegrationEvent</c>, declares an <c>int SchemaVersion</c>, and lives in a
-/// <c>*.IntegrationEvents</c> namespace in the Shared layer.
+/// <c>*.IntegrationEvents</c> namespace in the Shared layer. The last two facts police the upcasters
+/// that carry a retired contract forward (ADR-090); a repo with no upcasters passes them vacuously.
 /// </summary>
 public abstract class EventConventionTestsBase
 {
@@ -17,4 +18,10 @@ public abstract class EventConventionTestsBase
 
     [Fact]
     public void IntegrationEvents_ShouldResideIn_SharedIntegrationEventsNamespace() => ArchitectureRules.IntegrationEventsResideInSharedIntegrationEventsNamespace(Map);
+
+    [Fact]
+    public void EventUpcasters_ShouldHave_UniqueSourceTypes() => ArchitectureRules.EventUpcastersHaveUniqueSourceTypes(Map);
+
+    [Fact]
+    public void EventUpcasters_ShouldIncrease_SchemaVersion() => ArchitectureRules.EventUpcastersIncreaseSchemaVersion(Map);
 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+MMCA.Common.Testing.Architecture.EventConventionTestsBase.EventUpcasters_ShouldHave_UniqueSourceTypes() -> void
+MMCA.Common.Testing.Architecture.EventConventionTestsBase.EventUpcasters_ShouldIncrease_SchemaVersion() -> void
+static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersHaveUniqueSourceTypes(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
+static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersIncreaseSchemaVersion(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/EventUpcasterFitnessTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/EventUpcasterFitnessTests.cs
@@ -1,0 +1,81 @@
+using MMCA.Common.Architecture.Tests.UpcasterFixtures.IntegrationEvents;
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Verifies the two event-upcaster fitness functions (ADR-090) against deliberately-shaped fixtures
+/// under <c>UpcasterFixtures</c>: the unique-source rule flags a contract claimed by two upcasters,
+/// the version rule flags an upcaster pointing at a LOWER <c>SchemaVersion</c>, and neither touches
+/// the compliant ladder. A map that owns no upcasters (the framework's own, today) passes both.
+/// </summary>
+public sealed class EventUpcasterFitnessTests
+{
+    [Fact]
+    public void UniqueSourceRule_FlagsTheContestedContract_ButNotTheCompliantLadder()
+    {
+        var message = RunUniqueSourceRule();
+
+        message.Should().Contain(nameof(FixtureContestedV1), "two upcasters read that contract");
+        message.Should().Contain(nameof(FixtureContestedClaimUpcaster));
+        message.Should().Contain(nameof(FixtureRivalClaimUpcaster));
+        message.Should().NotContain(
+            nameof(FixtureCompliantV1ToV2Upcaster),
+            "each rung of the compliant ladder is the only claimant on its source");
+    }
+
+    /// <summary>
+    /// The compliant ladder chains V1 to V2 to V3, so its middle contract is both a target and a
+    /// source. That is a chain, not a duplicate claim, and the rule must leave it alone.
+    /// </summary>
+    [Fact]
+    public void UniqueSourceRule_DoesNotFlag_AnUpcasterWhoseSourceIsAnotherUpcastersTarget() =>
+        RunUniqueSourceRule().Should().NotContain(nameof(FixtureCompliantV2ToV3Upcaster));
+
+    [Fact]
+    public void SchemaVersionRule_FlagsTheBackwardsUpcaster_ButNotTheCompliantLadder()
+    {
+        var message = RunSchemaVersionRule();
+
+        message.Should().Contain(nameof(FixtureBackwardsVersionUpcaster));
+        message.Should().Contain(
+            "must declare a HIGHER SchemaVersion",
+            "the message has to say which direction an upcaster is allowed to move");
+        message.Should().NotContain(nameof(FixtureCompliantV1ToV2Upcaster));
+        message.Should().NotContain(nameof(FixtureCompliantV2ToV3Upcaster));
+    }
+
+    [Fact]
+    public void BothRules_Pass_OnAMapThatOwnsNoUpcasters()
+    {
+        var map = new CommonArchitectureMap();
+
+        FluentActions.Invoking(() => ArchitectureRules.EventUpcastersHaveUniqueSourceTypes(map))
+            .Should().NotThrow("the framework ships no upcaster of its own, so the rule passes vacuously");
+        FluentActions.Invoking(() => ArchitectureRules.EventUpcastersIncreaseSchemaVersion(map))
+            .Should().NotThrow();
+    }
+
+    private static string RunUniqueSourceRule()
+    {
+        var act = () => ArchitectureRules.EventUpcastersHaveUniqueSourceTypes(new UpcasterTestMap());
+
+        return act.Should().Throw<Exception>().Which.Message;
+    }
+
+    private static string RunSchemaVersionRule()
+    {
+        var act = () => ArchitectureRules.EventUpcastersIncreaseSchemaVersion(new UpcasterTestMap());
+
+        return act.Should().Throw<Exception>().Which.Message;
+    }
+
+    /// <summary>A map whose single Application layer is this test assembly, so the fixtures are in scope.</summary>
+    private sealed class UpcasterTestMap : ArchitectureMapBase
+    {
+        public override string RepoToken => "MMCA.Common";
+
+        protected override IEnumerable<LayerRef> DefineLayers() =>
+            [Framework(Layer.Application, typeof(EventUpcasterFitnessTests).Assembly)];
+    }
+}

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/UpcasterFixtures/IntegrationEvents/EventUpcasterFixtures.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/UpcasterFixtures/IntegrationEvents/EventUpcasterFixtures.cs
@@ -1,0 +1,81 @@
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Domain.DomainEvents;
+
+namespace MMCA.Common.Architecture.Tests.UpcasterFixtures.IntegrationEvents;
+
+/// <summary>
+/// Deliberately-shaped fixtures for <c>EventUpcasterFitnessTests</c>: one compliant version ladder,
+/// one source contract claimed by two upcasters, and one upcaster pointing at a LOWER schema version.
+/// <para>
+/// The contracts live in a <c>*.IntegrationEvents</c> namespace so the residency rule (exercised over
+/// this assembly by <c>EventScopeFitnessTests</c>' consumer-shaped map) stays satisfied, and they never
+/// leave this test assembly, so no shipped event contract churns because of them.
+/// </para>
+/// </summary>
+internal sealed record FixtureCompliantV1(string Sku) : BaseIntegrationEvent;
+
+/// <summary>Compliant successor of <see cref="FixtureCompliantV1"/>.</summary>
+internal sealed record FixtureCompliantV2(string Sku) : BaseIntegrationEvent
+{
+    public override int SchemaVersion => 2;
+}
+
+/// <summary>Compliant terminal contract of the fixture ladder.</summary>
+internal sealed record FixtureCompliantV3(string Sku) : BaseIntegrationEvent
+{
+    public override int SchemaVersion => 3;
+}
+
+/// <summary>Source contract deliberately claimed by two upcasters.</summary>
+internal sealed record FixtureContestedV1(string Sku) : BaseIntegrationEvent;
+
+/// <summary>One of the two successors the contested source is upcast to.</summary>
+internal sealed record FixtureContestedV2(string Sku) : BaseIntegrationEvent
+{
+    public override int SchemaVersion => 2;
+}
+
+/// <summary>The other successor the contested source is upcast to.</summary>
+internal sealed record FixtureContestedV3(string Sku) : BaseIntegrationEvent
+{
+    public override int SchemaVersion => 3;
+}
+
+/// <summary>Older contract of the backwards pair: the upcaster points AT this one, which is the offence.</summary>
+internal sealed record FixtureBackwardsV1(string Sku) : BaseIntegrationEvent;
+
+/// <summary>Newer contract of the backwards pair, used as the upcaster's SOURCE.</summary>
+internal sealed record FixtureBackwardsV2(string Sku) : BaseIntegrationEvent
+{
+    public override int SchemaVersion => 2;
+}
+
+/// <summary>Compliant: one claimant on V1, and the target declares a higher SchemaVersion.</summary>
+internal sealed class FixtureCompliantV1ToV2Upcaster : IEventUpcaster<FixtureCompliantV1, FixtureCompliantV2>
+{
+    public FixtureCompliantV2 Upcast(FixtureCompliantV1 integrationEvent) => new(integrationEvent.Sku);
+}
+
+/// <summary>Compliant: the second rung of the same ladder.</summary>
+internal sealed class FixtureCompliantV2ToV3Upcaster : IEventUpcaster<FixtureCompliantV2, FixtureCompliantV3>
+{
+    public FixtureCompliantV3 Upcast(FixtureCompliantV2 integrationEvent) => new(integrationEvent.Sku);
+}
+
+/// <summary>Offender: shares its source contract with <see cref="FixtureRivalClaimUpcaster"/>.</summary>
+internal sealed class FixtureContestedClaimUpcaster : IEventUpcaster<FixtureContestedV1, FixtureContestedV2>
+{
+    public FixtureContestedV2 Upcast(FixtureContestedV1 integrationEvent) => new(integrationEvent.Sku);
+}
+
+/// <summary>Offender: the second claimant on <see cref="FixtureContestedV1"/>.</summary>
+internal sealed class FixtureRivalClaimUpcaster : IEventUpcaster<FixtureContestedV1, FixtureContestedV3>
+{
+    public FixtureContestedV3 Upcast(FixtureContestedV1 integrationEvent) => new(integrationEvent.Sku);
+}
+
+/// <summary>Offender: upcasts a SchemaVersion 2 contract down to a SchemaVersion 1 one.</summary>
+internal sealed class FixtureBackwardsVersionUpcaster : IEventUpcaster<FixtureBackwardsV2, FixtureBackwardsV1>
+{
+    public FixtureBackwardsV1 Upcast(FixtureBackwardsV2 integrationEvent) => new(integrationEvent.Sku);
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/DomainEventDispatcherAdditionalTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/DomainEventDispatcherAdditionalTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Services;
 using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Domain.Interfaces;
 
 namespace MMCA.Common.Application.Tests;
 
@@ -112,5 +113,106 @@ public sealed class DomainEventDispatcherAdditionalTests
 
         handler1.Called.Should().BeTrue();
         handler2.Called.Should().BeTrue();
+    }
+
+    // ── Upcasted integration-event dispatch (ADR-090) ──
+    // The tests above are the no-registry regression guard: with no IEventUpcasterRegistry in the
+    // provider the dispatcher behaves exactly as it always did. These add the registry.
+    private sealed record RetiredEvent(string FullName) : BaseIntegrationEvent;
+
+    private sealed record SuccessorEvent(string FullName) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 2;
+    }
+
+    private sealed class RetiredToSuccessorUpcaster : IEventUpcaster<RetiredEvent, SuccessorEvent>
+    {
+        public SuccessorEvent Upcast(RetiredEvent integrationEvent) => new(integrationEvent.FullName);
+    }
+
+    private sealed class RecordingIntegrationHandler<TEvent> : IIntegrationEventHandler<TEvent>
+        where TEvent : class, IIntegrationEvent
+    {
+        public List<TEvent> HandledEvents { get; } = [];
+
+        public Task HandleAsync(TEvent integrationEvent, CancellationToken cancellationToken = default)
+        {
+            HandledEvents.Add(integrationEvent);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingDomainHandlerForRetired : IDomainEventHandler<RetiredEvent>
+    {
+        public List<RetiredEvent> HandledEvents { get; } = [];
+
+        public Task HandleAsync(RetiredEvent domainEvent, CancellationToken cancellationToken = default)
+        {
+            HandledEvents.Add(domainEvent);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithRegisteredUpcaster_InvokesTheSuccessorHandlerOnly()
+    {
+        var successorHandler = new RecordingIntegrationHandler<SuccessorEvent>();
+        var retiredHandler = new RecordingIntegrationHandler<RetiredEvent>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IIntegrationEventHandler<SuccessorEvent>>(successorHandler);
+        services.AddSingleton<IIntegrationEventHandler<RetiredEvent>>(retiredHandler);
+        services.AddSingleton<IEventUpcasterRegistry>(new EventUpcasterRegistry([new RetiredToSuccessorUpcaster()]));
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        var dispatcher = new DomainEventDispatcher(provider, NullLogger<DomainEventDispatcher>.Instance);
+        var retired = new RetiredEvent("Ada Lovelace");
+
+        await dispatcher.DispatchAsync([retired]);
+
+        successorHandler.HandledEvents.Should().ContainSingle()
+            .Which.FullName.Should().Be("Ada Lovelace");
+        successorHandler.HandledEvents[0].MessageId.Should().Be(retired.MessageId,
+            "the registry preserves the envelope across the hop");
+        retiredHandler.HandledEvents.Should().BeEmpty(
+            "handlers are written once, against the newest contract: the retired-type handler must not also fire");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithRegisteredUpcaster_StillGivesDomainHandlersTheOriginalInstance()
+    {
+        var domainHandler = new RecordingDomainHandlerForRetired();
+        var successorHandler = new RecordingIntegrationHandler<SuccessorEvent>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IDomainEventHandler<RetiredEvent>>(domainHandler);
+        services.AddSingleton<IIntegrationEventHandler<SuccessorEvent>>(successorHandler);
+        services.AddSingleton<IEventUpcasterRegistry>(new EventUpcasterRegistry([new RetiredToSuccessorUpcaster()]));
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        var dispatcher = new DomainEventDispatcher(provider, NullLogger<DomainEventDispatcher>.Instance);
+        var retired = new RetiredEvent("Ada Lovelace");
+
+        await dispatcher.DispatchAsync([retired]);
+
+        domainHandler.HandledEvents.Should().ContainSingle()
+            .Which.Should().BeSameAs(retired, "intra-module domain handlers keep the original type and instance");
+        successorHandler.HandledEvents.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WithEmptyRegistry_LeavesTheOriginalContractInPlace()
+    {
+        var retiredHandler = new RecordingIntegrationHandler<RetiredEvent>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IIntegrationEventHandler<RetiredEvent>>(retiredHandler);
+        services.AddSingleton<IEventUpcasterRegistry>(new EventUpcasterRegistry([]));
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        var dispatcher = new DomainEventDispatcher(provider, NullLogger<DomainEventDispatcher>.Instance);
+        var retired = new RetiredEvent("Ada Lovelace");
+
+        await dispatcher.DispatchAsync([retired]);
+
+        retiredHandler.HandledEvents.Should().ContainSingle()
+            .Which.Should().BeSameAs(retired);
     }
 }

--- a/Tests/Core/MMCA.Common.Application.Tests/Services/EventUpcasterRegistryTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Services/EventUpcasterRegistryTests.cs
@@ -1,0 +1,271 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Services;
+using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Application.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="EventUpcasterRegistry"/> (ADR-090): identity for an unregistered
+/// contract, one hop, a whole V1 to V2 to V3 ladder applied in order, envelope preservation across
+/// every hop (whether or not the author copies it), and the three constructor-time misconfigurations
+/// that must fail loudly (duplicate source, cycle, self-map).
+/// <para>
+/// The sample contracts below live in this TEST assembly only, so the frozen integration-event
+/// contract snapshot of the framework never churns on them.
+/// </para>
+/// </summary>
+public sealed class EventUpcasterRegistryTests
+{
+    // ── Sample contract ladder: V1 carries one composite field, V2 adds a trace of the hops taken,
+    //    V3 splits the composite field. Every hop appends to Trace, so ORDER is observable. ──
+    private sealed record CustomerRenamedV1(string FullName) : BaseIntegrationEvent;
+
+    private sealed record CustomerRenamedV2(string FullName, string Trace) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 2;
+    }
+
+    private sealed record CustomerRenamedV3(string FirstName, string LastName, string Trace) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 3;
+    }
+
+    private sealed record UnrelatedEvent(string Data) : BaseIntegrationEvent;
+
+    // ── Upcasters: payload-only mapping, exactly as the doc comments instruct authors to write them ──
+    private sealed class V1ToV2Upcaster : IEventUpcaster<CustomerRenamedV1, CustomerRenamedV2>
+    {
+        public CustomerRenamedV2 Upcast(CustomerRenamedV1 integrationEvent) =>
+            new(integrationEvent.FullName, "v1->v2");
+    }
+
+    private sealed class V2ToV3Upcaster : IEventUpcaster<CustomerRenamedV2, CustomerRenamedV3>
+    {
+        public CustomerRenamedV3 Upcast(CustomerRenamedV2 integrationEvent)
+        {
+            var parts = integrationEvent.FullName.Split(' ');
+            return new CustomerRenamedV3(parts[0], parts[^1], integrationEvent.Trace + "|v2->v3");
+        }
+    }
+
+    /// <summary>An author who copies the envelope by hand: the registry stamp must be idempotent.</summary>
+    private sealed class EnvelopeCopyingV1ToV2Upcaster : IEventUpcaster<CustomerRenamedV1, CustomerRenamedV2>
+    {
+        public CustomerRenamedV2 Upcast(CustomerRenamedV1 integrationEvent) =>
+            new(integrationEvent.FullName, "v1->v2")
+            {
+                MessageId = integrationEvent.MessageId,
+                DateOccurred = integrationEvent.DateOccurred,
+            };
+    }
+
+    /// <summary>A second claimant on <c>CustomerRenamedV1</c>, used for the duplicate-source case.</summary>
+    private sealed class RivalV1ToV3Upcaster : IEventUpcaster<CustomerRenamedV1, CustomerRenamedV3>
+    {
+        public CustomerRenamedV3 Upcast(CustomerRenamedV1 integrationEvent) =>
+            new("rival", integrationEvent.FullName, "rival");
+    }
+
+    /// <summary>Closes a cycle back onto V1, used for the cycle case.</summary>
+    private sealed class V2ToV1Upcaster : IEventUpcaster<CustomerRenamedV2, CustomerRenamedV1>
+    {
+        public CustomerRenamedV1 Upcast(CustomerRenamedV2 integrationEvent) =>
+            new(integrationEvent.FullName);
+    }
+
+    /// <summary>Maps a contract onto itself, used for the self-map case.</summary>
+    private sealed class SelfMappingUpcaster : IEventUpcaster<CustomerRenamedV1, CustomerRenamedV1>
+    {
+        public CustomerRenamedV1 Upcast(CustomerRenamedV1 integrationEvent) => integrationEvent;
+    }
+
+    private static EventUpcasterRegistry CreateSut(params IEventUpcaster[] upcasters) => new(upcasters);
+
+    // ── Identity: a contract nobody claims comes back untouched ──
+    [Fact]
+    public void UpcastToTerminal_WithNoUpcasterForTheType_ReturnsTheSameInstance()
+    {
+        var sut = CreateSut(new V1ToV2Upcaster());
+        var unrelated = new UnrelatedEvent("payload");
+
+        var result = sut.UpcastToTerminal(unrelated);
+
+        result.Should().BeSameAs(unrelated);
+        sut.HasUpcasterFor(typeof(UnrelatedEvent)).Should().BeFalse();
+        sut.ResolveTerminalType(typeof(UnrelatedEvent)).Should().Be<UnrelatedEvent>();
+    }
+
+    // ── Single hop: the payload mapping the author wrote is what lands ──
+    [Fact]
+    public void UpcastToTerminal_WithSingleHop_AppliesThePayloadMapping()
+    {
+        var sut = CreateSut(new V1ToV2Upcaster());
+
+        var result = sut.UpcastToTerminal(new CustomerRenamedV1("Ada Lovelace"));
+
+        result.Should().BeOfType<CustomerRenamedV2>()
+            .Which.FullName.Should().Be("Ada Lovelace");
+        sut.HasUpcasterFor(typeof(CustomerRenamedV1)).Should().BeTrue();
+        sut.ResolveTerminalType(typeof(CustomerRenamedV1)).Should().Be<CustomerRenamedV2>();
+    }
+
+    // ── Chain: both hops run, and they run in ladder order ──
+    [Fact]
+    public void UpcastToTerminal_WithChain_AppliesEveryHopInOrder()
+    {
+        var sut = CreateSut(new V1ToV2Upcaster(), new V2ToV3Upcaster());
+
+        var result = sut.UpcastToTerminal(new CustomerRenamedV1("Ada Lovelace"));
+
+        var terminal = result.Should().BeOfType<CustomerRenamedV3>().Which;
+        terminal.FirstName.Should().Be("Ada");
+        terminal.LastName.Should().Be("Lovelace");
+        terminal.Trace.Should().Be("v1->v2|v2->v3", "each hop appends to the trace as it runs");
+    }
+
+    // ── Chain: registration order at the container must not change the walk ──
+    [Fact]
+    public void UpcastToTerminal_WithChainRegisteredOutOfOrder_StillWalksTheLadder()
+    {
+        var sut = CreateSut(new V2ToV3Upcaster(), new V1ToV2Upcaster());
+
+        var result = sut.UpcastToTerminal(new CustomerRenamedV1("Ada Lovelace"));
+
+        result.Should().BeOfType<CustomerRenamedV3>()
+            .Which.Trace.Should().Be("v1->v2|v2->v3");
+    }
+
+    // ── Terminal type resolution follows the whole chain, not just the first hop ──
+    [Fact]
+    public void ResolveTerminalType_WithChain_ReturnsTheEndOfTheLadder()
+    {
+        var sut = CreateSut(new V1ToV2Upcaster(), new V2ToV3Upcaster());
+
+        sut.ResolveTerminalType(typeof(CustomerRenamedV1)).Should().Be<CustomerRenamedV3>();
+        sut.ResolveTerminalType(typeof(CustomerRenamedV2)).Should().Be<CustomerRenamedV3>();
+        sut.ResolveTerminalType(typeof(CustomerRenamedV3)).Should().Be<CustomerRenamedV3>();
+    }
+
+    // ── Envelope: preserved across EVERY hop even though neither upcaster copies it ──
+    [Fact]
+    public void UpcastToTerminal_AcrossMultipleHops_PreservesMessageIdAndDateOccurred()
+    {
+        var sut = CreateSut(new V1ToV2Upcaster(), new V2ToV3Upcaster());
+        var original = new CustomerRenamedV1("Ada Lovelace")
+        {
+            MessageId = Guid.NewGuid(),
+            DateOccurred = new DateTime(2024, 3, 14, 9, 26, 53, DateTimeKind.Utc),
+        };
+
+        var result = sut.UpcastToTerminal(original);
+
+        result.MessageId.Should().Be(original.MessageId, "inbox deduplication stays keyed on the id the producer published");
+        result.DateOccurred.Should().Be(original.DateOccurred);
+    }
+
+    // ── Envelope: an author who copies it by hand gets the same values written twice, not a conflict ──
+    [Fact]
+    public void UpcastToTerminal_WhenTheUpcasterCopiesTheEnvelope_IsIdempotent()
+    {
+        var sut = CreateSut(new EnvelopeCopyingV1ToV2Upcaster());
+        var original = new CustomerRenamedV1("Ada Lovelace")
+        {
+            MessageId = Guid.NewGuid(),
+            DateOccurred = new DateTime(2024, 3, 14, 9, 26, 53, DateTimeKind.Utc),
+        };
+
+        var result = sut.UpcastToTerminal(original);
+
+        result.MessageId.Should().Be(original.MessageId);
+        result.DateOccurred.Should().Be(original.DateOccurred);
+    }
+
+    // ── Empty registry: every operation is identity ──
+    [Fact]
+    public void UpcastToTerminal_WithNoRegistrationsAtAll_IsIdentity()
+    {
+        var sut = CreateSut();
+        var original = new CustomerRenamedV1("Ada Lovelace");
+
+        sut.UpcastToTerminal(original).Should().BeSameAs(original);
+        sut.HasUpcasterFor(typeof(CustomerRenamedV1)).Should().BeFalse();
+        sut.ResolveTerminalType(typeof(CustomerRenamedV1)).Should().Be<CustomerRenamedV1>();
+    }
+
+    // ── Misconfiguration: two upcasters claiming one source, named in the message ──
+    [Fact]
+    public void Constructor_WithTwoUpcastersClaimingOneSource_ThrowsNamingBoth()
+    {
+        var act = () => CreateSut(new V1ToV2Upcaster(), new RivalV1ToV3Upcaster());
+
+        var message = act.Should().Throw<InvalidOperationException>().Which.Message;
+        message.Should().Contain(nameof(CustomerRenamedV1));
+        message.Should().Contain(nameof(V1ToV2Upcaster));
+        message.Should().Contain(nameof(RivalV1ToV3Upcaster));
+    }
+
+    // ── Misconfiguration: a chain that loops back would never terminate ──
+    [Fact]
+    public void Constructor_WithCyclicChain_ThrowsNamingTheCycle()
+    {
+        var act = () => CreateSut(new V1ToV2Upcaster(), new V2ToV1Upcaster());
+
+        var message = act.Should().Throw<InvalidOperationException>().Which.Message;
+        message.Should().Contain("cycle");
+        message.Should().Contain(nameof(CustomerRenamedV1));
+        message.Should().Contain(nameof(CustomerRenamedV2));
+    }
+
+    // ── Misconfiguration: a source mapped onto itself is a cycle of length one ──
+    [Fact]
+    public void Constructor_WithSourceEqualToTarget_ThrowsNamingTheUpcaster()
+    {
+        var act = () => CreateSut(new SelfMappingUpcaster());
+
+        var message = act.Should().Throw<InvalidOperationException>().Which.Message;
+        message.Should().Contain(nameof(SelfMappingUpcaster));
+        message.Should().Contain("onto itself");
+    }
+
+    // ── Null guards ──
+    [Fact]
+    public void Constructor_WithNullUpcasters_ThrowsArgumentNullException()
+    {
+        var act = () => new EventUpcasterRegistry(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("upcasters");
+    }
+
+    [Fact]
+    public void UpcastToTerminal_WithNullEvent_ThrowsArgumentNullException()
+    {
+        var sut = CreateSut();
+
+        var act = () => sut.UpcastToTerminal(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("integrationEvent");
+    }
+
+    [Fact]
+    public void TypeProbes_WithNullType_ThrowArgumentNullException()
+    {
+        var sut = CreateSut();
+
+        FluentActions.Invoking(() => sut.HasUpcasterFor(null!)).Should().Throw<ArgumentNullException>();
+        FluentActions.Invoking(() => sut.ResolveTerminalType(null!)).Should().Throw<ArgumentNullException>();
+    }
+
+    // ── The registry is an IIntegrationEvent pipeline: the walk advances by DECLARED target type ──
+    [Fact]
+    public void UpcastToTerminal_ReturnsAnIntegrationEvent_ForEveryHop()
+    {
+        var sut = CreateSut(new V1ToV2Upcaster(), new V2ToV3Upcaster());
+
+        IIntegrationEvent result = sut.UpcastToTerminal(new CustomerRenamedV1("Ada Lovelace"));
+
+        result.Should().BeAssignableTo<IIntegrationEvent>();
+        result.GetType().Should().Be(sut.ResolveTerminalType(typeof(CustomerRenamedV1)));
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/EventUpcasterStartupValidatorTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/EventUpcasterStartupValidatorTests.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Services;
+using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Infrastructure.Services;
+
+namespace MMCA.Common.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Tests for the internal <c>EventUpcasterStartupValidator</c> (ADR-090): the hosted service whose
+/// only job is to force <see cref="IEventUpcasterRegistry"/> to be constructed at host start, so a
+/// bad registration graph fails the host instead of dead-lettering the first retired-contract
+/// message hours later. The type is internal, and this assembly is on the framework's
+/// <c>InternalsVisibleTo</c> list, so it is exercised directly AND through the DI surface it is
+/// registered on.
+/// </summary>
+public sealed class EventUpcasterStartupValidatorTests
+{
+    // ── Sample contracts (TEST assembly only) ──
+    public sealed record class ValidatorSampleV1(string Sku) : BaseIntegrationEvent;
+
+    public sealed record class ValidatorSampleV2(string Sku) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 2;
+    }
+
+    public sealed record class ValidatorSampleV3(string Sku) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 3;
+    }
+
+    private sealed class SampleV1ToV2Upcaster : IEventUpcaster<ValidatorSampleV1, ValidatorSampleV2>
+    {
+        public ValidatorSampleV2 Upcast(ValidatorSampleV1 integrationEvent) => new(integrationEvent.Sku);
+    }
+
+    private sealed class RivalV1ToV3Upcaster : IEventUpcaster<ValidatorSampleV1, ValidatorSampleV3>
+    {
+        public ValidatorSampleV3 Upcast(ValidatorSampleV1 integrationEvent) => new(integrationEvent.Sku);
+    }
+
+    /// <summary>
+    /// Builds the same shape <c>AddApplication</c> plus <c>AddInfrastructure</c> produce: the registry
+    /// as a singleton over whatever upcasters were registered, and the validator as one
+    /// <see cref="IHostedService"/> entry.
+    /// </summary>
+    private static ServiceProvider BuildProvider(params Type[] upcasterTypes)
+    {
+        var services = new ServiceCollection();
+
+        foreach (var upcasterType in upcasterTypes)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IEventUpcaster), upcasterType));
+        }
+
+        services.TryAddSingleton<IEventUpcasterRegistry, EventUpcasterRegistry>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, EventUpcasterStartupValidator>());
+
+        return services.BuildServiceProvider();
+    }
+
+    // ── Clean graph: the host starts ──
+    [Fact]
+    public async Task StartAsync_WithAValidRegistrationGraph_Completes()
+    {
+        await using ServiceProvider provider = BuildProvider(typeof(SampleV1ToV2Upcaster));
+        var validator = provider.GetServices<IHostedService>().Should().ContainSingle().Which;
+
+        Func<Task> act = () => validator.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        await validator.StopAsync(CancellationToken.None);
+    }
+
+    // ── No upcasters at all: the empty registry is still resolved, and costs nothing ──
+    [Fact]
+    public async Task StartAsync_WithNoUpcastersRegistered_Completes()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var validator = provider.GetServices<IHostedService>().Should().ContainSingle().Which;
+
+        Func<Task> act = () => validator.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    // ── Bad graph: resolving the hosted service is where the misconfiguration surfaces, naming both
+    //    offending upcasters, so the host never reaches a running state ──
+    [Fact]
+    public void ResolvingTheValidator_WithADuplicateSourceRegistration_ThrowsNamingBothUpcasters()
+    {
+        using ServiceProvider provider = BuildProvider(typeof(SampleV1ToV2Upcaster), typeof(RivalV1ToV3Upcaster));
+
+        var act = () => provider.GetServices<IHostedService>().ToList();
+
+        var message = act.Should().Throw<InvalidOperationException>().Which.Message;
+        message.Should().Contain(nameof(ValidatorSampleV1));
+        message.Should().Contain(nameof(SampleV1ToV2Upcaster));
+        message.Should().Contain(nameof(RivalV1ToV3Upcaster));
+    }
+
+    // ── Constructed directly: the validated registry is the dependency, and Stop is a no-op ──
+    [Fact]
+    public async Task StartAsync_ConstructedDirectly_ResolvesThroughTheInjectedRegistry()
+    {
+        var registry = new EventUpcasterRegistry([new SampleV1ToV2Upcaster()]);
+        var sut = new EventUpcasterStartupValidator(registry);
+
+        await sut.StartAsync(CancellationToken.None);
+        await sut.StopAsync(CancellationToken.None);
+
+        registry.ResolveTerminalType(typeof(ValidatorSampleV1)).Should().Be<ValidatorSampleV2>();
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/InProcessMessageBusTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/InProcessMessageBusTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Services;
 using MMCA.Common.Domain.DomainEvents;
@@ -146,6 +147,84 @@ public sealed class InProcessMessageBusTests
         Func<Task> act = () => sut.PublishAsync(new TestIntegrationEvent(), CancellationToken.None);
 
         await act.Should().NotThrowAsync();
+    }
+
+    // ── Real dispatcher + AddApplication/AddEventUpcaster wiring: a retired contract published on the
+    //    in-process path reaches the handler written against its successor, envelope intact (ADR-090) ──
+    [Fact]
+    public async Task PublishAsync_WithRegisteredUpcaster_DeliversTheUpcastedEventToTheSuccessorHandler()
+    {
+        var handler = new RecordingSuccessorHandler();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddApplication();
+        services.AddEventUpcaster<RetiredTestIntegrationEvent, TestIntegrationEventV2, RetiredToV2Upcaster>();
+        services.AddSingleton<IIntegrationEventHandler<TestIntegrationEventV2>>(handler);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var sut = new InProcessMessageBus(provider.GetRequiredService<IDomainEventDispatcher>());
+        var retired = new RetiredTestIntegrationEvent("SKU-1");
+
+        await sut.PublishAsync(retired, CancellationToken.None);
+
+        var received = handler.HandledEvents.Should().ContainSingle().Which;
+        received.Sku.Should().Be("SKU-1");
+        received.Source.Should().Be("upcasted");
+        received.MessageId.Should().Be(retired.MessageId, "the registry preserves the envelope across the hop");
+        received.DateOccurred.Should().Be(retired.DateOccurred);
+    }
+
+    // ── Same wiring, no upcaster for the type: the original contract is delivered untouched ──
+    [Fact]
+    public async Task PublishAsync_WithUpcasterRegistryButNoUpcasterForTheType_DeliversTheOriginalEvent()
+    {
+        var handler = new RecordingOriginalHandler();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddApplication();
+        services.AddSingleton<IIntegrationEventHandler<TestIntegrationEvent>>(handler);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var sut = new InProcessMessageBus(provider.GetRequiredService<IDomainEventDispatcher>());
+        var integrationEvent = new TestIntegrationEvent();
+
+        await sut.PublishAsync(integrationEvent, CancellationToken.None);
+
+        handler.HandledEvents.Should().ContainSingle().Which.Should().BeSameAs(integrationEvent);
+    }
+
+    // ── Upcasting sample contracts (TEST assembly only, so the frozen event contract never churns) ──
+    public sealed record class RetiredTestIntegrationEvent(string Sku) : BaseIntegrationEvent;
+
+    public sealed record class TestIntegrationEventV2(string Sku, string Source) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 2;
+    }
+
+    private sealed class RetiredToV2Upcaster : IEventUpcaster<RetiredTestIntegrationEvent, TestIntegrationEventV2>
+    {
+        public TestIntegrationEventV2 Upcast(RetiredTestIntegrationEvent integrationEvent) =>
+            new(integrationEvent.Sku, "upcasted");
+    }
+
+    private sealed class RecordingSuccessorHandler : IIntegrationEventHandler<TestIntegrationEventV2>
+    {
+        public List<TestIntegrationEventV2> HandledEvents { get; } = [];
+
+        public Task HandleAsync(TestIntegrationEventV2 integrationEvent, CancellationToken cancellationToken = default)
+        {
+            HandledEvents.Add(integrationEvent);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingOriginalHandler : IIntegrationEventHandler<TestIntegrationEvent>
+    {
+        public List<TestIntegrationEvent> HandledEvents { get; } = [];
+
+        public Task HandleAsync(TestIntegrationEvent integrationEvent, CancellationToken cancellationToken = default)
+        {
+            HandledEvents.Add(integrationEvent);
+            return Task.CompletedTask;
+        }
     }
 
     // ── Test handlers ──

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/UpcastingIntegrationEventConsumerTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/UpcastingIntegrationEventConsumerTests.cs
@@ -1,0 +1,214 @@
+using AwesomeAssertions;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Services;
+using MMCA.Common.Domain.DomainEvents;
+using MMCA.Common.Infrastructure.Persistence.Inbox;
+using MMCA.Common.Infrastructure.Services;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="UpcastingIntegrationEventConsumer{TEvent}"/> (ADR-090): the draining consumer
+/// bound to a RETIRED contract. It dedups on the ORIGINAL message id, upcasts to the terminal
+/// contract, dispatches to the handlers registered for THAT contract, rethrows a handler failure so
+/// MassTransit can retry, and records the inbox row only after every handler succeeded.
+/// <para>
+/// Harness mirrors <see cref="IntegrationEventConsumerTests"/>: a mocked
+/// <see cref="ConsumeContext{T}"/>, a mocked <see cref="IInboxStore"/>, and Moq handlers, plus a real
+/// service provider because this consumer resolves its handlers non-generically at runtime. The V1/V2
+/// contracts live in this TEST assembly only.
+/// </para>
+/// </summary>
+public sealed class UpcastingIntegrationEventConsumerTests
+{
+    // ── Sample contracts: retired V1 and its successor V2 ──
+    public sealed record class RetiredOrderPlaced(string Sku) : BaseIntegrationEvent;
+
+    public sealed record class OrderPlacedV2(string Sku, string Source) : BaseIntegrationEvent
+    {
+        public override int SchemaVersion => 2;
+    }
+
+    private sealed class RetiredToV2Upcaster : IEventUpcaster<RetiredOrderPlaced, OrderPlacedV2>
+    {
+        public OrderPlacedV2 Upcast(RetiredOrderPlaced integrationEvent) =>
+            new(integrationEvent.Sku, "upcasted");
+    }
+
+    private static Mock<ConsumeContext<RetiredOrderPlaced>> ContextFor(RetiredOrderPlaced evt)
+    {
+        var context = new Mock<ConsumeContext<RetiredOrderPlaced>>();
+        context.SetupGet(c => c.Message).Returns(evt);
+        return context;
+    }
+
+    private static Mock<IInboxStore> InboxFor(RetiredOrderPlaced evt, bool alreadyProcessed = false)
+    {
+        var inbox = new Mock<IInboxStore>();
+        inbox.Setup(x => x.AlreadyProcessedAsync(evt.MessageId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(alreadyProcessed);
+        return inbox;
+    }
+
+    private static UpcastingIntegrationEventConsumer<RetiredOrderPlaced> CreateSut(
+        IServiceProvider provider,
+        IInboxStore inbox,
+        params IEventUpcaster[] upcasters) =>
+        new(new EventUpcasterRegistry(upcasters),
+            provider,
+            inbox,
+            Mock.Of<ILogger<UpcastingIntegrationEventConsumer<RetiredOrderPlaced>>>());
+
+    // ── Upcast + dispatch: the terminal handler sees the upcasted instance, original envelope intact ──
+    [Fact]
+    public async Task Consume_WithUpcaster_InvokesTerminalHandlerWithUpcastedEventCarryingTheOriginalMessageId()
+    {
+        var evt = new RetiredOrderPlaced("SKU-1");
+        var terminalHandler = new Mock<IIntegrationEventHandler<OrderPlacedV2>>();
+        var retiredHandler = new Mock<IIntegrationEventHandler<RetiredOrderPlaced>>();
+        var services = new ServiceCollection();
+        services.AddSingleton(terminalHandler.Object);
+        services.AddSingleton(retiredHandler.Object);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var inbox = InboxFor(evt);
+
+        var sut = CreateSut(provider, inbox.Object, new RetiredToV2Upcaster());
+
+        await sut.Consume(ContextFor(evt).Object);
+
+        terminalHandler.Verify(
+            x => x.HandleAsync(
+                It.Is<OrderPlacedV2>(e => e.Sku == "SKU-1" && e.Source == "upcasted" && e.MessageId == evt.MessageId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        retiredHandler.Verify(
+            x => x.HandleAsync(It.IsAny<RetiredOrderPlaced>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Inbox dedup: a redelivery of an already-recorded message runs nothing ──
+    [Fact]
+    public async Task Consume_WhenAlreadyProcessed_SkipsHandlersAndDoesNotRecord()
+    {
+        var evt = new RetiredOrderPlaced("SKU-1");
+        var terminalHandler = new Mock<IIntegrationEventHandler<OrderPlacedV2>>();
+        var services = new ServiceCollection();
+        services.AddSingleton(terminalHandler.Object);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var inbox = InboxFor(evt, alreadyProcessed: true);
+
+        var sut = CreateSut(provider, inbox.Object, new RetiredToV2Upcaster());
+
+        await sut.Consume(ContextFor(evt).Object);
+
+        terminalHandler.Verify(
+            x => x.HandleAsync(It.IsAny<OrderPlacedV2>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        inbox.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Handler failure: rethrown for the MassTransit retry policy, inbox left un-recorded ──
+    [Fact]
+    public async Task Consume_WhenHandlerThrows_RethrowsAndLeavesTheMessageUnrecorded()
+    {
+        var evt = new RetiredOrderPlaced("SKU-1");
+        var failure = new InvalidOperationException("handler failed");
+        var terminalHandler = new Mock<IIntegrationEventHandler<OrderPlacedV2>>();
+        terminalHandler
+            .Setup(x => x.HandleAsync(It.IsAny<OrderPlacedV2>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(failure);
+        var services = new ServiceCollection();
+        services.AddSingleton(terminalHandler.Object);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var inbox = InboxFor(evt);
+
+        var sut = CreateSut(provider, inbox.Object, new RetiredToV2Upcaster());
+
+        Func<Task> act = () => sut.Consume(ContextFor(evt).Object);
+
+        var thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+        thrown.Which.Should().BeSameAs(failure);
+        inbox.Verify(
+            x => x.MarkProcessedAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Success: recorded under the ORIGINAL message id and the retired type name ──
+    [Fact]
+    public async Task Consume_OnSuccess_MarksProcessedWithTheOriginalMessageId()
+    {
+        var evt = new RetiredOrderPlaced("SKU-1");
+        var services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<IIntegrationEventHandler<OrderPlacedV2>>());
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var inbox = InboxFor(evt);
+
+        var sut = CreateSut(provider, inbox.Object, new RetiredToV2Upcaster());
+
+        await sut.Consume(ContextFor(evt).Object);
+
+        inbox.Verify(
+            x => x.MarkProcessedAsync(evt.MessageId, nameof(RetiredOrderPlaced), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Degrade path: no upcaster registered means plain dispatch on the original contract ──
+    [Fact]
+    public async Task Consume_WithNoUpcasterRegistered_DispatchesToTheHandlersOfTheOriginalContract()
+    {
+        var evt = new RetiredOrderPlaced("SKU-1");
+        var retiredHandler = new Mock<IIntegrationEventHandler<RetiredOrderPlaced>>();
+        var services = new ServiceCollection();
+        services.AddSingleton(retiredHandler.Object);
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var inbox = InboxFor(evt);
+
+        var sut = CreateSut(provider, inbox.Object);
+
+        await sut.Consume(ContextFor(evt).Object);
+
+        retiredHandler.Verify(x => x.HandleAsync(evt, It.IsAny<CancellationToken>()), Times.Once);
+        inbox.Verify(
+            x => x.MarkProcessedAsync(evt.MessageId, nameof(RetiredOrderPlaced), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Nobody handles the terminal contract in this process: ack the message, do not retry it ──
+    [Fact]
+    public async Task Consume_WithNoHandlersForTheTerminalContract_CompletesAndMarksProcessed()
+    {
+        var evt = new RetiredOrderPlaced("SKU-1");
+        var services = new ServiceCollection();
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        var inbox = InboxFor(evt);
+
+        var sut = CreateSut(provider, inbox.Object, new RetiredToV2Upcaster());
+
+        Func<Task> act = () => sut.Consume(ContextFor(evt).Object);
+
+        await act.Should().NotThrowAsync();
+        inbox.Verify(
+            x => x.MarkProcessedAsync(evt.MessageId, nameof(RetiredOrderPlaced), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Null guard ──
+    [Fact]
+    public async Task Consume_WithNullContext_ThrowsArgumentNullException()
+    {
+        var services = new ServiceCollection();
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        var sut = CreateSut(provider, Mock.Of<IInboxStore>(), new RetiredToV2Upcaster());
+
+        Func<Task> act = () => sut.Consume(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("context");
+    }
+}


### PR DESCRIPTION
Ships the consumer-side mechanism ADR-010 named as follow-up work: the event upcaster registration extension point.

## What's new
- `IEventUpcaster` / `IEventUpcaster<TSource, TTarget>` (Application): a pure payload mapping from a retired integration-event contract to its successor; the non-generic members come from default interface implementations so authors write one method.
- `EventUpcasterRegistry`: indexes by source type, follows chains (V1 -> V2 -> V3) by declared target type, preserves `MessageId`/`DateOccurred` across every hop (inbox dedup keys survive by construction), and throws at construction, naming the offenders, on duplicate sources, self-maps, or cycles. An internal hosted service resolves it at host start so misconfiguration fails startup, not the first message.
- `services.AddEventUpcaster<TSource, TTarget, TUpcaster>()`: TryAddEnumerable idiom (same shape as `AddScheduledJob`), accumulates across modules.
- Both delivery paths consult the registry: `DomainEventDispatcher` upcasts before selecting `IIntegrationEventHandler<>` (covers monolith mode and pre-upgrade outbox rows; domain-handler dispatch untouched), and broker hosts drain a retired contract via `RegisterUpcastedIntegrationEventConsumer<TOld>()` backed by the new dedicated `UpcastingIntegrationEventConsumer<TOld>` (existing consumer hot path and shipped ctor untouched).
- Two new fitness functions on `EventConventionTestsBase`, inherited by every consumer tree with no edit: unique upcaster source types, and target `SchemaVersion` strictly higher than source. Pass trivially at zero upcasters.

## Deliberately out of scope (recorded in ADR-090)
Outbox type-name aliasing for prematurely deleted types; producer-side rewriting of old rows.

## Verification
- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors (TWAE + five analyzers + PublicAPI gate; all new public symbols baselined in PublicAPI.Unshipped).
- Full suite Release: 3804 passed, 0 failed (35 new tests: registry chaining/cycle/envelope, dispatcher upcast + no-registry regression guard, broker consumer flow, startup validator, rule-level fitness tests with fixture maps, in-process end-to-end).
- FACTS regenerated (fitness methods 104 -> 106); `--check` clean.
- All V1/V2/V3 sample contracts live in test assemblies only, so frozen integration-event contract snapshots do not churn.

Companion docs PR: ivanball/ivanball.github.io#120 (ADR-090 + ADR-010 addendum). Additive change; release + consumer pin sweep will follow later via the normal /push-release flow (minor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016usKhixm2drfHmwmmmqwbn