### PR TITLE
§11: build-failing fitness tests for the password hashing invariants

### DIFF
--- a/FACTS.md
+++ b/FACTS.md
@@ -44,7 +44,7 @@ it owns the range/count and the one-line summaries. Do not restate the `(001-NNN
 - **109 test methods across 37 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **125** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **128** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,12 @@ fix before public disclosure.
   `true` in every environment except Development. A resolved `false` outside Development stays
   legal (an internal-ingress cleartext `h2c` authority is the reason it must) but logs one warning
   at startup naming the configuration key, so the opt-out is auditable instead of silent.
-- **Password hashing:** PBKDF2-SHA512 with a high iteration count and constant-time comparison.
+- **Password hashing:** PBKDF2-SHA512 with a high iteration count and constant-time comparison. Both
+  are build-failing invariants, not conventions: `PasswordHasherSecurityTests` recomputes the digest
+  independently (known-answer tests, plus a negative one proving the work factor participates in
+  verification) and pins the iteration count, salt size, digest size and legacy-salt discriminator by
+  reflection, while `PasswordHashingFitnessTests` asserts structurally that the hasher still depends on
+  a slow key derivation function and on the fixed-time comparison.
 - **Field encryption:** AES-256-GCM via `EncryptedStringConverter` for sensitive columns.
 - **Authorization:** server-side; `Result` → HTTP status mapping never leaks internal detail.
 - **CORS:** the permissive `AllowAnyOrigin` policy is **development-only**; production uses an

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/PasswordHashingFitnessTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/PasswordHashingFitnessTests.cs
@@ -1,0 +1,60 @@
+using MMCA.Common.Infrastructure.Services;
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Structural credential-storage rule for <see cref="PasswordHasher"/>, asserted against the compiled IL
+/// rather than the source: the type must depend on <c>Rfc2898DeriveBytes</c> (a deliberately slow key
+/// derivation function, not a bare fast hash) and on <c>CryptographicOperations</c> (the constant-time
+/// comparison that keeps verification off a timing side channel). The known-answer and constant pins in
+/// <c>PasswordHasherSecurityTests</c> cover the parameter values; this covers the shape, so a rewrite that
+/// swapped PBKDF2 for a raw SHA-512 or replaced the fixed-time compare with <c>SequenceEqual</c> fails the
+/// build even if it kept the same output length.
+/// </summary>
+public sealed class PasswordHashingFitnessTests
+{
+    private const string CryptographicOperationsType = "System.Security.Cryptography.CryptographicOperations";
+
+    private const string Rfc2898DeriveBytesType = "System.Security.Cryptography.Rfc2898DeriveBytes";
+
+    private static Assembly Infrastructure => typeof(PasswordHasher).Assembly;
+
+    [Fact]
+    public void ScannedPasswordHasherSet_IsNotEmpty() =>
+        PasswordHasherTypes().GetTypes().Should().ContainSingle(
+            t => string.Equals(t.FullName, typeof(PasswordHasher).FullName, StringComparison.Ordinal),
+            "a rule that selects nothing passes vacuously: the scan must actually reach PasswordHasher");
+
+    [Fact]
+    public void PasswordHasher_DependsOnASlowKeyDerivationFunction()
+    {
+        var result = PasswordHasherTypes()
+            .Should()
+            .HaveDependencyOnAll(Rfc2898DeriveBytesType)
+            .GetResult();
+
+        ArchitectureAssert.NoViolations(result,
+            "credentials must be stretched with PBKDF2; a bare hash lets commodity GPUs try billions of "
+            + "candidate passwords per second against a stolen table");
+    }
+
+    [Fact]
+    public void PasswordHasher_DependsOnConstantTimeComparison()
+    {
+        var result = PasswordHasherTypes()
+            .Should()
+            .HaveDependencyOnAll(CryptographicOperationsType)
+            .GetResult();
+
+        ArchitectureAssert.NoViolations(result,
+            "verification must compare with CryptographicOperations.FixedTimeEquals; a short-circuiting "
+            + "comparison leaks the matching prefix length through response timing, recovering a digest "
+            + "byte by byte");
+    }
+
+    private static PredicateList PasswordHasherTypes() =>
+        Types.InAssembly(Infrastructure)
+            .That()
+            .HaveName(nameof(PasswordHasher));
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PasswordHasherSecurityTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PasswordHasherSecurityTests.cs
@@ -1,0 +1,131 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using AwesomeAssertions;
+using MMCA.Common.Infrastructure.Services;
+
+namespace MMCA.Common.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Executable security invariants for <see cref="PasswordHasher"/>. The behavioural round-trips live in
+/// <see cref="PasswordHasherTests"/> and stay green even if every cryptographic parameter is weakened,
+/// because a hasher that hashes and verifies with the same weak parameters still round-trips. These tests
+/// pin the parameters themselves: two known-answer tests recompute the digest independently with the
+/// OWASP-recommended settings (PBKDF2-HMAC-SHA512, 600,000 iterations, 32-byte salt, 64-byte output), a
+/// negative known-answer test proves the iteration count actually participates in verification, and
+/// reflection pins the private constants so lowering one fails the build instead of silently shipping.
+/// </summary>
+public sealed class PasswordHasherSecurityTests
+{
+    private const int PinnedIterations = 600_000;
+    private const int PinnedSaltSize = 32;
+    private const int PinnedHashSize = 64;
+    private const int PinnedLegacyHmacSaltSize = 128;
+
+    private readonly PasswordHasher _sut = new();
+
+    // ── Known-answer tests (the parameters, not the round-trip) ──
+    [Fact]
+    public void VerifyPassword_AcceptsADigestComputedWithThePinnedPbkdf2Parameters()
+    {
+        const string password = "KnownAnswerPassword123";
+        var salt = DeterministicSalt();
+        var expected = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password),
+            salt,
+            PinnedIterations,
+            HashAlgorithmName.SHA512,
+            PinnedHashSize);
+
+        _sut.VerifyPassword(password, expected, salt).Should().BeTrue(
+            "a lowered iteration count, a swapped hash algorithm or a changed output length would stop "
+            + "matching this independently computed digest, so weakening the KDF fails the build instead "
+            + "of quietly making every stored credential cheaper to crack offline");
+    }
+
+    [Fact]
+    public void HashPassword_ProducesTheDigestThePinnedPbkdf2ParametersProduce()
+    {
+        const string password = "KnownAnswerPassword123";
+
+        var (hash, salt) = _sut.HashPassword(password);
+
+        var expected = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password),
+            salt,
+            PinnedIterations,
+            HashAlgorithmName.SHA512,
+            PinnedHashSize);
+
+        hash.Should().Equal(expected,
+            "the hash path must derive its digest with PBKDF2-HMAC-SHA512 at 600,000 iterations: any other "
+            + "algorithm or work factor produces different bytes here");
+        salt.Should().HaveCount(PinnedSaltSize,
+            "a shortened salt makes precomputed rainbow tables viable again");
+        hash.Should().HaveCount(PinnedHashSize,
+            "a truncated digest throws away entropy an attacker would otherwise have to search");
+    }
+
+    [Fact]
+    public void VerifyPassword_RejectsADigestComputedWithAWeakerIterationCount()
+    {
+        const string password = "KnownAnswerPassword123";
+        var salt = DeterministicSalt();
+        var weakDigest = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password),
+            salt,
+            100_000,
+            HashAlgorithmName.SHA512,
+            PinnedHashSize);
+
+        _sut.VerifyPassword(password, weakDigest, salt).Should().BeFalse(
+            "the iteration count must actually participate in verification: if a digest derived at a "
+            + "fraction of the work factor verified, an attacker who downgraded the stored work factor "
+            + "would still authenticate");
+    }
+
+    // ── Constant pins (the invariants, read straight off the type) ──
+    [Fact]
+    public void Iterations_IsPinnedToTheOwaspRecommendedWorkFactor() =>
+        ReadPrivateConstant("Iterations").Should().Be(PinnedIterations,
+            "the work factor is the entire defense against offline brute force; lowering it is a security "
+            + "change that must be argued for, not an edit that slips through");
+
+    [Fact]
+    public void SaltSize_IsPinnedTo32Bytes() =>
+        ReadPrivateConstant("SaltSize").Should().Be(PinnedSaltSize,
+            "256 bits of per-credential salt is what keeps precomputation and cross-account correlation "
+            + "off the table");
+
+    [Fact]
+    public void HashSize_IsPinnedTo64Bytes() =>
+        ReadPrivateConstant("HashSize").Should().Be(PinnedHashSize,
+            "the stored digest must keep the full 512-bit output of the KDF, not a truncation of it");
+
+    [Fact]
+    public void LegacyHmacSaltSize_IsPinnedTo128Bytes() =>
+        ReadPrivateConstant("LegacyHmacSaltSize").Should().Be(PinnedLegacyHmacSaltSize,
+            "this length is the discriminator that routes a credential to the weak legacy HMAC path: "
+            + "moving it to 32 would send every current PBKDF2 credential down the unsalted-HMAC branch");
+
+    private static byte[] DeterministicSalt()
+    {
+        var salt = new byte[PinnedSaltSize];
+        for (var i = 0; i < salt.Length; i++)
+        {
+            salt[i] = (byte)(i * 7 + 3);
+        }
+
+        return salt;
+    }
+
+    private static int ReadPrivateConstant(string name)
+    {
+        FieldInfo? field = typeof(PasswordHasher).GetField(name, BindingFlags.NonPublic | BindingFlags.Static);
+
+        field.Should().NotBeNull($"'{name}' is the constant this invariant is written against; renaming or "
+            + "removing it must fail here rather than silently drop the pin");
+
+        return (int)field!.GetValue(null)!;
+    }
+}


### PR DESCRIPTION
## Summary

Article 17 and SECURITY.md both note that the password hashing invariants (slow KDF, salted, constant-time) were protected by code review and the BCL types, not by a fitness rule. This PR turns those conventions into build-failing checks, following the two styles established by #269.

- **`PasswordHasherSecurityTests`** (Infrastructure.Tests, 7 tests): known-answer tests that recompute the PBKDF2-HMAC-SHA512 digest independently (600,000 iterations, 32-byte salt, 64-byte output) on both the hash and verify paths; a negative KAT proving a digest derived at a lower work factor does not verify; reflection pins on the four private constants, including the 128-byte legacy-salt discriminator that routes to the HMAC fallback.
- **`PasswordHashingFitnessTests`** (Architecture.Tests, 3 tests): NetArchTest structural rules asserting `PasswordHasher` depends on `Rfc2898DeriveBytes` (a slow KDF, not a bare hash) and `CryptographicOperations` (fixed-time compare), plus a non-vacuity guard so the rule cannot pass by scanning nothing.
- **SECURITY.md**: the password-hashing bullet now names the enforcing tests.
- **FACTS.md**: regenerated; the executed fitness count moved 125 -> 128.

## Verification

- `dotnet build MMCA.Common.slnx`: 0 warnings, 0 errors.
- Both new classes pass (7/7 and 3/3).
- Negative proof: with `Iterations` temporarily lowered to 500,000, both KATs and the iteration pin fail; reverted.
- Fitness-rule non-vacuity: pointing the expected KDF type at a nonexistent type fails exactly that rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016usKhixm2drfHmwmmmqwbn