### PR TITLE
§9: in-repo contract-surface fitness checks (OpenAPI baseline + [ServiceContract] purity)

### DIFF
--- a/FACTS.md
+++ b/FACTS.md
@@ -41,10 +41,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **109 test methods across 37 abstract `*TestsBase` classes**, shipped once in the
+- **110 test methods across 38 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **128** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **129** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Core/MMCA.Common.Shared/Abstractions/ServiceContractAttribute.cs
+++ b/Source/Core/MMCA.Common.Shared/Abstractions/ServiceContractAttribute.cs
@@ -3,11 +3,13 @@ namespace MMCA.Common.Shared.Abstractions;
 /// <summary>
 /// Marks an interface or DTO as part of a service contract published in a <c>*.Contracts</c>
 /// NuGet package, identifying the wire surface of an extracted microservice (see ADR-007).
-/// The intended invariant (contract types must not depend on the producing service's
-/// <c>Domain</c>, <c>Application</c>, or <c>Infrastructure</c>) is currently upheld by the
-/// transport- and layer-purity fitness rules (ADR-015), not by a dedicated <c>[ServiceContract]</c>
-/// architecture test. This attribute is an available documentation marker that no contract type
-/// carries yet (MMCA.Common itself ships no <c>[ServiceContract]</c> types).
+/// The invariant (contract types must not depend on the producing service's <c>Domain</c>,
+/// <c>Application</c>, or <c>Infrastructure</c>) is enforced directly by the dedicated
+/// <c>ServiceContractPurityTestsBase</c> fitness rule, which scans every mapped assembly for types
+/// carrying this attribute, alongside the transport- and layer-purity rules that guard the same
+/// boundary from the layer side (ADR-015). The attribute is an adoptable marker that MMCA.Common
+/// itself applies to no type (the framework ships no <c>[ServiceContract]</c> types), so the rule is
+/// a ratchet here and bites in a repo the moment its first contract type is marked.
 /// <para>
 /// Apply to the C# interface that consumers depend on (e.g. <c>IProductVariantService</c>),
 /// the integration event records that flow over the message bus (e.g. <c>ProductVariantChanged</c>),

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Contracts.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Contracts.cs
@@ -1,0 +1,75 @@
+namespace MMCA.Common.Testing.Architecture;
+
+public static partial class ArchitectureRules
+{
+    /// <summary>
+    /// The full name of the framework's <c>[ServiceContract]</c> marker (ADR-007). Matched as a string,
+    /// exactly like the other framework types this package detects, so the rule library keeps its
+    /// deliberate zero-reference stance toward the framework assemblies (see the csproj comment).
+    /// </summary>
+    public const string ServiceContractAttributeFullName =
+        "MMCA.Common.Shared.Abstractions.ServiceContractAttribute";
+
+    /// <summary>
+    /// Every <c>[ServiceContract]</c> type stays pure with respect to the producing service: the wire
+    /// surface of an extracted service (ADR-007) carries only Shared and contract types, never the
+    /// producing service's Domain, Application or Infrastructure types. A contract that leaks a domain
+    /// entity, a handler abstraction or a persistence type forces every consumer to take the producer's
+    /// internals as a package dependency, which is what makes an extraction irreversible.
+    /// </summary>
+    /// <remarks>
+    /// Attribute-driven rather than <see cref="Layer.Contracts"/>-driven: the rule scans every assembly
+    /// the map registers for types carrying the marker, so it enforces the invariant wherever the
+    /// contract types live and starts biting the moment the first type is marked. A repo that marks no
+    /// type yet passes vacuously.
+    /// <para>
+    /// A marked type that lives inside a Domain, Application or Infrastructure assembly fails by
+    /// construction, and that is the intent: a published contract belongs in a <c>*.Contracts</c> (or
+    /// Shared) assembly, not inside the service it describes.
+    /// </para>
+    /// </remarks>
+    /// <param name="map">The repo's architecture map.</param>
+    public static void ServiceContractsDoNotDependOnServiceInternals(IArchitectureMap map)
+    {
+        var forbidden = ServiceInternalNamespaces(map);
+        if (forbidden.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var layerRef in map.Layers)
+        {
+            var result = Types.InAssembly(layerRef.Assembly)
+                .That()
+                .MeetCustomRule(CarriesServiceContractAttribute)
+                .ShouldNot()
+                .HaveDependencyOnAny(forbidden)
+                .GetResult();
+
+            ArchitectureAssert.NoViolations(result,
+                $"{layerRef.RootNamespace}: a [ServiceContract] type is the published wire surface of an "
+                    + "extracted service (ADR-007), so it must expose only Shared and contract types, never "
+                    + $"the producing service's internals ({string.Join(", ", forbidden)})");
+        }
+    }
+
+    /// <summary>The Domain/Application/Infrastructure namespaces a contract type must never reach into.</summary>
+    private static string[] ServiceInternalNamespaces(IArchitectureMap map)
+    {
+        Layer[] internalLayers = [Layer.Domain, Layer.Application, Layer.Infrastructure];
+
+        return [.. map.Layers
+            .Where(l => internalLayers.Contains(l.Layer))
+            .Select(l => l.RootNamespace)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)];
+    }
+
+    /// <summary>True when the type carries the framework's <c>[ServiceContract]</c> marker, matched by name.</summary>
+    private static bool CarriesServiceContractAttribute(Mono.Cecil.TypeDefinition type) =>
+        type.HasCustomAttributes
+        && type.CustomAttributes.Any(attribute => string.Equals(
+            attribute.AttributeType.FullName,
+            ServiceContractAttributeFullName,
+            StringComparison.Ordinal));
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ServiceContractPurityTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ServiceContractPurityTestsBase.cs
@@ -1,0 +1,27 @@
+namespace MMCA.Common.Testing.Architecture;
+
+/// <summary>
+/// Purity fitness function for the <c>[ServiceContract]</c> wire surface: a type marked as part of a
+/// published service contract (ADR-007) must not depend on the producing service's Domain, Application
+/// or Infrastructure, so a consumer takes the contract package without taking the producer's internals.
+/// </summary>
+/// <remarks>
+/// Attribute-driven, not <see cref="Layer.Contracts"/>-driven: no repo registers that layer in its map
+/// today, so a layer-iterating rule would pass vacuously forever. This base scans every assembly the map
+/// registers for types carrying the marker, wherever those types live.
+/// <para>
+/// Honest about the vacuous case, like <see cref="ProtoContractTestsBase"/>: a repo that marks no type
+/// yet (MMCA.Common itself ships no <c>[ServiceContract]</c> type) passes without asserting anything.
+/// The value is the ratchet: the invariant is enforced from the first marked type onward, with no test
+/// to remember to write. It complements, and does not replace, the transport- and layer-purity rules
+/// (ADR-015) that guard the same boundary from the layer side.
+/// </para>
+/// </remarks>
+public abstract class ServiceContractPurityTestsBase
+{
+    protected abstract IArchitectureMap Map { get; }
+
+    [Fact]
+    public void ServiceContracts_ShouldNotDependOn_ServiceInternals() =>
+        ArchitectureRules.ServiceContractsDoNotDependOnServiceInternals(Map);
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
@@ -7,11 +7,17 @@ MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AnonymousEndpoints_A
 MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.ScannedEndpointSet_IsNotEmpty() -> void
 MMCA.Common.Testing.Architecture.EventConventionTestsBase.EventUpcasters_ShouldHave_UniqueSourceTypes() -> void
 MMCA.Common.Testing.Architecture.EventConventionTestsBase.EventUpcasters_ShouldIncrease_SchemaVersion() -> void
+MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase
+MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase.ServiceContractPurityTestsBase() -> void
+MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase.ServiceContracts_ShouldNotDependOn_ServiceInternals() -> void
 abstract MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AllowedAnonymousEndpoints.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 abstract MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.TargetAssemblies.get -> System.Collections.Generic.IReadOnlyCollection<System.Reflection.Assembly!>!
+abstract MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
+const MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractAttributeFullName = "MMCA.Common.Shared.Abstractions.ServiceContractAttribute" -> string!
 static MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.IsController(System.Type! type) -> bool
 static MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.IsRoutableComponent(System.Type! type) -> bool
 static MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.IsScannedEndpointType(System.Type! type) -> bool
 static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersHaveUniqueSourceTypes(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersIncreaseSchemaVersion(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
+static MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractsDoNotDependOnServiceInternals(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 virtual MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.MinimumScannedTypes.get -> int

--- a/Source/Presentation/MMCA.Common.API/Startup/OpenApiEndpointExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/OpenApiEndpointExtensions.cs
@@ -9,9 +9,13 @@ namespace MMCA.Common.API.Startup;
 /// built-in <c>MapOpenApi()</c> so every service serves a machine-readable contract at
 /// <c>/openapi/v1.json</c> the same way; pair it with <c>AddCommonOpenApi()</c> (see
 /// <see cref="WebApplicationBuilderExtensions"/>). The document is the source of truth for the API
-/// surface and is intended to be guarded by a contract-snapshot test in the consumer integration
-/// tiers so it cannot drift silently (the framework deliberately does not duplicate that gate — the
-/// API surface lives in the consumer hosts). Mapped <b>outside Production only</b> — these are internal
+/// surface, and it is guarded at two levels so it cannot drift silently. The framework-owned part of
+/// the generated document (the versioned document naming convention, the unbound-route-token
+/// backfill, the generated <c>ProblemDetails</c> error schema) is diffed against a committed baseline
+/// in-repo by <c>OpenApiBaselineTests</c> (Tests/Presentation/MMCA.Common.API.Tests/OpenApi), which
+/// fails on any change until the baseline is regenerated deliberately in the same pull request. Each
+/// consumer's concrete API surface stays the concern of the contract-snapshot tests in that host's
+/// integration tier. Mapped <b>outside Production only</b>: these are internal
 /// services reached through the Gateway (which does not route the endpoint), so the spec is a dev/CI
 /// artifact, not a public production surface. <see cref="MapCommonScalarUi"/> optionally renders it.
 /// </summary>

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/ServiceContractPurityTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/ServiceContractPurityTests.cs
@@ -1,0 +1,14 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// <c>[ServiceContract]</c> purity rule (a published contract type must not reach into the producing
+/// service's Domain/Application/Infrastructure), driven by the shared
+/// <see cref="ServiceContractPurityTestsBase"/>. MMCA.Common marks no type today, so the framework run
+/// is a ratchet rather than an assertion; see the base for why the rule is attribute-driven.
+/// </summary>
+public sealed class ServiceContractPurityTests : ServiceContractPurityTestsBase
+{
+    protected override IArchitectureMap Map { get; } = new CommonArchitectureMap();
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/ApiParameterDescriptorBackfillProviderTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/ApiParameterDescriptorBackfillProviderTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Reflection;
 using System.Text.Json;
 using Asp.Versioning;
 using AwesomeAssertions;
@@ -7,13 +6,9 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.ApplicationParts;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using MMCA.Common.API.OpenApi;
 using MMCA.Common.API.Startup;
 
@@ -143,50 +138,12 @@ public sealed class ApiParameterDescriptorBackfillProviderTests
     }
 
     // ── Helpers ──
-    private static async Task<WebApplication> CreateHostAsync()
-    {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
-        {
-            EnvironmentName = Environments.Development,
-        });
-
-        builder.WebHost.UseTestServer();
-        builder.Logging.ClearProviders();
-
-        // Restrict discovery to this file's probe controllers so the assertions cannot be
-        // perturbed by controllers belonging to other tests or to MMCA.Common.API itself.
-        builder.Services.AddControllers().ConfigureApplicationPartManager(manager =>
-        {
-            for (int i = manager.FeatureProviders.Count - 1; i >= 0; i--)
-            {
-                if (manager.FeatureProviders[i] is IApplicationFeatureProvider<ControllerFeature>)
-                {
-                    manager.FeatureProviders.RemoveAt(i);
-                }
-            }
-
-            manager.FeatureProviders.Add(new ProbeControllerFeatureProvider());
-        });
-
-        builder.Services.AddCommonApiVersioning();
-        builder.Services.AddCommonOpenApi();
-
-        WebApplication app = builder.Build();
-        app.MapControllers();
-        app.MapCommonOpenApi();
-        await app.StartAsync();
-
-        return app;
-    }
-
-    private sealed class ProbeControllerFeatureProvider : IApplicationFeatureProvider<ControllerFeature>
-    {
-        public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
-        {
-            feature.Controllers.Add(typeof(SegmentVersionedProbeController).GetTypeInfo());
-            feature.Controllers.Add(typeof(UnboundRouteTokenProbeController).GetTypeInfo());
-        }
-    }
+    // Discovery is restricted to this file's probe controllers so the assertions cannot be
+    // perturbed by controllers belonging to other tests or to MMCA.Common.API itself.
+    private static Task<WebApplication> CreateHostAsync() =>
+        OpenApiProbeHost.CreateAsync(
+            typeof(SegmentVersionedProbeController),
+            typeof(UnboundRouteTokenProbeController));
 }
 
 /// <summary>

--- a/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/OpenApiBaselineTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/OpenApiBaselineTests.cs
@@ -1,0 +1,181 @@
+using System.Buffers;
+using System.Globalization;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using Asp.Versioning;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+
+namespace MMCA.Common.API.Tests.OpenApi;
+
+/// <summary>
+/// Contract-snapshot gate over the framework-owned OpenAPI surface: the document that
+/// <c>AddCommonApiVersioning</c> + <c>AddCommonOpenApi</c> + <c>MapCommonOpenApi</c> generate is fetched
+/// from a real in-memory host, normalized, and diffed against the committed
+/// <c>openapi-baseline.v1.json</c>. Anything that moves the generated contract (an SDK or
+/// <c>Asp.Versioning.OpenApi</c> bump, a change to the framework's OpenAPI registration, the
+/// unbound-route-token backfill, the versioned document naming convention, or the generated
+/// <c>ProblemDetails</c> error schema) fails this test instead of reaching consumers unnoticed.
+/// <para>
+/// The probe controllers stand in for a consumer's real controllers deliberately: this test guards the
+/// framework's document-generation behaviour, not any concrete API. Consumer hosts keep their own
+/// contract-snapshot tests over their own endpoints.
+/// </para>
+/// <para>
+/// Regeneration is deliberate, never automatic. After an intended contract change, set
+/// <c>MMCA_UPDATE_OPENAPI_BASELINE=1</c>, re-run this test to rewrite the baseline in the source tree,
+/// then review the diff and commit it in the same pull request as the change that caused it.
+/// </para>
+/// </summary>
+public sealed class OpenApiBaselineTests
+{
+    /// <summary>Set to <c>1</c> to rewrite the committed baseline instead of asserting against it.</summary>
+    private const string UpdateBaselineVariable = "MMCA_UPDATE_OPENAPI_BASELINE";
+
+    /// <summary>Root properties dropped before comparison because they vary per host, not per contract.</summary>
+    private static readonly HashSet<string> VolatileRootProperties =
+        new(StringComparer.Ordinal) { "servers" };
+
+    // ── The gate: the generated document must equal the committed baseline ──
+    [Fact]
+    public async Task GeneratedOpenApiDocument_MatchesTheCommittedBaseline()
+    {
+        await using WebApplication app = await OpenApiProbeHost.CreateAsync(
+            typeof(SegmentVersionedProbeController),
+            typeof(UnboundRouteTokenProbeController),
+            typeof(ProblemDetailsProbeController));
+        using HttpClient client = app.GetTestClient();
+
+        using var response = await client.GetAsync(new Uri("/openapi/v1.json", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "the contract surface cannot be compared if the document does not generate");
+
+        string actual = Normalize(await response.Content.ReadAsStringAsync());
+        string baselinePath = GetBaselinePath();
+
+        if (IsUpdatingBaseline())
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+            await File.WriteAllTextAsync(baselinePath, actual.ReplaceLineEndings());
+            return;
+        }
+
+        File.Exists(baselinePath).Should().BeTrue(
+            "the committed OpenAPI baseline is missing from " + baselinePath + ". "
+            + RegenerationGuidance);
+
+        string expected = Normalize(await File.ReadAllTextAsync(baselinePath));
+        actual.Should().Be(
+            expected,
+            "the framework-owned OpenAPI contract surface changed against " + baselinePath + ". "
+            + RegenerationGuidance);
+    }
+
+    // ── Normalization must be stable, or the gate would flag noise as drift ──
+    [Fact]
+    public void Normalize_SortsPropertiesAndDropsVolatileRootContent()
+    {
+        const string json = """
+            {"paths":{},"servers":[{"url":"http://localhost:5000"}],"openapi":"3.1.1"}
+            """;
+
+        string normalized = Normalize(json);
+
+        normalized.Should().NotContain("servers", "a host-assigned server URL is not part of the contract");
+        normalized.IndexOf("openapi", StringComparison.Ordinal).Should().BeLessThan(
+            normalized.IndexOf("paths", StringComparison.Ordinal),
+            "object properties are sorted ordinally so generator ordering never shows up as drift");
+    }
+
+    // ── Helpers ──
+
+    /// <summary>The guidance appended to every failure so the fix is one documented step.</summary>
+    private static string RegenerationGuidance =>
+        "If the change is intended, regenerate the baseline deliberately in the same pull request: set "
+        + UpdateBaselineVariable
+        + "=1 and re-run this test, then review and commit the updated openapi-baseline.v1.json. "
+        + "If it is not intended, the framework's OpenAPI generation regressed.";
+
+    /// <summary>
+    /// Reduces a generated document to a comparable form: volatile root content is dropped, every object's
+    /// properties are ordered ordinally (generators do not promise a stable property order), arrays keep
+    /// their order (it is contractual for parameters and enum values), and the result is re-serialized
+    /// indented with LF endings so the diff on a failure is readable and platform-independent.
+    /// </summary>
+    private static string Normalize(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = true }))
+        {
+            WriteNormalized(writer, document.RootElement, isRoot: true);
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan).ReplaceLineEndings("\n").Trim();
+    }
+
+    private static void WriteNormalized(Utf8JsonWriter writer, JsonElement element, bool isRoot)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            writer.WriteStartObject();
+            foreach (JsonProperty property in element.EnumerateObject()
+                .Where(property => !isRoot || !VolatileRootProperties.Contains(property.Name))
+                .OrderBy(property => property.Name, StringComparer.Ordinal))
+            {
+                writer.WritePropertyName(property.Name);
+                WriteNormalized(writer, property.Value, isRoot: false);
+            }
+
+            writer.WriteEndObject();
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            writer.WriteStartArray();
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                WriteNormalized(writer, item, isRoot: false);
+            }
+
+            writer.WriteEndArray();
+        }
+        else
+        {
+            element.WriteTo(writer);
+        }
+    }
+
+    private static bool IsUpdatingBaseline() =>
+        string.Equals(Environment.GetEnvironmentVariable(UpdateBaselineVariable), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Locates the baseline next to this source file rather than next to the built test assembly, so the
+    /// regeneration path writes the file a developer actually commits.
+    /// </summary>
+    /// <param name="callerFilePath">Supplied by the compiler; never passed explicitly.</param>
+    private static string GetBaselinePath([CallerFilePath] string callerFilePath = "") =>
+        Path.Combine(Path.GetDirectoryName(callerFilePath)!, "openapi-baseline.v1.json");
+}
+
+/// <summary>
+/// Probe controller declaring a <c>ProblemDetails</c> failure response, so the baseline covers the error
+/// schema the framework's generated contract emits for every consumer, not just the success shapes.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/baseline-probe")]
+public sealed class ProblemDetailsProbeController : ControllerBase
+{
+    /// <summary>Returns the supplied identifier, or a ProblemDetails failure when it is not positive.</summary>
+    /// <param name="id">The identifier to look up.</param>
+    [HttpGet("{id}")]
+    [ProducesResponseType<string>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    public IActionResult Get(int id) =>
+        id > 0 ? Ok(id.ToString(CultureInfo.InvariantCulture)) : NotFound();
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/OpenApiProbeHost.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/OpenApiProbeHost.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.API.Startup;
+
+namespace MMCA.Common.API.Tests.OpenApi;
+
+/// <summary>
+/// Boots a started in-memory <see cref="WebApplication"/> over the real MVC + <c>AddCommonApiVersioning</c>
+/// + <c>AddCommonOpenApi</c> + <c>MapCommonOpenApi</c> pipeline, so <c>/openapi/v1.json</c> is served by the
+/// same code path a service host runs. Controller discovery is restricted to an explicit probe list: the
+/// default feature providers would otherwise sweep in every controller in the test assembly (and in
+/// MMCA.Common.API itself), which would make each caller's document depend on unrelated test files.
+/// </summary>
+internal static class OpenApiProbeHost
+{
+    /// <summary>
+    /// Creates and starts a host whose only controllers are <paramref name="controllerTypes"/>.
+    /// The caller owns the returned application and must dispose it (<c>await using</c>).
+    /// </summary>
+    /// <param name="controllerTypes">The probe controllers this host should describe.</param>
+    public static async Task<WebApplication> CreateAsync(params Type[] controllerTypes)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddControllers();
+        builder.Services.AddCommonApiVersioning();
+        builder.Services.AddCommonOpenApi();
+
+        // Restricting discovery has to happen AFTER the framework registrations: the API-versioning
+        // builder runs AddMvcCore internally, which puts MVC's default ControllerFeatureProvider back
+        // whenever it is absent, so a strip done earlier is silently undone.
+        builder.Services.AddControllers().ConfigureApplicationPartManager(manager =>
+        {
+            for (int i = manager.FeatureProviders.Count - 1; i >= 0; i--)
+            {
+                if (manager.FeatureProviders[i] is IApplicationFeatureProvider<ControllerFeature>)
+                {
+                    manager.FeatureProviders.RemoveAt(i);
+                }
+            }
+
+            manager.FeatureProviders.Add(new ProbeControllerFeatureProvider(controllerTypes));
+        });
+
+        WebApplication app = builder.Build();
+        app.MapControllers();
+        app.MapCommonOpenApi();
+        await app.StartAsync();
+
+        return app;
+    }
+
+    private sealed class ProbeControllerFeatureProvider(Type[] controllerTypes)
+        : IApplicationFeatureProvider<ControllerFeature>
+    {
+        public void PopulateFeature(IEnumerable<ApplicationPart> parts, ControllerFeature feature)
+        {
+            foreach (Type controllerType in controllerTypes)
+            {
+                feature.Controllers.Add(controllerType.GetTypeInfo());
+            }
+        }
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/openapi-baseline.v1.json
+++ b/Tests/Presentation/MMCA.Common.API.Tests/OpenApi/openapi-baseline.v1.json
@@ -1,0 +1,233 @@
+{
+  "components": {
+    "schemas": {
+      "ProblemDetails": {
+        "properties": {
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "",
+    "title": "MMCA.Common.API.Tests | v1",
+    "version": "1.0"
+  },
+  "openapi": "3.1.1",
+  "paths": {
+    "/api/backfill-probe/{tenant}/items": {
+      "get": {
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "tenant",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The requested API version",
+            "in": "header",
+            "name": "api-version",
+            "schema": {
+              "enum": [
+                "1.0"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "",
+        "tags": [
+          "UnboundRouteTokenProbe"
+        ]
+      }
+    },
+    "/api/v{version}/backfill-probe/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ]
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The requested API version",
+            "in": "header",
+            "name": "api-version",
+            "schema": {
+              "enum": [
+                "1.0"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "",
+        "tags": [
+          "SegmentVersionedProbe"
+        ]
+      }
+    },
+    "/api/v{version}/baseline-probe/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ]
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The requested API version",
+            "in": "header",
+            "name": "api-version",
+            "schema": {
+              "enum": [
+                "1.0"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "",
+        "tags": [
+          "ProblemDetailsProbe"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "SegmentVersionedProbe"
+    },
+    {
+      "name": "UnboundRouteTokenProbe"
+    },
+    {
+      "name": "ProblemDetailsProbe"
+    }
+  ]
+}


### PR DESCRIPTION
Closes the scorecard #9 (API & Contract Design) maturity gap: the rubric's Maturity-4 bar is "enforced automatically (analyzers/tests/CI)", and both #9 mechanisms now run in-repo. Backlog item: common-RemediationBacklog #9 (pre-authorized as "a minimal in-repo contract-surface fitness check over the framework-owned pieces").

## Lever A: OpenAPI baseline snapshot test

- `OpenApiBaselineTests` spins up the shared probe host (`OpenApiProbeHost`, extracted from `ApiParameterDescriptorBackfillProviderTests`), fetches `/openapi/v1.json`, normalizes it (recursive ordinal key sort, `servers` stripped, LF newlines), and diffs against the committed `openapi-baseline.v1.json` (232 lines: 3 probe paths + the `ProblemDetails` schema).
- Regeneration doctrine mirrors the perf gate: set `MMCA_UPDATE_OPENAPI_BASELINE=1`, re-run the test, review and commit the updated baseline in the same PR.
- This does not reverse the consumer-owned delegation: ADC/Store hosts keep their `OpenApiContractTestsBase` snapshots over the concrete API surface; the framework guards only its own generated surface. `OpenApiEndpointExtensions`' doc comment records the two-level guard.
- Fix folded in: the old probe host stripped MVC's `ControllerFeatureProvider` before `AddCommonApiVersioning()`, which re-adds it via `AddMvcCore`, so unrelated test controllers leaked into the document (40 paths). The strip now happens after framework registrations; the document is exactly the probe surface.

## Lever B: [ServiceContract] purity rule

- `ArchitectureRules.Contracts.ServiceContractsDoNotDependOnServiceInternals(map)`: attribute-driven scan (full-name string match, no new references) over all mapped assemblies; any `[ServiceContract]` type depending on a mapped Domain/Application/Infrastructure root namespace fails with the offending type named.
- `ServiceContractPurityTestsBase` (new shipped base, PublicAPI tracked) + sealed Common subclass. Vacuous pass while no type carries the attribute is documented in the base's doc comment, mirroring `ProtoContractTestsBase`.
- `ServiceContractAttribute` doc comment updated: the invariant is enforced by the dedicated rule plus the ADR-015 purity rules; the attribute remains an adoptable marker Common does not yet apply.

## Verification

- Release build: 0 warnings. Full suite: 3840/3840 passed.
- Negative checks performed: perturbed baseline fails with the regeneration message; a scratch leaky `[ServiceContract]` type fails the purity rule naming the type, while a pure one passes.
- FACTS regenerated in this PR (110 fitness methods / 38 bases); `build/facts --check` green.

Follow-up (next release sweep, not this PR): consumers subclass `ServiceContractPurityTestsBase` and may adopt `[ServiceContract]` on their `*.Contracts` projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016usKhixm2drfHmwmmmqwbn