### PR TITLE
chore: remove dead section-heading watermark rules from app.css

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/app.css
@@ -395,26 +395,6 @@ h1:focus {
     padding-bottom: var(--mmca-space-xs, 0.25rem);
 }
 
-.mmca-section-heading .mud-icon {
-    font-size: 8rem !important;
-    /* Palette-aware watermark: the ink follows the theme, the opacity keeps it a ghost behind the
-       title. A hardcoded black at 4% disappeared entirely on a dark surface. */
-    color: var(--mud-palette-text-primary);
-    opacity: 0.05;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    pointer-events: none;
-}
-
-.mmca-section-heading-light .mud-icon {
-    /* Sits on a deliberately dark band in both themes, so it keeps its white and resets the
-       opacity the base rule applies (the alpha is already in the color). */
-    color: rgba(255, 255, 255, 0.06);
-    opacity: 1;
-}
-
 .mmca-section-heading .mud-typography {
     position: relative;
     font-weight: 700;


### PR DESCRIPTION
Removes the two `.mmca-section-heading .mud-icon` rules (base + `-light` variant) from `MMCA.Common.UI/wwwroot/app.css`.

**Why removal, not a selector fix:** MudBlazor emits `mud-icon-root`, not `mud-icon`, so the 8rem ghost watermark has never rendered for any consumer - the rules are dead. Repairing the selector would be worse than deleting: the current section-heading design (ADC #127 / Store home) places small inline eyebrow `MudIcon`s inside `.mmca-section-heading`, and a fixed selector would seize those and turn them into 8rem absolute-positioned ghosts. Deletion preserves the shipped, AA-verified visuals byte-for-byte (the rules match nothing today).

The `.mud-typography` layering rules below them are kept - they stand on their own.

No consumer change needed; this rides the next `MMCA.Common` release and consumer sweep. Follow-up recorded 2026-08-19 (ADC UI polish); the only other repo-side reference is a historical CHANGELOG entry, left as history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016usKhixm2drfHmwmmmqwbn