### PR TITLE
fix: mobile-head scroll-lock release + Android approximate-location grants

### DIFF
--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiGeolocationService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiGeolocationService.cs
@@ -22,13 +22,28 @@ public sealed class MauiGeolocationService : IGeolocationService
         try
         {
             var status = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>().ConfigureAwait(false);
-            if (status != PermissionStatus.Granted)
+#if ANDROID
+            // Android 12+ "Approximate only" grants coarse and denies fine, and the composite
+            // LocationWhenInUse check reports that as Denied. Probe coarse alone so an existing
+            // approximate grant is honored without re-showing the precise-upgrade prompt on
+            // every read.
+            if (status != PermissionStatus.Granted
+                && await Permissions.CheckStatusAsync<CoarseLocationOnly>().ConfigureAwait(false) == PermissionStatus.Granted)
+            {
+                status = PermissionStatus.Restricted;
+            }
+#endif
+            if (status is not (PermissionStatus.Granted or PermissionStatus.Restricted))
             {
                 status = await MainThread.InvokeOnMainThreadAsync(
                     static () => Permissions.RequestAsync<Permissions.LocationWhenInUse>()).ConfigureAwait(false);
             }
 
-            if (status != PermissionStatus.Granted)
+            // Restricted is a partial grant (Android approximate-only: RequestAsync counts one of
+            // the two runtime permissions granted). Essentials' own Geolocation calls accept
+            // Granted-or-Restricted; rejecting Restricted here would turn the deliberate coarse
+            // design into a silent no-hint for every approximate user.
+            if (status is not (PermissionStatus.Granted or PermissionStatus.Restricted))
             {
                 return null;
             }
@@ -60,4 +75,17 @@ public sealed class MauiGeolocationService : IGeolocationService
 
     private static bool IsFresh(Location location) =>
         location.Timestamp >= DateTimeOffset.UtcNow - LastKnownFreshness;
+
+#if ANDROID
+    /// <summary>
+    /// Coarse-only status probe. MAUI's <c>LocationWhenInUse</c> lists BOTH coarse and fine as
+    /// required, so its <c>CheckStatusAsync</c> can never say Granted for an approximate-only
+    /// grant; this subclass asks about coarse alone.
+    /// </summary>
+    private sealed class CoarseLocationOnly : Permissions.BasePlatformPermission
+    {
+        public override (string, bool)[] RequiredPermissions =>
+            [(global::Android.Manifest.Permission.AccessCoarseLocation, true)];
+    }
+#endif
 }

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/navmenu.js
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/navmenu.js
@@ -7,8 +7,9 @@
         var toggler = getToggler();
         if (toggler && toggler.checked) {
             toggler.checked = false;
-            toggler.dispatchEvent(new Event('change'));
+            toggler.dispatchEvent(new Event('change', { bubbles: true }));
         }
+        syncOverflow();
     }
 
     // Ensure body overflow matches the actual toggler state.


### PR DESCRIPTION
Two mobile-head framework fixes surfaced by on-device testing of the ADC MAUI app. Both are in shared UI packages; consumers pick them up on the next release + sweep.

## 1. Stale body scroll-lock when the mobile nav closes via link or backdrop (`MMCA.Common.UI/wwwroot/navmenu.js`)

`closeMenu()` dispatched a non-bubbling `Event('change')` after unchecking the hamburger toggler. The document-level `change` listener that clears `document.body.style.overflow = 'hidden'` never fired, so the menu closed visually (the `:checked` CSS selector reacts to the property) but the body stayed scroll-locked.

Why only the MAUI head, and only sometimes: the web head is masked by the `enhancedload` re-sync; the MAUI `BlazorWebView` head uses the interactive router (`enhancedload` never fires, `pageshow` only at startup), so the stale lock persisted until app restart. Closing via the hamburger icon itself fires a native bubbling change and unlocks correctly - hence the intermittency (unscrollable Home/speaker pages on Android after navigating through the menu).

Fix: dispatch the synthetic change with `{ bubbles: true }` (also restores `aria-expanded`) and call `syncOverflow()` directly from `closeMenu()`.

## 2. `MauiGeolocationService` rejects Android approximate-only location grants (`MMCA.Common.UI.Maui`)

MAUI's `Permissions.LocationWhenInUse` lists BOTH coarse and fine as required runtime permissions on Android:

- An approximate-only grant (Android 12+ "Approximate": coarse granted, fine denied) makes the composite `CheckStatusAsync` report `Denied`, and `RequestAsync` reports it as `Restricted` (one of two granted). The service accepted only `Granted`, so every approximate user silently lost the proximity hint - even though Essentials' own `Geolocation` calls accept Granted-or-Restricted.
- A new Android-only `CoarseLocationOnly` probe (`BasePlatformPermission` over `ACCESS_COARSE_LOCATION` alone) detects an existing coarse grant up front, so approximate users are not nagged with the precise-upgrade dialog on every read.

The service now treats `Granted` or `Restricted` as success on both the check and request paths.

Consumer note: this is necessary but not sufficient - a head declaring only `ACCESS_COARSE_LOCATION` gets `PermissionException` from every `LocationWhenInUse` call (MAUI's `EnsureDeclared` demands fine be declared too). The companion manifest fix is ADC PR ivanball/ADC#138.

## Verification

- navmenu.js: reasoning-level (event bubbling semantics); behavior change is MAUI-head navigation unlock.
- Geolocation: all four `MMCA.Common.UI.Maui` TFMs build warning-free (net10.0-android/ios/maccatalyst/windows; only the two pre-existing `NativeThemeSync.razor` bundling notices).
- Verified against dotnet/maui Essentials source: `LocationWhenInUse.RequiredPermissions` = coarse + fine, `EnsureDeclared` throws on undeclared, `RequestAsync` maps a 1-of-2 grant to `Restricted`, and `Geolocation.android.cs` uses `EnsureGrantedOrRestrictedAsync`.

## Rollout

Ships with the next MMCA.Common release; ADC picks both up on the consumer sweep + Android rebuild/redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Sd9LPEuNxdVZeygtUDEbm
