### PR TITLE
fix: Result-taking fetch path for MobileInfiniteScrollList (v1.164.1)

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/Components/MobileInfiniteScrollList.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/MobileInfiniteScrollList.razor
@@ -36,7 +36,7 @@ else
     @if (_loadError && _hasMore)
     {
         <div class="d-flex flex-column align-center pa-4 gap-2">
-            <MudText Typo="Typo.body2" Color="Color.Error">@L["Grid.LoadMoreFailed"]</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Error">@(_loadErrorMessage ?? L["Grid.LoadMoreFailed"].Value)</MudText>
             <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="RetryAsync">@L["Common.Button.Retry"]</MudButton>
         </div>
     }

--- a/Source/Presentation/MMCA.Common.UI/Components/MobileInfiniteScrollList.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/MobileInfiniteScrollList.razor.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.UI.Common;
 using MMCA.Common.UI.Resources;
 using MudBlazor;
 
@@ -24,9 +26,27 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
     [EditorRequired]
     public RenderFragment<TItem> CardTemplate { get; set; } = default!;
 
+    /// <summary>
+    /// The page fetcher, in the shape every Result-returning UI service already has
+    /// (<c>IEntityService.GetPagedAsync</c> without the filter/sort arguments): page number
+    /// (1-based), page size, cancellation token. A failure <see cref="Result"/> renders the inline
+    /// load-failure message plus its Retry button, exactly where a thrown exception used to.
+    /// Supply either this or the obsolete <see cref="FetchPage"/>, never both.
+    /// </summary>
     [Parameter]
-    [EditorRequired]
-    public Func<int, int, CancellationToken, Task<(IReadOnlyList<TItem> Items, int TotalItems)>> FetchPage { get; set; } = default!;
+    public Func<int, int, CancellationToken, Task<Result<(IReadOnlyList<TItem> Items, int TotalItems)>>>? FetchPageResult { get; set; }
+
+    /// <summary>
+    /// The pre-Result page fetcher, whose only failure signal is a thrown exception.
+    /// Kept working for call sites that have not switched yet: its tuple is lifted into a success
+    /// <see cref="Result"/> internally, so both parameters run the same single load path.
+    /// </summary>
+    [Parameter]
+#pragma warning disable S1133 // Deprecated code should be removed: the obsoletion IS the migration mechanism; it turns every remaining tuple call site into a build warning during the lockstep sweep, and the parameter is removed once all consumers are swept.
+    [Obsolete("Services no longer throw for server answers, so a failure has to reach the component as a Result to keep the inline retry affordance. Use FetchPageResult, whose delegate returns Task<Result<(IReadOnlyList<TItem> Items, int TotalItems)>>.")]
+#pragma warning restore S1133
+    public Func<int, int, CancellationToken, Task<(IReadOnlyList<TItem> Items, int TotalItems)>>? FetchPage { get; set; }
+
     [Parameter] public int PageSize { get; set; } = 10;
     [Parameter] public EventCallback<TItem> OnCardClick { get; set; }
 
@@ -56,6 +76,14 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
     private bool _isLoadingMore;
     private bool _hasMore = true;
     private bool _loadError;
+
+    /// <summary>
+    /// The localized message from a failure <see cref="Result"/>, rendered in place of the generic
+    /// load-failure text. Null when the failure carried no message or came from an exception, in
+    /// which case the generic resource string is shown instead.
+    /// </summary>
+    private string? _loadErrorMessage;
+
     private ElementReference _sentinelRef;
     private IJSObjectReference? _jsModule;
     private DotNetObjectReference<MobileInfiniteScrollList<TItem>>? _dotNetRef;
@@ -66,8 +94,47 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
+        ValidateFetchParameters();
+
         await LoadNextPageAsync(isInitial: true);
         _isInitialLoad = false;
+    }
+
+    /// <summary>
+    /// Exactly one fetcher must be supplied. Checked here rather than inside the load, so a
+    /// misconfigured call site fails loudly instead of rendering as a load failure with a Retry
+    /// button that can never succeed.
+    /// </summary>
+    private void ValidateFetchParameters()
+    {
+#pragma warning disable CS0618 // The obsolete parameter stays supported; reading it is the support.
+        bool hasTupleFetch = FetchPage is not null;
+#pragma warning restore CS0618
+        bool hasResultFetch = FetchPageResult is not null;
+
+        if (hasTupleFetch == hasResultFetch)
+        {
+            throw new InvalidOperationException(
+                "MobileInfiniteScrollList requires exactly one of FetchPageResult (preferred) or the obsolete FetchPage.");
+        }
+    }
+
+    /// <summary>
+    /// The single fetch path. The obsolete tuple delegate is lifted into a success
+    /// <see cref="Result"/>, so the caller below has one shape to handle regardless of which
+    /// parameter the call site supplied (an exception from it still travels as an exception).
+    /// </summary>
+    private async Task<Result<(IReadOnlyList<TItem> Items, int TotalItems)>> FetchAsync(
+        int page, CancellationToken cancellationToken)
+    {
+        if (FetchPageResult is not null)
+        {
+            return await FetchPageResult(page, PageSize, cancellationToken);
+        }
+
+#pragma warning disable CS0618 // Back-compat path for call sites still on the tuple delegate.
+        return Result.Success(await FetchPage!(page, PageSize, cancellationToken));
+#pragma warning restore CS0618
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -135,6 +202,7 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
 
         _isLoadingMore = true;
         _loadError = false;
+        _loadErrorMessage = null;
 
         // Snapshot the generation this load belongs to. Whoever supersedes it (ResetAsync) owns
         // cancelling and disposing the token source it publishes here.
@@ -149,15 +217,25 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
 
         try
         {
-            var (items, totalCount) = await FetchPage(targetPage, PageSize, cts.Token);
+            var fetched = await FetchAsync(targetPage, cts.Token);
 
-            // The generation, not the token, is authoritative: FetchPage is consumer-supplied and may
-            // ignore the CancellationToken entirely, so a superseded fetch can still complete
+            // The generation, not the token, is authoritative: the fetcher is consumer-supplied and
+            // may ignore the CancellationToken entirely, so a superseded fetch can still complete
             // successfully. This check is what keeps its rows out of the list ResetAsync just cleared.
             if (_disposed || generation != _generation)
             {
                 return;
             }
+
+            if (!fetched.TryGetValue(out var page))
+            {
+                // A failure Result is the answer an exception used to be: same error state, same
+                // inline Retry button, and the page counter still never advanced.
+                SetLoadFailed(isInitial, fetched);
+                return;
+            }
+
+            var (items, totalCount) = page;
 
             _currentPage = targetPage;
             _items.AddRange(items);
@@ -178,14 +256,7 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
                 return;
             }
 
-            _loadError = true;
-
-            if (isInitial)
-            {
-                // Localized, sanitized message: raw exception text is neither translatable nor safe to
-                // surface (ADR-027 / rubric §24).
-                Snackbar.Add(L["Grid.Snackbar.LoadFailed"], Severity.Error);
-            }
+            SetLoadFailed(isInitial, failure: null);
         }
         finally
         {
@@ -203,6 +274,28 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
                 _cts = null;
                 cts.Dispose();
             }
+        }
+    }
+
+    /// <summary>
+    /// Raises the error state both failure signals share: the inline message plus its Retry button,
+    /// and on the very first load a snackbar as well (the initial failure renders as an empty state,
+    /// so the snackbar is the only thing the user would otherwise see).
+    /// </summary>
+    /// <param name="isInitial">Whether this was the initial load.</param>
+    /// <param name="failure">
+    /// The failed result whose localized message is shown, or <see langword="null"/> for an
+    /// exception, whose raw text is neither translatable nor safe to surface (ADR-027 / rubric §24)
+    /// and which therefore falls back to the generic resource string.
+    /// </param>
+    private void SetLoadFailed(bool isInitial, Result? failure)
+    {
+        _loadError = true;
+        _loadErrorMessage = failure?.LocalizedErrorMessage(L);
+
+        if (isInitial)
+        {
+            Snackbar.Add(_loadErrorMessage ?? L["Grid.Snackbar.LoadFailed"].Value, Severity.Error);
         }
     }
 
@@ -241,6 +334,7 @@ public partial class MobileInfiniteScrollList<TItem> : IAsyncDisposable
         _totalCount = 0;
         _hasMore = true;
         _loadError = false;
+        _loadErrorMessage = null;
         _isInitialLoad = true;
 
         await DetachObserverAsync();

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -197,3 +197,7 @@ override MMCA.Common.UI.Pages.Auth.Sessions.OnInitializedAsync() -> System.Threa
 static readonly MMCA.Common.UI.Common.RoutePaths.Sessions -> string!
 virtual MMCA.Common.UI.Pages.Auth.Sessions.Dispose(bool disposing) -> void
 ~override MMCA.Common.UI.Pages.Auth.Sessions.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+*REMOVED*MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPage.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>!
+MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPage.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>?
+MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>!>?
+MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.set -> void

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/Pages/ComponentsGallery.razor
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/Pages/ComponentsGallery.razor
@@ -1,4 +1,5 @@
 @page "/components"
+@using MMCA.Common.Shared.Abstractions
 @using MMCA.Common.UI.Components.Notifications
 
 <PageTitle>Components</PageTitle>
@@ -53,7 +54,7 @@
     <UnsavedChangesGuard IsDirty="_isDirty" />
 
     <MudText Typo="Typo.h5" Class="mt-6 mb-2">Mobile infinite-scroll list</MudText>
-    <MobileInfiniteScrollList TItem="SampleItem" FetchPage="FetchSamplePageAsync" PageSize="3"
+    <MobileInfiniteScrollList TItem="SampleItem" FetchPageResult="FetchSamplePageAsync" PageSize="3"
                               EmptyMessage="No items to show.">
         <CardTemplate>
             <MudText Typo="Typo.subtitle2">@context.Name</MudText>
@@ -93,7 +94,7 @@
 
     private Task ShowDeleteConfirmationAsync() => _deleteConfirmation.ShowAsync("First item");
 
-    private Task<(IReadOnlyList<SampleItem> Items, int TotalItems)> FetchSamplePageAsync(
+    private Task<Result<(IReadOnlyList<SampleItem> Items, int TotalItems)>> FetchSamplePageAsync(
         int page, int pageSize, CancellationToken cancellationToken)
-        => Task.FromResult<(IReadOnlyList<SampleItem>, int)>((_items, _items.Count));
+        => Task.FromResult(Result.Success<(IReadOnlyList<SampleItem>, int)>((_items, _items.Count)));
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/MobileInfiniteScrollListTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/MobileInfiniteScrollListTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Testing.UI;
 using MMCA.Common.UI.Components;
 using MudBlazor;
@@ -10,16 +11,16 @@ namespace MMCA.Common.UI.Tests.Components;
 
 public sealed class MobileInfiniteScrollListTests : BunitTestBase
 {
-    private static Func<int, int, CancellationToken, Task<(IReadOnlyList<string> Items, int TotalItems)>> Fetch(
+    private static Func<int, int, CancellationToken, Task<Result<(IReadOnlyList<string> Items, int TotalItems)>>> Fetch(
         IReadOnlyList<string> page, int total)
-        => (_, _, _) => Task.FromResult((page, total));
+        => (_, _, _) => Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((page, total)));
 
     [Fact]
     public void RendersEmptyState_WhenFetchReturnsNothing()
     {
         var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
             .Add(c => c.CardTemplate, item => item)
-            .Add(c => c.FetchPage, Fetch([], 0))
+            .Add(c => c.FetchPageResult, Fetch([], 0))
             .Add(c => c.EmptyMessage, "Nothing here"));
 
         cut.Markup.Should().Contain("Nothing here");
@@ -33,7 +34,7 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
 
         var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
             .Add(c => c.CardTemplate, item => item)
-            .Add(c => c.FetchPage, Fetch(items, items.Count)));
+            .Add(c => c.FetchPageResult, Fetch(items, items.Count)));
 
         cut.Markup.Should().Contain("Alpha").And.Contain("Bravo");
         cut.FindComponents<MudCard>().Count.Should().Be(2);
@@ -50,7 +51,7 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
             .Add(c => c.CardTemplate, item => item)
             .Add(c => c.PageSize, 2)
             .Add(c => c.MaxRenderedItems, 2)
-            .Add(c => c.FetchPage, Fetch(items, 10)));
+            .Add(c => c.FetchPageResult, Fetch(items, 10)));
 
         cut.FindComponents<MudCard>().Count.Should().Be(2);
         cut.FindAll(".infinite-scroll-sentinel").Should().BeEmpty();
@@ -63,7 +64,7 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
 
         var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
             .Add(c => c.CardTemplate, item => item)
-            .Add(c => c.FetchPage, Fetch(["Alpha", "Bravo"], 2))
+            .Add(c => c.FetchPageResult, Fetch(["Alpha", "Bravo"], 2))
             .Add(c => c.OnCardClick, EventCallback.Factory.Create<string>(this, s => clicked = s)));
 
         cut.FindAll(".mobile-list-card")[0].Click();
@@ -72,7 +73,94 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
     }
 
     [Fact]
-    public async Task WhenLoadMoreFails_ShowsRetry_ThenRecoversOnRetry()
+    public void SupplyingNeitherFetcher_Throws()
+    {
+        var render = () => RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
+            .Add(c => c.CardTemplate, item => item));
+
+        render.Should().Throw<InvalidOperationException>().WithMessage("*exactly one*");
+    }
+
+    [Fact]
+    public async Task WhenLoadMoreFails_ShowsLocalizedResultError_ThenRecoversOnRetry()
+    {
+        var page2Attempts = 0;
+
+        Task<Result<(IReadOnlyList<string> Items, int TotalItems)>> Fetch(int page, int pageSize, CancellationToken ct)
+        {
+            if (page == 1)
+            {
+                return Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((["Alpha"], 5)));
+            }
+
+            // First attempt at the second page fails as a Result (services no longer throw for a
+            // server answer); the retry succeeds.
+            page2Attempts++;
+            return page2Attempts == 1
+                ? Task.FromResult(Result.Failure<(IReadOnlyList<string>, int)>(
+                    Error.NotFoundError("Catalog.Unavailable", "The catalog is unavailable.")))
+                : Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((["Bravo"], 5)));
+        }
+
+        var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
+            .Add(c => c.CardTemplate, item => item)
+            .Add(c => c.PageSize, 1)
+            .Add(c => c.FetchPageResult, Fetch));
+
+        cut.Markup.Should().Contain("Alpha");
+
+        // Simulate the IntersectionObserver firing for the bottom sentinel.
+        await cut.InvokeAsync(() => cut.Instance.OnSentinelVisible());
+
+        // The failure's own message is shown (localized with pass-through), not the generic one.
+        cut.Markup.Should().Contain("The catalog is unavailable.")
+            .And.NotContain("Failed to load more items.");
+
+        await cut.FindButtonByText("Retry").ClickAsync(new MouseEventArgs());
+
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("Bravo"));
+        cut.Markup.Should().NotContain("The catalog is unavailable.");
+        page2Attempts.Should().Be(2, "the retry must re-fetch the page that failed");
+    }
+
+    [Fact]
+    public async Task WhenFetchIsCancelled_RendersNoErrorState()
+    {
+        static Task<Result<(IReadOnlyList<string> Items, int TotalItems)>> Fetch(int page, int pageSize, CancellationToken ct)
+            => page == 1
+                ? Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((["Alpha"], 5)))
+                : throw new OperationCanceledException();
+
+        var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
+            .Add(c => c.CardTemplate, item => item)
+            .Add(c => c.PageSize, 1)
+            .Add(c => c.FetchPageResult, Fetch));
+
+        await cut.InvokeAsync(() => cut.Instance.OnSentinelVisible());
+
+        // Cancellation is not a failure: no message, no retry button, nothing to undo.
+        cut.Markup.Should().NotContain("Failed to load more items.");
+        cut.FindAll("button").Should().BeEmpty();
+        cut.FindComponents<MudCard>().Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void ObsoleteTupleFetch_RendersCards()
+    {
+        var items = new List<string> { "Alpha", "Bravo" };
+
+        var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
+            .Add(c => c.CardTemplate, item => item)
+#pragma warning disable CS0618 // The obsolete tuple path must keep working until every call site is swept.
+            .Add(c => c.FetchPage, (_, _, _) => Task.FromResult<(IReadOnlyList<string>, int)>((items, items.Count))));
+#pragma warning restore CS0618
+
+        cut.Markup.Should().Contain("Alpha").And.Contain("Bravo");
+        cut.FindComponents<MudCard>().Count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ObsoleteTupleFetch_WhenLoadMoreThrows_ShowsRetry_ThenRecoversOnRetry()
     {
         var page2Attempts = 0;
 
@@ -93,12 +181,16 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
         var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
             .Add(c => c.CardTemplate, item => item)
             .Add(c => c.PageSize, 1)
+#pragma warning disable CS0618 // The obsolete tuple path must keep working until every call site is swept.
             .Add(c => c.FetchPage, Fetch));
+#pragma warning restore CS0618
 
         cut.Markup.Should().Contain("Alpha");
 
         // Simulate the IntersectionObserver firing for the bottom sentinel.
         await cut.InvokeAsync(() => cut.Instance.OnSentinelVisible());
+
+        // An exception carries no message that is safe to surface, so the generic one is shown.
         cut.Markup.Should().Contain("Failed to load more items.");
 
         await cut.FindButtonByText("Retry").ClickAsync(new MouseEventArgs());
@@ -110,9 +202,9 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
     public async Task ResetDuringAnInFlightFetch_DiscardsTheStalePage_AndReloadsWithoutRefetching()
     {
         var requestedPages = new List<int>();
-        var stalePage = new TaskCompletionSource<(IReadOnlyList<string> Items, int TotalItems)>();
+        var stalePage = new TaskCompletionSource<Result<(IReadOnlyList<string> Items, int TotalItems)>>();
 
-        Task<(IReadOnlyList<string> Items, int TotalItems)> GatedFetch(int page, int pageSize, CancellationToken ct)
+        Task<Result<(IReadOnlyList<string> Items, int TotalItems)>> GatedFetch(int page, int pageSize, CancellationToken ct)
         {
             requestedPages.Add(page);
 
@@ -120,7 +212,7 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
             // lands while it is still outstanding. Everything after that answers immediately.
             if (requestedPages.Count == 1)
             {
-                return Task.FromResult<(IReadOnlyList<string>, int)>((["Original"], 3));
+                return Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((["Original"], 3)));
             }
 
             if (requestedPages.Count == 2)
@@ -129,14 +221,14 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
             }
 
             return page == 1
-                ? Task.FromResult<(IReadOnlyList<string>, int)>((["FreshPageOne"], 3))
-                : Task.FromResult<(IReadOnlyList<string>, int)>((["FreshPageTwo"], 3));
+                ? Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((["FreshPageOne"], 3)))
+                : Task.FromResult(Result.Success<(IReadOnlyList<string>, int)>((["FreshPageTwo"], 3)));
         }
 
         var cut = RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
             .Add(c => c.CardTemplate, item => item)
             .Add(c => c.PageSize, 1)
-            .Add(c => c.FetchPage, GatedFetch));
+            .Add(c => c.FetchPageResult, GatedFetch));
 
         cut.Markup.Should().Contain("Original");
 
@@ -150,7 +242,7 @@ public sealed class MobileInfiniteScrollListTests : BunitTestBase
 
             await cut.Instance.ResetAsync();
 
-            stalePage.SetResult((["Stale"], 50));
+            stalePage.SetResult(Result.Success<(IReadOnlyList<string>, int)>((["Stale"], 50)));
         });
 
         await supersededLoad!;


### PR DESCRIPTION
All three consumer conversion sweeps independently hit this: the infinite-scroll component signaled failure via caught exception, so the v1.164 Result conversion cost mobile lists their inline retry. Adds FetchPageResult (failure renders the localized message + Retry), obsoletes the tuple path without breaking it, guards misconfiguration loudly. 4,536 tests green; gallery + E2E merge-gate projects build; gallery adopted the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqsypdW5pSzPJZVduZua7G