### PR TITLE
feat: Wave 6 Tier 2 extractions (scoped event handler base, gRPC decoder, host extensions, push providers, gateway hardening base, UI + testing bundles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,175 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.165.0] - 2026-08-28
+
+Wave 6 extraction release: framework surface hoisted from duplicated ADC/Store/Helpdesk code
+(Tier 1 items 6.1-6.7 and Tier 2 items 6.8-6.15 of the extraction plan), all additive and opt-in.
+
+### Added
+
+- **Read-scoping hook on `EntityControllerBase`.** An async `GetReadSpecificationAsync` hook is
+  honored by all five read actions (both `GetAll` overloads, lookup, `GetById`, and export), closing
+  the unscoped-export hazard class at the base; the sync `GetExportSpecification` folds in as the
+  default, and `SetConcurrencyETag` widens to `protected`.
+- **CRUD handler bases.** `CreateEntityHandlerBase`, `MutateEntityHandlerCore`/`Base` (Result and
+  DTO shapes, with the load / NotFound / `SetOriginalRowVersion` / mutate / save sequence and
+  EntityId/RowVersion/include/log extension points), and `AddChildEntityHandlerBase` /
+  `RemoveChildEntityHandlerBase` join `DeleteEntityHandler`, collapsing roughly fifty near-identical
+  per-app handlers.
+- **Persistence read surface.** `IEntityQuerier` gains `FirstOrDefaultAsync` (predicate and
+  specification overloads), `CountByAsync`/`SumByAsync` grouped aggregates, and
+  `FindIncludingDeletedAsync` (active vs soft-deleted split), with `EFReadRepository` and decorator
+  implementations, retiring the materialize-all-then-filter call sites.
+- **Unique-constraint violation detection.** `IUniqueConstraintViolationDetector` with a
+  `SqlServerUniqueConstraintViolationDetector` (SQL 2601/2627 plus message fallback), registered by
+  `AddInfrastructure`.
+- **Aggregate child helpers.** `RemoveChildOrNotFound` and `RestoreChild` beside the shipped
+  `GetChildOrNotFound`, plus `IReactivatable`.
+- **`ScopedIntegrationEventHandlerBase<TEvent>`.** The `CreateAsyncScope` preamble and
+  log-and-rethrow envelope (cancellation excluded, mirroring `SafeDomainEventHandler`) hoisted from
+  eighteen per-app integration-event handlers; `HandleScopedAsync` and `LogHandlerFailure` are the
+  extension points.
+- **gRPC Result trailer decoder.** `Metadata.ToErrors()` and `RpcException.ToResult`/`ToResult<T>`,
+  the exact inverse of the shipped `ToRpcException` and living in the same file so encoder and
+  decoder cannot drift; unstructured RPC failures synthesize a `Grpc.{StatusCode}` error.
+- **Opt-in service-host extensions.** `AddCommonSerilog(logFilePath)` (the identical Serilog
+  bootstrap all seven consumer hosts repeat, with a post-defaults configure hook) and
+  `AddModuleHost()` (settings binding, `ModuleLoader` construction, and a `RegisterModules` method
+  group the host drops into its own pipeline call), leaving `Program.cs` orchestration and the
+  `AddApplicationDecorators()`-last ordering host-owned.
+- **Push device-token providers (MMCA.Common.UI.Maui).** Both halves: the FCM provider plus
+  `MauiFirebaseMessagingService` (Android) and the APNs provider plus a now-public
+  `ApnsTokenBridge` (iOS/MacCatalyst), registered by `AddMauiPushDeviceTokenProvider()`; AppDelegate
+  hooks, manifest/plist entries, and credentials stay app-side. Adds the `Xamarin.Firebase.Messaging`
+  dependency to the MAUI package.
+- **`MmcaGatewayHardeningTestsBase<TEntryPoint>`** (MMCA.Common.Testing) with eight gateway gates
+  (rate-limit window, named policy, bypass paths, correlation-id generation and echo, per-downstream
+  readiness, active health-check probes, forwarded-client-IP partitioning) over abstract
+  route/limit/downstream inputs, plus a public `RecordingHttpForwarder` and
+  `NeutralizeGlobalRateLimiter()`. Adds the `Yarp.ReverseProxy` dependency to Testing.
+- **UI component bundle.** `ListPageActions`, `ListNoRecordsContent`, `InfiniteScrollSentinel`,
+  `SharePageButton` + `QrCodeButton` over a new `IPublicLinkBuilder` (browser implementation
+  registered by default, MAUI implementation via `AddCommonMauiPublicLinkBuilder()`),
+  `ApiFileDownloadButton` (the generalized download-from-endpoint button), and
+  `OfflineFirstPageSnapshot<TItem>` over `ILocalCacheStore`, all localized en+es and independently
+  consumable.
+- **Testing bundle.** bUnit `ConfigureDataGridListPageHost()` (encoding the load-bearing
+  `SetRendererInfo`-last ordering), `ErrorSummaryMessages()`, a now-public
+  `AddDeviceCapabilityDefaults()`, and E2E `SearchAndWaitForRowAsync` (deterministic waits, no
+  sleeps), `ConfirmDeleteAsync`, `WaitForGridToSettleAsync`, `MeasureWebVitalsAsync`, and
+  `PseudoLocalizationTestsBase`.
+- **Leaf additions.** `CommonInvariants` bundle 2 (enum-defined, end-not-before-start, string
+  length windows, optional max length, time-zone validity, URL well-formedness, count/uniqueness/
+  flag/nullable-int members), an optional `errorCode` parameter on every `CommonValidationRules`
+  rule class plus `AbsoluteUrlRules` (rejecting `javascript:`/`data:`/relative values),
+  `RequireUserId()` on `ICurrentUserService`, `NotificationScopeKey` (formatter and validation
+  pattern in one place, now the `ChannelKeyPattern` default), `AddMailDev()` for AppHosts,
+  `GetRequiredJwtAuthority()`, `EvictTagsAsync`/`TryEvictTagsAsync` output-cache params extensions
+  (throwing and best-effort variants), and `UseCommonForwardedHeaders()` reachable from the Gateway
+  package.
+
+### Changed
+
+- **`CommonValidationRules` rule-class constructors** gained a trailing optional `errorCode`
+  parameter: source-compatible for subclasses, binary-breaking for the superseded signatures (the
+  PublicAPI log records the removals). Omitting the parameter is behavior-identical to before.
+
+## [1.164.1] - 2026-08-27
+
+### Fixed
+
+- **`MobileInfiniteScrollList` regained its inline retry affordance under the Result contract.**
+  v1.164.0 converted the UI HTTP services to Result-returning, but the infinite-scroll component
+  still signaled failure by caught exception, so converted consumers lost the inline
+  failure-message-plus-Retry rendering. A new `FetchPageResult` parameter accepts the
+  Result-returning fetcher and renders the failure's localized message with a Retry button; the
+  tuple-returning `FetchPage` parameter keeps working but is `[Obsolete]`. Exactly one fetcher must
+  be supplied (misconfiguration throws at initialization), and cancellation semantics are unchanged.
+
+## [1.164.0] - 2026-08-27
+
+### Added
+
+- **Per-device session management surface.** Issued and rotated refresh sessions now stamp a `sid`
+  claim (additive), and `AuthControllerBase` gains `GET my-sessions` plus `POST revoke/{sessionId}`
+  backed by `RefreshSessionSummaryResponse`, an ownership-scoped `FindByIdAsync`, and
+  `GetSessionsAsync`/`RevokeSessionByIdAsync` on the authentication service, so a user can review
+  devices and sign out one of them or everywhere.
+- **Refresh-session retention sweep.** `RefreshSessionCleanupService` purges session rows that
+  stopped being usable more than `RefreshSessions:RetentionDays` (default 30) ago, gated on
+  `RefreshSessions:Enabled`, with the reuse-detection-window trade-off documented on the setting.
+- **Shared severity ranking and ProblemDetails reader.** `ErrorTypeSeverity` is hoisted so the HTTP
+  and gRPC edges classify multi-error aggregates identically (gRPC no longer picks the first error
+  positionally), and `ProblemDetailsResultReader` converts RFC 9457 payloads back into typed `Error`
+  lists (`ErrorType` preserved on the MMCA error-array shape; the lossy plain-400 reverse mapping is
+  documented), forming the foundation of the UI Result conversion below.
+- **Result ergonomics for pages.** `ResultUiExtensions` (`TryGetValue`, `OnFailureSetError`,
+  `NotifyOnFailure` with localization, deduplication, and severity ordering, plus `HasErrorType`
+  helpers) and a shared deduplicating `ErrorSummary` alert component, so consumer pages convert to
+  the Result contract uniformly.
+- **Sessions page.** A `/profile/sessions` page (device list with a current-device badge, per-row
+  revoke, sign-out-everywhere), its nav entry, and 23 localized keys in en and es, axe-scanned in
+  the gallery; `NavigationFlow.md` updated.
+
+### Changed
+
+- **BREAKING: every `MMCA.Common.UI` HTTP-typed-client service returns `Result`/`Result<T>` instead
+  of throwing `DomainInvariantViolationException`.** `ServiceExceptionHelper` is deleted;
+  `HttpResultExecutor` and `ProblemDetailsResultReader` preserve `ErrorType` end to end, and
+  `OperationCanceledException` still propagates for cancellation.
+  `EntityServiceBase`/`ChildEntityServiceBase`/`AuthUIService` and the notification services are all
+  converted (41 removals and 98 additions in the public API surface). Consumer pages migrate onto
+  `ResultUiExtensions`/`ErrorSummary` rather than try/catch blocks.
+
+## [1.163.0] - 2026-08-26
+
+### Added
+
+- **`MMCA.Common.Gateway` package.** The YARP gateway pieces both consumers hand-rolled now ship as
+  a package: cluster profile defaults, passive health-check defaults, a route/cluster trace-header
+  transform, and per-route rate-limiter policies. Route tables stay app-side by design.
+- **Soft-delete completion.** `DeletedOn`/`DeletedBy` audit columns are stamped on the `IsDeleted`
+  transition, the unique-index convention now appends the soft-delete clause to hand-authored
+  filters instead of skipping them, a `DeleteChildren` cascade helper joins the aggregate base, and
+  `SoftDeleteEnforcementTestsBase` adds a hard-delete fitness rule.
+- **Result combinators.** `Bind`/`Tap`/`Ensure`/`MatchAsync` with `Task<Result<T>>` overloads and
+  implicit conversions, so handler and service code chains Results without ceremony.
+- **MudForm validation bridge.** An `IModelValidator`/DataAnnotations adapter for MudBlazor forms
+  with localization support (`NotificationSend` converted as the reference page), and the duplicate
+  `ApiEndpoint` guard removed.
+- **Three new fitness rules** in `MMCA.Common.Testing.Architecture`:
+  `DomainEventHandlerSaveTestsBase` (transitive IL call-graph walk proving no `SaveChanges` under an
+  `IDomainEventHandler`), `ErrorCatalogTestsBase` (error-code uniqueness plus module prefix), and
+  `SortableColumnConventionTestsBase` (no `TemplateColumn` with `Sortable="true"`).
+
+### Changed
+
+- **BREAKING: multi-device refresh sessions.** `IAuthUser` loses
+  `RefreshToken`/`RefreshTokenExpiry`/`UpdateRefreshToken`/`RevokeRefreshToken`; refresh tokens now
+  live in a per-user `RefreshSessions` table, SHA-256 hashed at rest, with rotation chains
+  (`ReplacedByTokenHash`), reuse-detection family revocation, per-device or all-device sign-out, a
+  configurable session cap, and IP/UserAgent capture. Mapping is opt-in via
+  `ApplyRefreshSessionConfiguration` on the Identity context only. `AuthenticationServiceBase`
+  signatures gain `ipAddress`/`userAgent`, the duplicate `user_id` claim is dropped in favor of
+  `sub` only (`ClaimsPrincipalExtensions` and `AuthClaimTypes.Subject` added), and RS256 tokens now
+  emit the JWKS `kid` header.
+- **`ErrorType.Unexpected` maps to 500 on both edges**, and HTTP/gRPC status selection is
+  severity-ranked instead of first-error-positional, so a validation error can no longer mask an
+  unexpected failure in an aggregate Result.
+- **h2c health probes default to HTTP/2 exact** on gateway cluster destinations, with a
+  per-downstream opt-out for mixed-protocol services.
+
+### Fixed
+
+- **Mobile nav Logout row clearance.** The `.nav-auth-section` pinned at the bottom of the mobile
+  menu had no bottom inset, so the Logout row could land under the bottom browser bar or home
+  indicator; it now adds 0.75rem plus `env(safe-area-inset-bottom)`.
+
+### Dependencies
+
+- AngleSharp and 16 other package bumps, plus the analyzers group (3 updates).
+
 ## [1.162.0] - 2026-08-24
 
 ### Fixed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -151,6 +151,11 @@
          Lifecycle 2.9.2.x); newer builds (.32+) pull AndroidX versions past the Ktx packages'
          upper bounds and fail restore with NU1608. Bump together with Microsoft.Maui.Controls. -->
     <PackageVersion Include="Xamarin.AndroidX.Biometric" Version="1.1.0.30" />
+    <!-- Android-only Firebase Cloud Messaging binding for UI.Maui's FCM device-token provider
+         (ADR-044). Bindings track the Google Play services train, not the MAUI one, but they pull
+         AndroidX packages: verify a restore of the android TFM after any bump (the Biometric pin
+         above is the one that reacts first, with NU1608). -->
+    <PackageVersion Include="Xamarin.Firebase.Messaging" Version="124.1.2" />
     <!-- BlazorWebView host support for UI.Maui (Wave 5: MainPageBase / NativeThemeSync);
          versions on the MAUI train, bump together with Microsoft.Maui.Controls. -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.80" />
@@ -224,9 +229,11 @@
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
-    <!-- Gateway (MMCA.Common.Gateway ONLY) — the YARP reverse proxy the shared gateway building
-         blocks are written against. Deliberately not referenced from MMCA.Common.Aspire: a service
-         host that takes AddServiceDefaults must not inherit a proxy dependency it never uses. -->
+    <!-- Gateway (MMCA.Common.Gateway and MMCA.Common.Testing) — the YARP reverse proxy the shared
+         gateway building blocks are written against; MMCA.Common.Testing takes it for the gateway
+         hardening test base and its recording forwarder. Deliberately not referenced from
+         MMCA.Common.Aspire: a service host that takes AddServiceDefaults must not inherit a proxy
+         dependency it never uses. -->
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- Aspire / ServiceDefaults -->
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
@@ -239,6 +246,15 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
+    <!-- Serilog, for MMCA.Common.Aspire's AddCommonSerilog: the host-logging bootstrap every
+         service host repeated verbatim. Serilog.AspNetCore supplies the ILoggingBuilder.AddSerilog
+         provider registration (never UseSerilog, which would replace the whole ILoggerFactory and
+         silence the OpenTelemetry provider AddServiceDefaults adds); the two sink packages are the
+         console and rolling-file sinks the shared configuration writes to. Versions match the pins
+         both consumer apps already carry. -->
+    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <!-- Aspire AppHost -->
     <PackageVersion Include="Aspire.Hosting" Version="13.5.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="13.5.2" />

--- a/Source/Core/MMCA.Common.Application/DomainEvents/ScopedIntegrationEventHandlerBase.cs
+++ b/Source/Core/MMCA.Common.Application/DomainEvents/ScopedIntegrationEventHandlerBase.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Domain.Interfaces;
+
+namespace MMCA.Common.Application.DomainEvents;
+
+/// <summary>
+/// Base class for integration event handlers, the cross-module sibling of
+/// <see cref="SafeDomainEventHandler{TDomainEvent}"/>. It supplies the two blocks every handler
+/// repeats: the DI scope preamble and the log-and-rethrow envelope.
+/// <para>
+/// <see cref="IIntegrationEventHandler{TIntegrationEvent}"/> implementations are registered as
+/// singletons, so they cannot constructor-inject a scoped service such as <c>IUnitOfWork</c>. Each
+/// handler therefore opens its own scope per delivery. This base runs
+/// <see cref="HandleScopedAsync"/> inside an <see cref="IServiceScopeFactory.CreateScope"/>-derived
+/// async scope and hands the subclass that scope's <see cref="IServiceProvider"/>, so a handler
+/// body is only its own resolutions plus its own logic, and the scope is always disposed.
+/// </para>
+/// <para>
+/// <see cref="HandleScopedAsync"/> runs inside an exception filter that writes one error log line
+/// and then lets the exception propagate unchanged; <see cref="OperationCanceledException"/> passes
+/// straight through without a log line, because host shutdown is not a delivery failure. This
+/// matches <see cref="SafeDomainEventHandler{TDomainEvent}"/> exactly.
+/// </para>
+/// <para>
+/// Propagating rather than swallowing is what makes the retry promise true: a handler that reports
+/// success has its delivery acknowledged, so nothing retries and the side effect is lost with only
+/// a log line to show for it. Letting the exception through hands the decision to the delivery
+/// mechanism, which is built for exactly this: on the outbox path the message keeps its retry
+/// count, backs off, and dead-letters after <c>Outbox:MaxRetries</c> attempts; on the broker path
+/// the inbox row stays unprocessed and MassTransit redelivers and then moves the message to the
+/// error queue. Delivery is therefore at-least-once and subclasses must be idempotent.
+/// </para>
+/// </summary>
+/// <typeparam name="TIntegrationEvent">The integration event type this handler processes.</typeparam>
+/// <param name="scopeFactory">Factory used to open one DI scope per delivery.</param>
+/// <param name="logger">Logger used by the default <see cref="LogHandlerFailure"/> implementation.</param>
+public abstract class ScopedIntegrationEventHandlerBase<TIntegrationEvent>(
+    IServiceScopeFactory scopeFactory,
+    ILogger logger) : IIntegrationEventHandler<TIntegrationEvent>
+    where TIntegrationEvent : IIntegrationEvent
+{
+    /// <inheritdoc />
+    public async Task HandleAsync(TIntegrationEvent integrationEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(integrationEvent);
+
+        try
+        {
+            AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+            await using (scope.ConfigureAwait(false))
+            {
+                await HandleScopedAsync(integrationEvent, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException && LogAndRethrow(ex, integrationEvent))
+        {
+            // Unreachable: the filter always returns false so the exception keeps propagating.
+            // Cancellation short-circuits the filter and propagates without an error log.
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Implement the integration event handling logic. Resolve scoped services from
+    /// <paramref name="services"/>; the scope is opened before this call and disposed after it.
+    /// Exceptions thrown here are logged by the base class and then propagate to the caller, so the
+    /// delivery mechanism can redeliver the event. Implementations must be idempotent.
+    /// </summary>
+    /// <param name="integrationEvent">The integration event to handle, never <see langword="null"/>.</param>
+    /// <param name="services">The service provider of the scope opened for this delivery.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    protected abstract Task HandleScopedAsync(
+        TIntegrationEvent integrationEvent,
+        IServiceProvider services,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Writes the one error log line for a failed delivery. Override to log the event's own
+    /// identifiers through a source-generated <c>[LoggerMessage]</c> method; the override runs
+    /// inside the exception filter, so it must not throw and must not rethrow.
+    /// </summary>
+    /// <param name="exception">The exception that failed the delivery.</param>
+    /// <param name="integrationEvent">The integration event being handled.</param>
+    protected virtual void LogHandlerFailure(Exception exception, TIntegrationEvent integrationEvent) =>
+        logger.LogError(
+            exception,
+            "Integration event handler {HandlerType} failed for event {EventType}. The delivery mechanism will redeliver the event.",
+            GetType().Name,
+            typeof(TIntegrationEvent).Name);
+
+    /// <summary>
+    /// Logs the failure and always returns <see langword="false"/> so the exception propagates.
+    /// Running as an exception filter keeps the log write ahead of any unwinding and leaves the
+    /// original stack trace untouched.
+    /// </summary>
+    private bool LogAndRethrow(Exception exception, TIntegrationEvent integrationEvent)
+    {
+        LogHandlerFailure(exception, integrationEvent);
+
+        return false;
+    }
+}

--- a/Source/Core/MMCA.Common.Application/Extensions/CurrentUserServiceExtensions.cs
+++ b/Source/Core/MMCA.Common.Application/Extensions/CurrentUserServiceExtensions.cs
@@ -1,0 +1,48 @@
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Application.Extensions;
+
+/// <summary>
+/// Extension members for <see cref="ICurrentUserService"/>.
+/// </summary>
+public static class CurrentUserServiceExtensions
+{
+    /// <summary>The message every app-side copy of the caller guard reports today.</summary>
+    public const string AccessDeniedMessage = "Access denied.";
+
+    extension(ICurrentUserService currentUserService)
+    {
+        /// <summary>
+        /// Resolves the current user's identifier, or returns a failure when the request carries no
+        /// authenticated user. Collapses the read-then-null-check-then-fail block that every
+        /// handler and controller guarding a per-user operation repeats.
+        /// </summary>
+        /// <param name="code">
+        /// The module's error code for a denied caller (e.g. "CheckIns.Forbidden"). Kept a
+        /// parameter because the code names the module, which the framework cannot know.
+        /// </param>
+        /// <param name="message">The error message. Defaults to <see cref="AccessDeniedMessage"/>.</param>
+        /// <param name="errorType">
+        /// The error classification. Defaults to <see cref="ErrorType.Forbidden"/>, which is what
+        /// the handler-side copies of this guard report; pass <see cref="ErrorType.Unauthorized"/>
+        /// where the edge answers 401 instead.
+        /// </param>
+        /// <param name="source">Optional origin context, typically the calling handler's name.</param>
+        /// <returns>
+        /// A success result carrying the user identifier, or a failure carrying one error.
+        /// </returns>
+        public Result<UserIdentifierType> RequireUserId(
+            string code,
+            string message = AccessDeniedMessage,
+            ErrorType errorType = ErrorType.Forbidden,
+            string? source = null)
+        {
+            ArgumentNullException.ThrowIfNull(currentUserService);
+
+            return currentUserService.UserId is { } userId
+                ? Result.Success(userId)
+                : Result.Failure<UserIdentifierType>(new Error(code, message, errorType, source));
+        }
+    }
+}

--- a/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
@@ -218,3 +218,31 @@ virtual MMCA.Common.Application.Users.UseCases.ForgotPassword.ForgotPasswordHand
 virtual MMCA.Common.Application.Users.UseCases.ForgotPassword.ForgotPasswordHandlerBase<TUser, TCommand>.ComposeResetLink(string! email, string! token) -> string?
 virtual MMCA.Common.Application.Users.UseCases.ForgotPassword.ForgotPasswordHandlerBase<TUser, TCommand>.ComposeSubject() -> string!
 virtual MMCA.Common.Application.Users.UseCases.ResetPassword.ResetPasswordHandlerBase<TUser, TCommand>.HandlerName.get -> string!
+*REMOVED*MMCA.Common.Application.Validation.EmailRules<T>.EmailRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string! fieldName, int maxLength) -> void
+*REMOVED*MMCA.Common.Application.Validation.NonNegativeIntRules<T>.NonNegativeIntRules(System.Linq.Expressions.Expression<System.Func<T, int>!>! selector, string! fieldName) -> void
+*REMOVED*MMCA.Common.Application.Validation.OptionalStringRules<T>.OptionalStringRules(System.Linq.Expressions.Expression<System.Func<T, string?>!>! selector, string! fieldName, int maxLength) -> void
+*REMOVED*MMCA.Common.Application.Validation.PasswordRules<T>.PasswordRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector) -> void
+*REMOVED*MMCA.Common.Application.Validation.PositiveDecimalRules<T>.PositiveDecimalRules(System.Linq.Expressions.Expression<System.Func<T, decimal>!>! selector, string! fieldName) -> void
+*REMOVED*MMCA.Common.Application.Validation.PositiveIntRules<T>.PositiveIntRules(System.Linq.Expressions.Expression<System.Func<T, int>!>! selector, string! fieldName) -> void
+*REMOVED*MMCA.Common.Application.Validation.RequiredStringRules<T>.RequiredStringRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string! fieldName, int maxLength) -> void
+*REMOVED*MMCA.Common.Application.Validation.StrongPasswordRules<T>.StrongPasswordRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector) -> void
+MMCA.Common.Application.DomainEvents.ScopedIntegrationEventHandlerBase<TIntegrationEvent>
+MMCA.Common.Application.DomainEvents.ScopedIntegrationEventHandlerBase<TIntegrationEvent>.HandleAsync(TIntegrationEvent integrationEvent, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+MMCA.Common.Application.DomainEvents.ScopedIntegrationEventHandlerBase<TIntegrationEvent>.ScopedIntegrationEventHandlerBase(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory! scopeFactory, Microsoft.Extensions.Logging.ILogger! logger) -> void
+MMCA.Common.Application.Extensions.CurrentUserServiceExtensions
+MMCA.Common.Application.Extensions.CurrentUserServiceExtensions.extension(MMCA.Common.Application.Interfaces.Infrastructure.ICurrentUserService!)
+MMCA.Common.Application.Extensions.CurrentUserServiceExtensions.extension(MMCA.Common.Application.Interfaces.Infrastructure.ICurrentUserService!).RequireUserId(string! code, string! message = "Access denied.", MMCA.Common.Shared.Abstractions.ErrorType errorType = MMCA.Common.Shared.Abstractions.ErrorType.Forbidden, string? source = null) -> MMCA.Common.Shared.Abstractions.Result<int>!
+MMCA.Common.Application.Validation.AbsoluteUrlRules<T>
+MMCA.Common.Application.Validation.AbsoluteUrlRules<T>.AbsoluteUrlRules(System.Linq.Expressions.Expression<System.Func<T, string?>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.EmailRules<T>.EmailRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.NonNegativeIntRules<T>.NonNegativeIntRules(System.Linq.Expressions.Expression<System.Func<T, int>!>! selector, string! fieldName, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.OptionalStringRules<T>.OptionalStringRules(System.Linq.Expressions.Expression<System.Func<T, string?>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.PasswordRules<T>.PasswordRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.PositiveDecimalRules<T>.PositiveDecimalRules(System.Linq.Expressions.Expression<System.Func<T, decimal>!>! selector, string! fieldName, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.PositiveIntRules<T>.PositiveIntRules(System.Linq.Expressions.Expression<System.Func<T, int>!>! selector, string! fieldName, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.RequiredStringRules<T>.RequiredStringRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.StrongPasswordRules<T>.StrongPasswordRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string? errorCode = null) -> void
+abstract MMCA.Common.Application.DomainEvents.ScopedIntegrationEventHandlerBase<TIntegrationEvent>.HandleScopedAsync(TIntegrationEvent integrationEvent, System.IServiceProvider! services, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+const MMCA.Common.Application.Extensions.CurrentUserServiceExtensions.AccessDeniedMessage = "Access denied." -> string!
+static MMCA.Common.Application.Extensions.CurrentUserServiceExtensions.RequireUserId(this MMCA.Common.Application.Interfaces.Infrastructure.ICurrentUserService! currentUserService, string! code, string! message = "Access denied.", MMCA.Common.Shared.Abstractions.ErrorType errorType = MMCA.Common.Shared.Abstractions.ErrorType.Forbidden, string? source = null) -> MMCA.Common.Shared.Abstractions.Result<int>!
+virtual MMCA.Common.Application.DomainEvents.ScopedIntegrationEventHandlerBase<TIntegrationEvent>.LogHandlerFailure(System.Exception! exception, TIntegrationEvent integrationEvent) -> void

--- a/Source/Core/MMCA.Common.Application/Validation/CommonValidationRules.cs
+++ b/Source/Core/MMCA.Common.Application/Validation/CommonValidationRules.cs
@@ -1,8 +1,36 @@
 using System.Globalization;
 using System.Linq.Expressions;
 using FluentValidation;
+using MMCA.Common.Domain.Invariants;
 
 namespace MMCA.Common.Application.Validation;
+
+/// <summary>
+/// Applies an optional error code to a rule without changing the rule when none is supplied.
+/// </summary>
+/// <remarks>
+/// Every rule class in this file takes an optional <c>errorCode</c>. Module validators used to
+/// bypass these bases entirely and re-write the rule by hand for the single reason that the bases
+/// set a message but no code, so a validator that needed a machine-readable code had nothing to
+/// compose. The code, when given, is applied to <b>every</b> rule the class declares for the field,
+/// so one field answers under one code. A field whose bounds must answer under distinct codes still
+/// declares its own rules.
+/// </remarks>
+internal static class OptionalErrorCodeExtensions
+{
+    /// <summary>
+    /// Returns <paramref name="rule"/> unchanged when <paramref name="errorCode"/> is
+    /// <see langword="null"/>, preserving the behaviour of every caller that omits it.
+    /// </summary>
+    /// <typeparam name="T">The type being validated.</typeparam>
+    /// <typeparam name="TProperty">The type of the property the rule applies to.</typeparam>
+    /// <param name="rule">The rule to apply the code to.</param>
+    /// <param name="errorCode">The error code, or <see langword="null"/> to leave the rule as is.</param>
+    /// <returns>The same rule, carrying the error code when one was supplied.</returns>
+    internal static IRuleBuilderOptions<T, TProperty> WithOptionalErrorCode<T, TProperty>(
+        this IRuleBuilderOptions<T, TProperty> rule, string? errorCode)
+        => errorCode is null ? rule : rule.WithErrorCode(errorCode);
+}
 
 /// <summary>
 /// Reusable validation rules for a required string field with a maximum length.
@@ -12,10 +40,10 @@ namespace MMCA.Common.Application.Validation;
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class RequiredStringRules<T> : AbstractValidator<T>
 {
-    public RequiredStringRules(Expression<Func<T, string>> selector, string fieldName, int maxLength)
+    public RequiredStringRules(Expression<Func<T, string>> selector, string fieldName, int maxLength, string? errorCode = null)
         => RuleFor(selector)
-            .NotEmpty().WithMessage($"You must enter a {fieldName}")
-            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters"));
+            .NotEmpty().WithMessage($"You must enter a {fieldName}").WithOptionalErrorCode(errorCode)
+            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters")).WithOptionalErrorCode(errorCode);
 }
 
 /// <summary>
@@ -24,9 +52,9 @@ public class RequiredStringRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class OptionalStringRules<T> : AbstractValidator<T>
 {
-    public OptionalStringRules(Expression<Func<T, string?>> selector, string fieldName, int maxLength)
+    public OptionalStringRules(Expression<Func<T, string?>> selector, string fieldName, int maxLength, string? errorCode = null)
         => RuleFor(selector)
-            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters"));
+            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters")).WithOptionalErrorCode(errorCode);
 }
 
 /// <summary>
@@ -35,11 +63,34 @@ public class OptionalStringRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class EmailRules<T> : AbstractValidator<T>
 {
-    public EmailRules(Expression<Func<T, string>> selector, string fieldName, int maxLength)
+    public EmailRules(Expression<Func<T, string>> selector, string fieldName, int maxLength, string? errorCode = null)
         => RuleFor(selector)
-            .NotEmpty().WithMessage($"You must enter a {fieldName}")
-            .EmailAddress().WithMessage($"You must enter a valid {fieldName}")
-            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters"));
+            .NotEmpty().WithMessage($"You must enter a {fieldName}").WithOptionalErrorCode(errorCode)
+            .EmailAddress().WithMessage($"You must enter a valid {fieldName}").WithOptionalErrorCode(errorCode)
+            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters")).WithOptionalErrorCode(errorCode);
+}
+
+/// <summary>
+/// Reusable validation rules for an optional absolute URL field: max length plus an absolute
+/// <c>http</c>/<c>https</c> URI check. A <see langword="null"/> or empty value passes.
+/// </summary>
+/// <remarks>
+/// The bounded-string treatment URL fields get today accepts <c>javascript:</c> and <c>data:</c>
+/// values, which become executable the moment a link or an image renders them. This rule adds the
+/// scheme check to the same length bound, and delegates it to
+/// <see cref="CommonInvariants.EnsureUrlIsWellFormed"/> so the validator and the domain invariant
+/// answer identically.
+/// </remarks>
+/// <typeparam name="T">The parent type containing the field.</typeparam>
+public class AbsoluteUrlRules<T> : AbstractValidator<T>
+{
+    public AbsoluteUrlRules(Expression<Func<T, string?>> selector, string fieldName, int maxLength, string? errorCode = null)
+        => RuleFor(selector)
+            .MaximumLength(maxLength).WithMessage(string.Create(CultureInfo.InvariantCulture, $"{fieldName} cannot be longer than {maxLength} characters")).WithOptionalErrorCode(errorCode)
+            .Must(BeAnAbsoluteHttpUrl).WithMessage($"{fieldName} must be an absolute http or https URL").WithOptionalErrorCode(errorCode);
+
+    private static bool BeAnAbsoluteHttpUrl(string? url) =>
+        CommonInvariants.EnsureUrlIsWellFormed(url, "Url.Invalid", "Url.Invalid", nameof(AbsoluteUrlRules<>), "url").IsSuccess;
 }
 
 /// <summary>
@@ -48,9 +99,9 @@ public class EmailRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class PositiveIntRules<T> : AbstractValidator<T>
 {
-    public PositiveIntRules(Expression<Func<T, int>> selector, string fieldName)
+    public PositiveIntRules(Expression<Func<T, int>> selector, string fieldName, string? errorCode = null)
         => RuleFor(selector)
-            .GreaterThan(0).WithMessage($"{fieldName} must be a positive value");
+            .GreaterThan(0).WithMessage($"{fieldName} must be a positive value").WithOptionalErrorCode(errorCode);
 }
 
 /// <summary>
@@ -59,9 +110,9 @@ public class PositiveIntRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class PositiveDecimalRules<T> : AbstractValidator<T>
 {
-    public PositiveDecimalRules(Expression<Func<T, decimal>> selector, string fieldName)
+    public PositiveDecimalRules(Expression<Func<T, decimal>> selector, string fieldName, string? errorCode = null)
         => RuleFor(selector)
-            .GreaterThan(0).WithMessage($"{fieldName} must be a positive value");
+            .GreaterThan(0).WithMessage($"{fieldName} must be a positive value").WithOptionalErrorCode(errorCode);
 }
 
 /// <summary>
@@ -70,9 +121,9 @@ public class PositiveDecimalRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class NonNegativeIntRules<T> : AbstractValidator<T>
 {
-    public NonNegativeIntRules(Expression<Func<T, int>> selector, string fieldName)
+    public NonNegativeIntRules(Expression<Func<T, int>> selector, string fieldName, string? errorCode = null)
         => RuleFor(selector)
-            .GreaterThanOrEqualTo(0).WithMessage($"{fieldName} must be greater than or equal to 0");
+            .GreaterThanOrEqualTo(0).WithMessage($"{fieldName} must be greater than or equal to 0").WithOptionalErrorCode(errorCode);
 }
 
 /// <summary>
@@ -82,11 +133,11 @@ public class NonNegativeIntRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class PasswordRules<T> : AbstractValidator<T>
 {
-    public PasswordRules(Expression<Func<T, string>> selector)
+    public PasswordRules(Expression<Func<T, string>> selector, string? errorCode = null)
         => RuleFor(selector)
-            .NotEmpty().WithMessage("Password is required.")
-            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
-            .MaximumLength(128).WithMessage("Password cannot be longer than 128 characters.");
+            .NotEmpty().WithMessage("Password is required.").WithOptionalErrorCode(errorCode)
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters.").WithOptionalErrorCode(errorCode)
+            .MaximumLength(128).WithMessage("Password cannot be longer than 128 characters.").WithOptionalErrorCode(errorCode);
 }
 
 /// <summary>
@@ -96,13 +147,13 @@ public class PasswordRules<T> : AbstractValidator<T>
 /// <typeparam name="T">The parent type containing the field.</typeparam>
 public class StrongPasswordRules<T> : AbstractValidator<T>
 {
-    public StrongPasswordRules(Expression<Func<T, string>> selector)
+    public StrongPasswordRules(Expression<Func<T, string>> selector, string? errorCode = null)
         => RuleFor(selector)
-            .NotEmpty().WithMessage("Password is required.")
-            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
-            .MaximumLength(128).WithMessage("Password cannot be longer than 128 characters.")
-            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
-            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.")
-            .Matches("\\d").WithMessage("Password must contain at least one digit.")
-            .Matches("[^a-zA-Z\\d]").WithMessage("Password must contain at least one special character.");
+            .NotEmpty().WithMessage("Password is required.").WithOptionalErrorCode(errorCode)
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters.").WithOptionalErrorCode(errorCode)
+            .MaximumLength(128).WithMessage("Password cannot be longer than 128 characters.").WithOptionalErrorCode(errorCode)
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.").WithOptionalErrorCode(errorCode)
+            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.").WithOptionalErrorCode(errorCode)
+            .Matches("\\d").WithMessage("Password must contain at least one digit.").WithOptionalErrorCode(errorCode)
+            .Matches("[^a-zA-Z\\d]").WithMessage("Password must contain at least one special character.").WithOptionalErrorCode(errorCode);
 }

--- a/Source/Core/MMCA.Common.Domain/Invariants/CommonInvariants.cs
+++ b/Source/Core/MMCA.Common.Domain/Invariants/CommonInvariants.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.Globalization;
 using MMCA.Common.Shared.ValueObjects;
@@ -161,4 +162,279 @@ public static class CommonInvariants
            || string.Equals(theme, DarkTheme, StringComparison.OrdinalIgnoreCase)
             ? Result.Success()
             : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that an enum value is one of the members declared on its type, rejecting the
+    /// arbitrary integers a cast or a deserialized payload can produce.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="value">The enum value to validate.</param>
+    /// <param name="code">The error code (e.g., "CheckIn.Scope.Invalid").</param>
+    /// <param name="message">The error message (e.g., "Check-in scope is not valid.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureEnumIsDefined<TEnum>(
+        TEnum value, string code, string message, string source, string target)
+        where TEnum : struct, Enum
+        => Enum.IsDefined(value)
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that the end of a range is not before its start. Equal values pass, so a
+    /// single-day event or a zero-length window is allowed; use a separate strict check when the
+    /// domain forbids a zero-length range.
+    /// </summary>
+    /// <typeparam name="T">The comparable range endpoint type (e.g. <see cref="DateOnly"/>, <see cref="DateTime"/>).</typeparam>
+    /// <param name="start">The start of the range.</param>
+    /// <param name="end">The end of the range.</param>
+    /// <param name="code">The error code (e.g., "Event.DateRange.Invalid").</param>
+    /// <param name="message">The error message (e.g., "Event end date must be on or after the start date.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureEndIsNotBeforeStart<T>(
+        T start, T end, string code, string message, string source, string target)
+        where T : IComparable<T>
+        => end.CompareTo(start) < 0
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that a required string's length falls within an inclusive range. A
+    /// <see langword="null"/>, empty, or whitespace-only value fails, so this is the single-error
+    /// equivalent of pairing <see cref="EnsureStringIsNotEmpty"/> with
+    /// <see cref="EnsureStringMaxLength"/> when the domain reports one bound violation rather
+    /// than two.
+    /// </summary>
+    /// <param name="value">The string value to validate.</param>
+    /// <param name="minLength">The minimum allowed length, inclusive.</param>
+    /// <param name="maxLength">The maximum allowed length, inclusive.</param>
+    /// <param name="code">The error code (e.g., "PointsEntry.SubjectKey.Invalid").</param>
+    /// <param name="message">The error message (e.g., "Subject key must be 1-100 characters.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureStringLengthIsWithin(
+        string? value, int minLength, int maxLength, string code, string message, string source, string target)
+        => string.IsNullOrWhiteSpace(value) || value.Length < minLength || value.Length > maxLength
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that an optional string is absent or within a maximum length. A
+    /// <see langword="null"/> or empty value passes.
+    /// </summary>
+    /// <remarks>
+    /// Behaviourally the same bound as <see cref="EnsureStringMaxLength"/>, which is already
+    /// null-tolerant. It exists so an optional field states that intent at the call site instead
+    /// of guarding with a redundant <c>string.IsNullOrEmpty(value) ? Result.Success() : ...</c>
+    /// ternary, which is what the duplicated app-side copies do today.
+    /// </remarks>
+    /// <param name="value">The optional string value to validate.</param>
+    /// <param name="maxLength">The maximum allowed length.</param>
+    /// <param name="code">The error code (e.g., "Activity.VenueUrl.TooLong").</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureOptionalStringMaxLength(
+        string? value, int maxLength, string code, string message, string source, string target)
+        => string.IsNullOrEmpty(value) || value.Length <= maxLength
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that a time zone identifier is <see langword="null"/> (the field is optional) or
+    /// resolves to a time zone this host recognizes.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="TimeZoneInfo.TryFindSystemTimeZoneById(string, out TimeZoneInfo?)"/> rather
+    /// than catching <see cref="TimeZoneNotFoundException"/> around
+    /// <see cref="TimeZoneInfo.FindSystemTimeZoneById(string)"/>, keeping the check off the
+    /// exception path and also rejecting a corrupt time zone entry, which the exception form let
+    /// through. An empty or whitespace identifier is not recognized and therefore fails; pair with
+    /// <see cref="EnsureStringIsNotEmpty"/> when the domain reports emptiness under its own code.
+    /// </remarks>
+    /// <param name="timeZone">The time zone identifier to validate (e.g., "America/New_York").</param>
+    /// <param name="code">The error code (e.g., "Event.TimeZone.Invalid").</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureTimeZoneIsValid(
+        string? timeZone, string code, string message, string source, string target)
+        => timeZone is null || TimeZoneInfo.TryFindSystemTimeZoneById(timeZone, out _)
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that a URL is absent (a <see langword="null"/> or empty optional field) or an
+    /// absolute <c>http</c>/<c>https</c> URI.
+    /// </summary>
+    /// <remarks>
+    /// Bounded-string validation alone lets <c>javascript:</c> and <c>data:</c> values through,
+    /// which reach the browser as executable content once a link or an image renders them.
+    /// Requiring an absolute URI on an http scheme closes that without constraining the host or
+    /// path. Length stays a separate concern: compose with
+    /// <see cref="EnsureOptionalStringMaxLength"/> via <see cref="Result.Combine"/>.
+    /// </remarks>
+    /// <param name="url">The URL to validate.</param>
+    /// <param name="code">The error code (e.g., "Sponsor.LogoUrl.Invalid").</param>
+    /// <param name="message">The error message.</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    [SuppressMessage(
+        "Design",
+        "CA1054:URI-like parameters should not be strings",
+        Justification = "The point of the check is to validate an untrusted string BEFORE anything turns it into a Uri; a Uri parameter would have already accepted the javascript:/data: value this rejects.")]
+    public static Result EnsureUrlIsWellFormed(
+        string? url, string code, string message, string source, string target)
+        => string.IsNullOrEmpty(url) || IsAbsoluteHttpUrl(url)
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that a count falls within an inclusive range.
+    /// </summary>
+    /// <param name="count">The count to validate.</param>
+    /// <param name="minCount">The minimum allowed count, inclusive.</param>
+    /// <param name="maxCount">The maximum allowed count, inclusive.</param>
+    /// <param name="code">The error code (e.g., "LivePoll.Options.CountInvalid").</param>
+    /// <param name="message">The error message (e.g., "A poll must have between 2 and 10 options.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureCountIsWithin(
+        int count, int minCount, int maxCount, string code, string message, string source, string target)
+        => count < minCount || count > maxCount
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that a collection holds no elements, the guard a delete needs when dependants
+    /// must be removed first. A <see langword="null"/> collection passes.
+    /// </summary>
+    /// <typeparam name="T">The collection element type.</typeparam>
+    /// <param name="value">The collection to validate.</param>
+    /// <param name="code">The error code (e.g., "Category.HasProducts").</param>
+    /// <param name="message">The error message (e.g., "Cannot delete a category that has products assigned to it.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureCollectionIsEmpty<T>(
+        IReadOnlyCollection<T>? value, string code, string message, string source, string target)
+        => value is null || value.Count == 0
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that a sequence contains no duplicates under <paramref name="comparer"/>. A
+    /// <see langword="null"/> sequence passes, being vacuously unique.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="values">The values to check for duplicates.</param>
+    /// <param name="comparer">
+    /// The equality comparer, or <see langword="null"/> for the type's default. Pass
+    /// <see cref="StringComparer.OrdinalIgnoreCase"/> for case-insensitive text uniqueness.
+    /// </param>
+    /// <param name="code">The error code (e.g., "LivePoll.Options.Duplicate").</param>
+    /// <param name="message">The error message (e.g., "Option texts must be unique.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureValuesAreUnique<T>(
+        IEnumerable<T>? values,
+        IEqualityComparer<T>? comparer,
+        string code,
+        string message,
+        string source,
+        string target)
+    {
+        if (values is null)
+        {
+            return Result.Success();
+        }
+
+        var seen = new HashSet<T>(comparer);
+
+        return values.Any(value => !seen.Add(value))
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+    }
+
+    /// <summary>
+    /// Validates that a state flag is set, the guard for an action that requires the flag
+    /// (e.g. an event must be published).
+    /// </summary>
+    /// <param name="value">The flag to validate.</param>
+    /// <param name="code">The error code (e.g., "Event.NotPublished").</param>
+    /// <param name="message">The error message (e.g., "This action requires the event to be published.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureFlagIsTrue(
+        bool value, string code, string message, string source, string target)
+        => value
+            ? Result.Success()
+            : Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target));
+
+    /// <summary>
+    /// Validates that a state flag is clear, the guard for an action the flag forbids
+    /// (e.g. a service session cannot be edited).
+    /// </summary>
+    /// <param name="value">The flag to validate.</param>
+    /// <param name="code">The error code (e.g., "Session.IsServiceSession").</param>
+    /// <param name="message">The error message (e.g., "This action is not available for service sessions.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureFlagIsFalse(
+        bool value, string code, string message, string source, string target)
+        => value
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that an optional integer is absent or greater than zero. A
+    /// <see langword="null"/> value passes; zero and negatives fail.
+    /// </summary>
+    /// <param name="value">The optional integer to validate.</param>
+    /// <param name="code">The error code (e.g., "Room.Capacity.Invalid").</param>
+    /// <param name="message">The error message (e.g., "Room capacity must be a positive integer.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureNullableIntIsPositive(
+        int? value, string code, string message, string source, string target)
+        => value is <= 0
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Validates that an integer is not negative. Zero passes, which is what separates this from
+    /// <see cref="EnsureIntIsPositive"/> (an on-hand quantity may legitimately be zero).
+    /// </summary>
+    /// <param name="value">The integer value to validate.</param>
+    /// <param name="code">The error code (e.g., "Inventory.AvailableQuantity.Negative").</param>
+    /// <param name="message">The error message (e.g., "Available quantity cannot be negative.").</param>
+    /// <param name="source">The calling method name, used for error tracing.</param>
+    /// <param name="target">The property name, used for error targeting.</param>
+    /// <returns>A <see cref="Result"/> indicating success or an invariant error.</returns>
+    public static Result EnsureIntIsNotNegative(
+        int value, string code, string message, string source, string target)
+        => value < 0
+            ? Result.Failure(Error.Invariant(code: code, message: message, source: source, target: target))
+            : Result.Success();
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="url"/> parses as an absolute URI whose
+    /// scheme is <c>http</c> or <c>https</c>.
+    /// </summary>
+    private static bool IsAbsoluteHttpUrl(string url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri)
+           && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+               || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal));
 }

--- a/Source/Core/MMCA.Common.Domain/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Domain/PublicAPI.Unshipped.txt
@@ -46,3 +46,16 @@ static MMCA.Common.Domain.Entities.AuditableAggregateRootEntity<TIdentifierType>
 static MMCA.Common.Domain.Entities.AuditableAggregateRootEntity<TIdentifierType>.RestoreChild<TChild, TChildId>(System.Collections.Generic.List<TChild!>! collection, TChild! child, string! notDeletedErrorCode, string! source) -> MMCA.Common.Shared.Abstractions.Result<TChild!>!
 virtual MMCA.Common.Domain.Entities.AuditableBaseEntity<TIdentifierType>.DeletedBy.get -> int?
 virtual MMCA.Common.Domain.Entities.AuditableBaseEntity<TIdentifierType>.DeletedOn.get -> System.DateTime?
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureCollectionIsEmpty<T>(System.Collections.Generic.IReadOnlyCollection<T>? value, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureCountIsWithin(int count, int minCount, int maxCount, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureEndIsNotBeforeStart<T>(T start, T end, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureEnumIsDefined<TEnum>(TEnum value, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureFlagIsFalse(bool value, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureFlagIsTrue(bool value, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureIntIsNotNegative(int value, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureNullableIntIsPositive(int? value, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureOptionalStringMaxLength(string? value, int maxLength, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureStringLengthIsWithin(string? value, int minLength, int maxLength, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureTimeZoneIsValid(string? timeZone, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureUrlIsWellFormed(string? url, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Domain.Invariants.CommonInvariants.EnsureValuesAreUnique<T>(System.Collections.Generic.IEnumerable<T>? values, System.Collections.Generic.IEqualityComparer<T>? comparer, string! code, string! message, string! source, string! target) -> MMCA.Common.Shared.Abstractions.Result!

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/PushNotificationSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/PushNotificationSettings.cs
@@ -1,3 +1,5 @@
+using MMCA.Common.Shared.Notifications;
+
 namespace MMCA.Common.Infrastructure.Settings;
 
 /// <summary>
@@ -19,6 +21,12 @@ public sealed class PushNotificationSettings : IPushNotificationSettings
     /// channel via the notification hub. Guards SignalR group names against arbitrary client input.
     /// Deliberately declared on the concrete settings class only so that
     /// <see cref="IPushNotificationSettings"/> stays unchanged (no breaking change for implementers).
+    /// <para>
+    /// The default is <see cref="NotificationScopeKey.Pattern"/>, the same constant
+    /// <see cref="NotificationScopeKey.ForEvent"/> and <see cref="NotificationScopeKey.ForSession"/>
+    /// format against, so the producer and the guard cannot drift apart. A host that overrides the
+    /// pattern from configuration takes on that alignment itself.
+    /// </para>
     /// </summary>
-    public string ChannelKeyPattern { get; init; } = "^(event|session):[0-9]+$";
+    public string ChannelKeyPattern { get; init; } = NotificationScopeKey.Pattern;
 }

--- a/Source/Core/MMCA.Common.Shared/Notifications/NotificationScopeKey.cs
+++ b/Source/Core/MMCA.Common.Shared/Notifications/NotificationScopeKey.cs
@@ -1,0 +1,59 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace MMCA.Common.Shared.Notifications;
+
+/// <summary>
+/// Canonical formatter and validator for a notification scope key (also called a channel key on
+/// the SignalR join path): the <c>event:{id}</c> / <c>session:{id}</c> string that narrows a push
+/// notification, or a live channel, to one subject.
+/// </summary>
+/// <remarks>
+/// The format and the pattern that guards it live together on purpose. The pattern is the default
+/// of <c>PushNotificationSettings.ChannelKeyPattern</c>, which the notification hub enforces before
+/// a client may join a group; the format was hand-written at each call site, so a change to either
+/// half could silently strand the other. Building every key through <see cref="ForEvent"/> or
+/// <see cref="ForSession"/> keeps them in step, and formats the identifier under
+/// <see cref="CultureInfo.InvariantCulture"/> so a culture with non-ASCII digits cannot produce a
+/// key the pattern rejects.
+/// </remarks>
+public static partial class NotificationScopeKey
+{
+    /// <summary>The prefix of an event-scoped key.</summary>
+    public const string EventPrefix = "event";
+
+    /// <summary>The prefix of a session-scoped key.</summary>
+    public const string SessionPrefix = "session";
+
+    /// <summary>
+    /// The regular expression a scope key must match. Shared with
+    /// <c>PushNotificationSettings.ChannelKeyPattern</c>, whose default it supplies.
+    /// </summary>
+    public const string Pattern = "^(event|session):[0-9]+$";
+
+    /// <summary>Builds the scope key for an event.</summary>
+    /// <param name="eventId">The event identifier.</param>
+    /// <returns>The key in the form <c>event:{id}</c>.</returns>
+    public static string ForEvent(long eventId) =>
+        string.Create(CultureInfo.InvariantCulture, $"{EventPrefix}:{eventId}");
+
+    /// <summary>Builds the scope key for a session.</summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <returns>The key in the form <c>session:{id}</c>.</returns>
+    public static string ForSession(long sessionId) =>
+        string.Create(CultureInfo.InvariantCulture, $"{SessionPrefix}:{sessionId}");
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="scopeKey"/> matches <see cref="Pattern"/>.
+    /// </summary>
+    /// <param name="scopeKey">The scope key to check.</param>
+    /// <returns><see langword="true"/> for a well-formed scope key; otherwise, <see langword="false"/>.</returns>
+    public static bool IsValid(string? scopeKey) =>
+        !string.IsNullOrEmpty(scopeKey) && ScopeKeyRegex.IsMatch(scopeKey);
+
+    // ExplicitCapture only suppresses the unused capture of the "(event|session)" alternation; the
+    // pattern text stays exactly the one PushNotificationSettings defaults to, and IsMatch is
+    // unaffected by the option.
+    [GeneratedRegex(Pattern, RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex ScopeKeyRegex { get; }
+}

--- a/Source/Core/MMCA.Common.Shared/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Shared/PublicAPI.Unshipped.txt
@@ -88,3 +88,10 @@ override MMCA.Common.Shared.Auth.RefreshSessionSummaryResponse.ToString() -> str
 ~override MMCA.Common.Shared.Auth.ResetPasswordRequest.ToString() -> string
 const MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest.BodyMaxLength = 2000 -> int
 const MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest.TitleMaxLength = 200 -> int
+MMCA.Common.Shared.Notifications.NotificationScopeKey
+const MMCA.Common.Shared.Notifications.NotificationScopeKey.EventPrefix = "event" -> string!
+const MMCA.Common.Shared.Notifications.NotificationScopeKey.Pattern = "^(event|session):[0-9]+$" -> string!
+const MMCA.Common.Shared.Notifications.NotificationScopeKey.SessionPrefix = "session" -> string!
+static MMCA.Common.Shared.Notifications.NotificationScopeKey.ForEvent(long eventId) -> string!
+static MMCA.Common.Shared.Notifications.NotificationScopeKey.ForSession(long sessionId) -> string!
+static MMCA.Common.Shared.Notifications.NotificationScopeKey.IsValid(string? scopeKey) -> bool

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
@@ -34,8 +34,49 @@ public static class Extensions
     /// </summary>
     public const int E2eRegistrationsPerIpPerHour = 1000;
 
+    /// <summary>
+    /// Default Aspire resource name used for the MailDev container.
+    /// </summary>
+    public const string DefaultMailDevResourceName = "maildev";
+
+    /// <summary>
+    /// Fixed host port MailDev's web UI is published on. Fixed rather than dynamic because a
+    /// developer opens it by hand and the appsettings SMTP defaults are written against the pair.
+    /// </summary>
+    public const int MailDevHttpPort = 1080;
+
+    /// <summary>
+    /// Fixed host port MailDev's SMTP listener is published on, matching the <c>Smtp:Port</c>
+    /// every consumer's appsettings declares.
+    /// </summary>
+    public const int MailDevSmtpPort = 1025;
+
     extension(IDistributedApplicationBuilder builder)
     {
+        /// <summary>
+        /// Provisions the local MailDev container: an SMTP sink for development email testing whose
+        /// web UI (<c>http://localhost:1080</c>) shows every message the app sent, so a host can run
+        /// its real mail path without a relay and without delivering anything.
+        /// <para>
+        /// Both ports are published on fixed host ports rather than Aspire's dynamic ones: the web UI
+        /// is opened by hand and the SMTP port is what each consumer's <c>Smtp:Port</c> setting
+        /// names. The container lifetime is persistent so the captured inbox survives an AppHost
+        /// restart.
+        /// </para>
+        /// </summary>
+        /// <param name="name">The resource name (defaults to <see cref="DefaultMailDevResourceName"/>).</param>
+        /// <returns>The MailDev container resource builder, for <c>WaitFor</c> wiring.</returns>
+        public IResourceBuilder<ContainerResource> AddMailDev(
+            string name = DefaultMailDevResourceName)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            return builder.AddContainer(name, "maildev/maildev")
+                .WithLifetime(ContainerLifetime.Persistent)
+                .WithHttpEndpoint(targetPort: MailDevHttpPort, port: MailDevHttpPort, name: "http")
+                .WithEndpoint(targetPort: MailDevSmtpPort, port: MailDevSmtpPort, name: "smtp", scheme: "tcp");
+        }
+
         /// <summary>
         /// Provisions a RabbitMQ container resource with the management plugin enabled and
         /// returns the resource builder for further wiring. Production deployments should

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+MMCA.Common.Aspire.Hosting.Extensions.extension(Aspire.Hosting.IDistributedApplicationBuilder!).AddMailDev(string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+const MMCA.Common.Aspire.Hosting.Extensions.DefaultMailDevResourceName = "maildev" -> string!
+const MMCA.Common.Aspire.Hosting.Extensions.MailDevHttpPort = 1080 -> int
+const MMCA.Common.Aspire.Hosting.Extensions.MailDevSmtpPort = 1025 -> int
+static MMCA.Common.Aspire.Hosting.Extensions.AddMailDev(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!

--- a/Source/Hosting/MMCA.Common.Aspire/Logging/SerilogHostExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Logging/SerilogHostExtensions.cs
@@ -1,0 +1,124 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+
+namespace MMCA.Common.Aspire.Logging;
+
+/// <summary>
+/// The Serilog bootstrap every MMCA service host repeats verbatim before
+/// <c>AddServiceDefaults()</c>: console always, a rolling file sink outside Production, the
+/// framework's minimum-level overrides, and registration as ONE logging provider.
+/// <para>
+/// The provider registration is the load-bearing part. <c>UseSerilog()</c> replaces the whole
+/// <c>ILoggerFactory</c> and so silently bypasses every other provider, including the OpenTelemetry
+/// to Azure Monitor one wired by <c>AddServiceDefaults()</c>: a host that calls it publishes no
+/// application log line to App Insights at all. <c>builder.Logging.AddSerilog(...)</c> adds Serilog
+/// alongside the others instead, which is why this helper does that and never the former.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with an extension(T) block in a static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
+public static class SerilogHostExtensions
+{
+    extension(WebApplicationBuilder builder)
+    {
+        /// <summary>
+        /// Configures the global <see cref="Log.Logger"/> from the framework defaults and registers
+        /// it as one logging provider on <paramref name="builder"/>. Call it before
+        /// <c>AddServiceDefaults()</c>, as the hosts do, so the OpenTelemetry provider registered
+        /// there joins the same factory.
+        /// </summary>
+        /// <param name="logFilePath">
+        /// Path of the rolling log file, relative to the content root (for example
+        /// <c>"logs/MyService.txt"</c>). Ignored in Production, where the file sink is not added.
+        /// </param>
+        /// <param name="configure">
+        /// Optional hook applied to the configuration after the defaults and before the logger is
+        /// created, for a host that needs an extra sink or enricher of its own.
+        /// </param>
+        /// <returns>The same builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="logFilePath"/> is null or whitespace.</exception>
+        public WebApplicationBuilder AddCommonSerilog(
+            string logFilePath,
+            Action<LoggerConfiguration>? configure = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            Log.Logger = CreateLoggerConfiguration(builder.Environment, logFilePath, configure).CreateLogger();
+            builder.Logging.AddSerilog(Log.Logger, dispose: true);
+
+            return builder;
+        }
+    }
+
+    /// <summary>
+    /// Creates a logger factory writing to the global <see cref="Log.Logger"/>, for the startup-time
+    /// diagnostics a host needs before the DI container exists (module discovery above all).
+    /// Dispose it once startup wiring is done; it does not own <see cref="Log.Logger"/>.
+    /// </summary>
+    /// <returns>A logger factory backed by the current global Serilog logger.</returns>
+    public static ILoggerFactory CreateBootstrapLoggerFactory() =>
+        LoggerFactory.Create(logging => logging.AddSerilog());
+
+    /// <summary>
+    /// The minimum level the framework defaults to: <see cref="LogEventLevel.Debug"/> in Development,
+    /// <see cref="LogEventLevel.Information"/> everywhere else.
+    /// </summary>
+    /// <param name="environment">The host environment.</param>
+    /// <returns>The resolved minimum level.</returns>
+    internal static LogEventLevel ResolveMinimumLevel(IHostEnvironment environment) =>
+        environment.IsDevelopment() ? LogEventLevel.Debug : LogEventLevel.Information;
+
+    /// <summary>
+    /// Whether the rolling file sink applies. Production containers write to ephemeral disk nothing
+    /// reads (stdout and OTel already carry production logs), so the sink is added everywhere except
+    /// Production: local development and the CI E2E stack, where the file is what a failure is
+    /// diagnosed from.
+    /// </summary>
+    /// <param name="environment">The host environment.</param>
+    /// <returns><see langword="true"/> when the file sink should be added.</returns>
+    internal static bool ShouldWriteFileSink(IHostEnvironment environment) =>
+        !environment.IsProduction();
+
+    /// <summary>
+    /// Builds the framework's logger configuration without creating or publishing a logger, so the
+    /// shape can be asserted in isolation.
+    /// </summary>
+    /// <param name="environment">The host environment.</param>
+    /// <param name="logFilePath">Path of the rolling log file, relative to the content root.</param>
+    /// <param name="configure">Optional post-defaults hook.</param>
+    /// <returns>The configured, uncreated logger configuration.</returns>
+    internal static LoggerConfiguration CreateLoggerConfiguration(
+        IHostEnvironment environment,
+        string logFilePath,
+        Action<LoggerConfiguration>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentException.ThrowIfNullOrWhiteSpace(logFilePath);
+
+        var loggerConfiguration = new LoggerConfiguration()
+            .MinimumLevel.Is(ResolveMinimumLevel(environment))
+            .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+            .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture);
+
+        if (ShouldWriteFileSink(environment))
+        {
+            loggerConfiguration = loggerConfiguration.WriteTo.File(
+                logFilePath,
+                rollingInterval: RollingInterval.Day,
+                formatProvider: CultureInfo.InvariantCulture);
+        }
+
+        configure?.Invoke(loggerConfiguration);
+
+        return loggerConfiguration;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
@@ -47,6 +47,13 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <!-- Host logging bootstrap (Logging/SerilogHostExtensions.AddCommonSerilog). Serilog lands on
+         this package rather than MMCA.Common.API because the bootstrap runs on the
+         WebApplicationBuilder immediately before AddServiceDefaults, alongside the other host-wiring
+         extensions here, and it needs no Application/Infrastructure type. -->
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
   <ItemGroup>
     <!-- Shared holds HttpResilienceDefaults — the single source of truth for the resilience

--- a/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
@@ -4,4 +4,9 @@ MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.GatewayDownstream
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeOverHttp2.get -> bool
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeOverHttp2.set -> void
 MMCA.Common.Aspire.Gateway.GatewayHealthCheckExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddGatewayDownstreamHealthChecks(System.Action<MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions!>? configure, params string![]! serviceNames) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.Aspire.Logging.SerilogHostExtensions
+MMCA.Common.Aspire.Logging.SerilogHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!)
+MMCA.Common.Aspire.Logging.SerilogHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!).AddCommonSerilog(string! logFilePath, System.Action<Serilog.LoggerConfiguration!>? configure = null) -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!
 static MMCA.Common.Aspire.Gateway.GatewayHealthCheckExtensions.AddGatewayDownstreamHealthChecks(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions!>? configure, params string![]! serviceNames) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static MMCA.Common.Aspire.Logging.SerilogHostExtensions.AddCommonSerilog(this Microsoft.AspNetCore.Builder.WebApplicationBuilder! builder, string! logFilePath, System.Action<Serilog.LoggerConfiguration!>? configure = null) -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!
+static MMCA.Common.Aspire.Logging.SerilogHostExtensions.CreateBootstrapLoggerFactory() -> Microsoft.Extensions.Logging.ILoggerFactory!

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -202,6 +202,39 @@
         "resolved": "5.0.0",
         "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
       },
+      "Serilog.AspNetCore": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Direct",
+        "requested": "[6.1.1, )",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "Direct",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
         "requested": "[10.33.0.1635, )",
@@ -380,6 +413,11 @@
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.11"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "RFYJR7APio/BiqdQunRq6DB+nDB6nc2qhHr77mlvZ0q0BT8PubMXN7XicmfzCbrDE/dzhBnUKBRXLTcqUiZDGg=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -724,6 +762,58 @@
         "dependencies": {
           "System.IO.Pipelines": "8.0.0",
           "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
         }
       },
       "StyleCop.Analyzers.Unstable": {

--- a/Source/Hosting/MMCA.Common.Gateway/ForwardedHeadersExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Gateway/ForwardedHeadersExtensions.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace MMCA.Common.Gateway;
+
+/// <summary>
+/// The framework's forwarded-headers wiring, reachable from a gateway host.
+/// <para>
+/// Service hosts get this step from <c>UseCommonMiddlewarePipeline</c> in <c>MMCA.Common.API</c>,
+/// but a gateway takes none of that package (no controllers, no DbContext, no auth middleware), so
+/// it lives here too: the one package every MMCA gateway already references, and one whose only
+/// runtime dependency is YARP. Without it a gateway hand-rolls the same five lines, and getting them
+/// wrong is not visible until production: behind Azure Container Apps ingress every connection
+/// arrives from the ingress proxy's IP, so an unforwarded gateway collapses the per-client-IP rate
+/// limit partition into ONE shared window for every real user.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with an extension(T) block in a static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
+public static class ForwardedHeadersExtensions
+{
+    extension(IApplicationBuilder app)
+    {
+        /// <summary>
+        /// Applies <c>X-Forwarded-For</c> / <c>-Proto</c> / <c>-Host</c> with the framework's
+        /// options, which is the same shape the service-side pipeline's <c>ForwardedHeaders</c> step
+        /// uses. Call it FIRST in a gateway pipeline, before the edge rate limiter: the limiter
+        /// partitions on the client IP and can only see the real one once the headers have been
+        /// applied.
+        /// </summary>
+        /// <returns>The same application builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="app"/> is null.</exception>
+        public IApplicationBuilder UseCommonForwardedHeaders()
+        {
+            ArgumentNullException.ThrowIfNull(app);
+
+            return app.UseForwardedHeaders(CreateForwardedHeadersOptions());
+        }
+    }
+
+    /// <summary>
+    /// Builds the framework's <see cref="ForwardedHeadersOptions"/>: the three
+    /// <c>X-Forwarded-*</c> headers, with the known-proxy and known-network allow-lists CLEARED.
+    /// <para>
+    /// Clearing them is deliberate and load-bearing. Cloud reverse proxies (Azure Container Apps,
+    /// AWS ALB) front the app from internal IPs that are in neither default allow-list, so leaving
+    /// the defaults in place makes the middleware ignore every forwarded header it receives and
+    /// report the ingress IP as the client.
+    /// </para>
+    /// </summary>
+    /// <returns>The configured options.</returns>
+    public static ForwardedHeadersOptions CreateForwardedHeadersOptions()
+    {
+        var options = new ForwardedHeadersOptions
+        {
+            ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
+        };
+
+        options.KnownProxies.Clear();
+        options.KnownIPNetworks.Clear();
+
+        return options;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Gateway/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Gateway/PublicAPI.Unshipped.txt
@@ -7,6 +7,9 @@ MMCA.Common.Gateway.Configuration.GatewayHealthCheckDefaultsConfigFilter
 MMCA.Common.Gateway.Configuration.GatewayHealthCheckDefaultsConfigFilter.ConfigureClusterAsync(Yarp.ReverseProxy.Configuration.ClusterConfig! cluster, System.Threading.CancellationToken cancel) -> System.Threading.Tasks.ValueTask<Yarp.ReverseProxy.Configuration.ClusterConfig!>
 MMCA.Common.Gateway.Configuration.GatewayHealthCheckDefaultsConfigFilter.ConfigureRouteAsync(Yarp.ReverseProxy.Configuration.RouteConfig! route, Yarp.ReverseProxy.Configuration.ClusterConfig? cluster, System.Threading.CancellationToken cancel) -> System.Threading.Tasks.ValueTask<Yarp.ReverseProxy.Configuration.RouteConfig!>
 MMCA.Common.Gateway.Configuration.GatewayHealthCheckDefaultsConfigFilter.GatewayHealthCheckDefaultsConfigFilter(Microsoft.Extensions.Options.IOptions<MMCA.Common.Gateway.GatewaySettings!>! options) -> void
+MMCA.Common.Gateway.ForwardedHeadersExtensions
+MMCA.Common.Gateway.ForwardedHeadersExtensions.extension(Microsoft.AspNetCore.Builder.IApplicationBuilder!)
+MMCA.Common.Gateway.ForwardedHeadersExtensions.extension(Microsoft.AspNetCore.Builder.IApplicationBuilder!).UseCommonForwardedHeaders() -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 MMCA.Common.Gateway.GatewayActiveHealthCheckDefaults
 MMCA.Common.Gateway.GatewayActiveHealthCheckDefaults.Enabled.get -> bool
 MMCA.Common.Gateway.GatewayActiveHealthCheckDefaults.Enabled.init -> void
@@ -93,6 +96,8 @@ MMCA.Common.Gateway.Transforms.GatewayTraceHeaderTransformProvider.ValidateRoute
 const MMCA.Common.Gateway.GatewaySettings.SectionName = "MmcaGateway" -> string!
 const MMCA.Common.Gateway.GatewayTraceHeaderSettings.DefaultClusterHeaderName = "X-MMCA-Cluster" -> string!
 const MMCA.Common.Gateway.GatewayTraceHeaderSettings.DefaultRouteHeaderName = "X-MMCA-Route" -> string!
+static MMCA.Common.Gateway.ForwardedHeadersExtensions.CreateForwardedHeadersOptions() -> Microsoft.AspNetCore.Builder.ForwardedHeadersOptions!
+static MMCA.Common.Gateway.ForwardedHeadersExtensions.UseCommonForwardedHeaders(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static MMCA.Common.Gateway.GatewayReverseProxyExtensions.AddMmcaGateway(this Microsoft.Extensions.DependencyInjection.IReverseProxyBuilder! builder, MMCA.Common.Gateway.GatewaySettings! settings) -> Microsoft.Extensions.DependencyInjection.IReverseProxyBuilder!
 static MMCA.Common.Gateway.GatewayReverseProxyExtensions.AddMmcaGateway(this Microsoft.Extensions.DependencyInjection.IReverseProxyBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> Microsoft.Extensions.DependencyInjection.IReverseProxyBuilder!
 static MMCA.Common.Gateway.RateLimiting.GatewayRoutePolicyExtensions.AddGatewayRoutePolicies(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, MMCA.Common.Gateway.GatewaySettings! settings) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PageExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PageExtensions.cs
@@ -18,6 +18,12 @@ namespace MMCA.Common.Testing.E2E.Infrastructure;
     Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class PageExtensions
 {
+    /// <summary>
+    /// The data-row selector of a MudDataGrid rendered in its table (non-card) layout. The default for
+    /// the list-page helpers here; a page with its own grid markup passes its own.
+    /// </summary>
+    public const string MudDataGridRowSelector = ".mud-table-body .mud-table-row";
+
     extension(IPage page)
     {
         /// <summary>
@@ -146,6 +152,99 @@ public static class PageExtensions
             // Wait for Blazor render cycle — covers both full-page and enhanced navigation.
             await page.EvaluateAsync(
                 "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))").ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Types <paramref name="text"/> into a list page's search field and waits for the debounced
+        /// server filter to surface a matching grid row. The single search helper shared by every
+        /// consumer list-page object; it replaces the per-page copies, one of which slept a fixed
+        /// 1.5 seconds and hoped.
+        /// </summary>
+        /// <remarks>
+        /// Three things make this reliable where the hand-rolled versions were not.
+        /// <list type="number">
+        /// <item><description>It waits for the grid's own loading indicator to clear rather than for a
+        /// row to exist. Filling the field while the first ServerData page is still arriving loses the
+        /// term to the re-render, but preconditioning on a ROW hangs on a list that is legitimately
+        /// empty (and on a filtered list whose default filter excludes the fixture's own
+        /// data).</description></item>
+        /// <item><description>It fills through <see cref="FillAndVerifyAsync"/>, which re-types when a
+        /// re-render wipes the value, so a grid that re-renders mid-fill cannot silently swallow the
+        /// search term.</description></item>
+        /// <item><description>It waits for the EFFECT (the matching row) instead of sleeping a fixed
+        /// interval: web-first, so it is both faster on a quick host and correct on a slow one.</description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="searchField">The list page's search input.</param>
+        /// <param name="text">The term to search for, which must also appear in the expected row.</param>
+        /// <param name="rowSelector">The grid's data-row selector.</param>
+        /// <param name="timeout">Per-step budget in milliseconds.</param>
+        public async Task SearchAndWaitForRowAsync(
+            ILocator searchField,
+            string text,
+            string rowSelector = MudDataGridRowSelector,
+            float timeout = 15_000)
+        {
+            ArgumentNullException.ThrowIfNull(page);
+            ArgumentNullException.ThrowIfNull(searchField);
+
+            await page.WaitForGridToSettleAsync(timeout).ConfigureAwait(false);
+            await searchField.FillAndVerifyAsync(text).ConfigureAwait(false);
+
+            await page.Locator(rowSelector).Filter(new() { HasText = text }).First
+                .WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeout }).ConfigureAwait(false);
+
+            await page.WaitForLoadStateAsync(LoadState.Load).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Clicks a delete affordance, confirms the dialog it opens, and waits for the resulting grid
+        /// reload to settle. Targets the confirmation button by TEST ID rather than by a MudBlazor
+        /// class: <c>.mud-message-box .mud-button-filled</c> matches whichever filled button the
+        /// message box renders first, which silently changed meaning when a dialog gained a second
+        /// filled action.
+        /// </summary>
+        /// <remarks>
+        /// The settle at the end is the part that is easy to leave out and expensive to debug: a
+        /// MudDataGrid reloads its page asynchronously after a delete, and an assertion issued against
+        /// the pre-reload DOM still sees the deleted row.
+        /// </remarks>
+        /// <param name="deleteButton">The row's (or detail page's) delete button.</param>
+        /// <param name="confirmTestId">The <c>data-testid</c> of the confirm button inside the dialog.</param>
+        /// <param name="timeout">Per-step budget in milliseconds.</param>
+        public async Task ConfirmDeleteAsync(
+            ILocator deleteButton,
+            string confirmTestId = "confirm-delete",
+            float timeout = 10_000)
+        {
+            ArgumentNullException.ThrowIfNull(page);
+            ArgumentNullException.ThrowIfNull(deleteButton);
+
+            await deleteButton
+                .WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeout }).ConfigureAwait(false);
+            await deleteButton.ClickAsync().ConfigureAwait(false);
+
+            var confirmButton = page.GetByTestId(confirmTestId);
+            await confirmButton
+                .WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeout }).ConfigureAwait(false);
+            await confirmButton.ClickAsync().ConfigureAwait(false);
+
+            await page.WaitForLoadStateAsync(LoadState.Load).ConfigureAwait(false);
+            await page.WaitForGridToSettleAsync(timeout).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Waits for a MudDataGrid page's async load to finish, WITHOUT requiring the grid to have
+        /// produced any rows. Deliberately not a wait for a row: an empty result set is a legitimate
+        /// state, and a helper that preconditions on rows turns it into a timeout.
+        /// </summary>
+        /// <param name="timeout">Budget in milliseconds.</param>
+        public async Task WaitForGridToSettleAsync(float timeout = 15_000)
+        {
+            ArgumentNullException.ThrowIfNull(page);
+
+            await Assertions.Expect(page.Locator("[role='progressbar']"))
+                .ToHaveCountAsync(0, new() { Timeout = timeout }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/WebVitalsPageExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/WebVitalsPageExtensions.cs
@@ -1,0 +1,66 @@
+using Microsoft.Playwright;
+
+namespace MMCA.Common.Testing.E2E.Infrastructure;
+
+/// <summary>
+/// The one-call Core Web Vitals measurement every consumer's <c>WebVitalsTests</c> hand-rolled as a
+/// private <c>MeasureAsync</c>: install the collector, load the page, optionally drive one scripted
+/// interaction so an INP sample is recorded, collect, write the dated artifact, and assert the sample
+/// against a budget. The order is the load-bearing part (the collector's observers must be installed
+/// BEFORE the navigation, or LCP/FCP/TTFB are never recorded for that load), which is exactly what a
+/// per-repo copy gets wrong once and then carries.
+/// </summary>
+public static class WebVitalsPageExtensions
+{
+    extension(IPage page)
+    {
+        /// <summary>
+        /// Measures one page's Core Web Vitals and asserts them against <paramref name="budget"/>.
+        /// </summary>
+        /// <param name="label">The artifact label (also the failure-message label), e.g. <c>"home"</c>.</param>
+        /// <param name="path">The path to load.</param>
+        /// <param name="budget">The budget to assert against.</param>
+        /// <param name="writeLine">Test output sink for the single-line sample record, or null.</param>
+        /// <param name="interactionPlaceholder">
+        /// The placeholder of an input to click and type into so the event-timing observer records a
+        /// single INP latency sample. Null measures the load only. Best-effort: an absent or invisible
+        /// field is skipped, and if no event clears the 16 ms threshold INP stays 0 and its assertion
+        /// is skipped by the budget.
+        /// </param>
+        /// <param name="interactionText">The text typed into that input.</param>
+        /// <returns>The collected sample, for any further app-specific assertion.</returns>
+        public async Task<WebVitalsSample> MeasureWebVitalsAsync(
+            string label,
+            string path,
+            WebVitalsBudget budget,
+            Action<string>? writeLine = null,
+            string? interactionPlaceholder = null,
+            string interactionText = "test")
+        {
+            ArgumentNullException.ThrowIfNull(page);
+            ArgumentNullException.ThrowIfNull(budget);
+
+            await WebVitalsCollector.InstallAsync(page).ConfigureAwait(false);
+            await page.GotoAndWaitForBlazorAsync(path).ConfigureAwait(false);
+
+            if (interactionPlaceholder is not null)
+            {
+                var field = page.GetByPlaceholder(interactionPlaceholder);
+                if (await field.IsVisibleAsync().ConfigureAwait(false))
+                {
+                    await field.ClickAsync().ConfigureAwait(false);
+                    await field.FillAsync(interactionText).ConfigureAwait(false);
+                }
+
+                // Give the event-timing observer a slice to record the interaction it just saw.
+                await page.WaitForTimeoutAsync(300).ConfigureAwait(false);
+            }
+
+            var sample = await WebVitalsCollector.CollectAsync(page).ConfigureAwait(false);
+            await WebVitalsCollector.WriteArtifactAsync(label, path, sample).ConfigureAwait(false);
+
+            budget.AssertWithinBudget(sample, label, path, writeLine);
+            return sample;
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing.E2E/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 #nullable enable
+MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.extension(Microsoft.Playwright.IPage!).ConfirmDeleteAsync(Microsoft.Playwright.ILocator! deleteButton, string! confirmTestId = "confirm-delete", float timeout = 10000) -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.extension(Microsoft.Playwright.IPage!).SearchAndWaitForRowAsync(Microsoft.Playwright.ILocator! searchField, string! text, string! rowSelector = ".mud-table-body .mud-table-row", float timeout = 15000) -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.extension(Microsoft.Playwright.IPage!).WaitForGridToSettleAsync(float timeout = 15000) -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.E2E.Infrastructure.WebVitalsPageExtensions
+MMCA.Common.Testing.E2E.Infrastructure.WebVitalsPageExtensions.extension(Microsoft.Playwright.IPage!)
+MMCA.Common.Testing.E2E.Infrastructure.WebVitalsPageExtensions.extension(Microsoft.Playwright.IPage!).MeasureWebVitalsAsync(string! label, string! path, MMCA.Common.Testing.E2E.Infrastructure.WebVitalsBudget! budget, System.Action<string!>? writeLine = null, string? interactionPlaceholder = null, string! interactionText = "test") -> System.Threading.Tasks.Task<MMCA.Common.Testing.E2E.Infrastructure.WebVitalsSample!>!
 MMCA.Common.Testing.E2E.PageObjects.ForgotPasswordPage
 MMCA.Common.Testing.E2E.PageObjects.ForgotPasswordPage.BackToLoginLink.get -> Microsoft.Playwright.ILocator!
 MMCA.Common.Testing.E2E.PageObjects.ForgotPasswordPage.ConfirmationAlert.get -> Microsoft.Playwright.ILocator!
@@ -20,6 +26,21 @@ MMCA.Common.Testing.E2E.PageObjects.ResetPasswordPage.ResetPasswordPage(Microsof
 MMCA.Common.Testing.E2E.PageObjects.ResetPasswordPage.SubmitButton.get -> Microsoft.Playwright.ILocator!
 MMCA.Common.Testing.E2E.PageObjects.ResetPasswordPage.SuccessAlert.get -> Microsoft.Playwright.ILocator!
 MMCA.Common.Testing.E2E.PageObjects.ResetPasswordPage.TokenField.get -> Microsoft.Playwright.ILocator!
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.DefaultCulture_DoesNotLeakPseudoSentinel() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.PseudoLocale_RendersSentinel_WithoutEnUsLeak_AndDoesNotOverflowHorizontally() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.PseudoLocalizationTestsBase(MMCA.Common.Testing.E2E.Infrastructure.PlaywrightFixture! fixture) -> void
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.<Clone>$() -> MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage!
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.Deconstruct(out string! Path, out string! EnglishProbe, out string? SettleSelector) -> void
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.EnglishProbe.get -> string!
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.EnglishProbe.init -> void
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.Equals(MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage? other) -> bool
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.Path.get -> string!
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.Path.init -> void
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.PseudoLocalizedPage(string! Path, string! EnglishProbe, string? SettleSelector = null) -> void
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.SettleSelector.get -> string?
+MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.SettleSelector.init -> void
 MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase
 MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase.ForgotPasswordPage_ShouldHaveNoAccessibilityViolations() -> System.Threading.Tasks.Task!
 MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase.ForgotPassword_WithUnknownEmail_ShowsTheSameConfirmation() -> System.Threading.Tasks.Task!
@@ -27,3 +48,20 @@ MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase.LoginPage_Forg
 MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase.PasswordResetTestsBase(MMCA.Common.Testing.E2E.Infrastructure.PlaywrightFixture! fixture) -> void
 MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase.ResetPasswordPage_ShouldHaveNoAccessibilityViolations() -> System.Threading.Tasks.Task!
 MMCA.Common.Testing.E2E.Workflows.Identity.PasswordResetTestsBase.ResetPassword_WithEmptyForm_ShowsClientValidationErrors() -> System.Threading.Tasks.Task!
+abstract MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.ScannedPages.get -> System.Collections.Generic.IReadOnlyList<MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage!>!
+const MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.MudDataGridRowSelector = ".mud-table-body .mud-table-row" -> string!
+override MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.Equals(object? obj) -> bool
+override MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.GetHashCode() -> int
+override MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.ToString() -> string!
+static MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.ConfirmDeleteAsync(this Microsoft.Playwright.IPage! page, Microsoft.Playwright.ILocator! deleteButton, string! confirmTestId = "confirm-delete", float timeout = 10000) -> System.Threading.Tasks.Task!
+static MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.SearchAndWaitForRowAsync(this Microsoft.Playwright.IPage! page, Microsoft.Playwright.ILocator! searchField, string! text, string! rowSelector = ".mud-table-body .mud-table-row", float timeout = 15000) -> System.Threading.Tasks.Task!
+static MMCA.Common.Testing.E2E.Infrastructure.PageExtensions.WaitForGridToSettleAsync(this Microsoft.Playwright.IPage! page, float timeout = 15000) -> System.Threading.Tasks.Task!
+static MMCA.Common.Testing.E2E.Infrastructure.WebVitalsPageExtensions.MeasureWebVitalsAsync(this Microsoft.Playwright.IPage! page, string! label, string! path, MMCA.Common.Testing.E2E.Infrastructure.WebVitalsBudget! budget, System.Action<string!>? writeLine = null, string? interactionPlaceholder = null, string! interactionText = "test") -> System.Threading.Tasks.Task<MMCA.Common.Testing.E2E.Infrastructure.WebVitalsSample!>!
+static MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.operator !=(MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage? left, MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage? right) -> bool
+static MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage.operator ==(MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage? left, MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizedPage? right) -> bool
+virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.AssertProbePresentUnderDefaultCulture.get -> bool
+virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.OverflowTolerancePx.get -> int
+virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.ProbeVisibleTextOnly.get -> bool
+virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.PseudoLocale.get -> string!
+virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.Sentinel.get -> string!
+virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.Timeout.get -> float

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Workflows/Globalization/PseudoLocalizationTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Workflows/Globalization/PseudoLocalizationTestsBase.cs
@@ -1,0 +1,185 @@
+using System.Globalization;
+using AwesomeAssertions;
+using MMCA.Common.Testing.E2E.Infrastructure;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace MMCA.Common.Testing.E2E.Workflows.Globalization;
+
+/// <summary>
+/// One page under the pseudo-localization gate: the path to load, an en-US probe string owned by a
+/// resource rendered on it, and an optional selector that proves the page's async content settled.
+/// </summary>
+/// <param name="Path">The path to load.</param>
+/// <param name="EnglishProbe">
+/// A string KNOWN to come from a resource rendered on this page. Under the pseudo culture every
+/// letter gains a combining accent, so the plain en-US form appearing means some render path bypassed
+/// the localizer.
+/// </param>
+/// <param name="SettleSelector">
+/// A selector whose visibility proves the page's async content rendered (a seeded grid row, a card, a
+/// static section). Null waits only for the loading indicator to clear.
+/// </param>
+public sealed record PseudoLocalizedPage(string Path, string EnglishProbe, string? SettleSelector = null);
+
+/// <summary>
+/// Pseudo-localization fitness gate for an app's own pages (ADR-027 section 8 / rubric section 27),
+/// authored once here and re-run as a thin sealed subclass per consumer repo. Each declared page is
+/// loaded under the <c>qps-Ploc</c> pseudo culture and asserted three ways:
+/// <list type="number">
+/// <item><description>at least one VISIBLE bracket sentinel renders, proving the app's own resx
+/// resources make the full round trip (resx -> IStringLocalizer -> PseudoStringLocalizer -> markup)
+/// rather than being hard-coded;</description></item>
+/// <item><description>the page does not overflow horizontally under the pseudo pass's roughly 40%
+/// text expansion, the rubric's layout-tolerance criterion;</description></item>
+/// <item><description>the page's en-US probe does NOT render in plain English, so a regression that
+/// bypasses the localizer fails the gate instead of shipping silently.</description></item>
+/// </list>
+/// A reverse leak guard asserts the sentinel is absent under the default culture (and, by default,
+/// that the probe IS plain English there), so pseudo text can never ship to a real locale unnoticed
+/// and the probes stay in sync with their resources.
+/// </summary>
+/// <remarks>
+/// Activation is the culture COOKIE via <c>GET /culture/set</c> (the shared <c>MapCultureEndpoint</c>
+/// the culture switcher uses), not a query-string culture provider: a Blazor Server circuit takes its
+/// culture from the request that STARTS the circuit, which carries cookies but not the original
+/// page's query string, so a query-string-only activation would pseudo-localize the prerender and
+/// then revert on hydration. <c>qps-Ploc</c> is allowlisted in Development only
+/// (<c>UseCommonRequestLocalization</c> / <c>MapCultureEndpoint</c>), which is what an Aspire-launched
+/// E2E stack runs, so this gate needs no host change. Public pages are the right subjects: no login
+/// keeps the gate robust.
+/// </remarks>
+public abstract class PseudoLocalizationTestsBase : E2ETestBase
+{
+    protected PseudoLocalizationTestsBase(PlaywrightFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    /// <summary>The pages this app puts under the gate, each with its own en-US probe.</summary>
+    protected abstract IReadOnlyList<PseudoLocalizedPage> ScannedPages { get; }
+
+    /// <summary>
+    /// The pseudo locale to activate. Mirrors <c>SupportedCultures.PseudoLocale</c>; stated here
+    /// because this shipped fixture library deliberately does not reference MMCA.Common.Shared.
+    /// </summary>
+    protected virtual string PseudoLocale => "qps-Ploc";
+
+    /// <summary>The PseudoLocalizer bracket-sentinel prefix, which opens every transformed string.</summary>
+    protected virtual string Sentinel => "[!!";
+
+    /// <summary>
+    /// Horizontal-overflow tolerance in CSS pixels. One pixel absorbs sub-pixel layout rounding
+    /// without admitting a genuine sideways scrollbar.
+    /// </summary>
+    protected virtual int OverflowTolerancePx => 1;
+
+    /// <summary>
+    /// Whether the en-US leak probe is searched in the page's VISIBLE text only (body innerText)
+    /// rather than in the whole document. The default (false) searches the whole document, which also
+    /// covers probes that live in attributes such as an input placeholder. Set true for an app whose
+    /// probes are visible text and whose markup legitimately carries the plain form elsewhere.
+    /// </summary>
+    protected virtual bool ProbeVisibleTextOnly => false;
+
+    /// <summary>
+    /// Whether the default-culture guard also asserts each probe IS present in plain English. On by
+    /// default: it is what keeps the probes honest, since a probe that drifted from its resource value
+    /// would otherwise make the pseudo test's leak assertion pass vacuously.
+    /// </summary>
+    protected virtual bool AssertProbePresentUnderDefaultCulture => true;
+
+    /// <summary>Per-step wait budget in milliseconds.</summary>
+    protected virtual float Timeout => 15_000;
+
+    [Fact]
+    public async Task PseudoLocale_RendersSentinel_WithoutEnUsLeak_AndDoesNotOverflowHorizontally()
+    {
+        ScannedPages.Should().NotBeEmpty(
+            "at least one page must be declared, or the pseudo-localization gate verifies nothing");
+
+        foreach (var scanned in ScannedPages)
+        {
+            // Activate qps-Ploc exactly like the app's culture switcher does: GET /culture/set writes
+            // the .AspNetCore.Culture cookie and LocalRedirects to the target page, so BOTH the SSR
+            // prerender and the interactive circuit render under the pseudo culture.
+            await Page.GotoAndWaitForBlazorAsync(
+                $"/culture/set?culture={PseudoLocale}&redirectUri={Uri.EscapeDataString(scanned.Path)}").ConfigureAwait(false);
+
+            await SettleAsync(scanned.SettleSelector).ConfigureAwait(false);
+
+            // (a) At least one VISIBLE sentinel: the pseudo pipeline is active end to end on this page.
+            await Expect(Page.GetByText(Sentinel).Filter(new() { Visible = true }).First)
+                .ToBeVisibleAsync(new() { Timeout = Timeout }).ConfigureAwait(false);
+
+            // (b) No en-US leak. The transform appends a combining accent to every letter, so the
+            // probe's plain-ASCII form can only appear if the string bypassed the resource pipeline.
+            var probed = await ProbedTextAsync().ConfigureAwait(false);
+            probed.Should().NotContain(
+                scanned.EnglishProbe,
+                $"{scanned.Path} must render '{scanned.EnglishProbe}' through the localizer, not hard-coded");
+
+            // (c) No horizontal page overflow under the roughly 40% expansion. Grids scroll inside
+            // their own containers; the DOCUMENT must not scroll sideways.
+            var overflow = await Page.EvaluateAsync<int>(
+                "() => Math.max(0, document.scrollingElement.scrollWidth - document.scrollingElement.clientWidth)").ConfigureAwait(false);
+            overflow.Should().BeLessThanOrEqualTo(
+                OverflowTolerancePx,
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{scanned.Path} overflows horizontally by {overflow}px under the {PseudoLocale} text expansion; the layout must tolerate longer translations"));
+        }
+    }
+
+    [Fact]
+    public async Task DefaultCulture_DoesNotLeakPseudoSentinel()
+    {
+        foreach (var scanned in ScannedPages)
+        {
+            // Fresh browser context per test (E2ETestBase), so no culture cookie is present and the
+            // default culture renders.
+            await Page.GotoAndWaitForBlazorAsync(scanned.Path).ConfigureAwait(false);
+            await SettleAsync(scanned.SettleSelector).ConfigureAwait(false);
+
+            var content = await Page.ContentAsync().ConfigureAwait(false);
+            content.Should().NotContain(
+                Sentinel,
+                $"{scanned.Path} must never ship pseudo-localized text to a real locale");
+
+            if (AssertProbePresentUnderDefaultCulture)
+            {
+                var probed = await ProbedTextAsync().ConfigureAwait(false);
+                probed.Should().Contain(
+                    scanned.EnglishProbe,
+                    $"the probe for {scanned.Path} must still match its resource, or the pseudo leak check passes vacuously");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The text the en-US probe is searched in: the whole document by default, or the body's visible
+    /// text when <see cref="ProbeVisibleTextOnly"/> is set.
+    /// </summary>
+    /// <returns>The text to probe.</returns>
+    private async Task<string> ProbedTextAsync() =>
+        ProbeVisibleTextOnly
+            ? await Page.InnerTextAsync("body").ConfigureAwait(false)
+            : await Page.ContentAsync().ConfigureAwait(false);
+
+    /// <summary>
+    /// Waits for the page's async content and for any loading indicator to clear, so the
+    /// sentinel/leak/overflow checks measure the settled DOM.
+    /// </summary>
+    /// <param name="settleSelector">The page's settle selector, or null.</param>
+    private async Task SettleAsync(string? settleSelector)
+    {
+        if (settleSelector is not null)
+        {
+            await Expect(Page.Locator(settleSelector).First)
+                .ToBeVisibleAsync(new() { Timeout = Timeout }).ConfigureAwait(false);
+        }
+
+        await Expect(Page.Locator("[role='progressbar']"))
+            .ToHaveCountAsync(0, new() { Timeout = Timeout }).ConfigureAwait(false);
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitComponentTestBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitComponentTestBase.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MMCA.Common.UI.Services;
+using Moq;
 using MudBlazor;
 using MudBlazor.Services;
 
@@ -50,6 +53,53 @@ public abstract class BunitComponentTestBase : BunitContext
         // resources in the component's own assembly) without per-test setup.
         Services.AddLogging();
         Services.AddLocalization();
+    }
+
+    /// <summary>
+    /// Wires the services a <c>DataGridListPageBase</c> page needs in bUnit and puts the renderer into
+    /// the mode the page's load path branches on. Call it LAST in a test class constructor, after every
+    /// <c>Services.Add*</c> call the test makes (its own and the base's).
+    /// <para>
+    /// The ordering is load-bearing, which is the whole reason this exists as one helper:
+    /// <c>SetRendererInfo</c> builds and FREEZES the bUnit service provider, so any registration made
+    /// after it is silently ignored, and the page then resolves the framework default instead of the
+    /// test's double. Fifteen call sites across the MMCA repos hand-rolled this block and each one had
+    /// to remember that rule.
+    /// </para>
+    /// <para>
+    /// <paramref name="stubViewport"/> substitutes MudBlazor's <see cref="IBrowserViewportService"/>
+    /// with an inert double so <c>IsMobile</c> stays deterministically false: in bUnit no browser
+    /// answers the breakpoint subscription, so the real service would leave the card/grid choice up to
+    /// timing. Pass false to exercise the real one. Registered with a plain Add (not TryAdd) on
+    /// purpose: <c>AddMudServices</c> already registered the real implementation, and last
+    /// registration wins.
+    /// </para>
+    /// </summary>
+    /// <param name="isInteractive">
+    /// Whether the renderer reports as interactive. True is the usual choice: list pages bound their
+    /// SSR prerender fetches on <c>RendererInfo.IsInteractive</c>, so a non-interactive renderer means
+    /// no data ever loads. Pass false to assert the prerender branch.
+    /// </param>
+    /// <param name="rendererName">The renderer name bUnit reports, matching the host under test.</param>
+    /// <param name="stubViewport">Whether to substitute an inert <see cref="IBrowserViewportService"/>.</param>
+    protected void ConfigureDataGridListPageHost(
+        bool isInteractive = true,
+        string rendererName = "Server",
+        bool stubViewport = true)
+    {
+        Services.TryAddScoped<ListPageStateService>();
+        Services.TryAddScoped<ListPageQueryStateService>();
+
+        if (stubViewport)
+        {
+            Services.AddSingleton(Mock.Of<IBrowserViewportService>());
+        }
+
+        // The list-page base persists its grid state across the prerender/interactive boundary.
+        AddBunitPersistentComponentState();
+
+        // MUST be last: this freezes the service provider.
+        SetRendererInfo(new RendererInfo(rendererName, isInteractive));
     }
 
     /// <summary>Sets the principal the injected <see cref="AuthenticationStateProvider"/> returns (and notifies listeners) without re-rendering a new root — useful for mid-test auth changes.</summary>

--- a/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/ErrorSummaryExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/ErrorSummaryExtensions.cs
@@ -1,0 +1,49 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace MMCA.Common.Testing.UI;
+
+/// <summary>
+/// Reads the shared <c>ErrorSummary</c> component out of a rendered component under test, so a form
+/// test can assert on the validation messages a user would see rather than on raw markup.
+/// </summary>
+public static class ErrorSummaryExtensions
+{
+    /// <summary>The class the summary's title carries, and the marker that identifies its alert.</summary>
+    public const string ErrorSummaryTitleClass = "mmca-error-summary-title";
+
+    extension<TComponent>(IRenderedComponent<TComponent> cut)
+        where TComponent : IComponent
+    {
+        /// <summary>
+        /// The messages the shared <c>ErrorSummary</c> is currently showing, one entry per broken rule,
+        /// or an empty list when no summary is rendered.
+        /// </summary>
+        /// <remarks>
+        /// The component renders SEVERAL messages as a <c>&lt;ul&gt;</c> but a SINGLE one as plain text
+        /// inside the alert, so a test that only queried <c>li</c> would read an empty summary exactly
+        /// when one rule is broken. This reads both shapes and strips the alert's title.
+        /// </remarks>
+        public IReadOnlyList<string> ErrorSummaryMessages()
+        {
+            ArgumentNullException.ThrowIfNull(cut);
+
+            var alert = cut.FindAll(".mud-alert")
+                .FirstOrDefault(element => element.QuerySelector("." + ErrorSummaryTitleClass) is not null);
+            if (alert is null)
+            {
+                return [];
+            }
+
+            var items = alert.QuerySelectorAll("li");
+            if (items.Length > 0)
+            {
+                return [.. items.Select(item => item.TextContent.Trim())];
+            }
+
+            var title = alert.QuerySelector("." + ErrorSummaryTitleClass)?.TextContent ?? string.Empty;
+            var single = alert.TextContent.Replace(title, string.Empty, StringComparison.Ordinal).Trim();
+            return single.Length == 0 ? [] : [single];
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing.UI/MMCA.Common.Testing.UI.csproj
+++ b/Source/Hosting/MMCA.Common.Testing.UI/MMCA.Common.Testing.UI.csproj
@@ -14,6 +14,11 @@
     <!-- Direct pin so the transitive AngleSharp resolves to the patched 1.5.0 (CVE-2026-54570). -->
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="MudBlazor" />
+    <!-- ConfigureDataGridListPageHost substitutes MudBlazor's IBrowserViewportService so the shared
+         list-page base resolves a deterministic (never-mobile) viewport in bUnit, where no browser
+         answers the JS breakpoint query. A hand-written stub would have to track every member
+         MudBlazor adds to that interface. -->
+    <PackageReference Include="Moq" />
     <PackageReference Include="MinVer">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build</IncludeAssets>

--- a/Source/Hosting/MMCA.Common.Testing.UI/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.UI/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+MMCA.Common.Testing.UI.BunitComponentTestBase.ConfigureDataGridListPageHost(bool isInteractive = true, string! rendererName = "Server", bool stubViewport = true) -> void
+MMCA.Common.Testing.UI.ErrorSummaryExtensions
+MMCA.Common.Testing.UI.ErrorSummaryExtensions.extension<TComponent>(Bunit.IRenderedComponent<TComponent>!)
+MMCA.Common.Testing.UI.ErrorSummaryExtensions.extension<TComponent>(Bunit.IRenderedComponent<TComponent>!).ErrorSummaryMessages() -> System.Collections.Generic.IReadOnlyList<string!>!
+const MMCA.Common.Testing.UI.ErrorSummaryExtensions.ErrorSummaryTitleClass = "mmca-error-summary-title" -> string!
+static MMCA.Common.Testing.UI.ErrorSummaryExtensions.ErrorSummaryMessages<TComponent>(this Bunit.IRenderedComponent<TComponent>! cut) -> System.Collections.Generic.IReadOnlyList<string!>!

--- a/Source/Hosting/MMCA.Common.Testing.UI/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing.UI/packages.lock.json
@@ -45,6 +45,15 @@
         "resolved": "7.0.0",
         "contentHash": "2lMTCQl5bGP4iv0JNkockPnyllC6eHLz+CoK2ICvalvHod+exXSxueu9hq+zNkU7bZBJf8wMfeRC/Edn8AGmEg=="
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.20.72, )",
+        "resolved": "4.20.72",
+        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "MudBlazor": {
         "type": "Direct",
         "requested": "[9.9.0, )",
@@ -88,6 +97,11 @@
           "AngleSharp": "1.1.2",
           "AngleSharp.Css": "1.0.0-beta.144"
         }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "Microsoft.AspNetCore.Components.WebAssembly": {
         "type": "Transitive",

--- a/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
+++ b/Source/Hosting/MMCA.Common.Testing/MMCA.Common.Testing.csproj
@@ -33,6 +33,10 @@
          (GHSA-q939-rpr3-3284); no code here uses it. See the pin comment in Directory.Packages.props. -->
     <PackageReference Include="SSH.NET" />
     <PackageReference Include="xunit.v3.extensibility.core" />
+    <!-- MmcaGatewayHardeningTestsBase asserts YARP cluster/health-check config and RecordingHttpForwarder
+         implements IHttpForwarder, so the gateway hardening base needs the proxy types here rather than
+         in every gateway test project (same precedent as the JwtBearer reference above). -->
+    <PackageReference Include="Yarp.ReverseProxy" />
   </ItemGroup>
   <ItemGroup>
     <!-- HandlerTestBase mocks the framework's IUnitOfWork/IRepository contracts and

--- a/Source/Hosting/MMCA.Common.Testing/MmcaGatewayHardeningTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing/MmcaGatewayHardeningTestsBase.cs
@@ -1,0 +1,379 @@
+using System.Net;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Yarp.ReverseProxy.Configuration;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Gateway edge-hardening fitness tests, authored once here and re-run as a thin sealed subclass per
+/// gateway host (ADR-015). Covers what a host adopts from the shared gateway kit: the per-client-IP
+/// rate limiter and its bypass list, an optional tighter named policy on the credential route, the
+/// correlation ID stamped and echoed on every response, the per-downstream readiness checks, and the
+/// active destination health probe on every cluster. The subclass supplies its own route table facts
+/// (the limited path, the permit limits, the bypassed paths, the downstream service names); the
+/// assertions and the test-server mechanics live here.
+/// <para>
+/// The rate-limit assertions go through <see cref="TestServer.SendAsync(Action{HttpContext}, CancellationToken)"/>
+/// rather than an <see cref="HttpClient"/> because the limiter partitions on
+/// <c>Connection.RemoteIpAddress</c>, which a <see cref="TestServer"/> request leaves null; the kit
+/// deliberately fails OPEN on an unresolvable IP, so a client-driven test could never observe a 429.
+/// Each test uses its own client IP (all inside the RFC 5737 TEST-NET-3 documentation range) so the
+/// fixture's shared host gives every one a fresh window.
+/// </para>
+/// <para>
+/// The subclass is expected to boot the real gateway in the Production environment with a
+/// <see cref="RecordingHttpForwarder"/> swapped in for <c>IHttpForwarder</c>, so a proxied route
+/// answers immediately instead of trying to reach a service-discovery name that resolves to nothing
+/// in-process.
+/// </para>
+/// </summary>
+/// <typeparam name="TEntryPoint">The gateway host's entry-point class, typically its <c>Program</c>.</typeparam>
+public abstract class MmcaGatewayHardeningTestsBase<TEntryPoint>
+    where TEntryPoint : class
+{
+    /// <summary>The forwarded caller whose own window the partitioning test exhausts.</summary>
+    private const string ForwardedCallerA = "203.0.113.101";
+
+    /// <summary>A second forwarded caller behind the same proxy IP, which must keep its own window.</summary>
+    private const string ForwardedCallerB = "203.0.113.102";
+
+    /// <summary>The client the throttle-exhaustion test burns its window as.</summary>
+    private static readonly IPAddress GlobalThrottleClientIp = IPAddress.Parse("203.0.113.10");
+
+    /// <summary>The client the bypass test burns its window as, so it cannot disturb the others.</summary>
+    private static readonly IPAddress BypassProbeClientIp = IPAddress.Parse("203.0.113.20");
+
+    /// <summary>The client the named-policy test uses, so its tighter window is independently observable.</summary>
+    private static readonly IPAddress NamedPolicyClientIp = IPAddress.Parse("203.0.113.30");
+
+    /// <summary>The connection-level address every forwarded-header request arrives from (the ingress proxy).</summary>
+    private static readonly IPAddress ForwardedProxyIp = IPAddress.Parse("203.0.113.100");
+
+    /// <summary>The booted gateway host under test, typically an xUnit class fixture's factory.</summary>
+    protected abstract WebApplicationFactory<TEntryPoint> Factory { get; }
+
+    /// <summary>
+    /// The configured per-IP allowance of the global edge limiter, as the host's own configuration
+    /// declares it. Stated by the subclass rather than read from the kit so an operator can see the
+    /// number without reading the framework.
+    /// </summary>
+    protected abstract int PermitLimit { get; }
+
+    /// <summary>A representative proxied route that IS subject to the global limiter.</summary>
+    protected abstract string LimitedPath { get; }
+
+    /// <summary>
+    /// The downstream services the gateway fronts, one readiness check each. The check name is
+    /// <see cref="DownstreamCheckPrefix"/> plus the service name.
+    /// </summary>
+    protected abstract IReadOnlyList<string> DownstreamServices { get; }
+
+    /// <summary>
+    /// Paths that must never be throttled. <c>/health</c> and <c>/.well-known</c> are always exempt
+    /// inside the kit: probes and JWKS discovery run at high frequency by design, and throttling them
+    /// turns a traffic spike into a failed liveness probe and a container restart. A host adds its own
+    /// (a SignalR hub prefix, say) through its bypass configuration and lists them here.
+    /// </summary>
+    protected virtual IReadOnlyList<string> BypassedPaths =>
+    [
+        "/.well-known/jwks.json",
+        "/health",
+    ];
+
+    /// <summary>
+    /// A path on a route carrying a tighter named rate-limiter policy (the credential surface is the
+    /// usual case), or null when the host declares no named policy. Null skips the named-policy test.
+    /// </summary>
+    protected virtual string? NamedPolicyPath => null;
+
+    /// <summary>
+    /// The per-IP allowance the <see cref="NamedPolicyPath"/> route carries on top of the global one.
+    /// Ignored when <see cref="NamedPolicyPath"/> is null.
+    /// </summary>
+    protected virtual int NamedPolicyPermitLimit => 0;
+
+    /// <summary>The active probe interval every cluster must carry, from the host's health-check defaults.</summary>
+    protected virtual TimeSpan ActiveProbeInterval => TimeSpan.FromSeconds(30);
+
+    /// <summary>The per-probe budget, normally left at the kit default.</summary>
+    protected virtual TimeSpan ActiveProbeTimeout => TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The path the active probe hits. <c>/alive</c>, not <c>/health</c>: readiness on a downstream
+    /// flips during its own rolling deployment, and ejecting a destination for that is the gateway
+    /// treating a healthy deploy as an outage.
+    /// </summary>
+    protected virtual string ActiveProbePath => "/alive";
+
+    /// <summary>The header the gateway correlation middleware stamps and echoes.</summary>
+    protected virtual string CorrelationHeader => "X-Correlation-ID";
+
+    /// <summary>The name prefix the per-downstream readiness checks are registered under.</summary>
+    protected virtual string DownstreamCheckPrefix => "downstream-";
+
+    /// <summary>The forwarded-client-IP header the edge honors ahead of the limiter.</summary>
+    protected virtual string ForwardedForHeader => "X-Forwarded-For";
+
+    [Fact]
+    public async Task Route_IsThrottledOnceTheClientExhaustsItsWindow()
+    {
+        // Act: the configured allowance, then one more.
+        var statusesWithinWindow = new List<int>();
+        for (var i = 0; i < PermitLimit; i++)
+        {
+            statusesWithinWindow.Add(await SendAsync(LimitedPath, GlobalThrottleClientIp).ConfigureAwait(false));
+        }
+
+        var overflowStatus = await SendAsync(LimitedPath, GlobalThrottleClientIp).ConfigureAwait(false);
+
+        // Assert: the edge sheds the excess rather than passing it to a backend. The limiter bounds
+        // ANONYMOUS traffic too, which is the whole reason the edge limiter is not the service-side
+        // per-user one.
+        statusesWithinWindow.Should().AllSatisfy(status => status
+            .Should().NotBe(StatusCodes.Status429TooManyRequests, "the configured allowance must be admitted in full"));
+        overflowStatus.Should().Be(
+            StatusCodes.Status429TooManyRequests,
+            "the request past the per-IP window must be rejected at the edge");
+    }
+
+    [Fact]
+    public async Task NamedPolicyRoute_IsThrottledAtItsOwnTighterAllowance()
+    {
+        // A declared dynamic skip would need xunit.v3.assert, which this shipped fixture library
+        // deliberately does not reference: a host with no named policy simply passes.
+        if (NamedPolicyPath is not { } namedPolicyPath)
+        {
+            return;
+        }
+
+        // Act: the named allowance, then one more. Both limiters see every one of these requests, so
+        // this also proves the two compose rather than one replacing the other.
+        var statusesWithinWindow = new List<int>();
+        for (var i = 0; i < NamedPolicyPermitLimit; i++)
+        {
+            statusesWithinWindow.Add(await SendAsync(namedPolicyPath, NamedPolicyClientIp).ConfigureAwait(false));
+        }
+
+        var overflowStatus = await SendAsync(namedPolicyPath, NamedPolicyClientIp).ConfigureAwait(false);
+        var otherRouteStatus = await SendAsync(LimitedPath, NamedPolicyClientIp).ConfigureAwait(false);
+
+        // Assert
+        statusesWithinWindow.Should().AllSatisfy(status => status
+            .Should().NotBe(StatusCodes.Status429TooManyRequests, "the tighter allowance must be admitted in full"));
+        overflowStatus.Should().Be(
+            StatusCodes.Status429TooManyRequests,
+            "the guarded surface must shed a burst well before the global window would");
+
+        // The same client, same window, on a route without the named policy: still fine. That is what
+        // makes the rejection above attributable to the ROUTE policy rather than to the global
+        // limiter, which is nowhere near exhausted at one over the tighter allowance.
+        otherRouteStatus.Should().NotBe(
+            StatusCodes.Status429TooManyRequests,
+            "the tighter policy must bind to its own route only, not throttle the caller everywhere");
+    }
+
+    [Fact]
+    public async Task BypassedPaths_AreNotThrottledEvenAfterTheWindowIsExhausted()
+    {
+        BypassedPaths.Should().NotBeEmpty(
+            "at least one exempt path must be declared, so the bypass list is actually verified");
+
+        // Arrange: burn the whole window for this client on a limited route.
+        for (var i = 0; i <= PermitLimit; i++)
+        {
+            await SendAsync(LimitedPath, BypassProbeClientIp).ConfigureAwait(false);
+        }
+
+        (await SendAsync(LimitedPath, BypassProbeClientIp).ConfigureAwait(false))
+            .Should().Be(StatusCodes.Status429TooManyRequests, "the window must genuinely be exhausted first");
+
+        foreach (var path in BypassedPaths)
+        {
+            // Act
+            var status = await SendAsync(path, BypassProbeClientIp).ConfigureAwait(false);
+
+            // Assert
+            status.Should().NotBe(
+                StatusCodes.Status429TooManyRequests,
+                $"{path} is exempt from the edge limiter");
+        }
+    }
+
+    [Fact]
+    public async Task Response_CarriesAGeneratedCorrelationId_WhenTheCallerSuppliesNone()
+    {
+        // Arrange
+        using var client = Factory.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(
+            new Uri(LimitedPath, UriKind.Relative),
+            TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        // Assert: the edge mints one so the proxied request carries it downstream and the service-side
+        // correlation middleware adopts it instead of minting a second.
+        response.Headers.TryGetValues(CorrelationHeader, out var values)
+            .Should().BeTrue("the gateway must stamp a correlation ID on every response");
+        values!.Single().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Response_EchoesTheCallerSuppliedCorrelationId()
+    {
+        // Arrange
+        const string suppliedId = "8b1d0a0e-caller-supplied";
+        using var client = Factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(LimitedPath, UriKind.Relative));
+        request.Headers.Add(CorrelationHeader, suppliedId);
+
+        // Act
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        // Assert: a caller-supplied ID is never replaced, so a trace that started upstream survives the
+        // hop through the edge.
+        response.Headers.GetValues(CorrelationHeader).Single().Should().Be(suppliedId);
+    }
+
+    [Fact]
+    public void Readiness_IncludesADownstreamCheckPerService()
+    {
+        DownstreamServices.Should().NotBeEmpty(
+            "a gateway fronts at least one service, and each must report on reaching it");
+
+        // Arrange
+        var registrations = Factory.Services
+            .GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+
+        foreach (var serviceName in DownstreamServices)
+        {
+            // Act
+            var registration = registrations.SingleOrDefault(r =>
+                string.Equals(r.Name, DownstreamCheckPrefix + serviceName, StringComparison.Ordinal));
+
+            // Assert: registered, and on the readiness endpoint only. A gateway that cannot reach its
+            // services must be pulled out of the load balancer, but restarting the gateway process
+            // fixes nothing about a downstream outage, so the check must never fail liveness.
+            registration.Should().NotBeNull($"the gateway fronts {serviceName} and must report on reaching it");
+            registration!.Tags.Should().Contain("ready");
+            registration.Tags.Should().NotContain("live");
+            registration.FailureStatus.Should().Be(
+                HealthStatus.Unhealthy,
+                "readiness is a binary routing decision and /health/ready treats Degraded as passing");
+        }
+    }
+
+    [Fact]
+    public async Task EveryCluster_CarriesAnActiveHealthCheckProbingAlive()
+    {
+        // Arrange
+        var config = Factory.Services.GetRequiredService<IProxyConfigProvider>().GetConfig();
+        var filters = Factory.Services.GetServices<IProxyConfigFilter>().ToArray();
+
+        config.Clusters.Should().NotBeEmpty("the gateway must front at least one cluster");
+
+        foreach (var rawCluster in config.Clusters)
+        {
+            // The provider hands out the PRE-filter config, so the defaults only appear after the
+            // registered filter chain has run, which is what YARP's config manager does at load time.
+            var cluster = rawCluster;
+            foreach (var filter in filters)
+            {
+                cluster = await filter
+                    .ConfigureClusterAsync(cluster, TestContext.Current.CancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            // Assert: passive checks only demote a destination after real traffic has already failed
+            // against it, so a restarting service keeps absorbing requests until enough of them error.
+            // The active probe polls out of band and ejects the destination first.
+            var active = cluster.HealthCheck?.Active;
+            active.Should().NotBeNull($"cluster '{cluster.ClusterId}' must carry an active health check");
+            active!.Enabled.Should().BeTrue($"cluster '{cluster.ClusterId}' declares the block but leaves it off");
+
+            active.Path.Should().Be(
+                ActiveProbePath,
+                $"cluster '{cluster.ClusterId}' must probe liveness, not readiness");
+            active.Interval.Should().Be(ActiveProbeInterval);
+            active.Timeout.Should().Be(ActiveProbeTimeout);
+        }
+    }
+
+    [Fact]
+    public async Task RateLimiter_PartitionsByForwardedClientIp_NotByProxyIp()
+    {
+        // Arrange: every request arrives from the SAME connection IP (the ingress proxy in production,
+        // where the platform terminates the public connection) while the forwarded-for header names
+        // the real caller. The forwarded-headers middleware must run BEFORE the limiter, or all users
+        // share one window.
+        for (var i = 0; i <= PermitLimit; i++)
+        {
+            await SendForwardedAsync(LimitedPath, ForwardedProxyIp, ForwardedCallerA).ConfigureAwait(false);
+        }
+
+        // Sanity: caller A's window is genuinely exhausted.
+        (await SendForwardedAsync(LimitedPath, ForwardedProxyIp, ForwardedCallerA).ConfigureAwait(false))
+            .Should().Be(StatusCodes.Status429TooManyRequests, "caller A's own window must be exhausted first");
+
+        // Act
+        var callerBStatus = await SendForwardedAsync(LimitedPath, ForwardedProxyIp, ForwardedCallerB).ConfigureAwait(false);
+
+        // Assert: a different forwarded caller behind the same proxy IP has its own window.
+        callerBStatus.Should().NotBe(
+            StatusCodes.Status429TooManyRequests,
+            "partitioning must follow the forwarded client IP, not the shared proxy connection IP");
+    }
+
+    /// <summary>
+    /// Issues one request through the test server with an explicit client IP, returning the status
+    /// code. The IP is what the edge limiter partitions on.
+    /// </summary>
+    /// <param name="path">The request path.</param>
+    /// <param name="clientIp">The client IP to attribute the request to.</param>
+    /// <returns>The response status code.</returns>
+    protected async Task<int> SendAsync(string path, IPAddress clientIp)
+    {
+        var context = await Factory.Server.SendAsync(
+            ctx =>
+            {
+                ctx.Request.Method = HttpMethods.Get;
+                ctx.Request.Scheme = Uri.UriSchemeHttps;
+                ctx.Request.Path = path;
+                ctx.Connection.RemoteIpAddress = clientIp;
+            },
+            TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        return context.Response.StatusCode;
+    }
+
+    /// <summary>
+    /// Issues one request attributed to a proxy connection IP with a forwarded-for caller, returning
+    /// the status code.
+    /// </summary>
+    /// <param name="path">The request path.</param>
+    /// <param name="proxyIp">The connection-level IP (the ingress proxy).</param>
+    /// <param name="forwardedFor">The forwarded client IP header value.</param>
+    /// <returns>The response status code.</returns>
+    protected async Task<int> SendForwardedAsync(string path, IPAddress proxyIp, string forwardedFor)
+    {
+        var forwardedHeader = ForwardedForHeader;
+        var context = await Factory.Server.SendAsync(
+            ctx =>
+            {
+                ctx.Request.Method = HttpMethods.Get;
+                ctx.Request.Scheme = Uri.UriSchemeHttps;
+                ctx.Request.Path = path;
+                ctx.Request.Headers[forwardedHeader] = forwardedFor;
+                ctx.Connection.RemoteIpAddress = proxyIp;
+            },
+            TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        return context.Response.StatusCode;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing/PublicAPI.Unshipped.txt
@@ -3,5 +3,50 @@ MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase
 MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.EdgePipeline_OrdersSteps_InDocumentedOrder() -> void
 MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.EdgePipeline_SatisfiesLoadBearingInvariants() -> void
 MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.MiddlewarePipelineOrderTestsBase() -> void
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.BypassedPaths_AreNotThrottledEvenAfterTheWindowIsExhausted() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.EveryCluster_CarriesAnActiveHealthCheckProbingAlive() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.MmcaGatewayHardeningTestsBase() -> void
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.NamedPolicyRoute_IsThrottledAtItsOwnTighterAllowance() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.RateLimiter_PartitionsByForwardedClientIp_NotByProxyIp() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.Readiness_IncludesADownstreamCheckPerService() -> void
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.Response_CarriesAGeneratedCorrelationId_WhenTheCallerSuppliesNone() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.Response_EchoesTheCallerSuppliedCorrelationId() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.Route_IsThrottledOnceTheClientExhaustsItsWindow() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.SendAsync(string! path, System.Net.IPAddress! clientIp) -> System.Threading.Tasks.Task<int>!
+MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.SendForwardedAsync(string! path, System.Net.IPAddress! proxyIp, string! forwardedFor) -> System.Threading.Tasks.Task<int>!
+MMCA.Common.Testing.RateLimiterTestExtensions
+MMCA.Common.Testing.RateLimiterTestExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!)
+MMCA.Common.Testing.RateLimiterTestExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).NeutralizeGlobalRateLimiter(string! partitionName = "tests") -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.Testing.RecordingHttpForwarder
+MMCA.Common.Testing.RecordingHttpForwarder.ClusterTraceHeaderName.get -> string!
+MMCA.Common.Testing.RecordingHttpForwarder.ClusterTraceHeaderName.init -> void
+MMCA.Common.Testing.RecordingHttpForwarder.RecordingHttpForwarder() -> void
+MMCA.Common.Testing.RecordingHttpForwarder.RouteTraceHeaderName.get -> string!
+MMCA.Common.Testing.RecordingHttpForwarder.RouteTraceHeaderName.init -> void
+MMCA.Common.Testing.RecordingHttpForwarder.SendAsync(Microsoft.AspNetCore.Http.HttpContext! context, string! destinationPrefix, System.Net.Http.HttpMessageInvoker! httpClient, Yarp.ReverseProxy.Forwarder.ForwarderRequestConfig! requestConfig, Yarp.ReverseProxy.Forwarder.HttpTransformer! transformer) -> System.Threading.Tasks.ValueTask<Yarp.ReverseProxy.Forwarder.ForwarderError>
+MMCA.Common.Testing.RecordingHttpForwarder.SendAsync(Microsoft.AspNetCore.Http.HttpContext! context, string! destinationPrefix, System.Net.Http.HttpMessageInvoker! httpClient, Yarp.ReverseProxy.Forwarder.ForwarderRequestConfig! requestConfig, Yarp.ReverseProxy.Forwarder.HttpTransformer! transformer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Yarp.ReverseProxy.Forwarder.ForwarderError>
+abstract MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.DownstreamServices.get -> System.Collections.Generic.IReadOnlyList<string!>!
+abstract MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.Factory.get -> Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TEntryPoint!>!
+abstract MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.LimitedPath.get -> string!
+abstract MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.PermitLimit.get -> int
+const MMCA.Common.Testing.RecordingHttpForwarder.ActivityTimeoutHeader = "X-Test-Forward-Activity-Timeout" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.ClusterHeader = "X-Test-Forward-Cluster" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.ClusterTraceEchoHeader = "X-Test-Forward-Cluster-Trace" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.DestinationHeader = "X-Test-Forward-Destination" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.RouteTraceEchoHeader = "X-Test-Forward-Route-Trace" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.UnsetValue = "(unset)" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.VersionHeader = "X-Test-Forward-Version" -> string!
+const MMCA.Common.Testing.RecordingHttpForwarder.VersionPolicyHeader = "X-Test-Forward-Version-Policy" -> string!
+static MMCA.Common.Testing.RateLimiterTestExtensions.NeutralizeGlobalRateLimiter(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! partitionName = "tests") -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 virtual MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.Configure.get -> System.Action<MMCA.Common.API.Startup.MiddlewarePipelineBuilder!>?
 virtual MMCA.Common.Testing.MiddlewarePipelineOrderTestsBase.ExpectedStepNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.ActiveProbeInterval.get -> System.TimeSpan
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.ActiveProbePath.get -> string!
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.ActiveProbeTimeout.get -> System.TimeSpan
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.BypassedPaths.get -> System.Collections.Generic.IReadOnlyList<string!>!
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.CorrelationHeader.get -> string!
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.DownstreamCheckPrefix.get -> string!
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.ForwardedForHeader.get -> string!
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.NamedPolicyPath.get -> string?
+virtual MMCA.Common.Testing.MmcaGatewayHardeningTestsBase<TEntryPoint>.NamedPolicyPermitLimit.get -> int

--- a/Source/Hosting/MMCA.Common.Testing/RateLimiterTestExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing/RateLimiterTestExtensions.cs
@@ -1,0 +1,41 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// Test helpers for lifting the shared HTTP edge rate limiter inside a test host.
+/// </summary>
+public static class RateLimiterTestExtensions
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Replaces the host's global rate limiter with an unlimited partition, so a test suite that
+        /// drives dozens of requests through one host in a few seconds is not throttled by the
+        /// production budget. Call it from <c>ConfigureTestServices</c> in a test
+        /// <c>WebApplicationFactory</c>.
+        /// <para>
+        /// It runs as a <c>PostConfigure</c>, so it wins over whatever the host registered no matter
+        /// when the host's own <c>AddRateLimiter</c> ran. The limiter MIDDLEWARE stays in the pipeline
+        /// (the pipeline-order fitness tests still see it); only its global limiter is neutralized, so
+        /// per-endpoint named policies a test deliberately exercises are untouched.
+        /// </para>
+        /// </summary>
+        /// <param name="partitionName">
+        /// The partition key the no-limiter is registered under. Only ever surfaces in limiter
+        /// diagnostics; defaults to <c>"tests"</c>.
+        /// </param>
+        /// <returns>The service collection for chaining.</returns>
+        public IServiceCollection NeutralizeGlobalRateLimiter(string partitionName = "tests")
+        {
+            services.PostConfigure<RateLimiterOptions>(options =>
+                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+                    _ => RateLimitPartition.GetNoLimiter(partitionName)));
+
+            return services;
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing/RecordingHttpForwarder.cs
+++ b/Source/Hosting/MMCA.Common.Testing/RecordingHttpForwarder.cs
@@ -1,0 +1,125 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Model;
+
+namespace MMCA.Common.Testing;
+
+/// <summary>
+/// An <see cref="IHttpForwarder"/> that never proxies: it echoes the destination prefix, the matched
+/// cluster, and the <see cref="ForwarderRequestConfig"/> it was handed into response headers, so a
+/// gateway test can assert which cluster a route targets and which forwarder budget it carries.
+/// Echoing into response headers rather than storing state keeps the singleton fake safe for
+/// concurrent requests.
+/// <para>
+/// Register it by replacing the real singleton in the test service collection
+/// (<c>services.Replace(ServiceDescriptor.Singleton&lt;IHttpForwarder&gt;(new RecordingHttpForwarder()))</c>).
+/// That still intercepts under a config-driven route table: YARP's own forwarder middleware resolves
+/// <see cref="IHttpForwarder"/> from DI, so <c>MapReverseProxy()</c> goes through this fake exactly as
+/// a hand-written <c>MapForwarder</c> call would. It also keeps every gateway test off the network,
+/// since configured destinations are usually service-discovery names that resolve to nothing in a
+/// test host.
+/// </para>
+/// <para>
+/// The REAL transform pipeline is run against a throwaway outbound request before the echo, so the
+/// request transforms (the gateway's route/cluster trace headers among them) are observable without a
+/// network hop, exactly as the real forwarder would produce them.
+/// </para>
+/// </summary>
+public sealed class RecordingHttpForwarder : IHttpForwarder
+{
+    /// <summary>Header the fake writes the destination prefix into.</summary>
+    public const string DestinationHeader = "X-Test-Forward-Destination";
+
+    /// <summary>Header the fake writes the matched cluster id into.</summary>
+    public const string ClusterHeader = "X-Test-Forward-Cluster";
+
+    /// <summary>Header the fake writes the forwarder's activity timeout into.</summary>
+    public const string ActivityTimeoutHeader = "X-Test-Forward-Activity-Timeout";
+
+    /// <summary>Header the fake writes the forwarded HTTP version into.</summary>
+    public const string VersionHeader = "X-Test-Forward-Version";
+
+    /// <summary>Header the fake writes the forwarded HTTP version policy into.</summary>
+    public const string VersionPolicyHeader = "X-Test-Forward-Version-Policy";
+
+    /// <summary>
+    /// Header the fake writes the value of the route trace header the transform pipeline stamped on
+    /// the OUTBOUND request into. The real transforms run to produce it, so this observes what a
+    /// downstream service would actually receive.
+    /// </summary>
+    public const string RouteTraceEchoHeader = "X-Test-Forward-Route-Trace";
+
+    /// <summary>Header the fake writes the stamped cluster trace header into. See <see cref="RouteTraceEchoHeader"/>.</summary>
+    public const string ClusterTraceEchoHeader = "X-Test-Forward-Cluster-Trace";
+
+    /// <summary>Value echoed when the forwarder config leaves a nullable setting unset.</summary>
+    public const string UnsetValue = "(unset)";
+
+    /// <summary>
+    /// The OUTBOUND route trace header the gateway's transform pipeline stamps, read back into
+    /// <see cref="RouteTraceEchoHeader"/>. Defaults to the shared gateway kit's own header name.
+    /// </summary>
+    public string RouteTraceHeaderName { get; init; } = "X-MMCA-Route";
+
+    /// <summary>
+    /// The OUTBOUND cluster trace header the gateway's transform pipeline stamps, read back into
+    /// <see cref="ClusterTraceEchoHeader"/>. Defaults to the shared gateway kit's own header name.
+    /// </summary>
+    public string ClusterTraceHeaderName { get; init; } = "X-MMCA-Cluster";
+
+    /// <inheritdoc />
+    public ValueTask<ForwarderError> SendAsync(
+        HttpContext context,
+        string destinationPrefix,
+        HttpMessageInvoker httpClient,
+        ForwarderRequestConfig requestConfig,
+        HttpTransformer transformer) =>
+        SendAsync(context, destinationPrefix, httpClient, requestConfig, transformer, CancellationToken.None);
+
+    /// <inheritdoc />
+    public async ValueTask<ForwarderError> SendAsync(
+        HttpContext context,
+        string destinationPrefix,
+        HttpMessageInvoker httpClient,
+        ForwarderRequestConfig requestConfig,
+        HttpTransformer transformer,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(requestConfig);
+        ArgumentNullException.ThrowIfNull(transformer);
+
+        context.Response.Headers[DestinationHeader] = destinationPrefix;
+        context.Response.Headers[ClusterHeader] =
+            context.Features.Get<IReverseProxyFeature>()?.Route.Config.ClusterId ?? UnsetValue;
+        context.Response.Headers[ActivityTimeoutHeader] =
+            requestConfig.ActivityTimeout?.ToString("c", CultureInfo.InvariantCulture) ?? UnsetValue;
+        context.Response.Headers[VersionHeader] =
+            requestConfig.Version?.ToString() ?? UnsetValue;
+        context.Response.Headers[VersionPolicyHeader] =
+            requestConfig.VersionPolicy?.ToString() ?? UnsetValue;
+
+        // Run the REAL transform pipeline against a throwaway outbound request so the request
+        // transforms (the route/cluster trace headers among them) are observable without a network
+        // hop. The real forwarder does exactly this before sending.
+        using var proxyRequest = new HttpRequestMessage();
+        await transformer.TransformRequestAsync(context, proxyRequest, destinationPrefix, cancellationToken)
+            .ConfigureAwait(false);
+
+        context.Response.Headers[RouteTraceEchoHeader] = HeaderOrUnset(proxyRequest, RouteTraceHeaderName);
+        context.Response.Headers[ClusterTraceEchoHeader] = HeaderOrUnset(proxyRequest, ClusterTraceHeaderName);
+
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        return ForwarderError.None;
+    }
+
+    /// <summary>Reads one outbound header, or <see cref="UnsetValue"/> when it was never stamped.</summary>
+    /// <param name="proxyRequest">The transformed outbound request.</param>
+    /// <param name="name">The header name.</param>
+    /// <returns>The single header value, or the unset marker.</returns>
+    private static string HeaderOrUnset(HttpRequestMessage proxyRequest, string name) =>
+        proxyRequest.Headers.TryGetValues(name, out var values)
+            ? string.Join(',', values)
+            : UnsetValue;
+}

--- a/Source/Hosting/MMCA.Common.Testing/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Testing/packages.lock.json
@@ -161,6 +161,15 @@
           "xunit.v3.common": "[4.0.0]"
         }
       },
+      "Yarp.ReverseProxy": {
+        "type": "Direct",
+        "requested": "[2.3.0, )",
+        "resolved": "2.3.0",
+        "contentHash": "gxtkN3a+9biu9V9Zd5NaTO6VZWXAnS2mhQ0R/VXmSPoTuiQNZsakKikrKpDtKxrL5nUYzbRsHtl40WNq+ZBKKg==",
+        "dependencies": {
+          "System.IO.Hashing": "8.0.0"
+        }
+      },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
         "resolved": "10.2.1",

--- a/Source/Presentation/MMCA.Common.API/Caching/OutputCacheEvictionExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Caching/OutputCacheEvictionExtensions.cs
@@ -1,6 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Services;
 using MMCA.Common.Domain.IntegrationEvents;
 
 namespace MMCA.Common.API.Caching;
@@ -10,9 +14,84 @@ namespace MMCA.Common.API.Caching;
 /// cross-service output-cache eviction path. The broker half is
 /// <c>RegisterOutputCacheEvictionConsumer()</c> on the MassTransit bus configurator; a host that
 /// wants the behaviour calls both.
+/// <para>
+/// Also carries the multi-tag eviction helpers a mutating controller reaches for after a write: one
+/// call naming every tag the write invalidated, instead of a private per-controller helper wrapping
+/// a run of <c>EvictByTagAsync</c> calls.
+/// </para>
 /// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class OutputCacheEvictionExtensions
 {
+    /// <summary>
+    /// Prefix of the best-effort operation name used by <c>TryEvictTagsAsync</c>. The tag is
+    /// appended so a failure is attributable to the cache it could not clear; keep call-site tags
+    /// low-cardinality literals, because the name becomes a metric tag.
+    /// </summary>
+    private const string EvictOperationPrefix = "output-cache-evict:";
+
+    extension(IOutputCacheStore store)
+    {
+        /// <summary>
+        /// Evicts every output-cache entry carrying any of <paramref name="tags"/>, in the order
+        /// given. Equivalent to a run of <see cref="IOutputCacheStore.EvictByTagAsync"/> calls, which
+        /// is what a mutating action needs after a write that invalidates more than one tag.
+        /// </summary>
+        /// <param name="cancellationToken">Token passed to each eviction.</param>
+        /// <param name="tags">The output-cache tags whose entries should be evicted.</param>
+        /// <returns>A task that completes when every tag has been evicted.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="store"/> or <paramref name="tags"/> is null.
+        /// </exception>
+        public async ValueTask EvictTagsAsync(CancellationToken cancellationToken, params string[] tags)
+        {
+            ArgumentNullException.ThrowIfNull(store);
+            ArgumentNullException.ThrowIfNull(tags);
+
+            foreach (var tag in tags)
+            {
+                await store.EvictByTagAsync(tag, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Best-effort sibling of <c>EvictTagsAsync</c>: evicts each tag, and turns a cache-store
+        /// failure (a Redis outage, a transient network fault) into one Warning plus one
+        /// <see cref="BestEffort"/> metric increment instead of an exception. The mutation this
+        /// follows has already committed, so surfacing the failure would turn a successful write into
+        /// a client-visible error while leaving the write in place; an entry that could not be
+        /// evicted expires on its own TTL.
+        /// <para>
+        /// Eviction runs under <see cref="CancellationToken.None"/>, not the request token: the write
+        /// has committed, so a client that disconnected mid-response must not abandon the cleanup.
+        /// </para>
+        /// </summary>
+        /// <param name="logger">Logger used to report a failed eviction.</param>
+        /// <param name="tags">The output-cache tags whose entries should be evicted.</param>
+        /// <returns>A task that completes when every tag has been evicted or its failure recorded.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="store"/>, <paramref name="logger"/> or <paramref name="tags"/> is null.
+        /// </exception>
+        public async ValueTask TryEvictTagsAsync(ILogger logger, params string[] tags)
+        {
+            ArgumentNullException.ThrowIfNull(store);
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(tags);
+
+            foreach (var tag in tags)
+            {
+                await BestEffort.ExecuteAsync(
+                    string.Concat(EvictOperationPrefix, tag),
+                    logger,
+                    ct => store.EvictByTagAsync(tag, ct).AsTask(),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+    }
+
     extension(IServiceCollection services)
     {
         /// <summary>

--- a/Source/Presentation/MMCA.Common.API/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.API/PublicAPI.Unshipped.txt
@@ -1,6 +1,9 @@
 ﻿#nullable enable
 *REMOVED*MMCA.Common.API.Startup.WebApplicationBuilderExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddForwardedJwtBearer(string! authority, string! audience, bool requireHttpsMetadata = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 *REMOVED*static MMCA.Common.API.Startup.WebApplicationBuilderExtensions.AddForwardedJwtBearer(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! authority, string! audience, bool requireHttpsMetadata = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.API.Caching.OutputCacheEvictionExtensions.extension(Microsoft.AspNetCore.OutputCaching.IOutputCacheStore!)
+MMCA.Common.API.Caching.OutputCacheEvictionExtensions.extension(Microsoft.AspNetCore.OutputCaching.IOutputCacheStore!).EvictTagsAsync(System.Threading.CancellationToken cancellationToken, params string![]! tags) -> System.Threading.Tasks.ValueTask
+MMCA.Common.API.Caching.OutputCacheEvictionExtensions.extension(Microsoft.AspNetCore.OutputCaching.IOutputCacheStore!).TryEvictTagsAsync(Microsoft.Extensions.Logging.ILogger! logger, params string![]! tags) -> System.Threading.Tasks.ValueTask
 MMCA.Common.API.Controllers.AuthControllerBase.ClientIpAddress.get -> string?
 MMCA.Common.API.Controllers.AuthControllerBase.ClientUserAgent.get -> string?
 MMCA.Common.API.Controllers.EntityControllerBase<TEntity, TEntityDTO, TIdentifierType>.SetConcurrencyETag(object? dto) -> void
@@ -9,6 +12,9 @@ MMCA.Common.API.Controllers.PasswordResetAuthControllerBase<TForgotPasswordComma
 MMCA.Common.API.Controllers.PasswordResetAuthControllerBase<TForgotPasswordCommand, TResetPasswordCommand>.ForgotPasswordHandler.get -> MMCA.Common.Application.UseCases.ICommandHandler<TForgotPasswordCommand, MMCA.Common.Shared.Abstractions.Result!>!
 MMCA.Common.API.Controllers.PasswordResetAuthControllerBase<TForgotPasswordCommand, TResetPasswordCommand>.PasswordResetAuthControllerBase(MMCA.Common.Application.UseCases.ICommandHandler<TForgotPasswordCommand, MMCA.Common.Shared.Abstractions.Result!>! forgotPasswordHandler, MMCA.Common.Application.UseCases.ICommandHandler<TResetPasswordCommand, MMCA.Common.Shared.Abstractions.Result!>! resetPasswordHandler) -> void
 MMCA.Common.API.Controllers.PasswordResetAuthControllerBase<TForgotPasswordCommand, TResetPasswordCommand>.ResetPasswordHandler.get -> MMCA.Common.Application.UseCases.ICommandHandler<TResetPasswordCommand, MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.API.Startup.JwtAuthorityExtensions
+MMCA.Common.API.Startup.JwtAuthorityExtensions.extension(Microsoft.Extensions.Configuration.IConfiguration!)
+MMCA.Common.API.Startup.JwtAuthorityExtensions.extension(Microsoft.Extensions.Configuration.IConfiguration!).GetRequiredJwtAuthority() -> string!
 MMCA.Common.API.Startup.MiddlewarePipelineBuilder
 MMCA.Common.API.Startup.MiddlewarePipelineBuilder.Build() -> System.Collections.Generic.IReadOnlyList<MMCA.Common.API.Startup.MiddlewarePipelineStep!>!
 MMCA.Common.API.Startup.MiddlewarePipelineBuilder.InsertAfter(string! anchor, MMCA.Common.API.Startup.MiddlewarePipelineStep! step) -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
@@ -26,10 +32,19 @@ MMCA.Common.API.Startup.MiddlewarePipelineStep.MiddlewarePipelineStep(string! Na
 MMCA.Common.API.Startup.MiddlewarePipelineStep.Name.get -> string!
 MMCA.Common.API.Startup.MiddlewarePipelineStep.Name.init -> void
 MMCA.Common.API.Startup.MiddlewarePipelineStepNames
+MMCA.Common.API.Startup.ModuleHostContext
+MMCA.Common.API.Startup.ModuleHostContext.ApplicationSettings.get -> MMCA.Common.Application.Settings.ApplicationSettings!
+MMCA.Common.API.Startup.ModuleHostContext.ModuleLoader.get -> MMCA.Common.Application.Modules.ModuleLoader!
+MMCA.Common.API.Startup.ModuleHostContext.ModulesSettings.get -> MMCA.Common.Application.Settings.ModulesSettings!
+MMCA.Common.API.Startup.ModuleHostContext.RegisterModules(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
+MMCA.Common.API.Startup.ModuleHostExtensions
+MMCA.Common.API.Startup.ModuleHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!)
+MMCA.Common.API.Startup.ModuleHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!).AddModuleHost(Microsoft.Extensions.Logging.ILogger<MMCA.Common.Application.Modules.ModuleLoader!>? moduleLoaderLogger = null) -> MMCA.Common.API.Startup.ModuleHostContext!
 MMCA.Common.API.Startup.WebApplicationBuilderExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddForwardedJwtBearer(string! authority, string! audience, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Extensions.Hosting.IHostEnvironment! environment, bool? requireHttpsMetadata = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 MMCA.Common.API.Startup.WebApplicationExtensions.extension(Microsoft.AspNetCore.Builder.WebApplication!).UseCommonMiddlewarePipeline(System.Action<MMCA.Common.API.Startup.MiddlewarePipelineBuilder!>! configure) -> Microsoft.AspNetCore.Builder.WebApplication!
 abstract MMCA.Common.API.Controllers.PasswordResetAuthControllerBase<TForgotPasswordCommand, TResetPasswordCommand>.CreateForgotPasswordCommand(MMCA.Common.Shared.Auth.ForgotPasswordRequest request) -> TForgotPasswordCommand
 abstract MMCA.Common.API.Controllers.PasswordResetAuthControllerBase<TForgotPasswordCommand, TResetPasswordCommand>.CreateResetPasswordCommand(MMCA.Common.Shared.Auth.ResetPasswordRequest request) -> TResetPasswordCommand
+const MMCA.Common.API.Startup.JwtAuthorityExtensions.JwtAuthorityConfigKey = "Authentication:JwtBearer:Authority" -> string!
 const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Authentication = "Authentication" -> string!
 const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Authorization = "Authorization" -> string!
 const MMCA.Common.API.Startup.MiddlewarePipelineStepNames.Controllers = "Controllers" -> string!
@@ -52,9 +67,13 @@ const MMCA.Common.API.Startup.WebApplicationBuilderExtensions.RequireHttpsMetada
 override MMCA.Common.API.Startup.MiddlewarePipelineStep.Equals(object? obj) -> bool
 override MMCA.Common.API.Startup.MiddlewarePipelineStep.GetHashCode() -> int
 override MMCA.Common.API.Startup.MiddlewarePipelineStep.ToString() -> string!
+static MMCA.Common.API.Caching.OutputCacheEvictionExtensions.EvictTagsAsync(this Microsoft.AspNetCore.OutputCaching.IOutputCacheStore! store, System.Threading.CancellationToken cancellationToken, params string![]! tags) -> System.Threading.Tasks.ValueTask
+static MMCA.Common.API.Caching.OutputCacheEvictionExtensions.TryEvictTagsAsync(this Microsoft.AspNetCore.OutputCaching.IOutputCacheStore! store, Microsoft.Extensions.Logging.ILogger! logger, params string![]! tags) -> System.Threading.Tasks.ValueTask
+static MMCA.Common.API.Startup.JwtAuthorityExtensions.GetRequiredJwtAuthority(this Microsoft.Extensions.Configuration.IConfiguration! configuration) -> string!
 static MMCA.Common.API.Startup.MiddlewarePipelineBuilder.CreateDefault() -> MMCA.Common.API.Startup.MiddlewarePipelineBuilder!
 static MMCA.Common.API.Startup.MiddlewarePipelineStep.operator !=(MMCA.Common.API.Startup.MiddlewarePipelineStep? left, MMCA.Common.API.Startup.MiddlewarePipelineStep? right) -> bool
 static MMCA.Common.API.Startup.MiddlewarePipelineStep.operator ==(MMCA.Common.API.Startup.MiddlewarePipelineStep? left, MMCA.Common.API.Startup.MiddlewarePipelineStep? right) -> bool
+static MMCA.Common.API.Startup.ModuleHostExtensions.AddModuleHost(this Microsoft.AspNetCore.Builder.WebApplicationBuilder! builder, Microsoft.Extensions.Logging.ILogger<MMCA.Common.Application.Modules.ModuleLoader!>? moduleLoaderLogger = null) -> MMCA.Common.API.Startup.ModuleHostContext!
 static MMCA.Common.API.Startup.WebApplicationBuilderExtensions.AddForwardedJwtBearer(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! authority, string! audience, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Extensions.Hosting.IHostEnvironment! environment, bool? requireHttpsMetadata = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static MMCA.Common.API.Startup.WebApplicationExtensions.UseCommonMiddlewarePipeline(this Microsoft.AspNetCore.Builder.WebApplication! app, System.Action<MMCA.Common.API.Startup.MiddlewarePipelineBuilder!>! configure) -> Microsoft.AspNetCore.Builder.WebApplication!
 virtual MMCA.Common.API.Controllers.AuthControllerBase.GetMySessionsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Auth.RefreshSessionSummaryResponse!>!>!>!

--- a/Source/Presentation/MMCA.Common.API/Startup/JwtAuthorityExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/JwtAuthorityExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Configuration;
+
+namespace MMCA.Common.API.Startup;
+
+/// <summary>
+/// Reads the JWT/JWKS authority a service host validates tokens against, failing fast when the
+/// AppHost never injected it.
+/// <para>
+/// Every extracted service that is not the token issuer resolves the same value immediately before
+/// <c>AddForwardedJwtBearer</c>, and every one of them has to fail at startup rather than boot with
+/// no authority: a host that silently starts without one answers every authenticated request with a
+/// 401 that looks like a token problem instead of a wiring problem.
+/// </para>
+/// </summary>
+public static class JwtAuthorityExtensions
+{
+    /// <summary>
+    /// Configuration key carrying the JWT bearer authority, set by the AppHost's
+    /// <c>WithJwksDiscovery(identityService)</c> (and by the deployment template in Azure).
+    /// </summary>
+    public const string JwtAuthorityConfigKey = "Authentication:JwtBearer:Authority";
+
+    extension(IConfiguration configuration)
+    {
+        /// <summary>
+        /// Returns the configured JWT bearer authority, or throws when
+        /// <see cref="JwtAuthorityConfigKey"/> is absent.
+        /// </summary>
+        /// <returns>The authority base URL to hand to <c>AddForwardedJwtBearer</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The authority is not configured, meaning nothing wired
+        /// <c>WithJwksDiscovery(identityService)</c> in the AppHost (or its deployment equivalent).
+        /// </exception>
+        public string GetRequiredJwtAuthority()
+        {
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            return configuration[JwtAuthorityConfigKey]
+                ?? throw new InvalidOperationException(
+                    "Authentication:JwtBearer:Authority is not configured. " +
+                    "Wire .WithJwksDiscovery(identityService) in the AppHost.");
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/ModuleHostContext.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/ModuleHostContext.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.Application.Modules;
+using MMCA.Common.Application.Settings;
+
+namespace MMCA.Common.API.Startup;
+
+/// <summary>
+/// The result of <c>AddModuleHost</c>: the settings a service host binds once at startup plus the
+/// <see cref="ModuleLoader"/> it discovers its modules with.
+/// <para>
+/// Module discovery itself is NOT run here. It has to happen inside the host's ADR-014 application
+/// pipeline, between <c>AddApplication()</c> and <c>AddApplicationDecorators()</c>, and its position
+/// relative to the host's other pipeline steps (gRPC client replacements, broker messaging) is a
+/// per-host decision. <see cref="RegisterModules"/> is therefore handed to the pipeline as a step,
+/// and <c>AddModuleHealthChecks(ModuleLoader)</c> is called by the host afterwards, since it can
+/// only enumerate modules that discovery has already found.
+/// </para>
+/// </summary>
+public sealed class ModuleHostContext
+{
+    private readonly IConfigurationManager _configuration;
+    private readonly string? _environmentName;
+
+    internal ModuleHostContext(
+        IConfigurationManager configuration,
+        string? environmentName,
+        ApplicationSettings applicationSettings,
+        ModulesSettings modulesSettings,
+        ModuleLoader moduleLoader)
+    {
+        _configuration = configuration;
+        _environmentName = environmentName;
+        ApplicationSettings = applicationSettings;
+        ModulesSettings = modulesSettings;
+        ModuleLoader = moduleLoader;
+    }
+
+    /// <summary>Gets the bound application settings the host was configured with.</summary>
+    public ApplicationSettings ApplicationSettings { get; }
+
+    /// <summary>Gets the bound per-module enabled/disabled configuration.</summary>
+    public ModulesSettings ModulesSettings { get; }
+
+    /// <summary>
+    /// Gets the loader registered as a singleton by <c>AddModuleHost</c>. Pass it to
+    /// <c>AddModuleHealthChecks</c> after the application pipeline has run
+    /// <see cref="RegisterModules"/>, and to <c>InitializeDatabaseAsync</c>.
+    /// </summary>
+    public ModuleLoader ModuleLoader { get; }
+
+    /// <summary>
+    /// Runs <see cref="ModuleLoader.DiscoverAndRegister(IServiceCollection, IConfigurationBuilder, ApplicationSettings, ModulesSettings, string?)"/>
+    /// with the configuration, settings and environment name captured at <c>AddModuleHost</c> time.
+    /// Register it as a step of the host's application pipeline
+    /// (<c>pipeline.Register(moduleHost.RegisterModules)</c>) so every module handler lands in the
+    /// container before <c>AddApplicationDecorators()</c> closes the pipeline.
+    /// </summary>
+    /// <param name="services">The service collection module registrations are added to.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="services"/> is null.</exception>
+    public void RegisterModules(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        ModuleLoader.DiscoverAndRegister(
+            services,
+            _configuration,
+            ApplicationSettings,
+            ModulesSettings,
+            _environmentName);
+    }
+}

--- a/Source/Presentation/MMCA.Common.API/Startup/ModuleHostExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/ModuleHostExtensions.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.Modules;
+using MMCA.Common.Application.Settings;
+
+namespace MMCA.Common.API.Startup;
+
+/// <summary>
+/// Collapses the settings-bind plus <see cref="ModuleLoader"/> construction every module-hosting
+/// service repeats verbatim in its <c>Program.cs</c>.
+/// <para>
+/// Deliberately narrow: it binds and validates the two settings sections, builds the loader and
+/// registers it as a singleton. It does NOT run discovery, add the module health checks, or touch
+/// the surrounding registration order. Those stay explicit at the host, because discovery has to sit
+/// at a host-chosen position inside the ADR-014 application pipeline and the health checks can only
+/// enumerate what discovery has already found.
+/// </para>
+/// </summary>
+public static class ModuleHostExtensions
+{
+    extension(WebApplicationBuilder builder)
+    {
+        /// <summary>
+        /// Binds <see cref="ApplicationSettings"/> and <see cref="ModulesSettings"/> from
+        /// configuration (both validated on start), constructs the host's
+        /// <see cref="ModuleLoader"/> and registers it as a singleton.
+        /// </summary>
+        /// <param name="moduleLoaderLogger">
+        /// Optional logger for module-discovery diagnostics. A host that has already bootstrapped a
+        /// logger passes one here (for example
+        /// <c>MMCA.Common.Aspire.Logging.SerilogHostExtensions.CreateBootstrapLoggerFactory()</c>);
+        /// when omitted the loader keeps its own <c>NullLogger</c> default and discovery runs
+        /// silently.
+        /// </param>
+        /// <returns>
+        /// The bound settings and the loader, plus the discovery step to register inside the
+        /// application pipeline.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="builder"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The <c>ApplicationSettings</c> configuration section is absent.
+        /// </exception>
+        public ModuleHostContext AddModuleHost(ILogger<ModuleLoader>? moduleLoaderLogger = null)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            var services = builder.Services;
+            var configuration = builder.Configuration;
+
+            services.AddOptions<ApplicationSettings>()
+                .Bind(configuration.GetSection(ApplicationSettings.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            var applicationSettings = configuration.GetSection(ApplicationSettings.SectionName).Get<ApplicationSettings>()
+                ?? throw new InvalidOperationException("ApplicationSettings section is not configured.");
+
+            services.AddOptions<ModulesSettings>()
+                .Bind(configuration.GetSection(ModulesSettings.SectionName))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            var modulesSettings = configuration
+                .GetSection(ModulesSettings.SectionName)
+                .Get<ModulesSettings>() ?? [];
+
+            var moduleLoader = moduleLoaderLogger is null
+                ? new ModuleLoader()
+                : new ModuleLoader { Logger = moduleLoaderLogger };
+
+            services.AddSingleton(moduleLoader);
+
+            return new ModuleHostContext(
+                configuration,
+                builder.Environment.EnvironmentName,
+                applicationSettings,
+                modulesSettings,
+                moduleLoader);
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.Grpc/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.Grpc/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+MMCA.Common.Grpc.ResultGrpcExtensions.extension(Grpc.Core.Metadata?)
+MMCA.Common.Grpc.ResultGrpcExtensions.extension(Grpc.Core.Metadata?).ToErrors() -> System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Abstractions.Error!>!
+MMCA.Common.Grpc.ResultGrpcExtensions.extension(Grpc.Core.RpcException!)
+MMCA.Common.Grpc.ResultGrpcExtensions.extension(Grpc.Core.RpcException!).ToResult(string! source = "") -> MMCA.Common.Shared.Abstractions.Result!
+MMCA.Common.Grpc.ResultGrpcExtensions.extension(Grpc.Core.RpcException!).ToResult<T>(string! source = "") -> MMCA.Common.Shared.Abstractions.Result<T>!
+static MMCA.Common.Grpc.ResultGrpcExtensions.ToErrors(this Grpc.Core.Metadata? trailers) -> System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Abstractions.Error!>!
+static MMCA.Common.Grpc.ResultGrpcExtensions.ToResult(this Grpc.Core.RpcException! exception, string! source = "") -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.Grpc.ResultGrpcExtensions.ToResult<T>(this Grpc.Core.RpcException! exception, string! source = "") -> MMCA.Common.Shared.Abstractions.Result<T>!

--- a/Source/Presentation/MMCA.Common.Grpc/ResultGrpcExtensions.cs
+++ b/Source/Presentation/MMCA.Common.Grpc/ResultGrpcExtensions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Grpc.Core;
 using MMCA.Common.Grpc.Exceptions;
 using MMCA.Common.Shared.Abstractions;
@@ -141,4 +142,149 @@ public static class ResultGrpcExtensions
             return new RpcException(new Status(statusCode, detail), trailers);
         }
     }
+
+    extension(Metadata? trailers)
+    {
+        /// <summary>
+        /// Reconstructs the <see cref="Error"/> list from the <c>error-{i}-*</c> trailers written by
+        /// <see cref="ToRpcException"/>, the exact inverse of the encoder. Index-based iteration
+        /// starts at zero and stops at the first missing <c>error-{i}-code</c>, matching the
+        /// contiguous layout the encoder writes.
+        /// <para>
+        /// A missing <c>error-{i}-message</c> decodes as the empty string and a missing
+        /// <c>error-{i}-source</c>/<c>error-{i}-target</c> as <see langword="null"/>, mirroring the
+        /// encoder's decision to omit an empty source or target entirely. An unrecognized
+        /// <c>error-{i}-type</c> falls back to <see cref="ErrorType.Failure"/> rather than throwing,
+        /// so a newer peer that adds an error type cannot break an older client.
+        /// </para>
+        /// </summary>
+        /// <returns>
+        /// The decoded errors, empty when the trailers carry no structured failure (a pure
+        /// transport fault such as a reset connection or an exceeded deadline).
+        /// </returns>
+        public IReadOnlyList<Error> ToErrors()
+        {
+            if (trailers is null || trailers.Count == 0)
+            {
+                return [];
+            }
+
+            var errors = new List<Error>();
+            var index = 0;
+            while (true)
+            {
+                var indexText = index.ToString(CultureInfo.InvariantCulture);
+                var code = trailers.GetValue($"error-{indexText}-code");
+                if (code is null)
+                {
+                    break;
+                }
+
+                var message = trailers.GetValue($"error-{indexText}-message") ?? string.Empty;
+                var typeText = trailers.GetValue($"error-{indexText}-type");
+                var source = trailers.GetValue($"error-{indexText}-source");
+                var target = trailers.GetValue($"error-{indexText}-target");
+
+                errors.Add(BuildError(ParseErrorType(typeText), code, message, source, target));
+                index++;
+            }
+
+            return errors;
+        }
+    }
+
+    extension(RpcException exception)
+    {
+        /// <summary>
+        /// Converts a caught <see cref="RpcException"/> back into a failed <see cref="Result"/>,
+        /// closing the round trip opened by <see cref="ToRpcException"/>. The structured
+        /// <c>error-{i}-*</c> trailers win when present; a transport-level fault that carries none
+        /// degrades to a single <see cref="ErrorType.Failure"/> error coded
+        /// <c>Grpc.{StatusCode}</c> carrying the RPC detail.
+        /// </summary>
+        /// <param name="source">
+        /// Origin context stamped on the synthesized transport error. Defaults to the calling
+        /// member's name.
+        /// </param>
+        /// <returns>A failed <see cref="Result"/>; never a success.</returns>
+        public Result ToResult([CallerMemberName] string source = "")
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            var errors = exception.Trailers.ToErrors();
+
+            return errors.Count > 0
+                ? Result.Failure(errors)
+                : Result.Failure(TransportError(exception, source));
+        }
+
+        /// <summary>
+        /// Converts a caught <see cref="RpcException"/> back into a failed <see cref="Result{T}"/>,
+        /// closing the round trip opened by <see cref="ToRpcException"/>. The structured
+        /// <c>error-{i}-*</c> trailers win when present; a transport-level fault that carries none
+        /// degrades to a single <see cref="ErrorType.Failure"/> error coded
+        /// <c>Grpc.{StatusCode}</c> carrying the RPC detail.
+        /// </summary>
+        /// <typeparam name="T">The value type the failed result stands in for.</typeparam>
+        /// <param name="source">
+        /// Origin context stamped on the synthesized transport error. Defaults to the calling
+        /// member's name.
+        /// </param>
+        /// <returns>A failed <see cref="Result{T}"/>; never a success.</returns>
+        public Result<T> ToResult<T>([CallerMemberName] string source = "")
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            var errors = exception.Trailers.ToErrors();
+
+            return errors.Count > 0
+                ? Result.Failure<T>(errors)
+                : Result.Failure<T>(TransportError(exception, source));
+        }
+    }
+
+    /// <summary>
+    /// The <see cref="Error"/> factory per <see cref="ErrorType"/>. A lookup table rather than a
+    /// switch so adding an error type stays a one-line entry instead of pushing the decoder past
+    /// the cyclomatic-complexity ceiling.
+    /// </summary>
+    private static readonly FrozenDictionary<ErrorType, Func<string, string, string?, string?, Error>> ErrorFactories =
+        new Dictionary<ErrorType, Func<string, string, string?, string?, Error>>
+        {
+            [ErrorType.Validation] = Error.Validation,
+            [ErrorType.Invariant] = Error.Invariant,
+            [ErrorType.NotFound] = Error.NotFoundError,
+            [ErrorType.Conflict] = Error.Conflict,
+            [ErrorType.Unauthorized] = Error.Unauthorized,
+            [ErrorType.Forbidden] = Error.Forbidden,
+            [ErrorType.UnprocessableEntity] = Error.UnprocessableEntity,
+            [ErrorType.Failure] = Error.Failure,
+            [ErrorType.Unexpected] = Error.Unexpected,
+        }.ToFrozenDictionary();
+
+    /// <summary>
+    /// Parses the <see cref="ErrorType"/> from the enum-name wire form the encoder writes,
+    /// defaulting to <see cref="ErrorType.Failure"/> on any mismatch.
+    /// </summary>
+    private static ErrorType ParseErrorType(string? typeText) =>
+        Enum.TryParse<ErrorType>(typeText, ignoreCase: false, out var errorType)
+            ? errorType
+            : ErrorType.Failure;
+
+    /// <summary>Builds an <see cref="Error"/> from the trailer fields via the factory for its type.</summary>
+    private static Error BuildError(ErrorType errorType, string code, string message, string? source, string? target) =>
+        ErrorFactories.TryGetValue(errorType, out var factory)
+            ? factory(code, message, source, target)
+            : Error.Failure(code, message, source, target);
+
+    /// <summary>
+    /// Builds the stand-in error for an <see cref="RpcException"/> that carries no structured
+    /// trailers, so a connection reset or an exceeded deadline still reaches the caller as a
+    /// <see cref="Result"/> failure rather than an exception.
+    /// </summary>
+    private static Error TransportError(RpcException exception, string source) =>
+        Error.Failure(
+            code: $"Grpc.{exception.StatusCode}",
+            message: exception.Status.Detail,
+            source: source);
 }

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsPushDeviceTokenProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsPushDeviceTokenProvider.cs
@@ -1,0 +1,80 @@
+#if IOS || MACCATALYST
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.UI.Services.Capabilities;
+using UIKit;
+using UserNotifications;
+
+namespace MMCA.Common.UI.Maui.Capabilities;
+
+/// <summary>
+/// Credentialed iOS <see cref="IPushDeviceTokenProvider"/> (ADR-044): registers with APNs and
+/// yields the hex device token Azure Notification Hubs targets as the <c>apns</c> platform.
+/// Gated on <c>Push:Apns:Enabled</c> so users are never shown the notification-permission prompt
+/// while the head ships without the aps-environment entitlement; with the flag off (the default)
+/// the provider yields <see langword="null"/> and the pipeline stays inert. Never throws: failures
+/// and the no-entitlement timeout log and yield <see langword="null"/>.
+/// <para>
+/// The head still owns the platform wiring: the aps-environment entitlement, the Info.plist
+/// background modes, and the two <c>AppDelegate</c> callbacks that publish into
+/// <see cref="ApnsTokenBridge"/>.
+/// </para>
+/// </summary>
+/// <param name="configuration">Supplies the <c>Push:Apns:Enabled</c> gate.</param>
+/// <param name="logger">Records best-effort registration failures.</param>
+public sealed partial class ApnsPushDeviceTokenProvider(
+    IConfiguration configuration,
+    ILogger<ApnsPushDeviceTokenProvider> logger) : IPushDeviceTokenProvider
+{
+    /// <summary>Configuration key gating APNs registration; false (the default) keeps it inert.</summary>
+    public const string EnabledConfigKey = "Push:Apns:Enabled";
+
+    private static readonly TimeSpan RegistrationTimeout = TimeSpan.FromSeconds(10);
+
+    /// <inheritdoc />
+    public async Task<PushDeviceToken?> GetTokenAsync(CancellationToken cancellationToken = default)
+    {
+        if (!configuration.GetValue<bool>(EnabledConfigKey))
+        {
+            return null;
+        }
+
+        try
+        {
+            var existing = ApnsTokenBridge.CurrentToken;
+            if (existing is not null)
+            {
+                return new PushDeviceToken(Platform: "apns", Token: existing);
+            }
+
+            // Interface contract: request permission as needed. A denial does not block
+            // registration (silent pushes still deliver); alerts simply will not display.
+            _ = await UNUserNotificationCenter.Current.RequestAuthorizationAsync(
+                    UNAuthorizationOptions.Alert | UNAuthorizationOptions.Badge | UNAuthorizationOptions.Sound)
+                .ConfigureAwait(false);
+
+            var wait = ApnsTokenBridge.WaitForTokenAsync();
+            await MainThread.InvokeOnMainThreadAsync(static () =>
+                UIApplication.SharedApplication.RegisterForRemoteNotifications()).ConfigureAwait(false);
+
+            var completed = await Task.WhenAny(wait, Task.Delay(RegistrationTimeout, cancellationToken)).ConfigureAwait(false);
+            var token = completed == wait ? await wait.ConfigureAwait(false) : null;
+            return token is null ? null : new PushDeviceToken(Platform: "apns", Token: token);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+#pragma warning disable CA1031 // Token minting is best-effort; a throw here would break the registration caller.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            LogTokenFailed(logger, ex);
+            return null;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "APNs registration failed; push registration stays inert.")]
+    private static partial void LogTokenFailed(ILogger logger, Exception ex);
+}
+#endif

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsTokenBridge.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsTokenBridge.cs
@@ -1,0 +1,46 @@
+#if IOS || MACCATALYST
+namespace MMCA.Common.UI.Maui.Capabilities;
+
+/// <summary>
+/// Hands the APNs device token from the head's <c>AppDelegate</c> UIKit callbacks to
+/// <see cref="ApnsPushDeviceTokenProvider"/> (ADR-044). UIKit reports remote-notification
+/// registration only through the app delegate, so a static rendezvous is the boundary between the
+/// callback and the awaiting provider.
+/// <para>
+/// The delegate hooks themselves stay app-side (the ObjC registrar binds the selectors to the
+/// head's own delegate instance). A head wires them like this:
+/// </para>
+/// <code>
+/// [Export("application:didRegisterForRemoteNotificationsWithDeviceToken:")]
+/// public void RegisteredForRemoteNotifications(UIApplication _, NSData deviceToken)
+///     =&gt; ApnsTokenBridge.Publish(Convert.ToHexStringLower([.. deviceToken]));
+///
+/// [Export("application:didFailToRegisterForRemoteNotificationsWithError:")]
+/// public void FailedToRegisterForRemoteNotifications(UIApplication _, NSError __)
+///     =&gt; ApnsTokenBridge.Publish(null);
+/// </code>
+/// </summary>
+public static class ApnsTokenBridge
+{
+    private static readonly TaskCompletionSource<string?> Pending =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>The most recent APNs token (lowercase hex), or null when none was issued.</summary>
+    public static string? CurrentToken { get; private set; }
+
+    /// <summary>Completes when the first registration attempt reports success or failure.</summary>
+    public static Task<string?> WaitForTokenAsync() => Pending.Task;
+
+    /// <summary>Publishes a callback outcome; null means registration failed.</summary>
+    /// <param name="hexToken">The lowercase-hex device token, or null on failure.</param>
+    public static void Publish(string? hexToken)
+    {
+        if (hexToken is not null)
+        {
+            CurrentToken = hexToken;
+        }
+
+        Pending.TrySetResult(hexToken);
+    }
+}
+#endif

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/FcmPushDeviceTokenProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/FcmPushDeviceTokenProvider.cs
@@ -1,0 +1,96 @@
+#if ANDROID
+using Android.Gms.Extensions;
+using Firebase;
+using Firebase.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.UI.Services.Capabilities;
+
+namespace MMCA.Common.UI.Maui.Capabilities;
+
+/// <summary>
+/// Credentialed Android <see cref="IPushDeviceTokenProvider"/> (ADR-044): mints the FCM
+/// registration token that Azure Notification Hubs targets as the <c>fcmv1</c> platform.
+/// Firebase is initialized manually from the <c>Push:Fcm</c> configuration section (no
+/// google-services.json build dependency), so while that section is blank the provider yields
+/// <see langword="null"/> and the whole registration pipeline stays inert, exactly like the
+/// framework's null default. Never throws: any Firebase/Play-services failure logs and yields
+/// <see langword="null"/> (registration is a best-effort side channel).
+/// <para>
+/// The head still owns its own credentials (the four <c>Push:Fcm</c> values) and the
+/// POST_NOTIFICATIONS manifest declaration.
+/// </para>
+/// </summary>
+/// <param name="configuration">Supplies the <c>Push:Fcm</c> credentials section.</param>
+/// <param name="localNotifications">Used to request the Android 13+ notification permission.</param>
+/// <param name="logger">Records best-effort token-minting failures.</param>
+public sealed partial class FcmPushDeviceTokenProvider(
+    IConfiguration configuration,
+    ILocalNotificationService localNotifications,
+    ILogger<FcmPushDeviceTokenProvider> logger) : IPushDeviceTokenProvider
+{
+    /// <summary>Configuration section holding the Firebase credentials; blank keeps the provider inert.</summary>
+    public const string ConfigSection = "Push:Fcm";
+
+    /// <inheritdoc />
+    public async Task<PushDeviceToken?> GetTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var section = configuration.GetSection(ConfigSection);
+        var projectId = section["ProjectId"];
+        var applicationId = section["ApplicationId"];
+        var apiKey = section["ApiKey"];
+        var senderId = section["ProjectNumber"];
+        if (string.IsNullOrWhiteSpace(projectId)
+            || string.IsNullOrWhiteSpace(applicationId)
+            || string.IsNullOrWhiteSpace(apiKey)
+            || string.IsNullOrWhiteSpace(senderId))
+        {
+            return null;
+        }
+
+        try
+        {
+            EnsureFirebaseApp(projectId, applicationId, apiKey, senderId);
+
+            // Interface contract: implementations request notification permission as needed.
+            // Android 13+ POST_NOTIFICATIONS through the same path local notifications use; a
+            // denial does not block registration (the token still carries data messages).
+            _ = await localNotifications.RequestPermissionAsync(cancellationToken).ConfigureAwait(false);
+
+            var token = (await FirebaseMessaging.Instance.GetToken()
+                .AsAsync<Java.Lang.String>().ConfigureAwait(false))?.ToString();
+            return string.IsNullOrWhiteSpace(token)
+                ? null
+                : new PushDeviceToken(Platform: "fcmv1", Token: token);
+        }
+#pragma warning disable CA1031 // Token minting is best-effort; a throw here would break the registration caller.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            LogTokenFailed(logger, ex);
+            return null;
+        }
+    }
+
+    private static void EnsureFirebaseApp(string projectId, string applicationId, string apiKey, string senderId)
+    {
+        var context = global::Android.App.Application.Context;
+        if (FirebaseApp.GetApps(context).Count > 0)
+        {
+            return;
+        }
+
+        using var builder = new FirebaseOptions.Builder();
+        var options = builder
+            .SetProjectId(projectId)
+            .SetApplicationId(applicationId)
+            .SetApiKey(apiKey)
+            .SetGcmSenderId(senderId)
+            .Build();
+        FirebaseApp.InitializeApp(context, options);
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "FCM token retrieval failed; push registration stays inert.")]
+    private static partial void LogTokenFailed(ILogger logger, Exception ex);
+}
+#endif

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiFirebaseMessagingService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/MauiFirebaseMessagingService.cs
@@ -1,0 +1,37 @@
+#if ANDROID
+using Android.App;
+using Firebase.Messaging;
+using MMCA.Common.UI.Services.Capabilities;
+
+namespace MMCA.Common.UI.Maui.Capabilities;
+
+/// <summary>
+/// Receives FCM lifecycle callbacks (ADR-044). <see cref="OnNewToken"/> fires when Play services
+/// rotates the registration token; re-registering re-upserts this device's installation so the
+/// server-side push handle never goes stale. Message display is deliberately not handled here:
+/// notification-type pushes are rendered by the system tray while the app is backgrounded, and the
+/// in-app SignalR hub owns foreground delivery.
+/// <para>
+/// The <c>Mmca</c>-free name would collide with the Firebase base class, so the package prefix used
+/// by every other type here is kept. The <c>[Service]</c>/<c>[IntentFilter]</c> attributes are
+/// merged into the consuming head's manifest by the Android build, so a head only has to reference
+/// this package; the credentials themselves stay app-side.
+/// </para>
+/// </summary>
+[Service(Exported = false)]
+[IntentFilter(["com.google.firebase.MESSAGING_EVENT"])]
+public sealed class MauiFirebaseMessagingService : FirebaseMessagingService
+{
+    /// <inheritdoc />
+    public override void OnNewToken(string token)
+    {
+        base.OnNewToken(token);
+
+        // Fire-and-forget by design: a rotation while signed out simply fails the
+        // authenticated upsert, and the next login registration pass
+        // (PushRegistrationListener) heals it.
+        _ = IPlatformApplication.Current?.Services
+            .GetService<IPushRegistrationService>()?.RegisterAsync();
+    }
+}
+#endif

--- a/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
@@ -74,6 +74,40 @@ public static class DependencyInjection
             services.AddScoped<ITokenStorageService, MauiTokenStorageService>();
 
         /// <summary>
+        /// Registers this platform's credentialed <see cref="IPushDeviceTokenProvider"/> (ADR-044):
+        /// the FCM registration token on Android, the APNs device token on iOS/MacCatalyst. The
+        /// windows TFM registers nothing and keeps the framework's null default, so the pipeline
+        /// stays inert there.
+        /// <para>
+        /// Call it AFTER <c>AddUIShared</c>: that is where the null default is TryAdd-registered,
+        /// and a plain Add only beats it by being the last registration. Both providers are
+        /// configuration-gated (<c>Push:Fcm</c> credentials / <c>Push:Apns:Enabled</c>), so a head
+        /// with no push configuration stays inert even after calling this. The platform wiring the
+        /// providers depend on stays app-side: the Android POST_NOTIFICATIONS declaration and
+        /// credentials, and on iOS the aps-environment entitlement plus the two AppDelegate
+        /// callbacks that publish into <c>ApnsTokenBridge</c>.
+        /// </para>
+        /// </summary>
+        public IServiceCollection AddMauiPushDeviceTokenProvider()
+        {
+#if ANDROID
+            services.AddSingleton<IPushDeviceTokenProvider, FcmPushDeviceTokenProvider>();
+#elif IOS || MACCATALYST
+            services.AddSingleton<IPushDeviceTokenProvider, ApnsPushDeviceTokenProvider>();
+#endif
+            return services;
+        }
+
+        /// <summary>
+        /// Registers <see cref="MauiPublicLinkBuilder"/> as the <c>IPublicLinkBuilder</c>, so share,
+        /// copy-link and QR affordances emit the public web URL (<c>PublicSite:BaseUrl</c>) instead
+        /// of the WebView's internal origin. Call it AFTER <c>AddUIShared</c> and after any module
+        /// registration that registers a builder of its own: last registration wins.
+        /// </summary>
+        public IServiceCollection AddCommonMauiPublicLinkBuilder() =>
+            services.AddScoped<IPublicLinkBuilder, MauiPublicLinkBuilder>();
+
+        /// <summary>
         /// Registers the native <see cref="IFormFactor"/> (<see cref="MauiFormFactor"/>: DeviceInfo
         /// idiom plus platform and version). Deliberately separate from
         /// <see cref="AddMauiDeviceCapabilities"/> so heads that still register their own

--- a/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
+++ b/Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj
@@ -60,6 +60,10 @@
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <PackageReference Include="Xamarin.AndroidX.Biometric" />
+    <!-- FCM registration token for native push (ADR-044): Android-only; iOS registers with APNs
+         through the OS and needs no SDK. Firebase is initialized from configuration, so no
+         google-services.json build item is required in this package or in the consuming head. -->
+    <PackageReference Include="Xamarin.Firebase.Messaging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiPublicLinkBuilder.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiPublicLinkBuilder.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Configuration;
+using MMCA.Common.UI.Services;
+
+namespace MMCA.Common.UI.Maui.Services;
+
+/// <summary>
+/// MAUI <see cref="IPublicLinkBuilder"/>: shared/copied links must point at the public web app,
+/// not the WebView's internal origin, so this builder resolves against the
+/// <c>PublicSite:BaseUrl</c> pinned in the head's embedded appsettings (the same mechanism as the
+/// gateway endpoint). Register it AFTER <c>AddUIShared</c> (and after any module registration that
+/// registers a builder of its own) so it overrides the browser-origin default; last registration
+/// wins.
+/// </summary>
+public sealed class MauiPublicLinkBuilder : IPublicLinkBuilder
+{
+    /// <summary>Configuration key holding the absolute public site base URL.</summary>
+    public const string BaseUrlConfigKey = "PublicSite:BaseUrl";
+
+    private readonly Uri _baseUrl;
+
+    /// <summary>Reads the pinned public site URL from the embedded configuration.</summary>
+    /// <param name="configuration">The head's configuration, which must supply <see cref="BaseUrlConfigKey"/>.</param>
+    /// <exception cref="InvalidOperationException">The key is missing or blank.</exception>
+    public MauiPublicLinkBuilder(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var configured = configuration[BaseUrlConfigKey];
+        _baseUrl = string.IsNullOrWhiteSpace(configured)
+            ? throw new InvalidOperationException(
+                $"{BaseUrlConfigKey} is required for shareable links on the MAUI head.")
+            : new Uri(configured, UriKind.Absolute);
+    }
+
+    /// <inheritdoc />
+    public Uri BuildAbsolute(string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+
+        return new Uri(_baseUrl, relativePath);
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Maui/packages.lock.json
@@ -98,6 +98,37 @@
           "Xamarin.AndroidX.Lifecycle.ViewModel": "2.9.2.1"
         }
       },
+      "Xamarin.Firebase.Messaging": {
+        "type": "Direct",
+        "requested": "[124.1.2, )",
+        "resolved": "124.1.2",
+        "contentHash": "Is7tsNnx/a6zWLE3FbyDMn9JvuOpk4TgWFdebgYl/rBZUAy/M2jEPtzEIzotrLZxuz7lQXvjkVuP2aOTneT91A==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Common": "121.0.0.6",
+          "Xamarin.Firebase.Common.Ktx": "121.0.0.6",
+          "Xamarin.Firebase.Components": "118.0.1.4",
+          "Xamarin.Firebase.Datatransport": "119.0.0.6",
+          "Xamarin.Firebase.Encoders": "117.0.0.22",
+          "Xamarin.Firebase.Encoders.JSON": "118.0.1.14",
+          "Xamarin.Firebase.Encoders.Proto": "116.0.0.17",
+          "Xamarin.Firebase.Iid.Interop": "117.1.0.22",
+          "Xamarin.Firebase.Installations": "118.0.0.6",
+          "Xamarin.Firebase.Installations.InterOp": "117.2.0.10",
+          "Xamarin.Firebase.Measurement.Connector": "120.0.1.10",
+          "Xamarin.Google.Android.DataTransport.TransportApi": "4.0.0.4",
+          "Xamarin.Google.Android.DataTransport.TransportBackendCct": "4.0.0.4",
+          "Xamarin.Google.Android.DataTransport.TransportRuntime": "4.0.0.4",
+          "Xamarin.Google.ErrorProne.Annotations": "2.39.0",
+          "Xamarin.GooglePlayServices.Base": "118.7.1",
+          "Xamarin.GooglePlayServices.Basement": "118.7.1",
+          "Xamarin.GooglePlayServices.CloudMessaging": "117.3.0.6",
+          "Xamarin.GooglePlayServices.Stats": "117.1.0.6",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.1",
+          "Xamarin.Kotlin.StdLib": "2.2.0"
+        }
+      },
       "ZXing.Net.Maui.Controls": {
         "type": "Direct",
         "requested": "[0.10.3, )",
@@ -1107,6 +1138,14 @@
           "Xamarin.Kotlin.StdLib": "2.2.0.1"
         }
       },
+      "Xamarin.AndroidX.DocumentFile": {
+        "type": "Transitive",
+        "resolved": "1.0.1.33",
+        "contentHash": "J2+iGQ2zBaghUH61wWpuQgR8L7b0heSQcyI2qD7eyzw5gpZe5UO9it0hZUBe0L6n4AEcYkO0lC2v0UoBSkbPgA==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4"
+        }
+      },
       "Xamarin.AndroidX.DrawerLayout": {
         "type": "Transitive",
         "resolved": "1.2.0.18",
@@ -1200,6 +1239,19 @@
         "contentHash": "PRLkeu5BFY57wbC128lPMHpQZO4fxEV6PL0gxe7gosfluAqggSn1x2v47paq4hOpSa0VvaXdz5JwFjL9j+1ZMA==",
         "dependencies": {
           "Xamarin.AndroidX.Annotation": "1.9.1.5"
+        }
+      },
+      "Xamarin.AndroidX.Legacy.Support.Core.Utils": {
+        "type": "Transitive",
+        "resolved": "1.0.0.33",
+        "contentHash": "Clz8d6lIOGrSWbDVKoXeciY9koLxeOUfgUcEuiF9qIZ2fWAeO24qptgD2CXNbLMX1QKq5aRihlI+ijFsmjn7kQ==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.AndroidX.Core": "1.16.0.2",
+          "Xamarin.AndroidX.DocumentFile": "1.0.1.33",
+          "Xamarin.AndroidX.Loader": "1.1.0.33",
+          "Xamarin.AndroidX.LocalBroadcastManager": "1.1.0.21",
+          "Xamarin.AndroidX.Print": "1.0.0.33"
         }
       },
       "Xamarin.AndroidX.Lifecycle.Common": {
@@ -1397,6 +1449,14 @@
           "Xamarin.AndroidX.Lifecycle.ViewModel": "2.9.2.1"
         }
       },
+      "Xamarin.AndroidX.LocalBroadcastManager": {
+        "type": "Transitive",
+        "resolved": "1.1.0.21",
+        "contentHash": "H3ubP8jC97/YLWg9BtNLggDILyLoX6ozze8vb6ecnnFwGK/SKU8Wl+RoK9xqeUFVbxCgskwug8mFqI0d8v/V8Q==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4"
+        }
+      },
       "Xamarin.AndroidX.Navigation.Common": {
         "type": "Transitive",
         "resolved": "2.9.2.1",
@@ -1498,6 +1558,14 @@
           "Xamarin.AndroidX.Navigation.Runtime": "[2.9.2.1, 2.9.3)",
           "Xamarin.AndroidX.Transition": "1.6.0.1",
           "Xamarin.Google.Android.Material": "1.12.0.5"
+        }
+      },
+      "Xamarin.AndroidX.Print": {
+        "type": "Transitive",
+        "resolved": "1.0.0.33",
+        "contentHash": "7bvbebDwSQOH3ZHyBKaNlvRdqs2ArMjIpG5bMzru4kOpQCKm1qYpxlmMNvpvdnRKI0yLLzYCM3A+LXoxUD07Fw==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4"
         }
       },
       "Xamarin.AndroidX.ProfileInstaller.ProfileInstaller": {
@@ -1737,6 +1805,181 @@
           "Xamarin.Kotlin.StdLib": "2.2.0.1"
         }
       },
+      "Xamarin.Build.Download": {
+        "type": "Transitive",
+        "resolved": "0.11.4",
+        "contentHash": "u2ROt0h6P7mfs0jbmgvmTrqU/YEpEZcf16xcHa78GSEp7fOZunNtJLCZxooeI1V5p+lrr9kYdg3Pa8FoTbgcXQ=="
+      },
+      "Xamarin.Firebase.Annotations": {
+        "type": "Transitive",
+        "resolved": "116.2.0.14",
+        "contentHash": "8Ajhgrzz5ScJsGugjWl5rweFI96qKQ4nx03ZXyjhid3+otu81hNJOb2q3JyaJVl7lZ8LWRq6pJ2tAee3XRLIbQ==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.JavaX.Inject": "1.0.0.20"
+        }
+      },
+      "Xamarin.Firebase.Common": {
+        "type": "Transitive",
+        "resolved": "121.0.0.6",
+        "contentHash": "leRpJxH+LhKkWB6enalbyf+KKW1QbFAC6sdlWV1fZM+6EN7tutEatgusXxPNU5XSPgC6B3HQ6zdasuvVbJAaCw==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.AndroidX.Concurrent.Futures": "1.2.0.7",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Annotations": "116.2.0.14",
+          "Xamarin.Firebase.Components": "118.0.1.4",
+          "Xamarin.GooglePlayServices.Basement": "118.7.0.2",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.0.2",
+          "Xamarin.Kotlin.StdLib": "2.0.21.4",
+          "Xamarin.KotlinX.Coroutines.Play.Services": "1.9.0.4"
+        }
+      },
+      "Xamarin.Firebase.Common.Ktx": {
+        "type": "Transitive",
+        "resolved": "121.0.0.6",
+        "contentHash": "TEz+8Cv8rBXHoyZ6KXKnTWwz7kpEKflCGlZ1H5++FHoCFQWX/8l9ltJTet3Gi7sRezYCmqYYXeG7xknMvsFFHw==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Annotations": "116.2.0.14",
+          "Xamarin.Firebase.Common": "121.0.0.6",
+          "Xamarin.Firebase.Components": "118.0.1.4",
+          "Xamarin.Kotlin.StdLib.Jdk8": "2.0.21.4"
+        }
+      },
+      "Xamarin.Firebase.Components": {
+        "type": "Transitive",
+        "resolved": "118.0.1.4",
+        "contentHash": "WjECpOrHY6GeJmkhKlDgbmJ2LzvjIvzEQ5pFDuKOONChn9EM/1Habkm+Wr1Hr2lhmID0K8xPN/fugz5Tf2N46Q==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Annotations": "116.2.0.14",
+          "Xamarin.Google.ErrorProne.Annotations": "2.37.0.2"
+        }
+      },
+      "Xamarin.Firebase.Datatransport": {
+        "type": "Transitive",
+        "resolved": "119.0.0.6",
+        "contentHash": "wALpF2tRuYMwzL+eXV73YjmmSTq3xQCQPdTKREYMor6pbUPTXtdJWbHA2l21qKvz+u5Lk3YUPNmzCKv8sqRmmg==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Common": "121.0.0.6",
+          "Xamarin.Firebase.Components": "118.0.1.4",
+          "Xamarin.Google.Android.DataTransport.TransportApi": "4.0.0.4",
+          "Xamarin.Google.Android.DataTransport.TransportBackendCct": "4.0.0.4",
+          "Xamarin.Google.Android.DataTransport.TransportRuntime": "4.0.0.4",
+          "Xamarin.Kotlin.StdLib.Jdk8": "2.0.21.4"
+        }
+      },
+      "Xamarin.Firebase.Encoders": {
+        "type": "Transitive",
+        "resolved": "117.0.0.22",
+        "contentHash": "edTM2eciJadPL1SDje64yl2GpKXPdW5LW0qcUKypW3+HExpTdNrufZ3obWiAktSOcJXzVtk0dWTHZ56DvJc4/A==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Build.Download": "0.11.4"
+        }
+      },
+      "Xamarin.Firebase.Encoders.JSON": {
+        "type": "Transitive",
+        "resolved": "118.0.1.14",
+        "contentHash": "p6F7myeylVF5ASViKr+DEpFLf74iHeJExE8EB4rWWcJvamKs2NwRp8mw/r8nCOleWYy8tkwzqOPtuRPW94f1Hg==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Encoders": "117.0.0.22",
+          "Xamarin.Kotlin.StdLib.Jdk8": "2.0.21.4"
+        }
+      },
+      "Xamarin.Firebase.Encoders.Proto": {
+        "type": "Transitive",
+        "resolved": "116.0.0.17",
+        "contentHash": "Ao9JRlJz8bYSZINehg+odP4b7JIKxc8VP5Z5/cfgXV8LBdKiRZRMX9H703ZdyTTPbh+hNEU2V7oEEAaemwCwZg==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Encoders": "117.0.0.22"
+        }
+      },
+      "Xamarin.Firebase.Iid.Interop": {
+        "type": "Transitive",
+        "resolved": "117.1.0.22",
+        "contentHash": "rm7JWXDVDOqlFtJeAoVBTkTFbYnGPt8imzXili7cY6HAb0gX3FG8CfL9WHV6+UnxiWdhDR0TZRXcecMQhO7vZQ==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.GooglePlayServices.Basement": "118.7.0.2",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.0.2"
+        }
+      },
+      "Xamarin.Firebase.Installations": {
+        "type": "Transitive",
+        "resolved": "118.0.0.6",
+        "contentHash": "tTL+JsNNMMTyoX4VEFP12GjHm6+XRz0cJbVvV56vYxszY4tXvaQvF6Ct6doAt8GRMBDvA0/YOA6SEcMczS+5Eg==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Annotations": "116.2.0.14",
+          "Xamarin.Firebase.Common": "121.0.0.6",
+          "Xamarin.Firebase.Common.Ktx": "121.0.0.6",
+          "Xamarin.Firebase.Components": "118.0.1.4",
+          "Xamarin.Firebase.Installations.InterOp": "117.2.0.10",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.0.2",
+          "Xamarin.Kotlin.StdLib": "2.0.21.4"
+        }
+      },
+      "Xamarin.Firebase.Installations.InterOp": {
+        "type": "Transitive",
+        "resolved": "117.2.0.10",
+        "contentHash": "axny1ObVrzPsEq5b6PagvhUDJF3y61EY+lKhXHvUTVaun4nB39j1Gzmxd3lOVZOuSsokBbuNv41zc+yy265oJA==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Annotations": "116.2.0.14",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.0.2"
+        }
+      },
+      "Xamarin.Firebase.Measurement.Connector": {
+        "type": "Transitive",
+        "resolved": "120.0.1.10",
+        "contentHash": "F/qilrrEddRoQCDiqF5gxfQb21GLN6jYqFmtNMGwiNUgY1WhEf6uTgHWfSi2RBQfJnY5/NHqBwLDHTE4uXH/Vg==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.Firebase.Annotations": "116.2.0.14",
+          "Xamarin.GooglePlayServices.Basement": "118.7.0.2"
+        }
+      },
+      "Xamarin.Google.Android.DataTransport.TransportApi": {
+        "type": "Transitive",
+        "resolved": "4.0.0.4",
+        "contentHash": "bwRpW2dSYLaEoRMFwPpt+D3oEk/T/0LbKFlFEc2QnnHfITOpch+cCiyLGFF5NJHPe4ofm8EPRn/lGZQxRcH2rg==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4"
+        }
+      },
+      "Xamarin.Google.Android.DataTransport.TransportBackendCct": {
+        "type": "Transitive",
+        "resolved": "4.0.0.4",
+        "contentHash": "gY75V+RqR4KFviWrioyTVJak6rlfw10ZvTaJecOSj8iUGwYwiEpYWN4DcepZzDlFJ5Ubf9rTAPYylEbMPt4agA==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Firebase.Encoders": "117.0.0.22",
+          "Xamarin.Firebase.Encoders.JSON": "118.0.1.14",
+          "Xamarin.Google.Android.DataTransport.TransportApi": "4.0.0.4",
+          "Xamarin.Google.Android.DataTransport.TransportRuntime": "4.0.0.4"
+        }
+      },
+      "Xamarin.Google.Android.DataTransport.TransportRuntime": {
+        "type": "Transitive",
+        "resolved": "4.0.0.4",
+        "contentHash": "Qcv5gOUyUOFX7WPEjgKUMJcB6oH/HrhGOKPGJnMdJTP/7Zfdcigu34paCZDCt58kVP+hkq8epa8Unx9jXaf2hQ==",
+        "dependencies": {
+          "Xamarin.AndroidX.Annotation": "1.9.1.4",
+          "Xamarin.Firebase.Encoders": "117.0.0.22",
+          "Xamarin.Firebase.Encoders.Proto": "116.0.0.17",
+          "Xamarin.Google.Android.DataTransport.TransportApi": "4.0.0.4",
+          "Xamarin.JavaX.Inject": "1.0.0.20"
+        }
+      },
       "Xamarin.Google.Android.Material": {
         "type": "Transitive",
         "resolved": "1.12.0.5",
@@ -1793,6 +2036,64 @@
         "resolved": "1.0.0.29",
         "contentHash": "5w1ErO9PmpGR3ii2qJkzV1ntOJGSrd7NyOdop3Sw+q/DQ6oCdyoOq3jbJ3Stg0ACOUItN7XO6EqAvNQ8jQaV0g=="
       },
+      "Xamarin.GooglePlayServices.Base": {
+        "type": "Transitive",
+        "resolved": "118.7.1",
+        "contentHash": "vFzAfEQXFBsRPr+wATEKiXjECnvUpWGP37HnpING950j+vnsn2Hg/Ei17xugb2yh8oehSy8PgnL3uprDwm8h2w==",
+        "dependencies": {
+          "Xamarin.AndroidX.Collection": "1.5.0.2",
+          "Xamarin.AndroidX.Core": "1.16.0.2",
+          "Xamarin.AndroidX.Fragment": "1.8.8",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.GooglePlayServices.Basement": "118.7.1",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.1"
+        }
+      },
+      "Xamarin.GooglePlayServices.Basement": {
+        "type": "Transitive",
+        "resolved": "118.7.1",
+        "contentHash": "abOjHL3xmmGL5V7TvJtuNqIfezb/+78O0fOEv7lKn4lKbZo3nT/TS7vveaGqspIHAFk2B1wzZVFfeXccdYG5gg==",
+        "dependencies": {
+          "Xamarin.AndroidX.Collection": "1.5.0.2",
+          "Xamarin.AndroidX.Core": "1.16.0.2",
+          "Xamarin.AndroidX.Fragment": "1.8.8",
+          "Xamarin.Build.Download": "0.11.4"
+        }
+      },
+      "Xamarin.GooglePlayServices.CloudMessaging": {
+        "type": "Transitive",
+        "resolved": "117.3.0.6",
+        "contentHash": "syY3sLoLGY/Dfe/5OAVjiBEUN0ii0J51bENiqK57UKGF4/l/m9HTbnOSwsFTNF+E2aNijiGydbfLqnG0Z73vuw==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.GooglePlayServices.Basement": "118.7.0.2",
+          "Xamarin.GooglePlayServices.Tasks": "118.3.0.2"
+        }
+      },
+      "Xamarin.GooglePlayServices.Stats": {
+        "type": "Transitive",
+        "resolved": "117.1.0.6",
+        "contentHash": "vJPmU/7vk1IsaYDPTtgbWCPT2fJ5fvIt7MaD2Sd4bcT5WClrXEoWksT9BdQvKABpI1yZPJ0PVpveLF5zdJOy/g==",
+        "dependencies": {
+          "Xamarin.AndroidX.Legacy.Support.Core.Utils": "1.0.0.33",
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.GooglePlayServices.Basement": "118.7.0.2"
+        }
+      },
+      "Xamarin.GooglePlayServices.Tasks": {
+        "type": "Transitive",
+        "resolved": "118.3.1",
+        "contentHash": "ax3r7uaXlj36w+jBM/G697ATKTZmTt8ofqokfUEfE/AahNOVHE+aY+80N5aGVtqYNAVRsT9TRt8tGnAl+IZ9dw==",
+        "dependencies": {
+          "Xamarin.Build.Download": "0.11.4",
+          "Xamarin.GooglePlayServices.Basement": "118.7.1"
+        }
+      },
+      "Xamarin.JavaX.Inject": {
+        "type": "Transitive",
+        "resolved": "1.0.0.20",
+        "contentHash": "xKiRbhe8av2s24CKTbe5xmKvMWnhRjORsBqkEaTkPmU3/FIg8sqTCHsSDeowUrD573PHYmcGajCazdkb/D+mGA=="
+      },
       "Xamarin.Jetbrains.Annotations": {
         "type": "Transitive",
         "resolved": "26.0.2.3",
@@ -1809,6 +2110,23 @@
         "contentHash": "jPxSvOvFabE8sTl+3v66s2q0RobE+KwJ9OkOqaxOFDesJJhNxo0qPa5DAoAiPRU00vbIQTu3op/cOpcK5ptRSQ==",
         "dependencies": {
           "Xamarin.Jetbrains.Annotations": "26.0.2.3"
+        }
+      },
+      "Xamarin.Kotlin.StdLib.Jdk7": {
+        "type": "Transitive",
+        "resolved": "2.0.21.4",
+        "contentHash": "pzLSNOG0rACQCAfAL7cMOuOxblXS1NGG4A5AVd8gCnWojPtYbS4Df4G+1gCp8WMybYc+F5k7wgRZtoKdxHbGqQ==",
+        "dependencies": {
+          "Xamarin.Kotlin.StdLib": "2.0.21.4"
+        }
+      },
+      "Xamarin.Kotlin.StdLib.Jdk8": {
+        "type": "Transitive",
+        "resolved": "2.0.21.4",
+        "contentHash": "eTSvkD4tPv9YP+ccJIDlJk0JXMAEpm6ry0K4a1QGZFa+1I3AtSyAKoVd63bcMwis9LeGhFoeu56kdylTw6j7rA==",
+        "dependencies": {
+          "Xamarin.Kotlin.StdLib": "2.0.21.4",
+          "Xamarin.Kotlin.StdLib.Jdk7": "2.0.21.4"
         }
       },
       "Xamarin.KotlinX.Coroutines.Android": {
@@ -1835,6 +2153,16 @@
         "dependencies": {
           "Xamarin.Jetbrains.Annotations": "26.0.2.3",
           "Xamarin.Kotlin.StdLib": "2.2.0.1"
+        }
+      },
+      "Xamarin.KotlinX.Coroutines.Play.Services": {
+        "type": "Transitive",
+        "resolved": "1.9.0.4",
+        "contentHash": "8MSL5qcltPeaSYOSLHJiyV3iokxMaZIwSV5FN7G1AnmPBlwVdbTABIHtEeIuqzGwM099gc60JvWuAoAmXAJJpQ==",
+        "dependencies": {
+          "Xamarin.GooglePlayServices.Tasks": "118.3.0.2",
+          "Xamarin.Kotlin.StdLib": "2.0.21.4",
+          "Xamarin.KotlinX.Coroutines.Core.Jvm": "1.9.0.4"
         }
       },
       "Xamarin.KotlinX.Serialization.Core": {

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -466,6 +466,53 @@
         "resolved": "7.2.1",
         "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg=="
       },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
       "SQLite": {
         "type": "Transitive",
         "resolved": "3.53.4",
@@ -591,7 +638,10 @@
           "OpenTelemetry.Extensions.Hosting": "[1.18.0, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.18.0, )",
           "OpenTelemetry.Instrumentation.Http": "[1.18.0, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )"
+          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Serilog.Sinks.Console": "[6.1.1, )",
+          "Serilog.Sinks.File": "[7.0.0, )"
         }
       },
       "mmca.common.domain": {
@@ -1102,6 +1152,39 @@
         "contentHash": "wHWaroody48jnlLoq/REwUltIFLxplXyHTP+sttrc8P7+jkiVqf38afDidJNv4qgD/6zz2NKOYg06xLZ1bG7wQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "10.0.0"
+        }
+      },
+      "Serilog.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.1, )",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
         }
       },
       "SixLabors.ImageSharp": {

--- a/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.es.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Button.Download.Aria" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Snackbar.ShareUnavailable" xml:space="preserve">
+    <value>Compartir este archivo no está disponible en este dispositivo</value>
+  </data>
+  <data name="Snackbar.DownloadFailed" xml:space="preserve">
+    <value>No se pudo descargar el archivo</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.razor
@@ -1,0 +1,36 @@
+@using Microsoft.Extensions.Options
+@using MMCA.Common.UI.Common.Settings
+@using MMCA.Common.UI.Services.Capabilities
+@inject IExternalLinkService ExternalLink
+@inject IShareService Share
+@inject IHttpClientFactory HttpClientFactory
+@inject IOptions<ApiSettings> ApiOptions
+@inject ISnackbar Snackbar
+@inject IStringLocalizer<ApiFileDownloadButton> L
+
+@* Downloads a file produced by an API endpoint (ADR-042). Browsers get a plain download link to
+   the endpoint (the response's attachment disposition does the rest). Native heads cannot download
+   through the WebView, so they fetch the bytes over the API client, stage a temp file, and open the
+   share sheet, which is where "save to Files", "open in Calendar" and the rest live on both
+   platforms. Callers supply the endpoint, the file name, the MIME type and the labels; the button
+   itself knows nothing about what the payload is. *@
+
+@if (ExternalLink.InterceptsLinks)
+{
+    <MudIconButton Icon="@Icon"
+                   Size="@Size"
+                   aria-label="@AccessibleLabel"
+                   title="@AccessibleLabel"
+                   Disabled="_isExporting"
+                   OnClick="ShareDownloadedFileAsync" />
+}
+else
+{
+    <MudIconButton Icon="@Icon"
+                   Size="@Size"
+                   aria-label="@AccessibleLabel"
+                   title="@AccessibleLabel"
+                   Href="@BrowserDownloadUrl" />
+}
+
+@* Logic lives in ApiFileDownloadButton.razor.cs (inline @code stays presentational, §18). *@

--- a/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.razor.cs
@@ -1,0 +1,147 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Components;
+
+/// <summary>
+/// Downloads a file produced by an API endpoint. Browsers get a plain download link to the
+/// endpoint (the response's attachment disposition does the rest). Native heads cannot download
+/// through the WebView, so they fetch the bytes over the API client, stage a temp file, and open
+/// the share sheet, which is where "save to Files", "open in Calendar" and the rest live on both
+/// platforms. Callers supply the endpoint, the file name, the MIME type and the labels; the button
+/// itself knows nothing about what the payload is.
+/// </summary>
+public partial class ApiFileDownloadButton
+{
+    /// <summary>Relative API path of the endpoint producing the file, e.g. <c>Sessions/42/ics</c>.</summary>
+    [Parameter]
+    [EditorRequired]
+    public string RelativeApiPath { get; set; } = string.Empty;
+
+    /// <summary>File name for the staged temp file on native heads, e.g. <c>session-42.ics</c>.</summary>
+    [Parameter]
+    [EditorRequired]
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Title shown on the native share sheet.</summary>
+    [Parameter]
+    [EditorRequired]
+    public string ShareTitle { get; set; } = string.Empty;
+
+    /// <summary>
+    /// MIME type handed to the native share sheet, which uses it to pick the target apps.
+    /// Defaults to <c>application/octet-stream</c>; pass the real type (e.g. <c>text/calendar</c>)
+    /// whenever a specific app should be offered.
+    /// </summary>
+    [Parameter]
+    public string ContentType { get; set; } = "application/octet-stream";
+
+    /// <summary>Button icon. Defaults to the generic download glyph.</summary>
+    [Parameter]
+    public string Icon { get; set; } = Icons.Material.Filled.Download;
+
+    /// <summary>Button size. Defaults to <see cref="MudBlazor.Size.Small"/>, matching the other detail-page affordances.</summary>
+    [Parameter]
+    public Size Size { get; set; } = Size.Small;
+
+    /// <summary>
+    /// Accessible name for the icon button (ADR-021: an icon-only control must carry one).
+    /// Defaults to the localized "Download" label; pass the caller's own wording
+    /// (e.g. "Add to calendar") when the generic one would not say what the file is.
+    /// </summary>
+    [Parameter]
+    public string? AriaLabel { get; set; }
+
+    /// <summary>
+    /// Toast shown on a native head when no share surface accepted the file. Defaults to the
+    /// localized generic sentence.
+    /// </summary>
+    [Parameter]
+    public string? UnavailableMessage { get; set; }
+
+    /// <summary>
+    /// Toast shown when the download or the temp-file staging failed. Defaults to the localized
+    /// generic sentence.
+    /// </summary>
+    [Parameter]
+    public string? FailureMessage { get; set; }
+
+    /// <summary>
+    /// Named <see cref="System.Net.Http.IHttpClientFactory"/> client used for the native fetch.
+    /// Defaults to the framework's <c>APIClient</c> (bearer token + culture header).
+    /// </summary>
+    [Parameter]
+    public string HttpClientName { get; set; } = "APIClient";
+
+    private bool _isExporting;
+
+    private string AccessibleLabel => AriaLabel ?? L["Button.Download.Aria"].Value;
+
+    // Browsers need the EXTERNAL gateway URL: WasmApiEndpoint on the Server head (its
+    // ApiEndpoint may be container-internal in prod), ApiEndpoint on the WASM head (already
+    // the browser-reachable value fetched from /client-config).
+    private string BrowserDownloadUrl
+    {
+        get
+        {
+            var baseUrl = ApiOptions.Value.WasmApiEndpoint ?? ApiOptions.Value.ApiEndpoint;
+            return string.IsNullOrWhiteSpace(baseUrl)
+                ? RelativeApiPath
+                : new Uri(new Uri(baseUrl), RelativeApiPath).OriginalString;
+        }
+    }
+
+    private async Task ShareDownloadedFileAsync()
+    {
+        if (_isExporting || string.IsNullOrWhiteSpace(RelativeApiPath))
+        {
+            return;
+        }
+
+        _isExporting = true;
+        try
+        {
+            using var client = HttpClientFactory.CreateClient(HttpClientName);
+            var bytes = await client.GetByteArrayAsync(new Uri(RelativeApiPath, UriKind.Relative));
+
+            var filePath = Path.Combine(Path.GetTempPath(), FileName);
+
+            // The staged file is not deleted after the share: on Android the share intent returns
+            // as soon as it launches, so deleting here would race the receiving app reading it.
+            // The path is per-entity, so a stale copy from a previous tap is simply replaced.
+            // Clearing it first keeps a truncated or half-written leftover from being shared.
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+
+            await File.WriteAllBytesAsync(filePath, bytes);
+
+            if (!await Share.ShareFileAsync(ShareTitle, filePath, ContentType))
+            {
+                Snackbar.Add(UnavailableMessage ?? L["Snackbar.ShareUnavailable"].Value, Severity.Warning);
+            }
+        }
+        catch (HttpRequestException)
+        {
+            Snackbar.Add(FailureMessage ?? L["Snackbar.DownloadFailed"].Value, Severity.Warning);
+        }
+        catch (OperationCanceledException)
+        {
+            // No token is passed to the download, so this is the HttpClient timeout, not a
+            // disposal. Report it rather than swallowing it: the user tapped and got nothing.
+            Snackbar.Add(FailureMessage ?? L["Snackbar.DownloadFailed"].Value, Severity.Warning);
+        }
+        catch (Exception)
+        {
+            // The staging write (IOException, UnauthorizedAccessException) and the share sheet
+            // itself run here too. This is an OnClick callback on the native heads, where an
+            // unhandled exception is fatal to the host, so nothing may escape.
+            Snackbar.Add(FailureMessage ?? L["Snackbar.DownloadFailed"].Value, Severity.Warning);
+        }
+        finally
+        {
+            _isExporting = false;
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Button.Download.Aria" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Snackbar.ShareUnavailable" xml:space="preserve">
+    <value>Sharing this file is not available on this device</value>
+  </data>
+  <data name="Snackbar.DownloadFailed" xml:space="preserve">
+    <value>Could not download the file</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/InfiniteScrollSentinel.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/InfiniteScrollSentinel.razor
@@ -1,0 +1,14 @@
+@* Bottom-of-list marker: when it scrolls into view the page appends its next page. The class names
+   are the shared ones from MMCA.Common.UI's app.css, so the sentinel and its progress row look the
+   same here as inside MobileInfiniteScrollList. *@
+<div @ref="_sentinelRef" class="infinite-scroll-sentinel">
+    @if (IsLoading)
+    {
+        @* role="status" + aria-live="polite" matches PageLoadingState's politeness: a screen reader
+           hears that more items are loading without the announcement interrupting reading. *@
+        <div class="infinite-scroll-loading" role="status" aria-live="polite" aria-busy="true">
+            <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Primary"
+                                 aria-label="@LoadingLabel" />
+        </div>
+    }
+</div>

--- a/Source/Presentation/MMCA.Common.UI/Components/InfiniteScrollSentinel.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/InfiniteScrollSentinel.razor.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace MMCA.Common.UI.Components;
+
+/// <summary>
+/// Bottom-of-list sentinel: raises <see cref="OnVisible"/> when it scrolls within 200px of the
+/// viewport so the hosting page can fetch and append its next page. It drives the same
+/// <c>_content/MMCA.Common.UI/infinite-scroll.js</c> IntersectionObserver module that
+/// <see cref="MobileInfiniteScrollList{TItem}"/> uses, but only the observer: the item markup, the
+/// fetch, and the accumulated list stay with the page. That split is what lets a page whose cards
+/// are its own (a public card grid, say) get infinite scroll without giving up its layout, its empty
+/// and error states, or the <c>DataGridListPageBase</c> mobile fetch path.
+/// Owning the observer in a child component is also what makes the lifecycle correct: a page
+/// deriving from <c>DataGridListPageBase</c> cannot hook async disposal (its <c>DisposeAsync</c> is
+/// not virtual), while this component is disposed by the renderer the moment the host stops
+/// rendering it, which is exactly when the last page has been loaded.
+/// Render it ONLY while more pages exist; the host re-renders a fresh instance (and therefore a
+/// fresh observer) after a filter reset refills the list.
+/// </summary>
+public partial class InfiniteScrollSentinel : IAsyncDisposable
+{
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    /// <summary>Raised when the sentinel enters (or nears) the viewport.</summary>
+    [Parameter] public EventCallback OnVisible { get; set; }
+
+    /// <summary>True while the host is fetching the next page; renders the inline progress row.</summary>
+    [Parameter] public bool IsLoading { get; set; }
+
+    /// <summary>Accessible name for the progress row (ADR-027: localized by the host).</summary>
+    [Parameter] public string? LoadingLabel { get; set; }
+
+    private readonly string _observerId = Guid.NewGuid().ToString("N");
+    private ElementReference _sentinelRef;
+    private IJSObjectReference? _module;
+    private DotNetObjectReference<InfiniteScrollSentinel>? _dotNetRef;
+    private bool _observing;
+    private bool _disposed;
+
+    /// <summary>
+    /// Invoked from JS when the IntersectionObserver reports the sentinel visible. The name is
+    /// fixed by the shared <c>infinite-scroll.js</c> module, which calls it by string.
+    /// </summary>
+    [JSInvokable]
+    public Task OnSentinelVisible() =>
+        _disposed ? Task.CompletedTask : InvokeAsync(() => OnVisible.InvokeAsync());
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !_disposed)
+        {
+            await AttachObserverAsync();
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            if (_module is not null)
+            {
+                if (_observing)
+                {
+                    await _module.InvokeVoidAsync("unobserve", _observerId);
+                }
+
+                await _module.DisposeAsync();
+            }
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone; nothing to detach.
+        }
+        catch (JSException)
+        {
+            // Best-effort: ignore shutdown-time interop races.
+        }
+        finally
+        {
+            _dotNetRef?.Dispose();
+        }
+    }
+
+    private async Task AttachObserverAsync()
+    {
+        try
+        {
+            _module ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/MMCA.Common.UI/infinite-scroll.js");
+            _dotNetRef ??= DotNetObjectReference.Create(this);
+            await _module.InvokeVoidAsync("observe", _dotNetRef, _sentinelRef, _observerId);
+            _observing = true;
+        }
+        catch (JSDisconnectedException)
+        {
+            // Expected during prerendering or circuit teardown: the list then simply stops at the
+            // pages already loaded rather than failing the render.
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/ListNoRecordsContent.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/ListNoRecordsContent.es.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.LoadFailed" xml:space="preserve">
+    <value>No se pudo cargar la lista</value>
+  </data>
+  <data name="Button.Retry" xml:space="preserve">
+    <value>Reintentar</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/ListNoRecordsContent.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/ListNoRecordsContent.razor
@@ -1,0 +1,38 @@
+@inject IStringLocalizer<ListNoRecordsContent> L
+
+@* Shared NoRecordsContent body for list pages built on DataGridListPageBase: branches on the base's
+   LoadFailed flag so a failed fetch renders an inline error-with-retry instead of the
+   indistinguishable "no records" empty state. *@
+
+@if (LoadFailed)
+{
+    <div class="d-flex flex-column align-center pa-6" role="alert">
+        <MudIcon Icon="@Icons.Material.Filled.CloudOff" Size="Size.Large" Color="Color.Error" Class="mb-2" />
+        <MudText Typo="Typo.subtitle1" Color="Color.Error" Class="mb-2">@L["Error.LoadFailed"]</MudText>
+        <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Refresh"
+                   OnClick="OnRetry">@L["Button.Retry"]</MudButton>
+    </div>
+}
+else if (EmptyIcon is not null)
+{
+    <EmptyState Icon="@EmptyIcon" Message="@EmptyMessage" />
+}
+else
+{
+    <EmptyState Message="@EmptyMessage" />
+}
+
+@code {
+    /// <summary>Whether the most recent grid fetch failed (the page's <c>DataGridListPageBase.LoadFailed</c>).</summary>
+    [Parameter] public bool LoadFailed { get; set; }
+
+    /// <summary>Localized empty-state text shown when the list is genuinely empty.</summary>
+    [Parameter] public string? EmptyMessage { get; set; }
+
+    /// <summary>Optional empty-state icon override; when null <c>EmptyState</c> keeps its default.</summary>
+    [Parameter] public string? EmptyIcon { get; set; }
+
+    /// <summary>Retries the failed fetch (typically reloads the grid's server data).</summary>
+    [Parameter] public EventCallback OnRetry { get; set; }
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/ListNoRecordsContent.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/ListNoRecordsContent.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.LoadFailed" xml:space="preserve">
+    <value>Could not load this list</value>
+  </data>
+  <data name="Button.Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.es.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Button.ShowQr.Aria" xml:space="preserve">
+    <value>Mostrar código QR de esta página</value>
+  </data>
+  <data name="Image.Qr.Alt" xml:space="preserve">
+    <value>Código QR que enlaza a {0}</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.razor
@@ -1,0 +1,82 @@
+@inject IPublicLinkBuilder LinkBuilder
+@inject IStringLocalizer<QrCodeButton> L
+
+@* QR affordance for public detail pages (ADR-042): shows the page's PUBLIC web URL as a scannable
+   code (a printed door sheet or another attendee's screen). Scanning needs no in-app scanner: the
+   OS camera opens the URL, and App Links / Universal Links (ADR-043) route it into the installed
+   app. Rendering goes through the shared QrCodeImage component, which encodes the payload locally,
+   so there is still no network round trip. *@
+
+<MudIconButton Icon="@Icons.Material.Filled.QrCode2"
+               Size="Size.Small"
+               aria-label="@L["Button.ShowQr.Aria"]"
+               title="@L["Button.ShowQr.Aria"]"
+               OnClick="ShowQr" />
+
+<MudDialog @bind-Visible="_visible" Options="_dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@QrTitle</MudText>
+    </TitleContent>
+    <DialogContent>
+        @if (_url is not null)
+        {
+            <MudStack AlignItems="AlignItems.Center" Spacing="2">
+                @* QrCodeImage sizes itself from PixelsPerModule, so the bitmap grows with the payload
+                   length. The scoped .qr-frame rule pins the rendered square to a fixed 260px, so
+                   every code fills the same space regardless of how long the url is. *@
+                <div class="qr-frame">
+                    <QrCodeImage Payload="@_url"
+                                 AltText="@L["Image.Qr.Alt", QrTitle]"
+                                 PixelsPerModule="@PixelsPerModule"
+                                 ErrorCorrection="@ErrorCorrection" />
+                </div>
+                <MudText Typo="Typo.caption" Style="word-break: break-all;">@_url</MudText>
+            </MudStack>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => _visible = false)">@L["Button.Close"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private static readonly DialogOptions _dialogOptions = new() { CloseOnEscapeKey = true, CloseButton = true };
+
+    /// <summary>App-relative route the QR should open, e.g. <c>/sessions/42</c>.</summary>
+    [Parameter]
+    [EditorRequired]
+    public string RelativePath { get; set; } = string.Empty;
+
+    /// <summary>Dialog title (the entity name).</summary>
+    [Parameter]
+    [EditorRequired]
+    public string QrTitle { get; set; } = string.Empty;
+
+    /// <summary>Rendered pixels per QR module, forwarded to <see cref="QrCodeImage"/>. Defaults to 10.</summary>
+    [Parameter]
+    public int PixelsPerModule { get; set; } = 10;
+
+    /// <summary>
+    /// Error-correction strength, forwarded to <see cref="QrCodeImage"/>. Defaults to
+    /// <see cref="QrErrorCorrectionLevel.Quartile"/>: these codes are read off screens and printed
+    /// sheets, where the extra redundancy pays for itself.
+    /// </summary>
+    [Parameter]
+    public QrErrorCorrectionLevel ErrorCorrection { get; set; } = QrErrorCorrectionLevel.Quartile;
+
+    private bool _visible;
+    private string? _url;
+
+    private void ShowQr()
+    {
+        if (string.IsNullOrWhiteSpace(RelativePath))
+        {
+            return;
+        }
+
+        // Always encode the WEB url (IPublicLinkBuilder), never the WebView-internal origin,
+        // so a code scanned from the app opens for anyone.
+        _url = LinkBuilder.BuildAbsolute(RelativePath).ToString();
+        _visible = true;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.razor.css
+++ b/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.razor.css
@@ -1,0 +1,9 @@
+/* The shared QrCodeImage emits a bare <img> whose natural size follows PixelsPerModule and the
+   payload length, so a long url would render a bigger code than a short one. Pinning the square
+   here keeps the dialog layout stable across every entity the button is used on.
+   ::deep is required: the img belongs to the child component, so it never carries this
+   component's scope attribute. The wrapping div does. */
+.qr-frame ::deep img {
+    width: 260px;
+    height: 260px;
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/QrCodeButton.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Button.ShowQr.Aria" xml:space="preserve">
+    <value>Show QR code for this page</value>
+  </data>
+  <data name="Image.Qr.Alt" xml:space="preserve">
+    <value>QR code linking to {0}</value>
+  </data>
+  <data name="Button.Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/SharePageButton.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/SharePageButton.es.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Button.Share.Aria" xml:space="preserve">
+    <value>Compartir esta página</value>
+  </data>
+  <data name="Snackbar.LinkCopied" xml:space="preserve">
+    <value>Enlace copiado al portapapeles</value>
+  </data>
+  <data name="Snackbar.ShareFailed" xml:space="preserve">
+    <value>Compartir no está disponible en este dispositivo</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Components/SharePageButton.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/SharePageButton.razor
@@ -1,0 +1,64 @@
+@using MMCA.Common.UI.Services.Capabilities
+@inject IShareService Share
+@inject IClipboardService Clipboard
+@inject IPublicLinkBuilder LinkBuilder
+@inject ISnackbar Snackbar
+@inject IStringLocalizer<SharePageButton> L
+
+@* Share affordance for public detail pages (ADR-042). Native heads open the OS share sheet;
+   browsers try navigator.share and fall back to copying the public web link to the clipboard.
+   Always shares the WEB url (IPublicLinkBuilder), never the WebView-internal origin, so a link
+   shared from the app opens for anyone. *@
+
+<MudIconButton Icon="@Icons.Material.Filled.Share"
+               Size="Size.Small"
+               aria-label="@L["Button.Share.Aria"]"
+               title="@L["Button.Share.Aria"]"
+               Disabled="_isSharing"
+               OnClick="ShareAsync" />
+
+@code {
+    /// <summary>App-relative route of the page being shared, e.g. <c>/sessions/42</c>.</summary>
+    [Parameter]
+    [EditorRequired]
+    public string RelativePath { get; set; } = string.Empty;
+
+    /// <summary>Title offered to the share sheet (the entity name).</summary>
+    [Parameter]
+    [EditorRequired]
+    public string ShareTitle { get; set; } = string.Empty;
+
+    private bool _isSharing;
+
+    private async Task ShareAsync()
+    {
+        if (_isSharing || string.IsNullOrWhiteSpace(RelativePath))
+        {
+            return;
+        }
+
+        _isSharing = true;
+        try
+        {
+            var url = LinkBuilder.BuildAbsolute(RelativePath);
+            if (await Share.ShareLinkAsync(ShareTitle, url))
+            {
+                return;
+            }
+
+            // No share surface (desktop browsers, null fallback): copy the link instead.
+            if (await Clipboard.SetTextAsync(url.ToString()))
+            {
+                Snackbar.Add(L["Snackbar.LinkCopied"].Value, Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add(L["Snackbar.ShareFailed"].Value, Severity.Warning);
+            }
+        }
+        finally
+        {
+            _isSharing = false;
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/SharePageButton.resx
+++ b/Source/Presentation/MMCA.Common.UI/Components/SharePageButton.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Button.Share.Aria" xml:space="preserve">
+    <value>Share this page</value>
+  </data>
+  <data name="Snackbar.LinkCopied" xml:space="preserve">
+    <value>Link copied to clipboard</value>
+  </data>
+  <data name="Snackbar.ShareFailed" xml:space="preserve">
+    <value>Sharing is not available on this device</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -98,6 +98,12 @@ public static class DependencyInjection
             // ASP.NET pipeline and the endpoint URL would resolve to the Blazor not-found page.
             services.TryAddScoped<ICultureApplier, EndpointCultureApplier>();
 
+            // Shareable public links (share sheet, copy-link, QR). The default resolves against the
+            // browser origin, which is correct for the Server and WebAssembly heads; a MAUI Blazor
+            // Hybrid head overrides it AFTER AddUIShared with AddCommonMauiPublicLinkBuilder(),
+            // because its WebView origin is a virtual host nobody else can open.
+            services.TryAddScoped<IPublicLinkBuilder, NavigationPublicLinkBuilder>();
+
             // Per-user culture/theme persistence to the backend (ADR-027/028) — best-effort, anon no-op.
             services.TryAddScoped<IUserPreferenceWriter, ApiUserPreferenceWriter>();
             services.TryAddScoped<IUserPreferenceReader, ApiUserPreferenceReader>();

--- a/Source/Presentation/MMCA.Common.UI/Pages/Common/ListPageActions.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Common/ListPageActions.cs
@@ -1,0 +1,93 @@
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.UI.Components;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Pages.Common;
+
+/// <summary>
+/// Shared actions for list pages built on <see cref="DataGridListPageBase{TDto}"/>: the
+/// mobile/desktop reload dispatch and the confirm-delete-reload flow that every organizer list
+/// page repeats. Kept as plain statics rather than members on the base so a page that composes
+/// its own layout (or holds several grids) can reuse them without inheriting anything.
+/// </summary>
+public static class ListPageActions
+{
+    /// <summary>
+    /// Reloads whichever layout is active: resets the mobile infinite-scroll list on mobile,
+    /// otherwise reloads the desktop data grid's server data. Either ref may be null while the
+    /// other layout is rendered.
+    /// </summary>
+    /// <typeparam name="TDto">The list item DTO type.</typeparam>
+    /// <param name="isMobile">Whether the mobile layout is active.</param>
+    /// <param name="mobileList">The mobile infinite-scroll list ref, if rendered.</param>
+    /// <param name="dataGrid">The desktop data grid ref, if rendered.</param>
+    public static async Task ReloadActiveLayoutAsync<TDto>(
+        bool isMobile,
+        MobileInfiniteScrollList<TDto>? mobileList,
+        MudDataGrid<TDto>? dataGrid)
+    {
+        if (isMobile && mobileList is not null)
+        {
+            await mobileList.ResetAsync();
+        }
+        else if (dataGrid is not null)
+        {
+            await dataGrid.ReloadServerData();
+        }
+    }
+
+    /// <summary>
+    /// Runs the canonical destructive-action flow: confirm via <see cref="DeleteConfirmation"/>,
+    /// delete, toast success, and reload the active layout; a failed <see cref="Result"/> toasts the
+    /// mapped error and cancellation (disposal / InteractiveAuto render mode transition) is swallowed.
+    /// </summary>
+    /// <param name="deleteConfirm">The page's delete-confirmation dialog ref.</param>
+    /// <param name="entityName">The display name of the entity being deleted.</param>
+    /// <param name="deleteAsync">The delete call, which reports its outcome as a <see cref="Result"/>.</param>
+    /// <param name="snackbar">The page's snackbar service.</param>
+    /// <param name="successMessage">The localized success message.</param>
+    /// <param name="errorMessage">
+    /// Maps the failed result to the localized error message. Pages that show a fixed sentence
+    /// ignore the argument; pages that want the API's own wording call
+    /// <c>result.LocalizedErrorMessage(L)</c>.
+    /// </param>
+    /// <param name="reloadAsync">Reloads the page's active layout after a successful delete.</param>
+    public static async Task DeleteWithConfirmationAsync(
+        DeleteConfirmation deleteConfirm,
+        string? entityName,
+        Func<Task<Result>> deleteAsync,
+        ISnackbar snackbar,
+        string successMessage,
+        Func<Result, string> errorMessage,
+        Func<Task> reloadAsync)
+    {
+        ArgumentNullException.ThrowIfNull(deleteConfirm);
+        ArgumentNullException.ThrowIfNull(deleteAsync);
+        ArgumentNullException.ThrowIfNull(snackbar);
+        ArgumentNullException.ThrowIfNull(errorMessage);
+        ArgumentNullException.ThrowIfNull(reloadAsync);
+
+        var confirmed = await deleteConfirm.ShowAsync(entityName);
+        if (confirmed is not true)
+        {
+            return;
+        }
+
+        try
+        {
+            var result = await deleteAsync();
+            if (result.IsFailure)
+            {
+                snackbar.Add(errorMessage(result), Severity.Error);
+                return;
+            }
+
+            snackbar.Add(successMessage, Severity.Success);
+            await reloadAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during component disposal or InteractiveAuto render mode transition
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Pages/Common/OfflineFirstPageSnapshot.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Common/OfflineFirstPageSnapshot.cs
@@ -1,0 +1,66 @@
+using MMCA.Common.UI.Services.Capabilities;
+
+namespace MMCA.Common.UI.Pages.Common;
+
+/// <summary>
+/// Last-known-good snapshot of a list page's FIRST page (ADR-042), so a dead network still shows
+/// content. Purely best-effort, and only ever consulted for page 1 while the device reports itself
+/// offline, so the live path is never affected: a page wires it into its server-data delegate,
+/// calling <see cref="RememberAsync"/> on every success and <see cref="TryReadAsync"/> when a fetch
+/// fails. Backed by <see cref="ILocalCacheStore"/>, which persists on the MAUI and WebAssembly heads
+/// and reports itself unavailable on Blazor Server (SSR always has the live API).
+/// </summary>
+/// <typeparam name="TItem">The list item DTO type; must be JSON round-trippable.</typeparam>
+/// <param name="store">The device-local cache store; unavailable on heads that have none.</param>
+/// <param name="connectivity">Reports whether the device currently has a network.</param>
+/// <param name="cacheKey">
+/// Cache key for this page's snapshot. Must be unique per list surface (and per scope, when one
+/// head shows the same list for different tenants or events), since a shared key would let one page
+/// serve another page's rows.
+/// </param>
+public sealed class OfflineFirstPageSnapshot<TItem>(
+    ILocalCacheStore store,
+    IConnectivityStatusService connectivity,
+    string cacheKey)
+{
+    private sealed record CachedPage(List<TItem> Items, int TotalItems);
+
+    /// <summary>True when a failed first-page fetch may be answered from the snapshot.</summary>
+    /// <param name="page">The 1-based page the grid asked for.</param>
+    public bool CanServe(int page) => !connectivity.IsOnline && store.IsAvailable && page == 1;
+
+    /// <summary>Records a freshly fetched first page; any other page is left alone.</summary>
+    /// <param name="fetched">The page the server returned.</param>
+    /// <param name="page">The 1-based page the grid asked for.</param>
+    /// <param name="cancellationToken">The fetch's cancellation token.</param>
+    public async Task RememberAsync(
+        (IReadOnlyList<TItem> Items, int TotalItems) fetched,
+        int page,
+        CancellationToken cancellationToken = default)
+    {
+        if (page == 1 && store.IsAvailable)
+        {
+            await store.SetAsync(
+                cacheKey, new CachedPage([.. fetched.Items], fetched.TotalItems), cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads the snapshot, or <see langword="null"/> when the device is online, the store is
+    /// unavailable, this is not the first page, or nothing was cached.
+    /// </summary>
+    /// <param name="page">The 1-based page the grid asked for.</param>
+    /// <param name="cancellationToken">The fetch's cancellation token.</param>
+    public async Task<(IReadOnlyList<TItem> Items, int TotalItems)?> TryReadAsync(
+        int page,
+        CancellationToken cancellationToken = default)
+    {
+        if (!CanServe(page))
+        {
+            return null;
+        }
+
+        var cached = await store.GetAsync<CachedPage>(cacheKey, cancellationToken);
+        return cached is null ? null : (cached.Items, cached.TotalItems);
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -201,3 +201,82 @@ virtual MMCA.Common.UI.Pages.Auth.Sessions.Dispose(bool disposing) -> void
 MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPage.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>?
 MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>!>?
 MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.set -> void
+MMCA.Common.UI.Services.Capabilities.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddDeviceCapabilityDefaults() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static MMCA.Common.UI.Services.Capabilities.DependencyInjection.AddDeviceCapabilityDefaults(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.UI.Components.ApiFileDownloadButton
+MMCA.Common.UI.Components.ApiFileDownloadButton.ApiFileDownloadButton() -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.AriaLabel.get -> string?
+MMCA.Common.UI.Components.ApiFileDownloadButton.AriaLabel.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.ContentType.get -> string!
+MMCA.Common.UI.Components.ApiFileDownloadButton.ContentType.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.FailureMessage.get -> string?
+MMCA.Common.UI.Components.ApiFileDownloadButton.FailureMessage.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.FileName.get -> string!
+MMCA.Common.UI.Components.ApiFileDownloadButton.FileName.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.HttpClientName.get -> string!
+MMCA.Common.UI.Components.ApiFileDownloadButton.HttpClientName.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.Icon.get -> string!
+MMCA.Common.UI.Components.ApiFileDownloadButton.Icon.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.RelativeApiPath.get -> string!
+MMCA.Common.UI.Components.ApiFileDownloadButton.RelativeApiPath.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.ShareTitle.get -> string!
+MMCA.Common.UI.Components.ApiFileDownloadButton.ShareTitle.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.Size.get -> MudBlazor.Size
+MMCA.Common.UI.Components.ApiFileDownloadButton.Size.set -> void
+MMCA.Common.UI.Components.ApiFileDownloadButton.UnavailableMessage.get -> string?
+MMCA.Common.UI.Components.ApiFileDownloadButton.UnavailableMessage.set -> void
+MMCA.Common.UI.Components.InfiniteScrollSentinel
+MMCA.Common.UI.Components.InfiniteScrollSentinel.DisposeAsync() -> System.Threading.Tasks.ValueTask
+MMCA.Common.UI.Components.InfiniteScrollSentinel.InfiniteScrollSentinel() -> void
+MMCA.Common.UI.Components.InfiniteScrollSentinel.IsLoading.get -> bool
+MMCA.Common.UI.Components.InfiniteScrollSentinel.IsLoading.set -> void
+MMCA.Common.UI.Components.InfiniteScrollSentinel.LoadingLabel.get -> string?
+MMCA.Common.UI.Components.InfiniteScrollSentinel.LoadingLabel.set -> void
+MMCA.Common.UI.Components.InfiniteScrollSentinel.OnSentinelVisible() -> System.Threading.Tasks.Task!
+MMCA.Common.UI.Components.InfiniteScrollSentinel.OnVisible.get -> Microsoft.AspNetCore.Components.EventCallback
+MMCA.Common.UI.Components.InfiniteScrollSentinel.OnVisible.set -> void
+MMCA.Common.UI.Components.ListNoRecordsContent
+MMCA.Common.UI.Components.ListNoRecordsContent.EmptyIcon.get -> string?
+MMCA.Common.UI.Components.ListNoRecordsContent.EmptyIcon.set -> void
+MMCA.Common.UI.Components.ListNoRecordsContent.EmptyMessage.get -> string?
+MMCA.Common.UI.Components.ListNoRecordsContent.EmptyMessage.set -> void
+MMCA.Common.UI.Components.ListNoRecordsContent.ListNoRecordsContent() -> void
+MMCA.Common.UI.Components.ListNoRecordsContent.LoadFailed.get -> bool
+MMCA.Common.UI.Components.ListNoRecordsContent.LoadFailed.set -> void
+MMCA.Common.UI.Components.ListNoRecordsContent.OnRetry.get -> Microsoft.AspNetCore.Components.EventCallback
+MMCA.Common.UI.Components.ListNoRecordsContent.OnRetry.set -> void
+MMCA.Common.UI.Components.QrCodeButton
+MMCA.Common.UI.Components.QrCodeButton.ErrorCorrection.get -> MMCA.Common.UI.Components.QrErrorCorrectionLevel
+MMCA.Common.UI.Components.QrCodeButton.ErrorCorrection.set -> void
+MMCA.Common.UI.Components.QrCodeButton.PixelsPerModule.get -> int
+MMCA.Common.UI.Components.QrCodeButton.PixelsPerModule.set -> void
+MMCA.Common.UI.Components.QrCodeButton.QrCodeButton() -> void
+MMCA.Common.UI.Components.QrCodeButton.QrTitle.get -> string!
+MMCA.Common.UI.Components.QrCodeButton.QrTitle.set -> void
+MMCA.Common.UI.Components.QrCodeButton.RelativePath.get -> string!
+MMCA.Common.UI.Components.QrCodeButton.RelativePath.set -> void
+MMCA.Common.UI.Components.SharePageButton
+MMCA.Common.UI.Components.SharePageButton.RelativePath.get -> string!
+MMCA.Common.UI.Components.SharePageButton.RelativePath.set -> void
+MMCA.Common.UI.Components.SharePageButton.SharePageButton() -> void
+MMCA.Common.UI.Components.SharePageButton.ShareTitle.get -> string!
+MMCA.Common.UI.Components.SharePageButton.ShareTitle.set -> void
+MMCA.Common.UI.Pages.Common.ListPageActions
+MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>
+MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.CanServe(int page) -> bool
+MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.OfflineFirstPageSnapshot(MMCA.Common.UI.Services.Capabilities.ILocalCacheStore! store, MMCA.Common.UI.Services.Capabilities.IConnectivityStatusService! connectivity, string! cacheKey) -> void
+MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.RememberAsync((System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems) fetched, int page, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.TryReadAsync(int page, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)?>!
+MMCA.Common.UI.Services.IPublicLinkBuilder
+MMCA.Common.UI.Services.IPublicLinkBuilder.BuildAbsolute(string! relativePath) -> System.Uri!
+MMCA.Common.UI.Services.NavigationPublicLinkBuilder
+MMCA.Common.UI.Services.NavigationPublicLinkBuilder.BuildAbsolute(string! relativePath) -> System.Uri!
+MMCA.Common.UI.Services.NavigationPublicLinkBuilder.NavigationPublicLinkBuilder(Microsoft.AspNetCore.Components.NavigationManager! navigationManager) -> void
+override MMCA.Common.UI.Components.InfiniteScrollSentinel.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+static MMCA.Common.UI.Pages.Common.ListPageActions.DeleteWithConfirmationAsync(MMCA.Common.UI.Components.DeleteConfirmation! deleteConfirm, string? entityName, System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!>! deleteAsync, MudBlazor.ISnackbar! snackbar, string! successMessage, System.Func<MMCA.Common.Shared.Abstractions.Result!, string!>! errorMessage, System.Func<System.Threading.Tasks.Task!>! reloadAsync) -> System.Threading.Tasks.Task!
+static MMCA.Common.UI.Pages.Common.ListPageActions.ReloadActiveLayoutAsync<TDto>(bool isMobile, MMCA.Common.UI.Components.MobileInfiniteScrollList<TDto>? mobileList, MudBlazor.MudDataGrid<TDto>? dataGrid) -> System.Threading.Tasks.Task!
+~override MMCA.Common.UI.Components.ApiFileDownloadButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.InfiniteScrollSentinel.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.ListNoRecordsContent.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.QrCodeButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.SharePageButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void

--- a/Source/Presentation/MMCA.Common.UI/Services/Capabilities/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Capabilities/DependencyInjection.cs
@@ -20,8 +20,14 @@ public static class DependencyInjection
         /// <summary>
         /// Registers the null/neutral default for every capability contract. Called by
         /// <c>AddUIShared</c>; TryAdd keeps repeated host calls idempotent.
+        /// <para>
+        /// Public so a consumer's bUnit test base can register the same set the production host gets
+        /// instead of mirroring it by hand: a hand-mirrored list silently rots the moment a new
+        /// capability contract ships here, and the component test that needed it fails with a DI
+        /// resolution error rather than a useful one.
+        /// </para>
         /// </summary>
-        internal IServiceCollection AddDeviceCapabilityDefaults()
+        public IServiceCollection AddDeviceCapabilityDefaults()
         {
             // Stateless no-op defaults — singletons.
             services.TryAddSingleton<IConnectivityStatusService, AlwaysOnlineConnectivityStatusService>();

--- a/Source/Presentation/MMCA.Common.UI/Services/IPublicLinkBuilder.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/IPublicLinkBuilder.cs
@@ -1,0 +1,14 @@
+namespace MMCA.Common.UI.Services;
+
+/// <summary>
+/// Builds absolute, publicly shareable web URLs for app routes (share sheet, copy-link, QR).
+/// Web heads derive them from the browser origin; the MAUI head cannot (its internal origin is
+/// the WebView's virtual host), so it substitutes the configured public site base URL and the
+/// shared pages stay head-agnostic.
+/// </summary>
+public interface IPublicLinkBuilder
+{
+    /// <summary>Returns the absolute public URL for an app-relative path (e.g. <c>/sessions/42</c>).</summary>
+    /// <param name="relativePath">The app-relative route to make absolute.</param>
+    Uri BuildAbsolute(string relativePath);
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/NavigationPublicLinkBuilder.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/NavigationPublicLinkBuilder.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components;
+
+namespace MMCA.Common.UI.Services;
+
+/// <summary>
+/// Default <see cref="IPublicLinkBuilder"/>: resolves against the browser origin
+/// (<see cref="NavigationManager.BaseUri"/>), correct for the Server and WebAssembly heads.
+/// The MAUI head overrides this registration with its configured public site URL
+/// (<c>AddCommonMauiPublicLinkBuilder()</c> in MMCA.Common.UI.Maui).
+/// </summary>
+public sealed class NavigationPublicLinkBuilder : IPublicLinkBuilder
+{
+    private readonly NavigationManager _navigationManager;
+
+    /// <summary>Initializes the builder over the host's navigation manager.</summary>
+    /// <param name="navigationManager">The host's navigation manager, supplying the browser origin.</param>
+    public NavigationPublicLinkBuilder(NavigationManager navigationManager) =>
+        _navigationManager = navigationManager;
+
+    /// <inheritdoc />
+    public Uri BuildAbsolute(string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativePath);
+
+        return new Uri(new Uri(_navigationManager.BaseUri, UriKind.Absolute), relativePath);
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/DomainEvents/ScopedIntegrationEventHandlerBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/DomainEvents/ScopedIntegrationEventHandlerBaseTests.cs
@@ -1,0 +1,227 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MMCA.Common.Application.DomainEvents;
+using MMCA.Common.Domain.DomainEvents;
+
+namespace MMCA.Common.Application.Tests.DomainEvents;
+
+/// <summary>
+/// The base opens one DI scope per delivery (integration event handlers are singletons and cannot
+/// hold a scoped service), hands the subclass that scope's provider, disposes it on every path,
+/// and logs a failure exactly once before letting it propagate so the delivery mechanism can
+/// redeliver. Cancellation passes through unlogged: host shutdown is not a delivery failure.
+/// </summary>
+public sealed class ScopedIntegrationEventHandlerBaseTests
+{
+    // ── The scope is opened, its provider is handed to the subclass, and it is disposed ──
+    [Fact]
+    public async Task HandleAsync_WhenHandlerSucceeds_ResolvesFromAScopeAndDisposesIt()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var logger = new RecordingLogger();
+        var sut = new TestScopedIntegrationEventHandler(provider.GetRequiredService<IServiceScopeFactory>(), logger);
+
+        await sut.HandleAsync(new TestIntegrationEvent("payload"));
+
+        sut.ResolvedService.Should().NotBeNull("the subclass resolves scoped services from the scope the base opened");
+        sut.ResolvedService!.IsDisposed.Should().BeTrue("the scope is disposed once the handler body returns");
+        logger.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForTwoDeliveries_OpensASeparateScopeEachTime()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var sut = new TestScopedIntegrationEventHandler(provider.GetRequiredService<IServiceScopeFactory>(), new RecordingLogger());
+
+        await sut.HandleAsync(new TestIntegrationEvent("first"));
+        ScopedProbe? first = sut.ResolvedService;
+
+        await sut.HandleAsync(new TestIntegrationEvent("second"));
+
+        sut.ResolvedService.Should().NotBeSameAs(first, "a singleton handler must not reuse one scope across deliveries");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNullEvent_ThrowsArgumentNullException()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var sut = new TestScopedIntegrationEventHandler(provider.GetRequiredService<IServiceScopeFactory>(), new RecordingLogger());
+
+        await FluentActions.Invoking(() => sut.HandleAsync(null!))
+            .Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ── Exception logged AND propagated ──
+    [Fact]
+    public async Task HandleAsync_WhenHandlerThrows_LogsAndPropagates()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var logger = new RecordingLogger();
+        var sut = new TestScopedIntegrationEventHandler(
+            provider.GetRequiredService<IServiceScopeFactory>(), logger, shouldThrow: true);
+
+        (await FluentActions.Invoking(() => sut.HandleAsync(new TestIntegrationEvent("payload")))
+                .Should().ThrowAsync<InvalidOperationException>(
+                    "the delivery mechanism, not the handler, decides what happens to a failed event"))
+            .WithMessage("Handler failed");
+
+        logger.Errors.Should().ContainSingle()
+            .Which.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenHandlerThrows_DisposesTheScope()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var sut = new TestScopedIntegrationEventHandler(
+            provider.GetRequiredService<IServiceScopeFactory>(), new RecordingLogger(), shouldThrow: true);
+
+        await FluentActions.Invoking(() => sut.HandleAsync(new TestIntegrationEvent("payload")))
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        sut.ResolvedService!.IsDisposed.Should().BeTrue("a failed delivery must not leak the scope it opened");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenHandlerThrows_WritesTheLogBeforeTheCallerSeesTheException()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var logger = new RecordingLogger();
+        var sut = new TestScopedIntegrationEventHandler(
+            provider.GetRequiredService<IServiceScopeFactory>(), logger, shouldThrow: true);
+
+        try
+        {
+            await sut.HandleAsync(new TestIntegrationEvent("payload"));
+        }
+        catch (InvalidOperationException)
+        {
+            logger.Sequence.Add("caught");
+        }
+
+        logger.Sequence.Should().Equal(
+            ["logged", "caught"],
+            "an exception filter logs on the first pass, so the handler context is recorded even if an outer frame rethrows or wraps");
+    }
+
+    // ── OperationCanceledException still passes straight through, unlogged ──
+    [Fact]
+    public async Task HandleAsync_WhenOperationCanceledException_PropagatesWithoutLogging()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var logger = new RecordingLogger();
+        var sut = new TestScopedIntegrationEventHandler(
+            provider.GetRequiredService<IServiceScopeFactory>(), logger, throwCancellation: true);
+
+        await FluentActions.Invoking(() => sut.HandleAsync(new TestIntegrationEvent("payload")))
+            .Should().ThrowAsync<OperationCanceledException>();
+
+        logger.Errors.Should().BeEmpty("host shutdown is not a delivery failure and must not be logged as one");
+        logger.Sequence.Should().BeEmpty();
+    }
+
+    // ── The log line is an extension point ──
+    [Fact]
+    public async Task HandleAsync_WhenSubclassOverridesTheLog_UsesTheOverride()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var logger = new RecordingLogger();
+        var sut = new CustomLoggingIntegrationEventHandler(provider.GetRequiredService<IServiceScopeFactory>(), logger);
+
+        await FluentActions.Invoking(() => sut.HandleAsync(new TestIntegrationEvent("payload")))
+            .Should().ThrowAsync<InvalidOperationException>();
+
+        sut.LoggedPayload.Should().Be("payload", "the override receives the event so it can log the event's own identifiers");
+        logger.Errors.Should().BeEmpty("the override replaced the default log line entirely");
+    }
+
+    [Fact]
+    public async Task HandleAsync_PassesTheCancellationTokenThrough()
+    {
+        await using ServiceProvider provider = BuildProvider();
+        var sut = new TestScopedIntegrationEventHandler(provider.GetRequiredService<IServiceScopeFactory>(), new RecordingLogger());
+        using var cts = new CancellationTokenSource();
+
+        await sut.HandleAsync(new TestIntegrationEvent("payload"), cts.Token);
+
+        sut.ObservedToken.Should().Be(cts.Token);
+    }
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ScopedProbe>();
+
+        return services.BuildServiceProvider();
+    }
+}
+
+// ── Test helpers ──
+public sealed record TestIntegrationEvent(string Payload) : BaseIntegrationEvent;
+
+/// <summary>Scoped service that records whether the scope that produced it was disposed.</summary>
+public sealed class ScopedProbe : IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose() => IsDisposed = true;
+}
+
+public sealed class TestScopedIntegrationEventHandler : ScopedIntegrationEventHandlerBase<TestIntegrationEvent>
+{
+    private readonly bool _shouldThrow;
+    private readonly bool _throwCancellation;
+
+    public TestScopedIntegrationEventHandler(
+        IServiceScopeFactory scopeFactory,
+        ILogger logger,
+        bool shouldThrow = false,
+        bool throwCancellation = false)
+        : base(scopeFactory, logger)
+    {
+        _shouldThrow = shouldThrow;
+        _throwCancellation = throwCancellation;
+    }
+
+    public ScopedProbe? ResolvedService { get; private set; }
+
+    public CancellationToken ObservedToken { get; private set; }
+
+    protected override Task HandleScopedAsync(
+        TestIntegrationEvent integrationEvent,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+    {
+        ResolvedService = services.GetRequiredService<ScopedProbe>();
+        ObservedToken = cancellationToken;
+
+        if (_throwCancellation)
+        {
+            throw new OperationCanceledException();
+        }
+
+        if (_shouldThrow)
+        {
+            throw new InvalidOperationException("Handler failed");
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class CustomLoggingIntegrationEventHandler(IServiceScopeFactory scopeFactory, ILogger logger)
+    : ScopedIntegrationEventHandlerBase<TestIntegrationEvent>(scopeFactory, logger)
+{
+    public string? LoggedPayload { get; private set; }
+
+    protected override Task HandleScopedAsync(
+        TestIntegrationEvent integrationEvent,
+        IServiceProvider services,
+        CancellationToken cancellationToken)
+        => throw new InvalidOperationException("Handler failed");
+
+    protected override void LogHandlerFailure(Exception exception, TestIntegrationEvent integrationEvent) =>
+        LoggedPayload = integrationEvent.Payload;
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Extensions/CurrentUserServiceExtensionsTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Extensions/CurrentUserServiceExtensionsTests.cs
@@ -1,0 +1,82 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using MMCA.Common.Application.Extensions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Shared.Abstractions;
+using Moq;
+
+namespace MMCA.Common.Application.Tests.Extensions;
+
+/// <summary>
+/// <c>RequireUserId</c> collapses the read-then-null-check-then-fail block that every handler and
+/// controller guarding a per-user operation repeats. The default classification is
+/// <see cref="ErrorType.Forbidden"/>, matching what the handler-side copies report today.
+/// </summary>
+public sealed class CurrentUserServiceExtensionsTests
+{
+    [Fact]
+    public void RequireUserId_WhenAuthenticated_ReturnsTheIdentifier()
+    {
+        ICurrentUserService currentUserService = CurrentUser(42);
+
+        Result<UserIdentifierType> result = currentUserService.RequireUserId("CheckIns.Forbidden");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void RequireUserId_WhenUnauthenticated_ReturnsForbiddenFailure()
+    {
+        ICurrentUserService currentUserService = CurrentUser(null);
+
+        Result<UserIdentifierType> result = currentUserService.RequireUserId("CheckIns.Forbidden");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle();
+        result.Errors[0].Code.Should().Be("CheckIns.Forbidden");
+        result.Errors[0].Message.Should().Be("Access denied.");
+        result.Errors[0].Type.Should().Be(ErrorType.Forbidden);
+        result.Errors[0].Source.Should().BeNull();
+    }
+
+    [Fact]
+    public void RequireUserId_WhenUnauthenticated_CarriesTheSuppliedMessageTypeAndSource()
+    {
+        ICurrentUserService currentUserService = CurrentUser(null);
+
+        Result<UserIdentifierType> result = currentUserService.RequireUserId(
+            "Users.Unauthorized",
+            "Authentication is required.",
+            ErrorType.Unauthorized,
+            "ExportUserDataAsync");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Users.Unauthorized");
+        result.Errors[0].Message.Should().Be("Authentication is required.");
+        result.Errors[0].Type.Should().Be(ErrorType.Unauthorized);
+        result.Errors[0].Source.Should().Be("ExportUserDataAsync");
+    }
+
+    [Fact]
+    public void RequireUserId_WithNullService_ThrowsArgumentNullException()
+    {
+        ICurrentUserService currentUserService = null!;
+
+        FluentActions.Invoking(() => currentUserService.RequireUserId("Any.Forbidden"))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AccessDeniedMessage_MatchesTheMessageTheAppSideCopiesReport() =>
+        CurrentUserServiceExtensions.AccessDeniedMessage.Should().Be("Access denied.");
+
+    private static ICurrentUserService CurrentUser(UserIdentifierType? userId)
+    {
+        var mock = new Mock<ICurrentUserService>();
+        mock.SetupGet(x => x.UserId).Returns(userId);
+        mock.SetupGet(x => x.User).Returns(new ClaimsPrincipal(new ClaimsIdentity()));
+
+        return mock.Object;
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Validation/CommonValidationRulesTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Validation/CommonValidationRulesTests.cs
@@ -314,6 +314,185 @@ public sealed class CommonValidationRulesTests
 
         result.ShouldNotHaveValidationErrorFor(x => x.Name);
     }
+
+    // ── Optional errorCode: omitted leaves the existing behaviour untouched ──
+    [Fact]
+    public void RequiredStringRules_WhenErrorCodeOmitted_UsesFluentValidationDefaultCode()
+    {
+        var validator = new RequiredStringRules<TestStringModel>(x => x.Name, "Name", 50);
+        var model = new TestStringModel { Name = string.Empty };
+
+        TestValidationResult<TestStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorCode("NotEmptyValidator");
+    }
+
+    [Fact]
+    public void RequiredStringRules_WhenErrorCodeSupplied_AppliesItToTheNotEmptyRule()
+    {
+        var validator = new RequiredStringRules<TestStringModel>(x => x.Name, "Name", 50, "Question.QuestionText.Required");
+        var model = new TestStringModel { Name = string.Empty };
+
+        TestValidationResult<TestStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorCode("Question.QuestionText.Required")
+            .WithErrorMessage("You must enter a Name");
+    }
+
+    [Fact]
+    public void RequiredStringRules_WhenErrorCodeSupplied_AppliesItToTheMaxLengthRuleToo()
+    {
+        var validator = new RequiredStringRules<TestStringModel>(x => x.Name, "Name", 5, "Question.QuestionText.Invalid");
+        var model = new TestStringModel { Name = "123456" };
+
+        TestValidationResult<TestStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorCode("Question.QuestionText.Invalid");
+    }
+
+    [Fact]
+    public void OptionalStringRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new OptionalStringRules<TestOptionalStringModel>(x => x.Description, "Description", 5, "Activity.VenueUrl.MaxLength");
+        var model = new TestOptionalStringModel { Description = "123456" };
+
+        TestValidationResult<TestOptionalStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorCode("Activity.VenueUrl.MaxLength");
+    }
+
+    [Fact]
+    public void EmailRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new EmailRules<TestStringModel>(x => x.Name, "Email", 100, "User.Email.Invalid");
+        var model = new TestStringModel { Name = "not-an-email" };
+
+        TestValidationResult<TestStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorCode("User.Email.Invalid");
+    }
+
+    [Fact]
+    public void PositiveIntRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new PositiveIntRules<TestIntModel>(x => x.Quantity, "Sponsor ID", "CheckIn.SponsorId.Required");
+        var model = new TestIntModel { Quantity = 0 };
+
+        TestValidationResult<TestIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Quantity)
+            .WithErrorCode("CheckIn.SponsorId.Required")
+            .WithErrorMessage("Sponsor ID must be a positive value");
+    }
+
+    [Fact]
+    public void PositiveDecimalRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new PositiveDecimalRules<TestDecimalModel>(x => x.Price, "Price", "Product.Price.NotPositive");
+        var model = new TestDecimalModel { Price = 0m };
+
+        TestValidationResult<TestDecimalModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Price)
+            .WithErrorCode("Product.Price.NotPositive");
+    }
+
+    [Fact]
+    public void NonNegativeIntRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new NonNegativeIntRules<TestIntModel>(x => x.Quantity, "Sort Order", "Activity.SortOrder.Negative");
+        var model = new TestIntModel { Quantity = -1 };
+
+        TestValidationResult<TestIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Quantity)
+            .WithErrorCode("Activity.SortOrder.Negative");
+    }
+
+    [Fact]
+    public void PasswordRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new PasswordRules<TestStringModel>(x => x.Name, "User.CurrentPassword.Required");
+        var model = new TestStringModel { Name = string.Empty };
+
+        TestValidationResult<TestStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorCode("User.CurrentPassword.Required");
+    }
+
+    [Fact]
+    public void StrongPasswordRules_WhenErrorCodeSupplied_AppliesItToEveryComplexityRule()
+    {
+        var validator = new StrongPasswordRules<TestStringModel>(x => x.Name, "User.NewPassword.Weak");
+        var model = new TestStringModel { Name = "nospecial1" };
+
+        TestValidationResult<TestStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorCode("User.NewPassword.Weak");
+    }
+
+    // ── AbsoluteUrlRules ──
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://example.com/logo.png")]
+    [InlineData("http://example.com")]
+    public void AbsoluteUrlRules_WhenAbsentOrAbsoluteHttp_NoErrors(string? url)
+    {
+        var validator = new AbsoluteUrlRules<TestOptionalStringModel>(x => x.Description, "Logo URL", 200);
+        var model = new TestOptionalStringModel { Description = url };
+
+        TestValidationResult<TestOptionalStringModel> result = validator.TestValidate(model);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4=")]
+    [InlineData("/relative/path")]
+    [InlineData("example.com")]
+    public void AbsoluteUrlRules_WhenNotAbsoluteHttp_HasValidationError(string url)
+    {
+        var validator = new AbsoluteUrlRules<TestOptionalStringModel>(x => x.Description, "Logo URL", 200);
+        var model = new TestOptionalStringModel { Description = url };
+
+        TestValidationResult<TestOptionalStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage("Logo URL must be an absolute http or https URL");
+    }
+
+    [Fact]
+    public void AbsoluteUrlRules_WhenTooLong_HasValidationError()
+    {
+        var validator = new AbsoluteUrlRules<TestOptionalStringModel>(x => x.Description, "Logo URL", 20);
+        var model = new TestOptionalStringModel { Description = "https://example.com/a-very-long-path/logo.png" };
+
+        TestValidationResult<TestOptionalStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage("Logo URL cannot be longer than 20 characters");
+    }
+
+    [Fact]
+    public void AbsoluteUrlRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new AbsoluteUrlRules<TestOptionalStringModel>(x => x.Description, "Logo URL", 200, "Sponsor.LogoUrl.Invalid");
+        var model = new TestOptionalStringModel { Description = "javascript:alert(1)" };
+
+        TestValidationResult<TestOptionalStringModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorCode("Sponsor.LogoUrl.Invalid");
+    }
 }
 
 // ── Test models ──

--- a/Tests/Core/MMCA.Common.Domain.Tests/Invariants/CommonInvariantsTests.cs
+++ b/Tests/Core/MMCA.Common.Domain.Tests/Invariants/CommonInvariantsTests.cs
@@ -314,4 +314,378 @@ public sealed class CommonInvariantsTests
         CommonInvariants.LightTheme.Should().Be("light");
         CommonInvariants.DarkTheme.Should().Be("dark");
     }
+
+    // ── EnsureEnumIsDefined ──
+    [Theory]
+    [InlineData(TestScope.Event)]
+    [InlineData(TestScope.Session)]
+    public void EnsureEnumIsDefined_WithDeclaredMember_ReturnsSuccess(TestScope scope)
+    {
+        Result result = CommonInvariants.EnsureEnumIsDefined(
+            scope, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureEnumIsDefined_WithUndeclaredValue_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureEnumIsDefined(
+            (TestScope)99, "CheckIn.Scope.Invalid", "Check-in scope is not valid.", "Create", "scope");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("CheckIn.Scope.Invalid");
+        result.Errors[0].Message.Should().Be("Check-in scope is not valid.");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    // ── EnsureEndIsNotBeforeStart ──
+    [Fact]
+    public void EnsureEndIsNotBeforeStart_WhenEndIsAfterStart_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureEndIsNotBeforeStart(
+            new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 3), "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureEndIsNotBeforeStart_WhenEndEqualsStart_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureEndIsNotBeforeStart(
+            new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 1), "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue("a single-day range is legitimate; a strict check is a separate invariant");
+    }
+
+    [Fact]
+    public void EnsureEndIsNotBeforeStart_WhenEndIsBeforeStart_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureEndIsNotBeforeStart(
+            new DateTime(2026, 1, 3, 9, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+            "Event.DateRange.Invalid",
+            "Event end date must be on or after the start date.",
+            "Create",
+            "endDate");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Event.DateRange.Invalid");
+    }
+
+    // ── EnsureStringLengthIsWithin ──
+    [Theory]
+    [InlineData("a")]
+    [InlineData("abcde")]
+    public void EnsureStringLengthIsWithin_WhenWithinBounds_ReturnsSuccess(string value)
+    {
+        Result result = CommonInvariants.EnsureStringLengthIsWithin(
+            value, 1, 5, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abcdef")]
+    public void EnsureStringLengthIsWithin_WhenOutsideBounds_ReturnsFailure(string? value)
+    {
+        Result result = CommonInvariants.EnsureStringLengthIsWithin(
+            value, 1, 5, "PointsEntry.SubjectKey.Invalid", "Subject key must be 1-5 characters.", "Create", "subjectKey");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("PointsEntry.SubjectKey.Invalid");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    [Fact]
+    public void EnsureStringLengthIsWithin_WhenShorterThanMinimum_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureStringLengthIsWithin(
+            "ab", 3, 5, "Test.TooShort", "Too short.", "Create", "Name");
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    // ── EnsureOptionalStringMaxLength ──
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("short")]
+    public void EnsureOptionalStringMaxLength_WhenAbsentOrWithinLimit_ReturnsSuccess(string? value)
+    {
+        Result result = CommonInvariants.EnsureOptionalStringMaxLength(
+            value, 10, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureOptionalStringMaxLength_WhenExceedsLimit_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureOptionalStringMaxLength(
+            "this is too long", 5, "Activity.VenueUrl.TooLong", "Too long.", "Create", "venueUrl");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Activity.VenueUrl.TooLong");
+    }
+
+    // ── EnsureTimeZoneIsValid ──
+    [Fact]
+    public void EnsureTimeZoneIsValid_WhenNull_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureTimeZoneIsValid(
+            null, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureTimeZoneIsValid_WithRecognizedIdentifier_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureTimeZoneIsValid(
+            "UTC", "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Not/AZone")]
+    public void EnsureTimeZoneIsValid_WithUnrecognizedIdentifier_ReturnsFailure(string timeZone)
+    {
+        Result result = CommonInvariants.EnsureTimeZoneIsValid(
+            timeZone, "Event.TimeZone.Invalid", "The time zone is not recognized.", "Create", "timeZone");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Event.TimeZone.Invalid");
+    }
+
+    // ── EnsureUrlIsWellFormed ──
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://example.com/logo.png")]
+    [InlineData("http://example.com")]
+    public void EnsureUrlIsWellFormed_WhenAbsentOrAbsoluteHttp_ReturnsSuccess(string? url)
+    {
+        Result result = CommonInvariants.EnsureUrlIsWellFormed(
+            url, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4=")]
+    [InlineData("/relative/path")]
+    [InlineData("example.com")]
+    [InlineData("ftp://example.com/file")]
+    public void EnsureUrlIsWellFormed_WhenNotAbsoluteHttp_ReturnsFailure(string url)
+    {
+        Result result = CommonInvariants.EnsureUrlIsWellFormed(
+            url, "Sponsor.LogoUrl.Invalid", "Logo URL must be an absolute http or https URL.", "Create", "logoUrl");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Sponsor.LogoUrl.Invalid");
+        result.Errors[0].Type.Should().Be(ErrorType.Invariant);
+    }
+
+    // ── EnsureCountIsWithin ──
+    [Theory]
+    [InlineData(2)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void EnsureCountIsWithin_WhenInRange_ReturnsSuccess(int count)
+    {
+        Result result = CommonInvariants.EnsureCountIsWithin(
+            count, 2, 10, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(11)]
+    public void EnsureCountIsWithin_WhenOutOfRange_ReturnsFailure(int count)
+    {
+        Result result = CommonInvariants.EnsureCountIsWithin(
+            count, 2, 10, "LivePoll.Options.CountInvalid", "A poll must have between 2 and 10 options.", "Create", "options");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("LivePoll.Options.CountInvalid");
+    }
+
+    // ── EnsureCollectionIsEmpty ──
+    [Fact]
+    public void EnsureCollectionIsEmpty_WhenEmpty_ReturnsSuccess()
+    {
+        string[] empty = [];
+
+        Result result = CommonInvariants.EnsureCollectionIsEmpty(
+            empty, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureCollectionIsEmpty_WhenNull_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureCollectionIsEmpty<string>(
+            null, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureCollectionIsEmpty_WhenPopulated_ReturnsFailure()
+    {
+        string[] products = ["child"];
+
+        Result result = CommonInvariants.EnsureCollectionIsEmpty(
+            products, "Category.HasProducts", "Cannot delete a category that has products assigned to it.", "Delete", "products");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Category.HasProducts");
+    }
+
+    // ── EnsureValuesAreUnique ──
+    [Fact]
+    public void EnsureValuesAreUnique_WhenAllDistinct_ReturnsSuccess()
+    {
+        string[] values = ["one", "two"];
+
+        Result result = CommonInvariants.EnsureValuesAreUnique(
+            values, StringComparer.OrdinalIgnoreCase, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureValuesAreUnique_WhenNull_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureValuesAreUnique<string>(
+            null, null, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureValuesAreUnique_WhenDuplicateUnderComparer_ReturnsFailure()
+    {
+        string[] values = ["Yes", "yes"];
+
+        Result result = CommonInvariants.EnsureValuesAreUnique(
+            values, StringComparer.OrdinalIgnoreCase, "LivePoll.Options.Duplicate", "Option texts must be unique.", "Create", "options");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("LivePoll.Options.Duplicate");
+    }
+
+    [Fact]
+    public void EnsureValuesAreUnique_WithDefaultComparer_TreatsCaseAsDistinct()
+    {
+        string[] values = ["Yes", "yes"];
+
+        Result result = CommonInvariants.EnsureValuesAreUnique(
+            values, null, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue("a null comparer means the type's default equality, which is case-sensitive for strings");
+    }
+
+    // ── EnsureFlagIsTrue / EnsureFlagIsFalse ──
+    [Fact]
+    public void EnsureFlagIsTrue_WhenSet_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureFlagIsTrue(
+            true, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureFlagIsTrue_WhenClear_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureFlagIsTrue(
+            false, "Event.NotPublished", "This action requires the event to be published.", "Publish", "isPublished");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Event.NotPublished");
+    }
+
+    [Fact]
+    public void EnsureFlagIsFalse_WhenClear_ReturnsSuccess()
+    {
+        Result result = CommonInvariants.EnsureFlagIsFalse(
+            false, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureFlagIsFalse_WhenSet_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureFlagIsFalse(
+            true, "Session.IsServiceSession", "This action is not available for service sessions.", "Update", "isServiceSession");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Session.IsServiceSession");
+    }
+
+    // ── EnsureNullableIntIsPositive ──
+    [Theory]
+    [InlineData(null)]
+    [InlineData(1)]
+    [InlineData(500)]
+    public void EnsureNullableIntIsPositive_WhenAbsentOrPositive_ReturnsSuccess(int? value)
+    {
+        Result result = CommonInvariants.EnsureNullableIntIsPositive(
+            value, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void EnsureNullableIntIsPositive_WhenZeroOrNegative_ReturnsFailure(int value)
+    {
+        Result result = CommonInvariants.EnsureNullableIntIsPositive(
+            value, "Room.Capacity.Invalid", "Room capacity must be a positive integer.", "Create", "capacity");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Room.Capacity.Invalid");
+    }
+
+    // ── EnsureIntIsNotNegative ──
+    [Theory]
+    [InlineData(0)]
+    [InlineData(7)]
+    public void EnsureIntIsNotNegative_WhenZeroOrPositive_ReturnsSuccess(int value)
+    {
+        Result result = CommonInvariants.EnsureIntIsNotNegative(
+            value, "Code", "Message", "Source", "Target");
+
+        result.IsSuccess.Should().BeTrue("zero is what separates this from EnsureIntIsPositive");
+    }
+
+    [Fact]
+    public void EnsureIntIsNotNegative_WhenNegative_ReturnsFailure()
+    {
+        Result result = CommonInvariants.EnsureIntIsNotNegative(
+            -1, "Inventory.AvailableQuantity.Negative", "Available quantity cannot be negative.", "Create", "availableQuantity");
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Inventory.AvailableQuantity.Negative");
+    }
+}
+
+// ── Test helpers ──
+public enum TestScope
+{
+    None = 0,
+    Event = 1,
+    Session = 2,
 }

--- a/Tests/Core/MMCA.Common.Shared.Tests/Notifications/NotificationScopeKeyTests.cs
+++ b/Tests/Core/MMCA.Common.Shared.Tests/Notifications/NotificationScopeKeyTests.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using AwesomeAssertions;
+using MMCA.Common.Shared.Notifications;
+
+namespace MMCA.Common.Shared.Tests.Notifications;
+
+/// <summary>
+/// The formatter and the pattern that guards it ship together so a change to either half cannot
+/// silently strand the other. Every key <see cref="NotificationScopeKey.ForEvent"/> and
+/// <see cref="NotificationScopeKey.ForSession"/> produce must satisfy
+/// <see cref="NotificationScopeKey.Pattern"/>, which is the default of
+/// <c>PushNotificationSettings.ChannelKeyPattern</c>, the regex the notification hub enforces.
+/// </summary>
+public sealed class NotificationScopeKeyTests
+{
+    [Fact]
+    public void ForEvent_ProducesThePrefixedKey() =>
+        NotificationScopeKey.ForEvent(42).Should().Be("event:42");
+
+    [Fact]
+    public void ForSession_ProducesThePrefixedKey() =>
+        NotificationScopeKey.ForSession(7).Should().Be("session:7");
+
+    [Fact]
+    public void Pattern_MatchesTheChannelKeyPatternDefault() =>
+        NotificationScopeKey.Pattern.Should().Be("^(event|session):[0-9]+$");
+
+    [Fact]
+    public void Prefixes_MatchTheAlternationInThePattern()
+    {
+        NotificationScopeKey.EventPrefix.Should().Be("event");
+        NotificationScopeKey.SessionPrefix.Should().Be("session");
+    }
+
+    // ── Format and validation cannot drift: everything the formatter emits validates ──
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(2147483647L)]
+    public void ForEvent_AlwaysProducesAValidKey(long eventId) =>
+        NotificationScopeKey.IsValid(NotificationScopeKey.ForEvent(eventId)).Should().BeTrue();
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(2147483647L)]
+    public void ForSession_AlwaysProducesAValidKey(long sessionId) =>
+        NotificationScopeKey.IsValid(NotificationScopeKey.ForSession(sessionId)).Should().BeTrue();
+
+    [Fact]
+    public void ForEvent_FormatsTheIdentifierInvariantly()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+
+            NotificationScopeKey.ForEvent(1234).Should().Be(
+                "event:1234",
+                "a culture with its own digit shapes would otherwise produce a key the pattern rejects");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // ── IsValid ──
+    [Theory]
+    [InlineData("event:1")]
+    [InlineData("session:100")]
+    public void IsValid_WithWellFormedKey_ReturnsTrue(string scopeKey) =>
+        NotificationScopeKey.IsValid(scopeKey).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("event:")]
+    [InlineData("event:abc")]
+    [InlineData("sponsor:1")]
+    [InlineData("Event:1")]
+    [InlineData("event:1 ")]
+    [InlineData("event:-1")]
+    public void IsValid_WithMalformedKey_ReturnsFalse(string? scopeKey) =>
+        NotificationScopeKey.IsValid(scopeKey).Should().BeFalse();
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Logging/SerilogHostExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Logging/SerilogHostExtensionsTests.cs
@@ -1,0 +1,186 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MMCA.Common.Aspire.Logging;
+using Serilog;
+using Serilog.Events;
+
+namespace MMCA.Common.Aspire.Tests.Logging;
+
+/// <summary>
+/// The shared host-logging bootstrap. Its two decisions carry real operational weight, so both are
+/// asserted directly: the minimum level (Debug only in Development) and whether the rolling file sink
+/// applies (everywhere except Production, where it duplicated every event onto ephemeral container
+/// disk that nothing reads). The provider registration is asserted too, because
+/// <c>builder.Logging.AddSerilog</c> rather than <c>UseSerilog</c> is what keeps the OpenTelemetry
+/// provider alive alongside Serilog.
+/// </summary>
+public sealed class SerilogHostExtensionsTests
+{
+    private static StubHostEnvironment Environment(string environmentName) =>
+        new() { EnvironmentName = environmentName };
+
+    [Theory]
+    [InlineData("Development", LogEventLevel.Debug)]
+    [InlineData("Staging", LogEventLevel.Information)]
+    [InlineData("Production", LogEventLevel.Information)]
+    public void MinimumLevel_IsDebugOnlyInDevelopment(string environmentName, LogEventLevel expected) =>
+        SerilogHostExtensions.ResolveMinimumLevel(Environment(environmentName)).Should().Be(expected);
+
+    [Theory]
+    [InlineData("Development", true)]
+    [InlineData("Staging", true)]
+    [InlineData("Testing", true)]
+    [InlineData("Production", false)]
+    public void FileSink_AppliesEverywhereExceptProduction(string environmentName, bool expected) =>
+        SerilogHostExtensions.ShouldWriteFileSink(Environment(environmentName)).Should().Be(expected);
+
+    [Fact]
+    public void DevelopmentLogger_EmitsDebugAndWritesTheFileSink()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            using var logger = SerilogHostExtensions
+                .CreateLoggerConfiguration(Environment(Environments.Development), Path.Combine(directory, "svc.txt"))
+                .CreateLogger();
+
+            logger.IsEnabled(LogEventLevel.Debug).Should().BeTrue();
+            logger.Information("hello");
+            logger.Dispose();
+
+            Directory.EnumerateFiles(directory, "svc*.txt").Should().NotBeEmpty(
+                "outside Production the rolling file is what a local or CI E2E failure is diagnosed from");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProductionLogger_DropsDebugAndWritesNoFile()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            using var logger = SerilogHostExtensions
+                .CreateLoggerConfiguration(Environment(Environments.Production), Path.Combine(directory, "svc.txt"))
+                .CreateLogger();
+
+            logger.IsEnabled(LogEventLevel.Debug).Should().BeFalse();
+            logger.Information("hello");
+            logger.Dispose();
+
+            Directory.EnumerateFiles(directory).Should().BeEmpty(
+                "stdout plus the OTel exporter already carry production logs; the file sink only filled ephemeral disk");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FrameworkNoise_IsCappedAtWarning()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            using var logger = SerilogHostExtensions
+                .CreateLoggerConfiguration(Environment(Environments.Development), Path.Combine(directory, "svc.txt"))
+                .CreateLogger();
+
+            logger.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Microsoft.EntityFrameworkCore.Database.Command")
+                .IsEnabled(LogEventLevel.Information).Should().BeFalse();
+            logger.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Microsoft.AspNetCore.Hosting.Diagnostics")
+                .IsEnabled(LogEventLevel.Information).Should().BeFalse();
+            logger.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "MMCA.Common.Application")
+                .IsEnabled(LogEventLevel.Debug).Should().BeTrue();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ConfigureHook_RunsAfterTheDefaults()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            using var logger = SerilogHostExtensions
+                .CreateLoggerConfiguration(
+                    Environment(Environments.Development),
+                    Path.Combine(directory, "svc.txt"),
+                    configuration => configuration.MinimumLevel.Error())
+                .CreateLogger();
+
+            logger.IsEnabled(LogEventLevel.Debug).Should().BeFalse(
+                "the hook is the per-host extension point, so it must be able to override a default");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BlankLogFilePath_IsRejected()
+    {
+        var act = () => SerilogHostExtensions.CreateLoggerConfiguration(Environment(Environments.Development), "  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddCommonSerilog_RegistersOneProviderAndPublishesTheGlobalLogger()
+    {
+        var directory = CreateTempDirectory();
+        var previous = Log.Logger;
+        try
+        {
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                EnvironmentName = Environments.Development,
+            });
+
+            var returned = builder.AddCommonSerilog(Path.Combine(directory, "svc.txt"));
+
+            returned.Should().BeSameAs(builder);
+            Log.Logger.IsEnabled(LogEventLevel.Debug).Should().BeTrue(
+                "AddCommonSerilog publishes the configured logger as the global Log.Logger the hosts rely on");
+            using var provider = builder.Services.BuildServiceProvider();
+            provider.GetServices<Microsoft.Extensions.Logging.ILoggerProvider>()
+                .Should().ContainSingle(p => p is Serilog.Extensions.Logging.SerilogLoggerProvider,
+                    "Serilog must be added as ONE provider alongside the others: UseSerilog would replace the whole ILoggerFactory and silence the OpenTelemetry provider AddServiceDefaults adds");
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+            Log.Logger = previous;
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "mmca-serilog-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class StubHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+
+        public string ApplicationName { get; set; } = "Tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
@@ -133,6 +133,11 @@
         "resolved": "10.9.0",
         "contentHash": "hO/IpudHBl+EMXm1Ag8+7ersCN7VuiR6ech1+cVk8I+o7ssPRKdTozIAO4HGPt49G/lY6lo7G2kY5Q00biMHew=="
       },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "RFYJR7APio/BiqdQunRq6DB+nDB6nc2qhHr77mlvZ0q0BT8PubMXN7XicmfzCbrDE/dzhBnUKBRXLTcqUiZDGg=="
+      },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
         "resolved": "10.9.0",
@@ -339,6 +344,53 @@
         "resolved": "7.0.0",
         "contentHash": "8YJz22mOSMtkbIVuVSz2HbJwbpKwRoXQ1uqbczDUt1w1Ds8dxFs6dkV/oZ8AlTmkErZjtQelHv+oBu52ud00WA=="
       },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
         "resolved": "1.2.0.556",
@@ -468,7 +520,10 @@
           "OpenTelemetry.Extensions.Hosting": "[1.18.0, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.18.0, )",
           "OpenTelemetry.Instrumentation.Http": "[1.18.0, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )"
+          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Serilog.Sinks.Console": "[6.1.1, )",
+          "Serilog.Sinks.File": "[7.0.0, )"
         }
       },
       "mmca.common.shared": {
@@ -654,6 +709,39 @@
         "requested": "[8.7.0, )",
         "resolved": "8.4.2",
         "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Serilog.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.1, )",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
       },
       "StackExchange.Redis": {
         "type": "CentralTransitive",

--- a/Tests/Hosting/MMCA.Common.Gateway.Tests/ForwardedHeadersExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Gateway.Tests/ForwardedHeadersExtensionsTests.cs
@@ -1,0 +1,95 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MMCA.Common.Gateway.Tests;
+
+/// <summary>
+/// The forwarded-headers wiring a gateway host used to hand-roll. Two things are load-bearing and
+/// both are asserted: the three headers that are honored, and the CLEARED known-proxy allow-lists.
+/// Leaving the framework defaults in place makes the middleware ignore every forwarded header a cloud
+/// ingress sends (its internal IP is in neither list), which collapses a per-client-IP rate-limit
+/// partition into one shared window for every real user, silently and only in production.
+/// </summary>
+public sealed class ForwardedHeadersExtensionsTests
+{
+    [Fact]
+    public void Options_HonorTheThreeForwardedHeaders() =>
+        ForwardedHeadersExtensions.CreateForwardedHeadersOptions().ForwardedHeaders.Should().Be(
+            ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost);
+
+    [Fact]
+    public void Options_ClearTheKnownProxyAllowLists()
+    {
+        var options = ForwardedHeadersExtensions.CreateForwardedHeadersOptions();
+
+        options.KnownProxies.Should().BeEmpty(
+            "an Azure Container Apps or ALB ingress front-ends from an internal IP that is in neither default list");
+        options.KnownIPNetworks.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Options_AreFreshPerCallSoAHostCanCustomizeWithoutLeaking() =>
+        ForwardedHeadersExtensions.CreateForwardedHeadersOptions().Should().NotBeSameAs(
+            ForwardedHeadersExtensions.CreateForwardedHeadersOptions());
+
+    [Fact]
+    public async Task UseCommonForwardedHeaders_RewritesTheRequestFromTheForwardedHeaders()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("ingress.internal");
+        context.Request.Headers["X-Forwarded-For"] = "203.0.113.7";
+        context.Request.Headers["X-Forwarded-Proto"] = "https";
+        context.Request.Headers["X-Forwarded-Host"] = "gateway.example.com";
+
+        await BuildPipeline().Invoke(context);
+
+        context.Connection.RemoteIpAddress?.ToString().Should().Be(
+            "203.0.113.7",
+            "the edge rate limiter partitions on the client IP, so it can only see the real caller once the headers have been applied");
+        context.Request.Scheme.Should().Be("https");
+        context.Request.Host.Value.Should().Be("gateway.example.com");
+    }
+
+    [Fact]
+    public async Task UseCommonForwardedHeaders_LeavesAnUnproxiedRequestAlone()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString("localhost:6001");
+
+        await BuildPipeline().Invoke(context);
+
+        context.Connection.RemoteIpAddress.Should().Be(System.Net.IPAddress.Loopback);
+        context.Request.Scheme.Should().Be("http");
+        context.Request.Host.Value.Should().Be("localhost:6001");
+    }
+
+    [Fact]
+    public void UseCommonForwardedHeaders_RejectsANullBuilder()
+    {
+        IApplicationBuilder app = null!;
+
+        var act = () => app.UseCommonForwardedHeaders();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static RequestDelegate BuildPipeline()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+
+        var appBuilder = new ApplicationBuilder(services.BuildServiceProvider());
+        appBuilder.UseCommonForwardedHeaders();
+        appBuilder.Run(static _ => Task.CompletedTask);
+
+        return appBuilder.Build();
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/MmcaGatewayHardeningTestsBaseTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/MmcaGatewayHardeningTestsBaseTests.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Guards the shape of <see cref="MmcaGatewayHardeningTestsBase{TEntryPoint}"/>. The gates themselves
+/// need a booted gateway host (a consumer's sealed subclass over its own <c>Program</c>), so they are
+/// not runnable here; what IS checkable headlessly is that the base still DECLARES every gate and
+/// still exposes the extension points a subclass supplies. A gate silently dropped from the base
+/// would otherwise stop running in three repos with nothing failing.
+/// <para>
+/// <see cref="SampleGatewayHardeningTests"/> below is compile coverage: it is abstract (so xUnit never
+/// collects it) and exists to prove the extension points are reachable and correctly typed from a
+/// subclass, which is the only part of the base a consumer interacts with.
+/// </para>
+/// </summary>
+public sealed class MmcaGatewayHardeningTestsBaseTests
+{
+    private static readonly string[] ExpectedGates =
+    [
+        "Route_IsThrottledOnceTheClientExhaustsItsWindow",
+        "NamedPolicyRoute_IsThrottledAtItsOwnTighterAllowance",
+        "BypassedPaths_AreNotThrottledEvenAfterTheWindowIsExhausted",
+        "Response_CarriesAGeneratedCorrelationId_WhenTheCallerSuppliesNone",
+        "Response_EchoesTheCallerSuppliedCorrelationId",
+        "Readiness_IncludesADownstreamCheckPerService",
+        "EveryCluster_CarriesAnActiveHealthCheckProbingAlive",
+        "RateLimiter_PartitionsByForwardedClientIp_NotByProxyIp",
+    ];
+
+    private static readonly string[] ExpectedAbstractMembers =
+    [
+        "Factory",
+        "PermitLimit",
+        "LimitedPath",
+        "DownstreamServices",
+    ];
+
+    [Fact]
+    public void Base_DeclaresEveryEdgeHardeningGate_AsAFact()
+    {
+        var facts = typeof(MmcaGatewayHardeningTestsBase<>)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttribute<FactAttribute>() is not null)
+            .Select(m => m.Name);
+
+        facts.Should().BeEquivalentTo(
+            ExpectedGates,
+            "every gate the base ships runs in each consumer's sealed subclass; dropping or renaming one silently stops it running everywhere");
+    }
+
+    [Fact]
+    public void Base_RequiresOnlyTheRouteTableFactsFromASubclass()
+    {
+        var abstractMembers = typeof(MmcaGatewayHardeningTestsBase<>)
+            .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(p => p.GetMethod is { IsAbstract: true })
+            .Select(p => p.Name);
+
+        // Everything else (bypass list, named policy, probe cadence, header names) is virtual with a
+        // framework default, so a host that matches the kit defaults writes four members and nothing more.
+        abstractMembers.Should().BeEquivalentTo(ExpectedAbstractMembers);
+    }
+
+}
+
+/// <summary>
+/// Compile coverage for a consumer subclass. Abstract on purpose so xUnit does not collect it:
+/// running these gates needs a real gateway host, which this project does not boot.
+/// </summary>
+internal abstract class SampleGatewayHardeningTests : MmcaGatewayHardeningTestsBase<SampleGatewayEntryPoint>
+{
+    protected override WebApplicationFactory<SampleGatewayEntryPoint> Factory =>
+        throw new NotSupportedException("Compile coverage only.");
+
+    protected override int PermitLimit => 120;
+
+    protected override string LimitedPath => "/Events/1";
+
+    protected override IReadOnlyList<string> DownstreamServices => ["identity", "conference"];
+
+    protected override IReadOnlyList<string> BypassedPaths =>
+        ["/hubs/notifications", "/.well-known/jwks.json", "/health"];
+
+    protected override string? NamedPolicyPath => "/Auth/login";
+
+    protected override int NamedPolicyPermitLimit => 30;
+
+    protected override TimeSpan ActiveProbeInterval => TimeSpan.FromSeconds(30);
+}
+
+/// <summary>Stands in for a gateway host's <c>Program</c> in the compile-coverage subclass.</summary>
+internal sealed class SampleGatewayEntryPoint;

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/RateLimiterTestExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/RateLimiterTestExtensionsTests.cs
@@ -1,0 +1,85 @@
+using System.Threading.RateLimiting;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Unit tests for <c>NeutralizeGlobalRateLimiter</c>: the helper every per-service integration test
+/// factory calls so a suite that drives dozens of requests through one host is not throttled by the
+/// production budget. The load-bearing part is that it wins over the host's own registration no
+/// matter which ran first, which is what the PostConfigure ordering buys.
+/// </summary>
+public sealed class RateLimiterTestExtensionsTests
+{
+    [Fact]
+    public async Task NeutralizeGlobalRateLimiter_OverridesAHostLimiterThatWouldRejectEveryRequest()
+    {
+        // Arrange: a host limiter with no permits at all, so any surviving limiter rejects.
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.Configure<RateLimiterOptions>(options =>
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+                _ => RateLimitPartition.GetFixedWindowLimiter(
+                    "host",
+                    _ => new FixedWindowRateLimiterOptions { PermitLimit = 1, Window = TimeSpan.FromHours(1), QueueLimit = 0 })));
+
+        // Act
+        services.NeutralizeGlobalRateLimiter();
+
+        // Assert: every acquisition succeeds, including well past the host's single permit.
+        var limiter = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<RateLimiterOptions>>().Value.GlobalLimiter;
+        limiter.Should().NotBeNull("the neutralizer must install a limiter, not clear the option");
+
+        for (var i = 0; i < 5; i++)
+        {
+            using var lease = await limiter!.AcquireAsync(
+                new DefaultHttpContext(), 1, TestContext.Current.CancellationToken);
+            lease.IsAcquired.Should().BeTrue("the neutralized limiter must admit every request");
+        }
+    }
+
+    [Fact]
+    public void NeutralizeGlobalRateLimiter_ReturnsTheSameCollection_ForChaining()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var returned = services.NeutralizeGlobalRateLimiter();
+
+        // Assert
+        returned.Should().BeSameAs(services);
+    }
+
+    [Fact]
+    public async Task NeutralizeGlobalRateLimiter_AppliesEvenWhenTheHostConfiguresItsLimiterAfterwards()
+    {
+        // Arrange: the neutralizer runs FIRST here, and the host's own Configure lands after it. A
+        // plain Configure would then be overwritten; the PostConfigure this helper uses still wins,
+        // which is the whole reason a test factory can call it without ordering ceremony.
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.NeutralizeGlobalRateLimiter("integration-tests");
+        services.Configure<RateLimiterOptions>(options =>
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+                _ => RateLimitPartition.GetConcurrencyLimiter(
+                    "host",
+                    _ => new ConcurrencyLimiterOptions { PermitLimit = 1, QueueLimit = 0 })));
+
+        // Act
+        var limiter = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<RateLimiterOptions>>().Value.GlobalLimiter;
+
+        // Assert: two concurrent leases both succeed, which the host's one-permit limiter would refuse.
+        using var first = await limiter!.AcquireAsync(new DefaultHttpContext(), 1, TestContext.Current.CancellationToken);
+        using var second = await limiter.AcquireAsync(new DefaultHttpContext(), 1, TestContext.Current.CancellationToken);
+        first.IsAcquired.Should().BeTrue();
+        second.IsAcquired.Should().BeTrue();
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/RecordingHttpForwarderTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/RecordingHttpForwarderTests.cs
@@ -1,0 +1,191 @@
+using System.Globalization;
+using System.Net;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+using Yarp.ReverseProxy.Forwarder;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// Unit tests for the shipped <see cref="RecordingHttpForwarder"/>: the gateway test fake that echoes
+/// the destination, the forwarder budget and the outbound trace headers into response headers instead
+/// of proxying. The echoes are what every consumer gateway route test asserts on, so a silent change
+/// to a header name or an unset marker would break those suites in three repos at once.
+/// </summary>
+public sealed class RecordingHttpForwarderTests
+{
+    private const string DestinationPrefix = "http://conference";
+
+    [Fact]
+    public async Task SendAsync_EchoesDestinationAndForwarderBudget()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var config = new ForwarderRequestConfig
+        {
+            ActivityTimeout = TimeSpan.FromSeconds(100),
+            Version = HttpVersion.Version20,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact,
+        };
+
+        // Act
+        var error = await new RecordingHttpForwarder().SendAsync(
+            context, DestinationPrefix, NoopInvoker, config, new StampingTransformer(), TestContext.Current.CancellationToken);
+
+        // Assert
+        error.Should().Be(ForwarderError.None);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        Header(context, RecordingHttpForwarder.DestinationHeader).Should().Be(DestinationPrefix);
+        Header(context, RecordingHttpForwarder.ActivityTimeoutHeader)
+            .Should().Be(TimeSpan.FromSeconds(100).ToString("c", CultureInfo.InvariantCulture));
+        Header(context, RecordingHttpForwarder.VersionHeader).Should().Be("2.0");
+        Header(context, RecordingHttpForwarder.VersionPolicyHeader).Should().Be(nameof(HttpVersionPolicy.RequestVersionExact));
+    }
+
+    [Fact]
+    public async Task SendAsync_EchoesTheUnsetMarker_ForEveryNullableSettingLeftUnset()
+    {
+        // Arrange: a cluster that declares no forwarder budget at all. The unset marker is what makes
+        // "the shared profile merge never reached this cluster" an assertable outcome rather than an
+        // empty header a test could pass over.
+        var context = new DefaultHttpContext();
+
+        // Act
+        await new RecordingHttpForwarder().SendAsync(
+            context,
+            DestinationPrefix,
+            NoopInvoker,
+            new ForwarderRequestConfig(),
+            new StampingTransformer(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Header(context, RecordingHttpForwarder.ActivityTimeoutHeader).Should().Be(RecordingHttpForwarder.UnsetValue);
+        Header(context, RecordingHttpForwarder.VersionHeader).Should().Be(RecordingHttpForwarder.UnsetValue);
+        Header(context, RecordingHttpForwarder.VersionPolicyHeader).Should().Be(RecordingHttpForwarder.UnsetValue);
+
+        // No IReverseProxyFeature on a bare context: the cluster echo degrades to the marker rather
+        // than throwing, so a route test that never went through YARP's own middleware still runs.
+        Header(context, RecordingHttpForwarder.ClusterHeader).Should().Be(RecordingHttpForwarder.UnsetValue);
+    }
+
+    [Fact]
+    public async Task SendAsync_RunsTheRealTransformPipeline_AndEchoesTheStampedTraceHeaders()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        // Act
+        await new RecordingHttpForwarder().SendAsync(
+            context,
+            DestinationPrefix,
+            NoopInvoker,
+            new ForwarderRequestConfig(),
+            new StampingTransformer("events-route", "conference"),
+            TestContext.Current.CancellationToken);
+
+        // Assert: the transforms genuinely ran against the outbound request, which is the only way a
+        // test can observe what a downstream would receive without a network hop.
+        Header(context, RecordingHttpForwarder.RouteTraceEchoHeader).Should().Be("events-route");
+        Header(context, RecordingHttpForwarder.ClusterTraceEchoHeader).Should().Be("conference");
+    }
+
+    [Fact]
+    public async Task SendAsync_EchoesTheUnsetMarker_WhenTheTransformsStampNoTraceHeaders()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+
+        // Act
+        await new RecordingHttpForwarder().SendAsync(
+            context,
+            DestinationPrefix,
+            NoopInvoker,
+            new ForwarderRequestConfig(),
+            new StampingTransformer(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Header(context, RecordingHttpForwarder.RouteTraceEchoHeader).Should().Be(RecordingHttpForwarder.UnsetValue);
+        Header(context, RecordingHttpForwarder.ClusterTraceEchoHeader).Should().Be(RecordingHttpForwarder.UnsetValue);
+    }
+
+    [Fact]
+    public async Task SendAsync_HonorsCustomTraceHeaderNames()
+    {
+        // Arrange: a gateway that renamed its trace headers still gets an observable echo.
+        var context = new DefaultHttpContext();
+        var forwarder = new RecordingHttpForwarder
+        {
+            RouteTraceHeaderName = "X-Custom-Route",
+            ClusterTraceHeaderName = "X-Custom-Cluster",
+        };
+
+        // Act
+        await forwarder.SendAsync(
+            context,
+            DestinationPrefix,
+            NoopInvoker,
+            new ForwarderRequestConfig(),
+            new StampingTransformer(routeTrace: "r", clusterTrace: "c", routeHeader: "X-Custom-Route", clusterHeader: "X-Custom-Cluster"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Header(context, RecordingHttpForwarder.RouteTraceEchoHeader).Should().Be("r");
+        Header(context, RecordingHttpForwarder.ClusterTraceEchoHeader).Should().Be("c");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutACancellationToken_BehavesLikeTheTokenOverload()
+    {
+        // Arrange: YARP's interface carries both overloads and its middleware may call either.
+        var context = new DefaultHttpContext();
+
+        // Act
+        var error = await new RecordingHttpForwarder().SendAsync(
+            context, DestinationPrefix, NoopInvoker, new ForwarderRequestConfig(), new StampingTransformer());
+
+        // Assert
+        error.Should().Be(ForwarderError.None);
+        Header(context, RecordingHttpForwarder.DestinationHeader).Should().Be(DestinationPrefix);
+    }
+
+    private static HttpMessageInvoker NoopInvoker => new(new HttpClientHandler());
+
+    private static string? Header(HttpContext context, string name) =>
+        context.Response.Headers.TryGetValue(name, out var values) ? values.ToString() : null;
+
+    /// <summary>
+    /// A transformer that stands in for the gateway's real request-transform chain: it stamps the
+    /// route and cluster trace headers onto the OUTBOUND request, exactly where the shipped
+    /// <c>GatewayTraceHeaderTransformProvider</c> puts them.
+    /// </summary>
+    private sealed class StampingTransformer(
+        string? routeTrace = null,
+        string? clusterTrace = null,
+        string routeHeader = "X-MMCA-Route",
+        string clusterHeader = "X-MMCA-Cluster") : HttpTransformer
+    {
+        public override ValueTask TransformRequestAsync(
+            HttpContext httpContext,
+            HttpRequestMessage proxyRequest,
+            string destinationPrefix,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(proxyRequest);
+
+            if (routeTrace is not null)
+            {
+                proxyRequest.Headers.TryAddWithoutValidation(routeHeader, routeTrace);
+            }
+
+            if (clusterTrace is not null)
+            {
+                proxyRequest.Headers.TryAddWithoutValidation(clusterHeader, clusterTrace);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/packages.lock.json
@@ -1116,6 +1116,7 @@
           "System.IdentityModel.Tokens.Jwt": "[8.22.0, )",
           "Testcontainers.MsSql": "[4.14.0, )",
           "Testcontainers.RabbitMq": "[4.14.0, )",
+          "Yarp.ReverseProxy": "[2.3.0, )",
           "xunit.v3.extensibility.core": "[4.0.0, )"
         }
       },
@@ -1580,6 +1581,15 @@
         "contentHash": "+tTe9VX2vwrUHGI48FE4ly956Ry084wPH4I/7g5D36AkAMGjQRZZDVz8eH2GwX/CLS9PDQRSca534WyrAYsyzw==",
         "dependencies": {
           "xunit.v3.common": "[4.0.0]"
+        }
+      },
+      "Yarp.ReverseProxy": {
+        "type": "CentralTransitive",
+        "requested": "[2.3.0, )",
+        "resolved": "2.3.0",
+        "contentHash": "gxtkN3a+9biu9V9Zd5NaTO6VZWXAnS2mhQ0R/VXmSPoTuiQNZsakKikrKpDtKxrL5nUYzbRsHtl40WNq+ZBKKg==",
+        "dependencies": {
+          "System.IO.Hashing": "8.0.0"
         }
       }
     }

--- a/Tests/Presentation/MMCA.Common.API.Tests/Caching/OutputCacheEvictTagsTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Caching/OutputCacheEvictTagsTests.cs
@@ -1,0 +1,118 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.API.Caching;
+using Moq;
+
+namespace MMCA.Common.API.Tests.Caching;
+
+/// <summary>
+/// Unit tests for the multi-tag eviction helpers on <see cref="IOutputCacheStore"/>. They replace the
+/// per-controller private helpers that wrapped a run of <c>EvictByTagAsync</c> calls, so what matters
+/// is that every named tag is evicted, in order, and that the best-effort variant never lets a cache
+/// outage surface as a failure of the write it follows.
+/// </summary>
+public sealed class OutputCacheEvictTagsTests
+{
+    [Fact]
+    public async Task EvictTagsAsync_EvictsEveryTagInOrder()
+    {
+        var evicted = new List<string>();
+        var store = new Mock<IOutputCacheStore>();
+        store.Setup(s => s.EvictByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback((string tag, CancellationToken _) => evicted.Add(tag))
+            .Returns(ValueTask.CompletedTask);
+
+        await store.Object.EvictTagsAsync(CancellationToken.None, "conference:sessions", "conference");
+
+        evicted.Should().Equal("conference:sessions", "conference");
+    }
+
+    [Fact]
+    public async Task EvictTagsAsync_PassesTheCallersToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var store = new Mock<IOutputCacheStore>();
+
+        await store.Object.EvictTagsAsync(cts.Token, "catalog:products");
+
+        store.Verify(s => s.EvictByTagAsync("catalog:products", cts.Token), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvictTagsAsync_WithNoTags_DoesNotTouchTheStore()
+    {
+        var store = new Mock<IOutputCacheStore>(MockBehavior.Strict);
+
+        var act = async () => await store.Object.EvictTagsAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task EvictTagsAsync_PropagatesAStoreFailure()
+    {
+        var store = new Mock<IOutputCacheStore>();
+        store.Setup(s => s.EvictByTagAsync("conference", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var act = async () => await store.Object.EvictTagsAsync(CancellationToken.None, "conference");
+
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "the plain helper is a straight sequence of evictions; a caller that wants the failure swallowed uses TryEvictTagsAsync");
+    }
+
+    [Fact]
+    public async Task TryEvictTagsAsync_EvictsEveryTag()
+    {
+        var evicted = new List<string>();
+        var store = new Mock<IOutputCacheStore>();
+        store.Setup(s => s.EvictByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback((string tag, CancellationToken _) => evicted.Add(tag))
+            .Returns(ValueTask.CompletedTask);
+
+        await store.Object.TryEvictTagsAsync(NullLogger.Instance, "catalog:products", "catalog");
+
+        evicted.Should().Equal("catalog:products", "catalog");
+    }
+
+    [Fact]
+    public async Task TryEvictTagsAsync_EvictsUnderNoneSoADisconnectedClientDoesNotAbandonTheCleanup()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var store = new Mock<IOutputCacheStore>();
+
+        await store.Object.TryEvictTagsAsync(NullLogger.Instance, "catalog:products");
+
+        store.Verify(s => s.EvictByTagAsync("catalog:products", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryEvictTagsAsync_SwallowsAStoreFailureAndKeepsGoing()
+    {
+        var store = new Mock<IOutputCacheStore>();
+        store.Setup(s => s.EvictByTagAsync("catalog:products", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var act = async () => await store.Object.TryEvictTagsAsync(
+            NullLogger.Instance, "catalog:products", "catalog");
+
+        await act.Should().NotThrowAsync(
+            "the mutation has already committed, so a cache outage must not turn a successful write into a client-visible error");
+        store.Verify(s => s.EvictByTagAsync("catalog", It.IsAny<CancellationToken>()), Times.Once,
+            "a failure on one tag must not skip the rest");
+    }
+
+    [Fact]
+    public async Task NullStore_IsRejected()
+    {
+        IOutputCacheStore store = null!;
+
+        var evict = async () => await store.EvictTagsAsync(CancellationToken.None, "tag");
+        var tryEvict = async () => await store.TryEvictTagsAsync(NullLogger.Instance, "tag");
+
+        await evict.Should().ThrowAsync<ArgumentNullException>();
+        await tryEvict.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Startup/JwtAuthorityExtensionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Startup/JwtAuthorityExtensionsTests.cs
@@ -1,0 +1,62 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using MMCA.Common.API.Startup;
+
+namespace MMCA.Common.API.Tests.Startup;
+
+/// <summary>
+/// Unit tests for the JWKS-authority guard every extracted service ran inline before
+/// <c>AddForwardedJwtBearer</c>. The failure message is part of the contract: it is the only thing
+/// that tells an operator the AppHost never wired <c>WithJwksDiscovery</c>, so it is asserted
+/// verbatim rather than by type alone.
+/// </summary>
+public sealed class JwtAuthorityExtensionsTests
+{
+    private const string ExpectedMessage =
+        "Authentication:JwtBearer:Authority is not configured. " +
+        "Wire .WithJwksDiscovery(identityService) in the AppHost.";
+
+    private static IConfiguration Config(string? authority) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [JwtAuthorityExtensions.JwtAuthorityConfigKey] = authority,
+            })
+            .Build();
+
+    [Fact]
+    public void ConfiguredAuthority_IsReturned() =>
+        Config("http://identity").GetRequiredJwtAuthority().Should().Be("http://identity");
+
+    [Fact]
+    public void MissingAuthority_ThrowsWithTheWiringInstruction()
+    {
+        var act = () => Config(null).GetRequiredJwtAuthority();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage(ExpectedMessage);
+    }
+
+    [Fact]
+    public void BlankAuthority_IsPassedThroughUnchanged() =>
+        // Exactly what the five inline guards this replaced did: a null check, not a blank check.
+        // A configured-but-blank authority is rejected one line later by AddForwardedJwtBearer's own
+        // ArgumentException.ThrowIfNullOrWhiteSpace, so the guard deliberately does not duplicate it
+        // and the hoist stays behavior-identical.
+        Config(string.Empty).GetRequiredJwtAuthority().Should().BeEmpty();
+
+    [Fact]
+    public void ConfigKey_MatchesTheOneTheAppHostInjects() =>
+        JwtAuthorityExtensions.JwtAuthorityConfigKey.Should().Be(
+            "Authentication:JwtBearer:Authority",
+            "WithJwksDiscovery sets Authentication__JwtBearer__Authority; renaming the key silently breaks every service host");
+
+    [Fact]
+    public void NullConfiguration_IsRejected()
+    {
+        IConfiguration configuration = null!;
+
+        var act = () => configuration.GetRequiredJwtAuthority();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Startup/ModuleHostExtensionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Startup/ModuleHostExtensionsTests.cs
@@ -1,0 +1,155 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.API.Startup;
+using MMCA.Common.Application.Modules;
+using MMCA.Common.Application.Settings;
+
+namespace MMCA.Common.API.Tests.Startup;
+
+/// <summary>
+/// Unit tests for <c>AddModuleHost</c>, the settings-bind plus <see cref="ModuleLoader"/>
+/// construction every module-hosting service repeated verbatim. The contract is deliberately narrow:
+/// it binds, builds and registers, and it does NOT run discovery, because discovery has to sit at a
+/// host-chosen position inside the ADR-014 application pipeline.
+/// </summary>
+public sealed class ModuleHostExtensionsTests
+{
+    private static WebApplicationBuilder CreateBuilder(params (string Key, string? Value)[] settings)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.Logging.ClearProviders();
+        builder.Configuration.AddInMemoryCollection(
+            settings.Select(s => new KeyValuePair<string, string?>(s.Key, s.Value)));
+
+        return builder;
+    }
+
+    private static (string Key, string? Value)[] MinimalApplicationSettings() =>
+        [("ApplicationSettings:MaxPageSize", "250")];
+
+    [Fact]
+    public void BindsApplicationSettingsForBothTheOptionsGraphAndTheReturnedContext()
+    {
+        var builder = CreateBuilder(("ApplicationSettings:MaxPageSize", "250"));
+
+        var moduleHost = builder.AddModuleHost();
+
+        moduleHost.ApplicationSettings.MaxPageSize.Should().Be(250);
+
+        using var provider = builder.Services.BuildServiceProvider();
+        provider.GetRequiredService<IOptions<ApplicationSettings>>().Value.MaxPageSize.Should().Be(250);
+    }
+
+    [Fact]
+    public void MissingApplicationSettingsSection_FailsFast()
+    {
+        var builder = CreateBuilder();
+
+        var act = () => builder.AddModuleHost();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("ApplicationSettings section is not configured.");
+    }
+
+    [Fact]
+    public void BindsModulesSettings()
+    {
+        var builder = CreateBuilder(
+            [.. MinimalApplicationSettings(), ("Modules:Tickets:Enabled", "true")]);
+
+        var moduleHost = builder.AddModuleHost();
+
+        moduleHost.ModulesSettings.Should().ContainKey("Tickets");
+        moduleHost.ModulesSettings["Tickets"].Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MissingModulesSection_YieldsEmptySettingsRatherThanNull()
+    {
+        var builder = CreateBuilder(MinimalApplicationSettings());
+
+        var moduleHost = builder.AddModuleHost();
+
+        moduleHost.ModulesSettings.Should().BeEmpty(
+            "a host with no Modules section runs every discovered module, exactly as before the hoist");
+    }
+
+    [Fact]
+    public void RegistersTheLoaderAsASingletonSoTheRestOfTheHostResolvesTheSameInstance()
+    {
+        var builder = CreateBuilder(MinimalApplicationSettings());
+
+        var moduleHost = builder.AddModuleHost();
+
+        using var provider = builder.Services.BuildServiceProvider();
+        provider.GetRequiredService<ModuleLoader>().Should().BeSameAs(moduleHost.ModuleLoader);
+    }
+
+    [Fact]
+    public void SuppliedLogger_IsUsedForDiscoveryDiagnostics()
+    {
+        var builder = CreateBuilder(MinimalApplicationSettings());
+        ILogger<ModuleLoader> logger = NullLoggerFactory.Instance.CreateLogger<ModuleLoader>();
+
+        var moduleHost = builder.AddModuleHost(logger);
+
+        moduleHost.ModuleLoader.Logger.Should().BeSameAs(logger);
+    }
+
+    [Fact]
+    public void NoLogger_LeavesTheLoadersOwnNullLoggerDefault()
+    {
+        var builder = CreateBuilder(MinimalApplicationSettings());
+
+        var moduleHost = builder.AddModuleHost();
+
+        moduleHost.ModuleLoader.Logger.Should().BeOfType<NullLogger<ModuleLoader>>();
+    }
+
+    [Fact]
+    public void DoesNotRunDiscoveryItself()
+    {
+        var builder = CreateBuilder(MinimalApplicationSettings());
+
+        var moduleHost = builder.AddModuleHost();
+
+        ReadCapturedModulesSettings(moduleHost.ModuleLoader).Should().BeNull(
+            "discovery belongs inside the host's application pipeline, between AddApplication and AddApplicationDecorators");
+    }
+
+    // There is deliberately no test driving RegisterModules through to a real discovery pass: it
+    // calls ModuleLoader's AppDomain-scanning overload, exactly as the hosts do, and in a test
+    // process that scan sweeps in whatever IModule types other test classes happen to have created
+    // (Moq's dynamic proxies among them), which would make the outcome depend on run order.
+    [Fact]
+    public void RegisterModules_RejectsANullServiceCollection()
+    {
+        var builder = CreateBuilder(MinimalApplicationSettings());
+        var moduleHost = builder.AddModuleHost();
+
+        var act = () => moduleHost.RegisterModules(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Reads the settings the loader captured on its last <c>DiscoverAndRegister</c> call. Private
+    /// state, but it is the only observable proof that the hoisted bind actually reached discovery
+    /// (the loader is sealed, so it cannot be mocked); the same reflection idiom is already used by
+    /// <c>DependencyInjectionTests</c>.
+    /// </summary>
+    private static ModulesSettings? ReadCapturedModulesSettings(ModuleLoader loader) =>
+        (ModulesSettings?)typeof(ModuleLoader)
+            .GetField("_modulesSettings", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(loader);
+}

--- a/Tests/Presentation/MMCA.Common.Grpc.Tests/ResultGrpcExtensionsDecoderTests.cs
+++ b/Tests/Presentation/MMCA.Common.Grpc.Tests/ResultGrpcExtensionsDecoderTests.cs
@@ -1,0 +1,243 @@
+using AwesomeAssertions;
+using Grpc.Core;
+using MMCA.Common.Shared.Abstractions;
+using Xunit;
+
+namespace MMCA.Common.Grpc.Tests;
+
+/// <summary>
+/// The decoder half of the shipped trailer contract: <c>Metadata.ToErrors()</c> and
+/// <c>RpcException.ToResult()</c> read back exactly what <c>ToRpcException</c> wrote, so a
+/// <see cref="Result"/> failure survives a gRPC hop unchanged. A transport fault that carries no
+/// structured trailers still reaches the caller as a failure rather than an exception.
+/// </summary>
+public sealed class ResultGrpcExtensionsDecoderTests
+{
+    // ── Round trip: encode then decode reproduces the original errors ──
+    [Fact]
+    public void ToErrors_AfterToRpcException_ReproducesEveryErrorExactly()
+    {
+        // Arrange
+        IReadOnlyList<Error> original =
+        [
+            Error.Conflict("Test.Conflict", "Already exists", source: "TestService", target: "Name"),
+            Error.Validation("Test.Validation", "Bad input"),
+            Error.Unexpected("Test.Unexpected", "Boom", source: "Inner"),
+        ];
+
+        // Act
+        var encoded = original.ToRpcException();
+        IReadOnlyList<Error> decoded = encoded.Trailers.ToErrors();
+
+        // Assert
+        decoded.Should().BeEquivalentTo(original, options => options.WithStrictOrdering());
+    }
+
+    [Theory]
+    [InlineData(ErrorType.Validation)]
+    [InlineData(ErrorType.Invariant)]
+    [InlineData(ErrorType.NotFound)]
+    [InlineData(ErrorType.Conflict)]
+    [InlineData(ErrorType.Unauthorized)]
+    [InlineData(ErrorType.Forbidden)]
+    [InlineData(ErrorType.UnprocessableEntity)]
+    [InlineData(ErrorType.Failure)]
+    [InlineData(ErrorType.Unexpected)]
+    public void ToErrors_RoundTripsEveryErrorType(ErrorType errorType)
+    {
+        // Arrange
+        IReadOnlyList<Error> original = [new Error("Test.Code", "Test message", errorType, "Source", "Target")];
+
+        // Act
+        IReadOnlyList<Error> decoded = original.ToRpcException().Trailers.ToErrors();
+
+        // Assert
+        decoded.Should().ContainSingle();
+        decoded[0].Type.Should().Be(errorType);
+        decoded[0].Code.Should().Be("Test.Code");
+        decoded[0].Message.Should().Be("Test message");
+        decoded[0].Source.Should().Be("Source");
+        decoded[0].Target.Should().Be("Target");
+    }
+
+    [Fact]
+    public void ToErrors_WhenSourceAndTargetWereAbsent_DecodesThemAsNull()
+    {
+        // Arrange: the encoder omits an empty source/target entirely
+        IReadOnlyList<Error> original = [Error.NotFoundError("Test.NotFound", "Item not found")];
+
+        // Act
+        IReadOnlyList<Error> decoded = original.ToRpcException().Trailers.ToErrors();
+
+        // Assert
+        decoded[0].Source.Should().BeNull();
+        decoded[0].Target.Should().BeNull();
+    }
+
+    // ── Decoding trailers directly ──
+    [Fact]
+    public void ToErrors_WithNoTrailers_ReturnsEmpty() =>
+        new Metadata().ToErrors().Should().BeEmpty();
+
+    [Fact]
+    public void ToErrors_WithNullTrailers_ReturnsEmpty()
+    {
+        // Arrange
+        Metadata? trailers = null;
+
+        // Act + Assert
+        trailers.ToErrors().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToErrors_StopsAtTheFirstMissingIndex()
+    {
+        // Arrange: index 0 present, index 1 skipped, index 2 present but unreachable
+        var trailers = new Metadata
+        {
+            { "error-0-code", "First.Code" },
+            { "error-0-message", "First message" },
+            { "error-0-type", "Validation" },
+            { "error-2-code", "Third.Code" },
+            { "error-2-message", "Third message" },
+            { "error-2-type", "Validation" },
+        };
+
+        // Act
+        IReadOnlyList<Error> decoded = trailers.ToErrors();
+
+        // Assert
+        decoded.Should().ContainSingle("the encoder writes contiguous indices, so a gap ends the sequence");
+        decoded[0].Code.Should().Be("First.Code");
+    }
+
+    [Fact]
+    public void ToErrors_WithMissingMessage_DecodesTheEmptyString()
+    {
+        // Arrange
+        var trailers = new Metadata
+        {
+            { "error-0-code", "Test.Code" },
+            { "error-0-type", "Validation" },
+        };
+
+        // Act
+        IReadOnlyList<Error> decoded = trailers.ToErrors();
+
+        // Assert
+        decoded[0].Message.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("notAType")]
+    [InlineData("validation")]
+    public void ToErrors_WithUnrecognizedType_FallsBackToFailure(string typeText)
+    {
+        // Arrange: the wire form is the exact enum member name, matched case-sensitively
+        var trailers = new Metadata
+        {
+            { "error-0-code", "Test.Code" },
+            { "error-0-message", "Test message" },
+            { "error-0-type", typeText },
+        };
+
+        // Act
+        IReadOnlyList<Error> decoded = trailers.ToErrors();
+
+        // Assert
+        decoded[0].Type.Should().Be(
+            ErrorType.Failure,
+            "a newer peer adding an error type must not break an older client");
+    }
+
+    // ── RpcException.ToResult ──
+    [Fact]
+    public void ToResult_WithStructuredTrailers_ReturnsTheDecodedErrors()
+    {
+        // Arrange
+        IReadOnlyList<Error> original = [Error.NotFoundError("Session.NotFound", "Session not found", source: "Svc")];
+        var exception = original.ToRpcException();
+
+        // Act
+        var result = exception.ToResult();
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void ToResultOfT_WithStructuredTrailers_ReturnsTheDecodedErrors()
+    {
+        // Arrange
+        IReadOnlyList<Error> original = [Error.Forbidden("Session.Forbidden", "Access denied.")];
+        var exception = original.ToRpcException();
+
+        // Act
+        var result = exception.ToResult<int>();
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().BeEquivalentTo(original);
+        result.Value.Should().Be(0);
+    }
+
+    [Fact]
+    public void ToResult_WithoutTrailers_SynthesizesATransportError()
+    {
+        // Arrange
+        var exception = new RpcException(new Status(StatusCode.Unavailable, "Connection reset"));
+
+        // Act
+        var result = exception.ToResult("GetEventLiveInfoAsync");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle();
+        result.Errors[0].Code.Should().Be("Grpc.Unavailable");
+        result.Errors[0].Message.Should().Be("Connection reset");
+        result.Errors[0].Source.Should().Be("GetEventLiveInfoAsync");
+        result.Errors[0].Type.Should().Be(ErrorType.Failure);
+    }
+
+    [Fact]
+    public void ToResultOfT_WithoutTrailers_SynthesizesATransportError()
+    {
+        // Arrange
+        var exception = new RpcException(new Status(StatusCode.DeadlineExceeded, "Deadline Exceeded"));
+
+        // Act
+        var result = exception.ToResult<string>("GetSessionIdsByEventAsync");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Errors[0].Code.Should().Be("Grpc.DeadlineExceeded");
+        result.Errors[0].Source.Should().Be("GetSessionIdsByEventAsync");
+    }
+
+    [Fact]
+    public void ToResult_WhenSourceOmitted_StampsTheCallingMember()
+    {
+        // Arrange
+        var exception = new RpcException(new Status(StatusCode.Internal, "Boom"));
+
+        // Act
+        var result = exception.ToResult();
+
+        // Assert
+        result.Errors[0].Source.Should().Be(
+            nameof(ToResult_WhenSourceOmitted_StampsTheCallingMember),
+            "the source defaults to the caller, which is what the hand-written adapters passed by hand");
+    }
+
+    [Fact]
+    public void ToResult_WithNullException_ThrowsArgumentNullException()
+    {
+        // Arrange
+        RpcException exception = null!;
+
+        // Act + Assert
+        FluentActions.Invoking(() => exception.ToResult("Any"))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/BunitTestBase.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/BunitTestBase.cs
@@ -32,5 +32,10 @@ public abstract class BunitTestBase : BunitComponentTestBase
         // cannot register these (it deliberately does not reference MMCA.Common.UI).
         Services.AddSingleton<IExternalAuthBroker, UnavailableExternalAuthBroker>();
         Services.AddSingleton<IConnectivityStatusService, AlwaysOnlineConnectivityStatusService>();
+
+        // Shareable public links (share/copy-link/QR components). The browser-origin default, which
+        // resolves against bUnit's http://localhost/ base uri; a test that cares about the MAUI
+        // public-site behaviour substitutes its own builder.
+        Services.AddScoped<IPublicLinkBuilder, NavigationPublicLinkBuilder>();
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/ApiFileDownloadButtonTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/ApiFileDownloadButtonTests.cs
@@ -1,0 +1,284 @@
+using System.Net;
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Common.Settings;
+using MMCA.Common.UI.Components;
+using MMCA.Common.UI.Services.Capabilities;
+using MMCA.Common.UI.Services.Capabilities.Fallbacks;
+using Moq;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// bUnit tests for <see cref="ApiFileDownloadButton"/> (ADR-042): browsers get a plain download
+/// link built on the browser-reachable API base, while native heads (link-intercepting hosts) fetch
+/// the bytes, stage a temp file, and open the share sheet with the caller's content type. Every
+/// failure path has to toast rather than escape: on the native heads an unhandled exception in an
+/// OnClick callback is fatal to the host.
+/// </summary>
+public sealed class ApiFileDownloadButtonTests : BunitTestBase
+{
+    private static readonly byte[] PayloadBytes = "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"u8.ToArray();
+
+    public ApiFileDownloadButtonTests()
+    {
+        // The button injects both capabilities unconditionally (it branches on InterceptsLinks at
+        // render time), so the shared null fallbacks stand in for the web head; the native-head
+        // arrangements below override them with plain Adds (last registration wins).
+        Services.AddSingleton<IExternalLinkService, NullExternalLinkService>();
+        Services.AddSingleton<IShareService, NullShareService>();
+    }
+
+    [Fact]
+    public void OnWeb_RendersDownloadLinkOnBrowserReachableApiBase()
+    {
+        // The Server head's ApiEndpoint may be container-internal; the anchor must prefer
+        // WasmApiEndpoint (the externally reachable gateway URL).
+        ArrangeWebHead();
+
+        var cut = RenderButton();
+
+        var anchor = cut.Find("a");
+        anchor.GetAttribute("href").Should().Be("https://gateway.test/Sessions/42/ics");
+        anchor.GetAttribute("aria-label").Should().Be("Add to calendar");
+    }
+
+    [Fact]
+    public void OnWeb_WithoutAnAriaLabel_FallsBackToTheLocalizedDefault()
+    {
+        ArrangeWebHead();
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/42/ics")
+            .Add(c => c.FileName, "session-42.ics")
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+
+        cut.Find("a").GetAttribute("aria-label").Should().Be("Download");
+    }
+
+    [Fact]
+    public async Task OnNativeHead_FetchesTheFileAndOpensTheShareSheet()
+    {
+        ArrangeWebHead();
+        ArrangeLinkInterceptingHead();
+
+        using var handler = new CapturingHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+        Services.AddSingleton(HttpTestDoubles.ClientFactory(handler));
+
+        string? sharedPath = null;
+        var share = new Mock<IShareService>();
+        share
+            .Setup(x => x.ShareFileAsync("Intro to Blazor", It.IsAny<string>(), "text/calendar", It.IsAny<CancellationToken>()))
+            .Callback((string _, string path, string _, CancellationToken _) => sharedPath = path)
+            .ReturnsAsync(true);
+        Services.AddSingleton(share.Object);
+
+        var cut = RenderButton();
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        handler.Requests.Should().ContainSingle()
+            .Which.Uri!.AbsoluteUri.Should().Be("https://gateway.test/Sessions/42/ics");
+        share.Verify(
+            x => x.ShareFileAsync("Intro to Blazor", It.IsAny<string>(), "text/calendar", It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The staged temp file carries the downloaded document.
+        sharedPath.Should().NotBeNull();
+        (await File.ReadAllBytesAsync(sharedPath!, Xunit.TestContext.Current.CancellationToken)).Should().Equal(PayloadBytes);
+        File.Delete(sharedPath!);
+    }
+
+    [Fact]
+    public async Task OnNativeHead_WhenNoShareSurfaceAccepts_WarnsWithTheCallersMessage()
+    {
+        var snackbar = ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+
+        var share = new Mock<IShareService>();
+        share
+            .Setup(x => x.ShareFileAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        Services.AddSingleton(share.Object);
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/43/ics")
+            .Add(c => c.FileName, "session-43.ics")
+            .Add(c => c.ShareTitle, "Intro to Blazor")
+            .Add(c => c.UnavailableMessage, "Calendar export is not available on this device"));
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        VerifyToast(snackbar, "Calendar export is not available on this device");
+        File.Delete(Path.Combine(Path.GetTempPath(), "session-43.ics"));
+    }
+
+    [Fact]
+    public async Task OnNativeHead_WhenTheDownloadTimesOut_WarnsInsteadOfKillingTheHost()
+    {
+        // No token is passed to GetByteArrayAsync, so an HttpClient timeout surfaces as an
+        // OperationCanceledException. This is an OnClick callback, and on the native heads an
+        // escaping exception is fatal to the host.
+        var snackbar = ArrangeNativeHead(_ => throw new TaskCanceledException("timeout"));
+
+        var cut = RenderButton();
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        VerifyToast(snackbar, "Could not download the file");
+    }
+
+    [Fact]
+    public async Task OnNativeHead_WhenTheServerFails_WarnsInsteadOfKillingTheHost()
+    {
+        var snackbar = ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var cut = RenderButton();
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        VerifyToast(snackbar, "Could not download the file");
+    }
+
+    [Fact]
+    public async Task OnNativeHead_WhenStagingTheFileFails_WarnsInsteadOfKillingTheHost()
+    {
+        // An IOException from the temp-file write escaped the HttpRequestException-only catch.
+        // A file name that is a directory separator makes the write fail deterministically.
+        var snackbar = ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/42/ics")
+            .Add(c => c.FileName, "no-such-directory/session-42.ics")
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        VerifyToast(snackbar, "Could not download the file");
+    }
+
+    [Fact]
+    public async Task OnNativeHead_ReplacesAStaleStagedFileBeforeSharing()
+    {
+        // Every tap writes to the same per-entity path, so a leftover from a previous tap must not
+        // survive into the share. Deleting AFTER the share is deliberately not done: on Android
+        // the intent returns as soon as it launches and the delete would race the receiving app.
+        var stalePath = Path.Combine(Path.GetTempPath(), "session-99.ics");
+        await File.WriteAllBytesAsync(stalePath, "STALE"u8.ToArray(), Xunit.TestContext.Current.CancellationToken);
+
+        ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+
+        string? sharedPath = null;
+        var share = new Mock<IShareService>();
+        share
+            .Setup(x => x.ShareFileAsync(
+                "Intro to Blazor", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string path, string _, CancellationToken _) => sharedPath = path)
+            .ReturnsAsync(true);
+        Services.AddSingleton(share.Object);
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/99/ics")
+            .Add(c => c.FileName, "session-99.ics")
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        sharedPath.Should().Be(stalePath);
+        (await File.ReadAllBytesAsync(stalePath, Xunit.TestContext.Current.CancellationToken)).Should().Equal(PayloadBytes);
+        File.Delete(stalePath);
+    }
+
+    [Fact]
+    public async Task OnNativeHead_DefaultsToTheOctetStreamContentType()
+    {
+        ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+
+        string? contentType = null;
+        var share = new Mock<IShareService>();
+        share
+            .Setup(x => x.ShareFileAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string _, string type, CancellationToken _) => contentType = type)
+            .ReturnsAsync(true);
+        Services.AddSingleton(share.Object);
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Exports/44")
+            .Add(c => c.FileName, "export-44.bin")
+            .Add(c => c.ShareTitle, "Export"));
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        contentType.Should().Be("application/octet-stream");
+        File.Delete(Path.Combine(Path.GetTempPath(), "export-44.bin"));
+    }
+
+    private IRenderedComponent<ApiFileDownloadButton> RenderButton() =>
+        RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/42/ics")
+            .Add(c => c.FileName, "session-42.ics")
+            .Add(c => c.ShareTitle, "Intro to Blazor")
+            .Add(c => c.ContentType, "text/calendar")
+            .Add(c => c.AriaLabel, "Add to calendar"));
+
+    private void ArrangeWebHead()
+    {
+        // The client factory is injected even on the web path (only the click handler uses it), so
+        // a never-called double keeps the anchor-rendering tests focused on the URL.
+        Services.AddSingleton(HttpTestDoubles.ClientFactory(
+            new CapturingHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))));
+        ArrangeApiSettings();
+    }
+
+    private void ArrangeApiSettings() =>
+        Services.AddSingleton(Options.Create(new ApiSettings
+        {
+            ApiEndpoint = "http://internal-gateway/",
+            WasmApiEndpoint = "https://gateway.test/",
+        }));
+
+    private void ArrangeLinkInterceptingHead()
+    {
+        var externalLink = new Mock<IExternalLinkService>();
+        externalLink.SetupGet(x => x.InterceptsLinks).Returns(true);
+        Services.AddSingleton(externalLink.Object);
+    }
+
+    private Mock<ISnackbar> ArrangeNativeHead(Func<HttpRequestMessage, HttpResponseMessage> respond)
+    {
+        ArrangeWebHead();
+        ArrangeLinkInterceptingHead();
+
+        var handler = new CapturingHttpMessageHandler(respond);
+        Services.AddSingleton(HttpTestDoubles.ClientFactory(handler));
+
+        // Last registration wins, so this recording double replaces the base's real snackbar.
+        var snackbar = new Mock<ISnackbar>();
+        Services.AddSingleton(snackbar.Object);
+
+        return snackbar;
+    }
+
+    private static void VerifyToast(Mock<ISnackbar> snackbar, string message) =>
+        snackbar.Verify(
+            s => s.Add(
+                message,
+                Severity.Warning,
+                It.IsAny<Action<SnackbarOptions>>(),
+                It.IsAny<string>()),
+            Times.Once);
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/ErrorSummaryExtensionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/ErrorSummaryExtensionsTests.cs
@@ -1,0 +1,56 @@
+using AwesomeAssertions;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers the shipped <c>ErrorSummaryMessages()</c> reader in <c>MMCA.Common.Testing.UI</c>. The
+/// reason it exists at all is the shape asymmetry it hides: <see cref="ErrorSummary"/> renders
+/// SEVERAL messages as a list but a SINGLE one as plain text inside the alert, so a form test that
+/// queried only <c>li</c> would read an empty summary exactly when one rule is broken.
+/// </summary>
+public sealed class ErrorSummaryExtensionsTests : BunitTestBase
+{
+    private const string Title = "Please fix the following";
+
+    [Fact]
+    public void ErrorSummaryMessages_IsEmpty_WhenNoSummaryIsRendered()
+    {
+        var cut = RenderUnderTest<ErrorSummary>(_ => { });
+
+        cut.ErrorSummaryMessages().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ErrorSummaryMessages_ReadsTheSingleMessageShape_AndStripsTheTitle()
+    {
+        // A single broken rule renders as plain text inside the alert, NOT as a list item.
+        var cut = RenderUnderTest<ErrorSummary>(p => p
+            .Add(c => c.Title, Title)
+            .Add(c => c.Messages, ["Name is required."]));
+
+        cut.ErrorSummaryMessages().Should().ContainSingle().Which.Should().Be("Name is required.");
+    }
+
+    [Fact]
+    public void ErrorSummaryMessages_ReadsTheListShape_OneEntryPerRule()
+    {
+        var cut = RenderUnderTest<ErrorSummary>(p => p
+            .Add(c => c.Title, Title)
+            .Add(c => c.Messages, ["Name is required.", "Email is required."]));
+
+        cut.ErrorSummaryMessages().Should().Equal("Name is required.", "Email is required.");
+    }
+
+    [Fact]
+    public void ErrorSummaryMessages_IsEmpty_WhenTheAlertCarriesNoSummaryTitle()
+    {
+        // The title class is the marker that identifies the summary's alert among any others on the
+        // page, so a titleless summary is deliberately not claimed by this reader.
+        var cut = RenderUnderTest<ErrorSummary>(p => p
+            .Add(c => c.Messages, ["Name is required."]));
+
+        cut.ErrorSummaryMessages().Should().BeEmpty();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/InfiniteScrollSentinelTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/InfiniteScrollSentinelTests.cs
@@ -1,0 +1,82 @@
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// bUnit tests for <see cref="InfiniteScrollSentinel"/>: the observer-only companion a page renders
+/// when it owns its own card markup. What matters here is the contract with the shared
+/// <c>infinite-scroll.js</c> module (the fixed <c>OnSentinelVisible</c> callback name), the
+/// accessible progress row, and that disposal after the last page is silent.
+/// </summary>
+public sealed class InfiniteScrollSentinelTests : BunitTestBase
+{
+    [Fact]
+    public void RendersTheSentinelElement()
+    {
+        var cut = RenderUnderTest<InfiniteScrollSentinel>(_ => { });
+
+        cut.Find("div.infinite-scroll-sentinel").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WhileIdle_RendersNoProgressRow()
+    {
+        var cut = RenderUnderTest<InfiniteScrollSentinel>(p => p.Add(c => c.IsLoading, false));
+
+        cut.FindAll("[role=status]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WhileLoading_RendersAPoliteProgressRow()
+    {
+        var cut = RenderUnderTest<InfiniteScrollSentinel>(p => p
+            .Add(c => c.IsLoading, true)
+            .Add(c => c.LoadingLabel, "Loading more sessions"));
+
+        var status = cut.Find("[role=status]");
+        status.GetAttribute("aria-live").Should().Be("polite");
+        status.GetAttribute("aria-busy").Should().Be("true");
+        cut.Markup.Should().Contain("Loading more sessions");
+    }
+
+    [Fact]
+    public async Task OnSentinelVisible_RaisesTheHostCallback()
+    {
+        var appended = 0;
+        var cut = RenderUnderTest<InfiniteScrollSentinel>(p => p
+            .Add(c => c.OnVisible, EventCallback.Factory.Create(this, () => appended++)));
+
+        await cut.Instance.OnSentinelVisible();
+
+        appended.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AfterDisposal_TheCallbackIsSuppressed()
+    {
+        // The host stops rendering the sentinel the moment the last page is loaded; an
+        // observer callback still in flight must not re-enter the disposed component.
+        var appended = 0;
+        var cut = RenderUnderTest<InfiniteScrollSentinel>(p => p
+            .Add(c => c.OnVisible, EventCallback.Factory.Create(this, () => appended++)));
+
+        await cut.Instance.DisposeAsync();
+        await cut.Instance.OnSentinelVisible();
+
+        appended.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DisposingTwiceIsSilent()
+    {
+        var cut = RenderUnderTest<InfiniteScrollSentinel>(_ => { });
+
+        await cut.Instance.DisposeAsync();
+        var act = async () => await cut.Instance.DisposeAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/ListNoRecordsContentTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/ListNoRecordsContentTests.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// bUnit tests for <see cref="ListNoRecordsContent"/>: the whole point of the component is that a
+/// failed fetch and a genuinely empty list stop looking identical, so the branch on
+/// <c>DataGridListPageBase.LoadFailed</c> and its retry affordance are what these pin.
+/// </summary>
+public sealed class ListNoRecordsContentTests : BunitTestBase
+{
+    [Fact]
+    public void WhenTheListIsEmpty_RendersTheEmptyState()
+    {
+        var cut = RenderUnderTest<ListNoRecordsContent>(p => p
+            .Add(c => c.LoadFailed, false)
+            .Add(c => c.EmptyMessage, "No sessions yet"));
+
+        cut.FindComponents<EmptyState>().Should().ContainSingle();
+        cut.Markup.Should().Contain("No sessions yet");
+        cut.FindAll("[role=alert]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WhenTheListIsEmpty_ForwardsTheIconOverride()
+    {
+        var cut = RenderUnderTest<ListNoRecordsContent>(p => p
+            .Add(c => c.LoadFailed, false)
+            .Add(c => c.EmptyMessage, "No sessions yet")
+            .Add(c => c.EmptyIcon, MudBlazor.Icons.Material.Filled.EventBusy));
+
+        cut.FindComponent<EmptyState>().Instance.Icon.Should().Be(MudBlazor.Icons.Material.Filled.EventBusy);
+    }
+
+    [Fact]
+    public void WhenTheFetchFailed_RendersAnAlertWithRetryInsteadOfTheEmptyState()
+    {
+        var cut = RenderUnderTest<ListNoRecordsContent>(p => p
+            .Add(c => c.LoadFailed, true)
+            .Add(c => c.EmptyMessage, "No sessions yet"));
+
+        cut.FindComponents<EmptyState>().Should().BeEmpty();
+        cut.Find("[role=alert]").TextContent.Should().Contain("Could not load this list");
+        cut.Markup.Should().NotContain("No sessions yet");
+    }
+
+    [Fact]
+    public async Task RetryInvokesTheCallback()
+    {
+        var retried = 0;
+        var cut = RenderUnderTest<ListNoRecordsContent>(p => p
+            .Add(c => c.LoadFailed, true)
+            .Add(c => c.OnRetry, EventCallback.Factory.Create(this, () => retried++)));
+
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        retried.Should().Be(1);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/QrCodeButtonTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/QrCodeButtonTests.cs
@@ -1,0 +1,95 @@
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components.Web;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// bUnit tests for <see cref="QrCodeButton"/> (ADR-042): the accessible-name contract, and the
+/// invariant that the encoded payload is the ABSOLUTE public URL. A code encoding an app-relative
+/// route (or a WebView-internal origin) is unscannable by the OS camera it is meant for.
+/// </summary>
+/// <remarks>
+/// The inline <c>MudDialog</c> renders its body through <c>MudDialogProvider</c>, so every
+/// post-click assertion is made against the provider's render tree, not the button's.
+/// </remarks>
+public sealed class QrCodeButtonTests : BunitTestBase
+{
+    [Fact]
+    public void RendersAccessibleIconButton()
+    {
+        var cut = RenderButton();
+
+        cut.Find("button").GetAttribute("aria-label").Should().Be("Show QR code for this page");
+    }
+
+    [Fact]
+    public void BeforeTheFirstClick_NoCodeIsEncoded()
+    {
+        var providers = RenderMudProviders();
+        RenderButton();
+
+        providers.Dialog.FindComponents<QrCodeImage>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ClickingEncodesTheAbsolutePublicUrl()
+    {
+        var providers = RenderMudProviders();
+        var cut = RenderButton();
+
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        var image = providers.Dialog.FindComponent<QrCodeImage>().Instance;
+        image.Payload.Should().Be("http://localhost/sessions/42");
+        image.AltText.Should().Be("QR code linking to Intro to Blazor");
+    }
+
+    [Fact]
+    public async Task ClickingRendersTheEncodedPngAndTheUrlAsText()
+    {
+        var providers = RenderMudProviders();
+        var cut = RenderButton();
+
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        providers.Dialog.Find("img").GetAttribute("src").Should().StartWith("data:image/png;base64,");
+        providers.Dialog.Markup.Should().Contain("http://localhost/sessions/42");
+    }
+
+    [Fact]
+    public async Task ForwardsTheEncodingParametersToTheImage()
+    {
+        var providers = RenderMudProviders();
+        var cut = RenderUnderTest<QrCodeButton>(p => p
+            .Add(c => c.RelativePath, "/sessions/42")
+            .Add(c => c.QrTitle, "Intro to Blazor")
+            .Add(c => c.PixelsPerModule, 4)
+            .Add(c => c.ErrorCorrection, QrErrorCorrectionLevel.High));
+
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        var image = providers.Dialog.FindComponent<QrCodeImage>().Instance;
+        image.PixelsPerModule.Should().Be(4);
+        image.ErrorCorrection.Should().Be(QrErrorCorrectionLevel.High);
+    }
+
+    [Fact]
+    public async Task WithoutARelativePath_NothingIsEncoded()
+    {
+        var providers = RenderMudProviders();
+        var cut = RenderUnderTest<QrCodeButton>(p => p
+            .Add(c => c.RelativePath, string.Empty)
+            .Add(c => c.QrTitle, "Intro to Blazor"));
+
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        providers.Dialog.FindComponents<QrCodeImage>().Should().BeEmpty();
+    }
+
+    private IRenderedComponent<QrCodeButton> RenderButton() =>
+        RenderUnderTest<QrCodeButton>(p => p
+            .Add(c => c.RelativePath, "/sessions/42")
+            .Add(c => c.QrTitle, "Intro to Blazor"));
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/SharePageButtonTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/SharePageButtonTests.cs
@@ -1,0 +1,104 @@
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.UI.Components;
+using MMCA.Common.UI.Services.Capabilities;
+using Moq;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// bUnit tests for <see cref="SharePageButton"/> (ADR-042): the native share path, the copy-link
+/// fallback when no share surface exists, and the accessible-name contract the axe gate depends on.
+/// The shared URL must always be absolute (built by <c>IPublicLinkBuilder</c>), never the raw
+/// app-relative route.
+/// </summary>
+public sealed class SharePageButtonTests : BunitTestBase
+{
+    private readonly Mock<IShareService> _share = new();
+    private readonly Mock<IClipboardService> _clipboard = new();
+
+    public SharePageButtonTests()
+    {
+        Services.AddSingleton(_share.Object);
+        Services.AddSingleton(_clipboard.Object);
+    }
+
+    [Fact]
+    public void RendersAccessibleIconButton()
+    {
+        var cut = RenderButton();
+
+        cut.Find("button").GetAttribute("aria-label").Should().Be("Share this page");
+    }
+
+    [Fact]
+    public async Task WhenNativeShareSucceeds_DoesNotFallBackToClipboard()
+    {
+        _share
+            .Setup(x => x.ShareLinkAsync("Intro to Blazor", It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var cut = RenderButton();
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        _clipboard.Verify(
+            x => x.SetTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenShareUnavailable_CopiesTheAbsolutePublicLink()
+    {
+        _share
+            .Setup(x => x.ShareLinkAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _clipboard
+            .Setup(x => x.SetTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var cut = RenderButton();
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        // bUnit's NavigationManager base uri is http://localhost/, so the copied link must be
+        // the absolute public URL, never the bare app-relative route.
+        _clipboard.Verify(
+            x => x.SetTextAsync("http://localhost/sessions/42", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SharesTheAbsoluteUrlBuiltFromThePublicLinkBuilder()
+    {
+        Uri? sharedUri = null;
+        _share
+            .Setup(x => x.ShareLinkAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, Uri uri, CancellationToken _) => sharedUri = uri)
+            .ReturnsAsync(true);
+
+        var cut = RenderButton();
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        sharedUri.Should().Be(new Uri("http://localhost/sessions/42"));
+    }
+
+    [Fact]
+    public async Task WithoutARelativePath_DoesNothing()
+    {
+        var cut = RenderUnderTest<SharePageButton>(p => p
+            .Add(c => c.RelativePath, string.Empty)
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        _share.Verify(
+            x => x.ShareLinkAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private IRenderedComponent<SharePageButton> RenderButton() =>
+        RenderUnderTest<SharePageButton>(p => p
+            .Add(c => c.RelativePath, "/sessions/42")
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
@@ -24,14 +24,14 @@ public sealed class DataGridListPageBaseTests : BunitTestBase
 
     public DataGridListPageBaseTests()
     {
-        Services.AddScoped<ListPageStateService>();
-        Services.AddScoped<ListPageQueryStateService>();
         // Last registration wins over the SnackbarService that AddMudServices registered, so the
         // page's error/cancel surface can be asserted without rendering a snackbar provider.
         Services.AddSingleton<ISnackbar>(_snackbar.Object);
-        AddBunitPersistentComponentState();
-        // LoadServerDataAsync consults RendererInfo.IsInteractive to bound SSR prerender fetches.
-        SetRendererInfo(new RendererInfo("Server", isInteractive: true));
+
+        // The shared list-page host block: state services, an inert viewport, persistent component
+        // state, and (LAST, because it freezes the provider) the interactive renderer info that
+        // LoadServerDataAsync consults to bound SSR prerender fetches.
+        ConfigureDataGridListPageHost();
     }
 
     // Public so Moq can proxy MudBlazor's Column&lt;WidgetRow&gt; over it (Castle cannot subclass a

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/ListPageActionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/ListPageActionsTests.cs
@@ -1,0 +1,212 @@
+using AwesomeAssertions;
+using Bunit;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Components;
+using MMCA.Common.UI.Pages.Common;
+using Moq;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Tests.Pages.Common;
+
+/// <summary>
+/// bUnit tests for <see cref="ListPageActions"/>: the reload dispatch that has to hit whichever
+/// layout is actually rendered, and the confirm-delete-reload flow every list page repeats. The
+/// failure branches are the load-bearing ones: a rejected confirmation must not delete, a failed
+/// <see cref="Result"/> must not toast success or reload, and a cancellation (component disposal or
+/// an InteractiveAuto render-mode transition) must stay silent.
+/// </summary>
+public sealed class ListPageActionsTests : BunitTestBase
+{
+    // Deliberately NOT registered in DI: DeleteWithConfirmationAsync takes the snackbar as an
+    // argument, and substituting the container's ISnackbar would break MudSnackbarProvider, which
+    // RenderMudProviders needs in order to host the confirmation dialog.
+    private readonly Mock<ISnackbar> _snackbar = new();
+
+    [Fact]
+    public async Task ReloadActiveLayout_OnMobile_ResetsTheMobileList()
+    {
+        var fetches = 0;
+        var list = RenderMobileList(() => fetches++);
+        var before = fetches;
+
+        await list.InvokeAsync(() =>
+            ListPageActions.ReloadActiveLayoutAsync<string>(true, list.Instance, null));
+
+        fetches.Should().BeGreaterThan(before);
+    }
+
+    [Fact]
+    public async Task ReloadActiveLayout_OnDesktop_LeavesTheMobileListAlone()
+    {
+        var fetches = 0;
+        var list = RenderMobileList(() => fetches++);
+        var before = fetches;
+
+        await list.InvokeAsync(() =>
+            ListPageActions.ReloadActiveLayoutAsync<string>(false, list.Instance, null));
+
+        fetches.Should().Be(before);
+    }
+
+    [Fact]
+    public async Task ReloadActiveLayout_WithNeitherLayoutRendered_IsANoOp()
+    {
+        var act = async () => await ListPageActions.ReloadActiveLayoutAsync<string>(true, null, null);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Delete_WhenConfirmed_TogglesSuccessAndReloads()
+    {
+        var providers = RenderMudProviders();
+        var confirm = RenderUnderTest<DeleteConfirmation>(p => p.Add(c => c.EntityType, "Session"));
+
+        var deleted = 0;
+        var reloaded = 0;
+        Task? flow = null;
+        await confirm.InvokeAsync(() =>
+        {
+            flow = ListPageActions.DeleteWithConfirmationAsync(
+                confirm.Instance,
+                "Intro to Blazor",
+                () =>
+                {
+                    deleted++;
+                    return Task.FromResult(Result.Success());
+                },
+                _snackbar.Object,
+                "Session deleted",
+                _ => "unused",
+                () =>
+                {
+                    reloaded++;
+                    return Task.CompletedTask;
+                });
+        });
+
+        await providers.Dialog.WaitForAssertionAsync(() => providers.Dialog.HasText("Intro to Blazor").Should().BeTrue());
+        providers.Dialog.ClickButtonByText("Delete");
+        await flow!;
+
+        deleted.Should().Be(1);
+        reloaded.Should().Be(1);
+        VerifyToast("Session deleted", Severity.Success);
+    }
+
+    [Fact]
+    public async Task Delete_WhenCancelled_NeverCallsTheDelete()
+    {
+        var providers = RenderMudProviders();
+        var confirm = RenderUnderTest<DeleteConfirmation>(p => p.Add(c => c.EntityType, "Session"));
+
+        var deleted = 0;
+        var reloaded = 0;
+        Task? flow = null;
+        await confirm.InvokeAsync(() =>
+        {
+            flow = ListPageActions.DeleteWithConfirmationAsync(
+                confirm.Instance,
+                "Intro to Blazor",
+                () =>
+                {
+                    deleted++;
+                    return Task.FromResult(Result.Success());
+                },
+                _snackbar.Object,
+                "Session deleted",
+                _ => "unused",
+                () =>
+                {
+                    reloaded++;
+                    return Task.CompletedTask;
+                });
+        });
+
+        await providers.Dialog.WaitForAssertionAsync(() => providers.Dialog.HasText("Intro to Blazor").Should().BeTrue());
+        providers.Dialog.ClickButtonByText("Cancel");
+        await flow!;
+
+        deleted.Should().Be(0);
+        reloaded.Should().Be(0);
+        _snackbar.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Delete_WhenTheDeleteFails_ToastsTheMappedErrorAndSkipsTheReload()
+    {
+        var providers = RenderMudProviders();
+        var confirm = RenderUnderTest<DeleteConfirmation>(p => p.Add(c => c.EntityType, "Session"));
+
+        var reloaded = 0;
+        Task? flow = null;
+        await confirm.InvokeAsync(() =>
+        {
+            flow = ListPageActions.DeleteWithConfirmationAsync(
+                confirm.Instance,
+                "Intro to Blazor",
+                () => Task.FromResult(
+                    Result.Failure(Error.Conflict("Session.InUse", "Session is on the schedule"))),
+                _snackbar.Object,
+                "Session deleted",
+                result => result.Errors[0].Message,
+                () =>
+                {
+                    reloaded++;
+                    return Task.CompletedTask;
+                });
+        });
+
+        await providers.Dialog.WaitForAssertionAsync(() => providers.Dialog.HasText("Intro to Blazor").Should().BeTrue());
+        providers.Dialog.ClickButtonByText("Delete");
+        await flow!;
+
+        reloaded.Should().Be(0);
+        VerifyToast("Session is on the schedule", Severity.Error);
+    }
+
+    [Fact]
+    public async Task Delete_WhenTheDeleteIsCancelled_StaysSilent()
+    {
+        // Component disposal or an InteractiveAuto render-mode transition cancels the in-flight
+        // call; surfacing that as an error toast would blame the user for navigating away.
+        var providers = RenderMudProviders();
+        var confirm = RenderUnderTest<DeleteConfirmation>(p => p.Add(c => c.EntityType, "Session"));
+
+        Task? flow = null;
+        await confirm.InvokeAsync(() =>
+        {
+            flow = ListPageActions.DeleteWithConfirmationAsync(
+                confirm.Instance,
+                "Intro to Blazor",
+                () => throw new OperationCanceledException(),
+                _snackbar.Object,
+                "Session deleted",
+                _ => "unused",
+                () => Task.CompletedTask);
+        });
+
+        await providers.Dialog.WaitForAssertionAsync(() => providers.Dialog.HasText("Intro to Blazor").Should().BeTrue());
+        providers.Dialog.ClickButtonByText("Delete");
+
+        var act = async () => await flow!;
+        await act.Should().NotThrowAsync();
+        _snackbar.VerifyNoOtherCalls();
+    }
+
+    private IRenderedComponent<MobileInfiniteScrollList<string>> RenderMobileList(Action onFetch) =>
+        RenderUnderTest<MobileInfiniteScrollList<string>>(p => p
+            .Add(c => c.CardTemplate, item => item)
+            .Add(c => c.FetchPageResult, (_, _, _) =>
+            {
+                onFetch();
+                return Task.FromResult(
+                    Result.Success<(IReadOnlyList<string> Items, int TotalItems)>((["Alpha"], 1)));
+            }));
+
+    private void VerifyToast(string message, Severity severity) =>
+        _snackbar.Verify(
+            s => s.Add(message, severity, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            Times.Once);
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/OfflineFirstPageSnapshotTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/OfflineFirstPageSnapshotTests.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using MMCA.Common.UI.Pages.Common;
+using MMCA.Common.UI.Services.Capabilities;
+
+namespace MMCA.Common.UI.Tests.Pages.Common;
+
+/// <summary>
+/// Unit tests for <see cref="OfflineFirstPageSnapshot{TItem}"/>: the last-known-good first page a
+/// list surface falls back to on a dead network (ADR-042). The guard rails matter more than the
+/// happy path here: only page 1 is ever remembered or served, an online device never reads the
+/// snapshot, and a head with no cache store stays completely inert.
+/// </summary>
+public sealed class OfflineFirstPageSnapshotTests
+{
+    private const string CacheKey = "tests.sessions.page1";
+
+    private static readonly IReadOnlyList<string> Page = ["Alpha", "Bravo"];
+
+    [Fact]
+    public async Task WhenOffline_ServesTheRememberedFirstPage()
+    {
+        var store = new FakeLocalCacheStore();
+        var snapshot = Build(store, online: false);
+
+        await snapshot.RememberAsync((Page, 7), page: 1, Xunit.TestContext.Current.CancellationToken);
+        var cached = await snapshot.TryReadAsync(page: 1, Xunit.TestContext.Current.CancellationToken);
+
+        cached.Should().NotBeNull();
+        cached!.Value.Items.Should().Equal(Page);
+        cached.Value.TotalItems.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task WhenOnline_NeverServesTheSnapshot()
+    {
+        var store = new FakeLocalCacheStore();
+        var offline = Build(store, online: false);
+        await offline.RememberAsync((Page, 7), page: 1, Xunit.TestContext.Current.CancellationToken);
+
+        var online = Build(store, online: true);
+
+        online.CanServe(1).Should().BeFalse();
+        (await online.TryReadAsync(page: 1, Xunit.TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task OnlyTheFirstPageIsRemembered()
+    {
+        var store = new FakeLocalCacheStore();
+        var snapshot = Build(store, online: false);
+
+        await snapshot.RememberAsync((Page, 7), page: 2, Xunit.TestContext.Current.CancellationToken);
+
+        store.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OnlyTheFirstPageIsServed()
+    {
+        var store = new FakeLocalCacheStore();
+        var snapshot = Build(store, online: false);
+        await snapshot.RememberAsync((Page, 7), page: 1, Xunit.TestContext.Current.CancellationToken);
+
+        snapshot.CanServe(2).Should().BeFalse();
+        (await snapshot.TryReadAsync(page: 2, Xunit.TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WithoutACacheStore_StaysInert()
+    {
+        // Blazor Server reports the store unavailable: SSR always has the live API, so nothing is
+        // written and nothing is ever served.
+        var store = new FakeLocalCacheStore { IsAvailable = false };
+        var snapshot = Build(store, online: false);
+
+        await snapshot.RememberAsync((Page, 7), page: 1, Xunit.TestContext.Current.CancellationToken);
+
+        store.Entries.Should().BeEmpty();
+        snapshot.CanServe(1).Should().BeFalse();
+        (await snapshot.TryReadAsync(page: 1, Xunit.TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WithNothingCached_ReturnsNull()
+    {
+        var snapshot = Build(new FakeLocalCacheStore(), online: false);
+
+        (await snapshot.TryReadAsync(page: 1, Xunit.TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SnapshotsAreKeyedPerSurface()
+    {
+        // Two list surfaces sharing one store must not read each other's rows.
+        var store = new FakeLocalCacheStore();
+        var sessions = new OfflineFirstPageSnapshot<string>(store, new FakeConnectivity(false), "tests.sessions");
+        var speakers = new OfflineFirstPageSnapshot<string>(store, new FakeConnectivity(false), "tests.speakers");
+
+        await sessions.RememberAsync((Page, 7), page: 1, Xunit.TestContext.Current.CancellationToken);
+
+        (await speakers.TryReadAsync(page: 1, Xunit.TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    private static OfflineFirstPageSnapshot<string> Build(ILocalCacheStore store, bool online) =>
+        new(store, new FakeConnectivity(online), CacheKey);
+
+    /// <summary>
+    /// In-memory <see cref="ILocalCacheStore"/> that JSON round-trips every value, so the snapshot's
+    /// own cached-page shape is genuinely exercised rather than handed back by reference.
+    /// </summary>
+    private sealed class FakeLocalCacheStore : ILocalCacheStore
+    {
+        public Dictionary<string, string> Entries { get; } = [];
+
+        public bool IsAvailable { get; init; } = true;
+
+        public Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default)
+        {
+            Entries[key] = JsonSerializer.Serialize(value);
+            return Task.CompletedTask;
+        }
+
+        public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Entries.TryGetValue(key, out var json) ? JsonSerializer.Deserialize<T>(json) : default);
+
+        public Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+        {
+            Entries.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeConnectivity(bool isOnline) : IConnectivityStatusService
+    {
+#pragma warning disable CS0067 // The snapshot never subscribes; the event exists only to satisfy the contract.
+        public event EventHandler? ConnectivityChanged;
+#pragma warning restore CS0067
+
+        public bool IsOnline => isOnline;
+
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/NavigationPublicLinkBuilderTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/NavigationPublicLinkBuilderTests.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Auth;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="NavigationPublicLinkBuilder"/>: the browser-origin default behind the
+/// share, copy-link and QR affordances. Every result must be absolute, since the whole point of the
+/// abstraction is that a shared link opens for someone who is not inside the app.
+/// </summary>
+public sealed class NavigationPublicLinkBuilderTests : BunitTestBase
+{
+    private NavigationPublicLinkBuilder Builder =>
+        new(Services.GetRequiredService<NavigationManager>());
+
+    [Theory]
+    [InlineData("/sessions/42")]
+    [InlineData("sessions/42")]
+    public void BuildsAnAbsoluteUrlOnTheBrowserOrigin(string relativePath) =>
+        Builder.BuildAbsolute(relativePath).Should().Be(new Uri("http://localhost/sessions/42"));
+
+    [Fact]
+    public void PreservesTheQueryString() =>
+        Builder.BuildAbsolute("/sessions?day=2").ToString().Should().Be("http://localhost/sessions?day=2");
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RejectsABlankPath(string relativePath)
+    {
+        var builder = Builder;
+
+        var act = () => builder.BuildAbsolute(relativePath);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddUIShared_RegistersTheBrowserOriginDefault()
+    {
+        // Every head gets a working builder without registering one; a MAUI head replaces it
+        // afterwards with the public-site builder (last registration wins).
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Api:ApiEndpoint"] = "https://localhost:6001" })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<ITokenStorageService>(new StubTokenStorageService());
+        services.AddUIShared(configuration);
+
+        // Asserted on the descriptor rather than a resolved instance: the implementation needs a
+        // NavigationManager, which only a rendering host supplies.
+        var descriptor = services.Single(s => s.ServiceType == typeof(IPublicLinkBuilder));
+        descriptor.ImplementationType.Should().Be<NavigationPublicLinkBuilder>();
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Scoped);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
@@ -754,6 +754,7 @@
         "dependencies": {
           "AngleSharp": "[1.7.2, )",
           "MMCA.Common.UI": "[1.0.0, )",
+          "Moq": "[4.20.72, )",
           "MudBlazor": "[9.9.0, )",
           "bunit": "[2.9.0, )"
         }

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -529,6 +529,53 @@
         "resolved": "7.2.1",
         "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg=="
       },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
       "SQLite": {
         "type": "Transitive",
         "resolved": "3.53.4",
@@ -719,7 +766,10 @@
           "OpenTelemetry.Extensions.Hosting": "[1.18.0, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.18.0, )",
           "OpenTelemetry.Instrumentation.Http": "[1.18.0, )",
-          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )"
+          "OpenTelemetry.Instrumentation.Runtime": "[1.18.0, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Serilog.Sinks.Console": "[6.1.1, )",
+          "Serilog.Sinks.File": "[7.0.0, )"
         }
       },
       "mmca.common.domain": {
@@ -1238,6 +1288,39 @@
         "contentHash": "wHWaroody48jnlLoq/REwUltIFLxplXyHTP+sttrc8P7+jkiVqf38afDidJNv4qgD/6zz2NKOYg06xLZ1bG7wQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "10.0.0"
+        }
+      },
+      "Serilog.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "CentralTransitive",
+        "requested": "[6.1.1, )",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
         }
       },
       "SixLabors.ImageSharp": {


### PR DESCRIPTION
Completes the Wave 6 extraction bundle for the pending v1.165.0 release (Tier 1 landed in #295; this PR carries Tier 2, items 6.8-6.15 of the extraction plan, all additive and opt-in).

## Items

- **6.8** `ScopedIntegrationEventHandlerBase<TEvent>`: the `CreateAsyncScope` preamble + log-and-rethrow envelope from 18 per-app integration-event handlers; cancellation excluded, mirroring `SafeDomainEventHandler`.
- **6.9** gRPC Result trailer decoder: `Metadata.ToErrors()`, `RpcException.ToResult`/`ToResult<T>`, the exact inverse of `ToRpcException`, in the same file so encoder and decoder cannot drift.
- **6.10** Opt-in host extensions: `AddCommonSerilog(logFilePath)` and `AddModuleHost()` (settings bind + `ModuleLoader` + a `RegisterModules` method group); `Program.cs` orchestration and the `AddApplicationDecorators()`-last ordering stay host-owned.
- **6.11** Push device-token providers in UI.Maui, both halves (FCM provider + `MauiFirebaseMessagingService` on Android; APNs provider + public `ApnsTokenBridge` on iOS/MacCatalyst) behind `AddMauiPushDeviceTokenProvider()`. `Xamarin.Firebase.Messaging` 124.1.2 accepted on the MAUI package (decision 2026-08-27). AppDelegate hooks, manifests, and credentials stay app-side.
- **6.12** `MmcaGatewayHardeningTestsBase<TEntryPoint>` with 8 gates (rate-limit window, named policy, bypass paths, correlation generation + echo, per-downstream readiness, active probes, forwarded-IP partitioning), public `RecordingHttpForwarder`, `NeutralizeGlobalRateLimiter()`. `Yarp.ReverseProxy` accepted on Testing (decision 2026-08-27; version 2.3.0, already pinned).
- **6.13** UI bundle: `ListPageActions`, `ListNoRecordsContent`, `InfiniteScrollSentinel`, `SharePageButton` + `QrCodeButton` over new `IPublicLinkBuilder` (browser impl by default, MAUI impl via `AddCommonMauiPublicLinkBuilder()`), `ApiFileDownloadButton`, `OfflineFirstPageSnapshot<TItem>`; all localized en+es, independently consumable.
- **6.14** Testing bundle: bUnit `ConfigureDataGridListPageHost()` (encodes the load-bearing `SetRendererInfo`-last ordering), `ErrorSummaryMessages()`, public `AddDeviceCapabilityDefaults()`, E2E `SearchAndWaitForRowAsync` (deterministic waits, no sleeps), `ConfirmDeleteAsync`, `WaitForGridToSettleAsync`, `MeasureWebVitalsAsync`, `PseudoLocalizationTestsBase`.
- **6.15** Leaves: `CommonInvariants` bundle 2, optional `errorCode` on every `CommonValidationRules` rule + `AbsoluteUrlRules`, `RequireUserId()`, `NotificationScopeKey` (formatter + pattern in one place, now the `ChannelKeyPattern` default), `AddMailDev()`, `GetRequiredJwtAuthority()`, `EvictTagsAsync`/`TryEvictTagsAsync`, `UseCommonForwardedHeaders()` reachable from Gateway.
- **CHANGELOG catch-up**: adds the missing 1.163.0 / 1.164.0 / 1.164.1 entries and the combined 1.165.0 (Tier 1 + Tier 2) entry.

## Verification

- Full solution Release: 0 warnings, **4,859/4,859 tests green** (+238 over the Tier 1 baseline).
- `MMCA.Common.UI.Maui` builds all four TFMs (android/ios/maccatalyst/windows).
- FACTS `--check` clean: no package-count or fitness-count drift.
- Consumer adoption commits follow on the same-name branches (coordinated-break canary), pin bumps after the v1.165.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw