### PR TITLE
feat: Medium-audit hardening wave (v1.166.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.166.0] - 2026-08-28
+
+Hardening release from the 2026-08-28 Medium-literature audit (20 articles cross-checked against the
+framework; report in the workspace `Reports/`).
+
+### Added
+
+- **`ContractImplementationTestsBase`.** New opt-in architecture fitness base asserting every class
+  implementing a `[ServiceContract]` interface is non-public, so module encapsulation is a build
+  gate rather than a convention; `AllowedPublicImplementations` is the escape hatch.
+- **`CHANGELOG.md` ships in every package**, and the pack metadata gains `Copyright` and
+  `PackageReleaseNotes`.
+
+### Changed
+
+- **BREAKING: write repositories are aggregate-root-only.** `IRepository` and `IWriteRepository`
+  (with `EFRepository` and its decorator) are constrained to `AuditableAggregateRootEntity`,
+  matching the constraint `IUnitOfWork.GetRepository` always had; the read-side surfaces
+  (`IReadRepository`, `IEntityReader`, `IEntityQuerier`) still accept any `AuditableBaseEntity`.
+  Code resolving a write repository for a child entity (including test doubles constrained to
+  `AuditableBaseEntity`) must widen to the aggregate-root constraint or move to the read side.
+- **All registered validators run.** `ValidatingCommandDecorator` and `ValidatingQueryDecorator`
+  previously ran only the first `IValidator<T>` DI happened to yield; they now run every registered
+  validator and union the failures, so a command carrying both a shared and a specific validator is
+  checked by both.
+- **Tenant index matches the composed filter.** For entities that are both `ITenantEntity` and
+  soft-deletable, the auto-created index is now composite (`TenantId`, `IsDeleted`), matching the
+  AND-composed query filters; tenant-only entities keep the single-column index. No consumer ships
+  tenant entities yet, so no migration is expected downstream.
+
+### Fixed
+
+- **`MessageBusSettings.EndpointPrefix` is actually applied.** The configured value now prefixes
+  kebab-case endpoint names (namespacing queues per service on a shared broker); previously it only
+  toggled kebab-casing and the value itself was discarded.
+
 ## [1.165.0] - 2026-08-28
 
 Wave 6 extraction release: framework surface hoisted from duplicated ADC/Store/Helpdesk code

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,7 @@
   <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('Source'))">
     <Authors>Ivan Ball</Authors>
     <Company>MMCA</Company>
+    <Copyright>Copyright (c) Ivan Ball-llovera</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/ivanball/MMCA.Common</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -51,6 +52,9 @@
     <PackageProjectUrl>https://ivanball.github.io/platform.html</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>modular-monolith;clean-architecture;ddd;cqrs;microservices;dotnet;aspnetcore;aspire;efcore;blazor;outbox;result-pattern</PackageTags>
+    <!-- The release notes live in one place (the GitHub releases feed, generated from the tag) rather
+         than being restated per package: sixteen packages ship in lockstep off a single tag. -->
+    <PackageReleaseNotes>https://github.com/ivanball/MMCA.Common/releases</PackageReleaseNotes>
     <!-- GitHub Packages has no symbol server, so a standalone .snupkg cannot be consumed.
          Embed the PDB into the shipped DLL instead (with repo + untracked-source info), so the
          debug symbols actually reach consumers via the .nupkg. -->
@@ -60,9 +64,12 @@
   </PropertyGroup>
 
   <!-- The icon referenced by PackageIcon above must itself be packed. Done once here rather than
-       in fifteen csproj files (each of which still packs README.md individually). -->
+       in fifteen csproj files (each of which still packs README.md individually). The changelog rides
+       along in every package for the same reason: a consumer inspecting a .nupkg gets the version
+       history without leaving the package. -->
   <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('Source'))">
     <None Include="$(MSBuildThisFileDirectory)assets\icon.png" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)CHANGELOG.md" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 
   <!--

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-08-28 (framework v1.165.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-08-29 (framework v1.165.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -42,10 +42,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **119 test methods across 44 abstract `*TestsBase` classes**, shipped once in the
+- **120 test methods across 45 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **169** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **170** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
+++ b/Source/Core/MMCA.Common.Application/Interfaces/Infrastructure/IRepository.cs
@@ -346,12 +346,21 @@ public interface IReadRepository<TEntity, TIdentifierType>
 }
 
 /// <summary>
-/// Write repository for persisting entity changes.
+/// Write repository for persisting AGGREGATE ROOT changes.
 /// </summary>
-/// <typeparam name="TEntity">The entity type.</typeparam>
+/// <remarks>
+/// The constraint is <see cref="AuditableAggregateRootEntity{TIdentifierType}"/>, not the wider
+/// <see cref="AuditableBaseEntity{TIdentifierType}"/> the read side accepts: a write enters the
+/// aggregate through its root, so that the root's invariants are enforced and its domain events are
+/// collected. A repository over a child entity would let a caller persist a change the root never
+/// saw. Reading a child directly is harmless and stays supported through
+/// <see cref="IReadRepository{TEntity, TIdentifierType}"/>. This mirrors the constraint on
+/// <c>IUnitOfWork.GetRepository</c>, which is how a handler is meant to obtain one.
+/// </remarks>
+/// <typeparam name="TEntity">The aggregate root entity type.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
 public interface IWriteRepository<TEntity, TIdentifierType>
-    where TEntity : AuditableBaseEntity<TIdentifierType>
+    where TEntity : AuditableAggregateRootEntity<TIdentifierType>
     where TIdentifierType : notnull
 {
     /// <summary>Adds a new entity to the persistence store.</summary>
@@ -451,10 +460,16 @@ public interface IWriteRepository<TEntity, TIdentifierType>
 }
 
 /// <summary>
-/// Combined read-write repository interface.
+/// Combined read-write repository interface, over an aggregate root.
 /// </summary>
-/// <typeparam name="TEntity">The entity type.</typeparam>
+/// <remarks>
+/// Inherits the write side's aggregate-root constraint (see
+/// <see cref="IWriteRepository{TEntity, TIdentifierType}"/>). A handler that only reads, and reads a
+/// child entity, depends on <see cref="IReadRepository{TEntity, TIdentifierType}"/> instead, which
+/// still accepts any auditable entity.
+/// </remarks>
+/// <typeparam name="TEntity">The aggregate root entity type.</typeparam>
 /// <typeparam name="TIdentifierType">The entity's primary key type.</typeparam>
 public interface IRepository<TEntity, TIdentifierType> : IReadRepository<TEntity, TIdentifierType>, IWriteRepository<TEntity, TIdentifierType>
-    where TEntity : AuditableBaseEntity<TIdentifierType>
+    where TEntity : AuditableAggregateRootEntity<TIdentifierType>
     where TIdentifierType : notnull;

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/ValidatingCommandDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/ValidatingCommandDecorator.cs
@@ -6,12 +6,19 @@ using MMCA.Common.Shared.Abstractions;
 namespace MMCA.Common.Application.UseCases.Decorators;
 
 /// <summary>
-/// Decorator that automatically validates the command using a registered <see cref="IValidator{T}"/>
-/// before invoking the inner handler. If validation fails, the handler is never called and a
-/// <see cref="Result"/> failure containing all validation errors is returned immediately.
+/// Decorator that automatically validates the command using EVERY registered
+/// <see cref="IValidator{T}"/> before invoking the inner handler. If any of them fails, the handler
+/// is never called and a <see cref="Result"/> failure containing the union of their validation
+/// errors is returned immediately.
 /// <para>
 /// This eliminates the need for handlers to inject and call <see cref="IValidator{T}"/> manually.
 /// Commands without a registered validator pass through to the handler unchanged.
+/// </para>
+/// <para>
+/// All registered validators run, not just the first one: a command commonly carries a
+/// module-authored validator beside a framework or cross-cutting one, and honoring only the first
+/// registration turns the others into dead code whose rules are silently unenforced. Running them
+/// all also means the caller sees every broken rule in one response instead of one per round trip.
 /// </para>
 /// <para>
 /// Placed between <see cref="CachingCommandDecorator{TCommand, TResult}"/> and
@@ -26,7 +33,7 @@ public sealed partial class ValidatingCommandDecorator<TCommand, TResult>(
     IEnumerable<IValidator<TCommand>> validators,
     ILogger<ValidatingCommandDecorator<TCommand, TResult>> logger) : ICommandHandler<TCommand, TResult>
 {
-    private readonly IValidator<TCommand>? _validator = validators.FirstOrDefault();
+    private readonly IValidator<TCommand>[] _validators = [.. validators];
 
     /// <summary>
     /// Cached delegate that creates a <typeparamref name="TResult"/> failure from a collection of
@@ -54,18 +61,32 @@ public sealed partial class ValidatingCommandDecorator<TCommand, TResult>(
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TCommand command, CancellationToken cancellationToken = default)
     {
-        if (_validator is null)
+        if (_validators.Length == 0)
         {
             return await inner.HandleAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
-        var validationResult = await _validator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
-        if (validationResult.IsValid)
+        // Sequential on purpose: a validator is free to reach the database through a scoped
+        // repository, and a DbContext is not thread-safe, so running the set concurrently would
+        // trade a correctness guarantee for a saving measured in microseconds.
+        List<Error>? errors = null;
+        foreach (var validator in _validators)
+        {
+            var validationResult = await validator.ValidateAsync(command, cancellationToken).ConfigureAwait(false);
+            if (validationResult.IsValid)
+            {
+                continue;
+            }
+
+            errors ??= [];
+            errors.AddRange(validationResult.ToErrors(typeof(TCommand).Name));
+        }
+
+        if (errors is null)
         {
             return await inner.HandleAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
-        var errors = validationResult.ToErrors(typeof(TCommand).Name).ToList();
         LogValidationFailure(errors);
 
         var createFailure = CreateFailure();

--- a/Source/Core/MMCA.Common.Application/UseCases/Decorators/ValidatingQueryDecorator.cs
+++ b/Source/Core/MMCA.Common.Application/UseCases/Decorators/ValidatingQueryDecorator.cs
@@ -6,15 +6,16 @@ using MMCA.Common.Shared.Abstractions;
 namespace MMCA.Common.Application.UseCases.Decorators;
 
 /// <summary>
-/// Decorator that automatically validates the query using a registered <see cref="IValidator{T}"/>
-/// before invoking the inner handler. If validation fails, the handler is never called and a
-/// <see cref="Result"/> failure containing all validation errors is returned immediately.
+/// Decorator that automatically validates the query using EVERY registered
+/// <see cref="IValidator{T}"/> before invoking the inner handler. If any of them fails, the handler
+/// is never called and a <see cref="Result"/> failure containing the union of their validation
+/// errors is returned immediately.
 /// <para>
 /// The query twin of <see cref="ValidatingCommandDecorator{TCommand, TResult}"/>: same validator
-/// resolution (first registered <c>IValidator&lt;TQuery&gt;</c> wins), same error aggregation, same
-/// pass-through when a query has no validator at all. Queries carrying paging, filter or sort input
-/// therefore reject a malformed request the same way commands do, instead of pushing the bad values
-/// into the data source.
+/// resolution (every registered <c>IValidator&lt;TQuery&gt;</c> runs, in registration order), same
+/// error aggregation, same pass-through when a query has no validator at all. Queries carrying
+/// paging, filter or sort input therefore reject a malformed request the same way commands do,
+/// instead of pushing the bad values into the data source.
 /// </para>
 /// <para>
 /// <b>Pipeline placement (ADR-014):</b> registered between
@@ -35,7 +36,7 @@ public sealed partial class ValidatingQueryDecorator<TQuery, TResult>(
     IEnumerable<IValidator<TQuery>> validators,
     ILogger<ValidatingQueryDecorator<TQuery, TResult>> logger) : IQueryHandler<TQuery, TResult>
 {
-    private readonly IValidator<TQuery>? _validator = validators.FirstOrDefault();
+    private readonly IValidator<TQuery>[] _validators = [.. validators];
 
     /// <summary>
     /// Cached delegate that creates a <typeparamref name="TResult"/> failure from a collection of
@@ -64,18 +65,31 @@ public sealed partial class ValidatingQueryDecorator<TQuery, TResult>(
     /// <inheritdoc />
     public async Task<TResult> HandleAsync(TQuery query, CancellationToken cancellationToken = default)
     {
-        if (_validator is null)
+        if (_validators.Length == 0)
         {
             return await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
         }
 
-        var validationResult = await _validator.ValidateAsync(query, cancellationToken).ConfigureAwait(false);
-        if (validationResult.IsValid)
+        // Sequential for the same reason as the command decorator: a validator may read through a
+        // scoped repository, and a DbContext is not thread-safe.
+        List<Error>? errors = null;
+        foreach (var validator in _validators)
+        {
+            var validationResult = await validator.ValidateAsync(query, cancellationToken).ConfigureAwait(false);
+            if (validationResult.IsValid)
+            {
+                continue;
+            }
+
+            errors ??= [];
+            errors.AddRange(validationResult.ToErrors(typeof(TQuery).Name));
+        }
+
+        if (errors is null)
         {
             return await inner.HandleAsync(query, cancellationToken).ConfigureAwait(false);
         }
 
-        var errors = validationResult.ToErrors(typeof(TQuery).Name).ToList();
         LogValidationFailure(errors);
 
         var createFailure = CreateFailure();

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -704,7 +704,12 @@ public static class DependencyInjection
             {
                 if (!string.IsNullOrWhiteSpace(settings.EndpointPrefix))
                 {
-                    x.SetKebabCaseEndpointNameFormatter();
+                    // The prefix is the whole point: the formatter has to carry it, or every service
+                    // on a shared broker derives the same kebab-case queue name from the same
+                    // consumer type and they collide. includeNamespace: false keeps the name to the
+                    // consumer's short type name, so the prefix is the only namespacing applied.
+                    x.SetEndpointNameFormatter(
+                        new KebabCaseEndpointNameFormatter(settings.EndpointPrefix, includeNamespace: false));
                 }
 
                 configureConsumers?.Invoke(x);

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/ApplicationDbContext.cs
@@ -406,7 +406,10 @@ public abstract class ApplicationDbContext(
     /// <b>Two named filters, composed by EF.</b> This one sits beside <c>SoftDelete</c>; EF combines
     /// named filters with AND, so a tenant-owned soft-deletable entity is filtered on both without
     /// either filter knowing about the other, and <c>IgnoreQueryFilters(["SoftDelete"])</c> can drop
-    /// one without dropping the other.
+    /// one without dropping the other. The supporting index follows the composition: a tenant entity
+    /// that is also an <see cref="IAuditableEntity"/> gets <c>(TenantId, IsDeleted)</c>, matching the
+    /// AND-composed predicate every read carries, while a tenant-only entity keeps
+    /// <c>(TenantId)</c>.
     /// </para>
     /// <para>
     /// <b>One model serves every tenant.</b> The filter body embeds this context instance as a
@@ -446,10 +449,21 @@ public abstract class ApplicationDbContext(
 
             // Every tenant-scoped read carries "TenantId = @tenant" as its leading predicate, so the
             // column that answers it must be indexed or shared-schema tenancy degrades into a scan
-            // per query.
+            // per query. When the entity is ALSO soft-deletable, EF composes the two named filters
+            // with AND and every read carries "TenantId = @tenant AND IsDeleted = 0": the index is
+            // widened to (TenantId, IsDeleted) so it matches that composed predicate rather than
+            // handing back the deleted rows for the server to discard afterwards. A tenant entity
+            // that is not auditable has no second conjunct, so it keeps the single-column index.
             if (physicalDataSource.Key.Engine != DataSource.CosmosDB)
             {
-                entity.HasIndex(TenantIdPropertyName);
+                if (typeof(IAuditableEntity).IsAssignableFrom(clrType))
+                {
+                    entity.HasIndex(TenantIdPropertyName, nameof(IAuditableEntity.IsDeleted));
+                }
+                else
+                {
+                    entity.HasIndex(TenantIdPropertyName);
+                }
             }
 
             var parameter = Expression.Parameter(clrType, "e");

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepository.cs
@@ -25,7 +25,7 @@ internal sealed class EFRepository<TEntity, TIdentifierType>(
     TimeProvider? timeProvider = null,
     ICurrentUserService? currentUserService = null
 ) : EFReadRepository<TEntity, TIdentifierType>(context), IRepository<TEntity, TIdentifierType>
-    where TEntity : AuditableBaseEntity<TIdentifierType>
+    where TEntity : AuditableAggregateRootEntity<TIdentifierType>
     where TIdentifierType : notnull
 {
     /// <inheritdoc />

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepositoryDecorator.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Repositories/EFRepositoryDecorator.cs
@@ -14,7 +14,7 @@ namespace MMCA.Common.Infrastructure.Persistence.Repositories;
 internal sealed class EFRepositoryDecorator<TEntity, TIdentifierType>(IRepository<TEntity, TIdentifierType> inner)
     : EFReadRepositoryDecorator<TEntity, TIdentifierType>(inner),
     IRepository<TEntity, TIdentifierType>
-    where TEntity : AuditableBaseEntity<TIdentifierType>
+    where TEntity : AuditableAggregateRootEntity<TIdentifierType>
     where TIdentifierType : notnull
 {
     private const string ClassName = "EFRepository";

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/MessageBusSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/MessageBusSettings.cs
@@ -27,8 +27,18 @@ public sealed class MessageBusSettings
 
     /// <summary>
     /// Gets the endpoint name prefix used to namespace queues per service (e.g. <c>store-catalog</c>).
-    /// MassTransit appends consumer-specific suffixes; this prefix lets multiple services coexist
-    /// on the same broker without colliding on queue names.
+    /// When set, the broker registration installs a kebab-case endpoint name formatter carrying this
+    /// prefix, so a consumer named <c>OrderPlacedConsumer</c> in a service prefixed
+    /// <c>store-catalog</c> binds the queue <c>store-catalog-order-placed</c> instead of the bare
+    /// <c>order-placed</c>. That is what lets several services with the same consumer type names
+    /// coexist on one broker without silently sharing a queue (competing consumers across service
+    /// boundaries, where each event reaches only one of them).
+    /// <para>
+    /// The consumer's namespace is deliberately left out of the generated name: the prefix is the
+    /// only namespacing applied, so a queue name stays readable and survives a type moving between
+    /// folders. Leave the setting unset and endpoint names are formatted by MassTransit's default,
+    /// which is the right choice for a single service on its own broker.
+    /// </para>
     /// </summary>
     [StringLength(64)]
     public string? EndpointPrefix { get; init; }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Contracts.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Contracts.cs
@@ -53,6 +53,69 @@ public static partial class ArchitectureRules
         }
     }
 
+    /// <summary>
+    /// The implementation behind a <c>[ServiceContract]</c> interface stays internal to the service
+    /// that owns it. The contract interface is the published surface (ADR-007); the class that serves
+    /// it is an implementation detail, and a public one invites a consumer to reference the concrete
+    /// type, new it up, or subclass it. Every such reference is a line the extraction has to sever
+    /// later, because a class cannot cross a process boundary and an interface can.
+    /// </summary>
+    /// <remarks>
+    /// Visibility is judged with <see cref="Type.IsVisible"/>, so a public class nested inside an
+    /// internal one is correctly treated as unreachable and passes. Abstract classes are exempt: an
+    /// abstract base carrying shared behavior for several implementations is not itself a resolvable
+    /// implementation, and a repo whose consumers subclass it is making that extension point
+    /// deliberate.
+    /// <para>
+    /// Like the purity rule above, this is attribute-driven and vacuous until the first interface is
+    /// marked, and the marker is matched by name so the package keeps its zero-reference stance
+    /// toward the framework assemblies.
+    /// </para>
+    /// </remarks>
+    /// <param name="map">The repo's architecture map.</param>
+    /// <param name="allowedPublicImplementations">
+    /// Type full names or namespace prefixes where a public implementation is the deliberate, reviewed
+    /// choice (a shipped default a consumer is meant to construct, a test double in a testing package).
+    /// An empty list requires every implementation to be non-public.
+    /// </param>
+    public static void ServiceContractImplementationsAreNotPublic(
+        IArchitectureMap map,
+        IReadOnlyCollection<string> allowedPublicImplementations)
+    {
+        ArgumentNullException.ThrowIfNull(map);
+        ArgumentNullException.ThrowIfNull(allowedPublicImplementations);
+
+        var violations = new List<string>();
+
+        foreach (var assembly in map.Layers.Select(l => l.Assembly).Distinct())
+        {
+            foreach (var type in assembly.ConcreteClasses.Where(t => t.IsVisible))
+            {
+                if (IsAllowed(type.FullName ?? type.Name, allowedPublicImplementations))
+                {
+                    continue;
+                }
+
+                var contract = ServiceContractInterfaceOf(type);
+                if (contract is not null)
+                {
+                    violations.Add(
+                        $"  - {type.FullName}: implements the [ServiceContract] interface {contract.Name} but is public");
+                }
+            }
+        }
+
+        ArchitectureAssert.NoViolations(violations,
+            "a [ServiceContract] interface is the published surface of an extracted service (ADR-007) "
+                + "and the class serving it is an implementation detail: a public implementation lets a "
+                + "consumer bind to the concrete type, which is exactly the coupling the contract exists "
+                + "to prevent");
+    }
+
+    /// <summary>The first <c>[ServiceContract]</c>-marked interface a type implements, or null.</summary>
+    private static Type? ServiceContractInterfaceOf(Type type) =>
+        Array.Find(type.GetInterfaces(), CarriesServiceContractAttribute);
+
     /// <summary>The Domain/Application/Infrastructure namespaces a contract type must never reach into.</summary>
     private static string[] ServiceInternalNamespaces(IArchitectureMap map)
     {
@@ -69,6 +132,16 @@ public static partial class ArchitectureRules
     private static bool CarriesServiceContractAttribute(Mono.Cecil.TypeDefinition type) =>
         type.HasCustomAttributes
         && type.CustomAttributes.Any(attribute => string.Equals(
+            attribute.AttributeType.FullName,
+            ServiceContractAttributeFullName,
+            StringComparison.Ordinal));
+
+    /// <summary>
+    /// The reflection twin of the overload above, for the rules that walk loaded types rather than
+    /// NetArchTest's Cecil model.
+    /// </summary>
+    private static bool CarriesServiceContractAttribute(Type contract) =>
+        contract.GetCustomAttributesData().Any(attribute => string.Equals(
             attribute.AttributeType.FullName,
             ServiceContractAttributeFullName,
             StringComparison.Ordinal));

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Slices.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Slices.cs
@@ -9,6 +9,16 @@ public static partial class ArchitectureRules
     /// folder away from its contract. Only same-assembly contracts are checked — a module that reuses
     /// a framework-generic command (e.g. <c>DeleteEntityCommand&lt;,&gt;</c> from MMCA.Common) is
     /// legitimately not co-located with it, so cross-assembly contracts are exempt.
+    /// <para>
+    /// <b>Scope, deliberately narrow.</b> The rule covers the command/query, its validator and its
+    /// handler, and nothing else. A module's <c>DTOs/</c>, <c>Specifications/</c> and any
+    /// <c>Validation/</c> rule set shared across slices are AGGREGATE-scoped by design: one DTO shape,
+    /// one specification and one shared rule set typically serve every use case over the same
+    /// aggregate, so forcing them into a single slice's folder would either duplicate them per slice
+    /// or make one slice the arbitrary owner that the others reach into. Cohesion is worth enforcing
+    /// exactly where a feature would otherwise be split across horizontal folders; the shared
+    /// aggregate-level types are already cohesive around the aggregate.
+    /// </para>
     /// </summary>
     public static void HandlersAreCoLocatedWithTheirContracts(IArchitectureMap map)
     {

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ContractImplementationTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ContractImplementationTestsBase.cs
@@ -1,0 +1,35 @@
+namespace MMCA.Common.Testing.Architecture;
+
+/// <summary>
+/// Encapsulation fitness function for the <c>[ServiceContract]</c> boundary: the interface is the
+/// published surface of a service (ADR-007), so the concrete class serving it must not be public.
+/// A public implementation lets a consumer reference, construct or subclass the type, and each of
+/// those references is a coupling the extraction has to sever later: an interface can be answered
+/// over a wire, a class cannot.
+/// </summary>
+/// <remarks>
+/// The twin of <see cref="ServiceContractPurityTestsBase"/>, guarding the same boundary from the
+/// other side: purity keeps the producer's internals out of the contract, this keeps the contract's
+/// implementation out of the consumer's reach.
+/// <para>
+/// Opt-in and honest about the vacuous case, like its twin: a repo that marks no interface yet
+/// (MMCA.Common itself marks none) passes without asserting anything. The value is the ratchet, with
+/// no test to remember to write when the first contract appears.
+/// </para>
+/// </remarks>
+public abstract class ContractImplementationTestsBase
+{
+    protected abstract IArchitectureMap Map { get; }
+
+    /// <summary>
+    /// Type full names (<c>MMCA.X.Infrastructure.Contracts.DefaultPricingService</c>) or namespace
+    /// prefixes (<c>MMCA.X.Infrastructure.Contracts</c>) where a public implementation is the
+    /// deliberate requirement: a shipped default a consumer is meant to construct, or a test double
+    /// in a testing package. Empty by default, which requires every implementation to be non-public.
+    /// </summary>
+    protected virtual IReadOnlyCollection<string> AllowedPublicImplementations => [];
+
+    [Fact]
+    public void ServiceContractImplementations_ShouldNotBe_Public() =>
+        ArchitectureRules.ServiceContractImplementationsAreNotPublic(Map, AllowedPublicImplementations);
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
@@ -9,6 +9,9 @@ MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase
 MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.CommandInventory_ShouldNotBe_Empty() -> void
 MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.CommandValidatorCoverageTestsBase() -> void
 MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.Commands_ShouldHave_ValidationCoverage() -> void
+MMCA.Common.Testing.Architecture.ContractImplementationTestsBase
+MMCA.Common.Testing.Architecture.ContractImplementationTestsBase.ContractImplementationTestsBase() -> void
+MMCA.Common.Testing.Architecture.ContractImplementationTestsBase.ServiceContractImplementations_ShouldNotBe_Public() -> void
 MMCA.Common.Testing.Architecture.DomainEventHandlerSaveTestsBase
 MMCA.Common.Testing.Architecture.DomainEventHandlerSaveTestsBase.DomainEventHandlerSaveTestsBase() -> void
 MMCA.Common.Testing.Architecture.DomainEventHandlerSaveTestsBase.DomainEventHandlers_ShouldNotReach_SaveChanges() -> void
@@ -34,6 +37,7 @@ MMCA.Common.Testing.Architecture.SortableColumnConventionTestsBase.SortableColum
 abstract MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AllowedAnonymousEndpoints.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 abstract MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.TargetAssemblies.get -> System.Collections.Generic.IReadOnlyCollection<System.Reflection.Assembly!>!
 abstract MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
+abstract MMCA.Common.Testing.Architecture.ContractImplementationTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
 abstract MMCA.Common.Testing.Architecture.DomainEventHandlerSaveTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
 abstract MMCA.Common.Testing.Architecture.DomainThrowTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
 abstract MMCA.Common.Testing.Architecture.ErrorCatalogTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
@@ -54,11 +58,13 @@ static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersHaveUniq
 static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersIncreaseSchemaVersion(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.HandledCommandCount(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> int
 static MMCA.Common.Testing.Architecture.ArchitectureRules.HardDeletesOnlyInAllowedTypes(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedTypesAndNamespaces) -> void
+static MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractImplementationsAreNotPublic(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedPublicImplementations) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractsDoNotDependOnServiceInternals(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.SortableGridColumnsUsePropertyColumn(System.Collections.Generic.IReadOnlyCollection<string!>! markupRoots) -> void
 virtual MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.MinimumScannedTypes.get -> int
 virtual MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.AllowedUnvalidatedCommands.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 virtual MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.MinimumCommands.get -> int
+virtual MMCA.Common.Testing.Architecture.ContractImplementationTestsBase.AllowedPublicImplementations.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 virtual MMCA.Common.Testing.Architecture.DomainEventHandlerSaveTestsBase.AllowedSavingTypes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 virtual MMCA.Common.Testing.Architecture.DomainEventHandlerSaveTestsBase.MaxCallDepth.get -> int
 virtual MMCA.Common.Testing.Architecture.DomainThrowTestsBase.AllowedThrowingTypes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/ContractImplementationTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/ContractImplementationTests.cs
@@ -1,0 +1,14 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// <c>[ServiceContract]</c> encapsulation rule (the class serving a published contract interface must
+/// not be public), driven by the shared <see cref="ContractImplementationTestsBase"/>. MMCA.Common
+/// marks no interface today, so the framework run is a ratchet rather than an assertion; see the base
+/// for why the rule is attribute-driven.
+/// </summary>
+public sealed class ContractImplementationTests : ContractImplementationTestsBase
+{
+    protected override IArchitectureMap Map { get; } = new CommonArchitectureMap();
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/ValidatingCommandDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/ValidatingCommandDecoratorTests.cs
@@ -82,6 +82,65 @@ public sealed class ValidatingCommandDecoratorTests
         inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ── Every registered validator runs ──
+    [Fact]
+    public async Task HandleAsync_TwoValidators_RunsBothAndUnionsTheirFailures()
+    {
+        // A command commonly carries a module-authored validator beside a cross-cutting one. Honoring
+        // only the first registration would leave the second one's rules silently unenforced.
+        var inner = new Mock<ICommandHandler<TestValidatingCommand, Result>>();
+
+        var first = new Mock<IValidator<TestValidatingCommand>>();
+        first.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("Name", "Name is required")]));
+
+        var second = new Mock<IValidator<TestValidatingCommand>>();
+        second.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("Name", "Name must be unique")]));
+
+        IEnumerable<IValidator<TestValidatingCommand>> validators = [first.Object, second.Object];
+        var sut = new ValidatingCommandDecorator<TestValidatingCommand, Result>(
+            inner.Object,
+            validators,
+            NullLogger<ValidatingCommandDecorator<TestValidatingCommand, Result>>.Instance);
+
+        Result result = await sut.HandleAsync(new TestValidatingCommand(string.Empty));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Select(e => e.Message).Should().BeEquivalentTo(
+            ["Name is required", "Name must be unique"],
+            "the caller sees every broken rule in one response, not one per round trip");
+        first.Verify(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        second.Verify(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_TwoValidators_FirstPasses_StillHonorsTheSecond()
+    {
+        var inner = new Mock<ICommandHandler<TestValidatingCommand, Result>>();
+
+        var passing = new Mock<IValidator<TestValidatingCommand>>();
+        passing.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        var failing = new Mock<IValidator<TestValidatingCommand>>();
+        failing.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("Name", "Name must be unique")]));
+
+        IEnumerable<IValidator<TestValidatingCommand>> validators = [passing.Object, failing.Object];
+        var sut = new ValidatingCommandDecorator<TestValidatingCommand, Result>(
+            inner.Object,
+            validators,
+            NullLogger<ValidatingCommandDecorator<TestValidatingCommand, Result>>.Instance);
+
+        Result result = await sut.HandleAsync(new TestValidatingCommand("valid"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Message == "Name must be unique");
+        inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // ── Result<T> generic variant ──
     [Fact]
     public async Task HandleAsync_GenericResult_ValidationFails_ReturnsTypedFailure()

--- a/Tests/Core/MMCA.Common.Application.Tests/Decorators/ValidatingQueryDecoratorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Decorators/ValidatingQueryDecoratorTests.cs
@@ -160,9 +160,39 @@ public sealed class ValidatingQueryDecoratorTests
         result.Value.Should().Be(42);
     }
 
-    // ── First registered validator wins, exactly like the command twin ──
+    // ── Every registered validator runs, exactly like the command twin ──
     [Fact]
-    public async Task HandleAsync_MultipleValidators_UsesOnlyTheFirst()
+    public async Task HandleAsync_MultipleValidators_RunsThemAllAndUnionsTheirFailures()
+    {
+        var inner = new Mock<IQueryHandler<TestValidatingQuery, Result>>();
+
+        var first = new Mock<IValidator<TestValidatingQuery>>();
+        first.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("PageSize", "PageSize must be greater than zero")]));
+
+        var second = new Mock<IValidator<TestValidatingQuery>>();
+        second.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult([new ValidationFailure("SortBy", "SortBy is not a known column")]));
+
+        IEnumerable<IValidator<TestValidatingQuery>> validators = [first.Object, second.Object];
+        var sut = new ValidatingQueryDecorator<TestValidatingQuery, Result>(
+            inner.Object,
+            validators,
+            NullLogger<ValidatingQueryDecorator<TestValidatingQuery, Result>>.Instance);
+
+        Result result = await sut.HandleAsync(new TestValidatingQuery(string.Empty));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Select(e => e.Message).Should().BeEquivalentTo(
+            ["PageSize must be greater than zero", "SortBy is not a known column"],
+            "a second registered validator is not dead code: its rules are enforced too");
+        first.Verify(x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        second.Verify(x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_MultipleValidators_AllPass_CallsInnerHandlerOnce()
     {
         var inner = new Mock<IQueryHandler<TestValidatingQuery, Result>>();
         inner.Setup(x => x.HandleAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()))
@@ -174,7 +204,7 @@ public sealed class ValidatingQueryDecoratorTests
 
         var second = new Mock<IValidator<TestValidatingQuery>>();
         second.Setup(x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ValidationResult([new ValidationFailure("PageSize", "never reached")]));
+            .ReturnsAsync(new ValidationResult());
 
         IEnumerable<IValidator<TestValidatingQuery>> validators = [first.Object, second.Object];
         var sut = new ValidatingQueryDecorator<TestValidatingQuery, Result>(
@@ -185,9 +215,8 @@ public sealed class ValidatingQueryDecoratorTests
         Result result = await sut.HandleAsync(new TestValidatingQuery("valid"));
 
         result.IsSuccess.Should().BeTrue();
-        second.Verify(
-            x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        second.Verify(x => x.ValidateAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()), Times.Once);
+        inner.Verify(x => x.HandleAsync(It.IsAny<TestValidatingQuery>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ── A handler whose TResult is neither Result nor Result<T>: the failure factory must stay lazy,

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/DependencyInjectionBrokerMessagingTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/DependencyInjectionBrokerMessagingTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using MassTransit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -84,4 +85,39 @@ public sealed class DependencyInjectionBrokerMessagingTests
 
         services.Should().BeEmpty("the in-process provider short-circuits before touching the container");
     }
+
+    [Fact]
+    public void AddBrokerMessaging_EndpointPrefix_ReachesTheEndpointNameFormatter()
+    {
+        // The setting exists so several services can share one broker: if the prefix never reaches the
+        // formatter, two services with the same consumer type name derive the same queue and become
+        // competing consumers of each other's events.
+        var services = new ServiceCollection();
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MessageBus:Provider"] = "RabbitMq",
+                ["MessageBus:ConnectionString"] = "amqp://guest:guest@localhost:5672",
+                ["MessageBus:EndpointPrefix"] = "store-catalog",
+            })
+            .Build();
+
+        services.AddBrokerMessaging(configuration);
+
+        var formatter = services
+            .Select(d => d.ImplementationInstance)
+            .OfType<IEndpointNameFormatter>()
+            .Should().ContainSingle().Subject;
+
+        formatter.Consumer<OrderPlacedConsumer>().Should().Be("store-catalog-order-placed");
+    }
+
+    /// <summary>A consumer that exists only to be named by the endpoint name formatter.</summary>
+    private sealed class OrderPlacedConsumer : IConsumer<OrderPlacedTestEvent>
+    {
+        public Task Consume(ConsumeContext<OrderPlacedTestEvent> context) => Task.CompletedTask;
+    }
+
+    /// <summary>The message the naming-only consumer above is closed over.</summary>
+    public sealed record OrderPlacedTestEvent(int OrderId);
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/ApplicationDbContextTenantFilterTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/ApplicationDbContextTenantFilterTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using MMCA.Common.Domain.Interfaces;
 using MMCA.Common.Infrastructure.Persistence.DbContexts;
 using MMCA.Common.Infrastructure.Persistence.Repositories;
 
@@ -152,16 +153,31 @@ public sealed class ApplicationDbContextTenantFilterTests : IDisposable
     }
 
     [Fact]
-    public void TenantIdColumn_IsIndexed()
+    public void TenantIdColumn_IsIndexed_CompositeWithIsDeleted_WhenTheEntityIsAlsoSoftDeletable()
     {
         using var context = TenantTestContext.Create(_connection);
 
         context.Model.FindEntityType(typeof(TenantThing))!
             .GetIndexes()
             .Should().Contain(index =>
+                index.Properties.Count == 2
+                && index.Properties[0].Name == ApplicationDbContext.TenantIdPropertyName
+                && index.Properties[1].Name == nameof(IAuditableEntity.IsDeleted),
+                "the two named filters compose with AND, so every read carries "
+                + "'TenantId = @tenant AND IsDeleted = 0' and the index must cover both conjuncts");
+    }
+
+    [Fact]
+    public void TenantIdColumn_IsIndexedAlone_WhenTheEntityIsNotSoftDeletable()
+    {
+        using var context = TenantTestContext.Create(_connection);
+
+        context.Model.FindEntityType(typeof(TenantOnlyThing))!
+            .GetIndexes()
+            .Should().ContainSingle(index =>
                 index.Properties.Count == 1
                 && index.Properties[0].Name == ApplicationDbContext.TenantIdPropertyName,
-                "every tenant-scoped read leads with TenantId, so an unindexed column is a scan per query");
+                "an entity with no soft-delete filter has no second conjunct to cover");
     }
 
     [Fact]

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantTestHarness.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Tenancy/TenantTestHarness.cs
@@ -44,6 +44,18 @@ public sealed class PlainThing : AuditableBaseEntity<int>
     public string Name { get; set; } = string.Empty;
 }
 
+/// <summary>
+/// A tenant-owned entity that is NOT soft-deletable: its reads carry the tenant predicate alone, so
+/// it must keep the single-column tenant index rather than the composite one.
+/// </summary>
+public sealed class TenantOnlyThing : BaseEntity<int>, ITenantEntity
+{
+    /// <summary>Gets or sets the owning tenant. Public setter for test seeding only.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+}
+
 /// <summary>An opted-in entity that is also change-trailed, for the trail's TenantId column.</summary>
 public sealed class TrailedTenantThing : AuditableBaseEntity<int>, ITenantEntity, IAuditedEntity
 {
@@ -152,6 +164,12 @@ public sealed class TenantTestContext : ApplicationDbContext
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).ValueGeneratedNever();
             entity.Property(e => e.RowVersion).IsConcurrencyToken();
+        });
+
+        modelBuilder.Entity<TenantOnlyThing>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedNever();
         });
 
         modelBuilder.Entity<TrailedTenantThing>(entity =>


### PR DESCRIPTION
PR 1 of 6 in the Medium-recs wave (plan: 20-article audit, `Reports/medium-articles-vs-mmca-2026-08-28.md`).

**Added**
- `ContractImplementationTestsBase`: opt-in fitness base asserting `[ServiceContract]` implementations are non-public
- `CHANGELOG.md` packed into every nupkg; `Copyright` + `PackageReleaseNotes` metadata

**Changed**
- **BREAKING**: `IRepository`/`IWriteRepository`/`EFRepository`(+decorator) constrained to `AuditableAggregateRootEntity` (read side untouched). All call sites in all four repos verified clean; ADC has three test-support files needing the widened constraint at pin-bump time.
- Both Validating decorators run ALL registered validators and union failures (was `FirstOrDefault`)
- Tenant index is composite `(TenantId, IsDeleted)` for soft-deletable tenant entities (no consumer has tenant entities; no downstream migrations)

**Fixed**
- `MessageBusSettings.EndpointPrefix` value is now actually applied as the kebab-case endpoint-name prefix (was a boolean toggle that discarded the value; no consumer sets it, so no live queue names change)

Verified: Release build zero warnings; 4,865 tests passing; `build/facts --check` green; `MMCA.Common.Shared` pack inspected (CHANGELOG + metadata present).

After merge: user E2E, then tag `v1.166.0` (post-tag FACTS PR follows), then one pin-bump PR per consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jQtUMpox3zJLNv3Mecpki