### PR TITLE
feat: h2c health gating, probe auto-negotiation, E2E interactivity gate (v1.167.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.167.0] - 2026-08-29
+
+Health-gating and E2E-reliability release closing the wave6 ledger items: Http2-only services become
+health-gateable under Aspire, the gateway probe negotiates its protocol on its own, and the E2E
+Blazor gate waits for real interactivity instead of a fixed settle.
+
+### Added
+
+- **`WithH2cHealthCheck` AppHost extension** (`MMCA.Common.Aspire.Hosting`). Health-gates a project
+  resource whose cleartext endpoint is Kestrel Http2-only (h2c prior knowledge), which Aspire's
+  stock `WithHttpHealthCheck` cannot probe (its HTTP/1.1 request answers `HTTP_1_1_REQUIRED`
+  forever, wedging every `WaitFor` on the resource). The check GETs the health path over HTTP/2
+  exact version against the existing endpoint: no service, Kestrel, or infra change needed. The
+  XML docs record why surfacing the `HealthProbe:Port` HTTP/1.1 listener as an Aspire endpoint was
+  rejected (explicit listeners override the `ASPNETCORE_URLS` binding locally and collide on the
+  fixed cleartext port).
+- **`GatewayDownstreamHealthCheckOptions.ProbeVersion`** (`DownstreamProbeVersion.Auto` default).
+  The downstream probe tries HTTP/2 exact first, falls back to HTTP/1.1 within the same check on a
+  protocol refusal, and latches the winner per downstream for process lifetime, so mixed
+  `Http1AndHttp2` cleartext services no longer need a manual opt-out registration.
+- **E2E interactivity marker.** `MmcaThemeProviders` stamps `data-mmca-interactive` on the document
+  root at its first interactive render (re-stamped across enhanced navigations), giving tests a
+  true hydration signal.
+
+### Changed
+
+- **`ProbeOverHttp2` is obsolete** (warning): it remains as a facade over `ProbeVersion`; delete
+  per-downstream opt-out registrations and let `Auto` negotiate.
+- **`WaitForBlazorAsync` waits for real interactivity.** After the Blazor runtime check it now
+  waits up to 3s for the interactivity marker (then settles one animation frame); pages that never
+  hydrate, or consumers on an older `MMCA.Common.UI`, fall back to the previous
+  two-frames-plus-500ms settle, so nothing hangs and the prerendered-dead-control failure class is
+  closed for every consumer suite at once.
+
 ## [1.166.0] - 2026-08-28
 
 Hardening release from the 2026-08-28 Medium-literature audit (20 articles cross-checked against the

--- a/MMCA.Common.slnx
+++ b/MMCA.Common.slnx
@@ -41,6 +41,7 @@
   </Folder>
   <Folder Name="/Tests/Hosting/">
     <Project Path="Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj" />
+    <Project Path="Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/MMCA.Common.Aspire.Hosting.Tests.csproj" />
     <Project Path="Tests/Hosting/MMCA.Common.Gateway.Tests/MMCA.Common.Gateway.Tests.csproj" />
     <Project Path="Tests/Hosting/MMCA.Common.Testing.Tests/MMCA.Common.Testing.Tests.csproj" />
   </Folder>

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cEndpointHealthCheck.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cEndpointHealthCheck.cs
@@ -1,0 +1,137 @@
+using System.Globalization;
+using System.Net;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MMCA.Common.Aspire.Hosting;
+
+/// <summary>
+/// GETs one path on an Aspire endpoint over HTTP/2 with prior knowledge (h2c) and reports the
+/// outcome as that resource's health.
+/// <para>
+/// A hand-rolled <see cref="IHealthCheck"/> rather than Aspire's stock HTTP health check: the stock
+/// one probes with a default <see cref="HttpClient"/>, so the request goes out HTTP/1.1 and an
+/// Http2-only cleartext endpoint refuses it with GOAWAY <c>HTTP_1_1_REQUIRED</c>. The version pair
+/// below is the whole difference, and it is the same pair the framework's gateway probes use.
+/// </para>
+/// <para>
+/// The endpoint URL is resolved on every check, not captured at registration time: the AppHost
+/// registers this check while building the application model, and Aspire only allocates the endpoint
+/// once the resource starts.
+/// </para>
+/// </summary>
+internal sealed class H2cEndpointHealthCheck : IHealthCheck
+{
+    /// <summary>
+    /// Proxy detection is off: the probe target is a sibling process on the developer's own machine
+    /// (or a sibling replica inside the deployment network), never something a proxy should see.
+    /// </summary>
+    private static readonly SocketsHttpHandler ProbeHandler = new() { UseProxy = false };
+
+    /// <summary>
+    /// One process-lifetime client for every probe. Static rather than per-registration so a handful
+    /// of gated resources do not each hold their own connection pool, and so this type owns no
+    /// disposable instance state.
+    /// </summary>
+    private static readonly HttpClient ProbeClient =
+        new(ProbeHandler, disposeHandler: false) { Timeout = H2cHealthCheckExtensions.ProbeTimeout };
+
+    private readonly Func<string> _resolveEndpointUrl;
+    private readonly string _path;
+    private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _send;
+
+    /// <summary>
+    /// Creates the probe used by <c>WithH2cHealthCheck</c>.
+    /// </summary>
+    /// <param name="endpoint">The resource endpoint to probe.</param>
+    /// <param name="path">The path to GET on that endpoint.</param>
+    internal H2cEndpointHealthCheck(EndpointReference endpoint, string path)
+        : this(() => endpoint.Url, path, ProbeClient.SendAsync)
+    {
+    }
+
+    /// <summary>
+    /// Test constructor: takes the URL resolver and the send delegate directly, so the probe can be
+    /// exercised against a stub handler and against an endpoint that is not yet allocated.
+    /// <para>
+    /// A send delegate rather than an <see cref="HttpMessageHandler"/> keeps this type free of a
+    /// disposable instance field: the shared client above is process-lifetime state, and a
+    /// per-instance client would make every health-check registration an owner of one.
+    /// </para>
+    /// </summary>
+    /// <param name="resolveEndpointUrl">Resolves the endpoint base URL, or throws while unallocated.</param>
+    /// <param name="path">The path to GET on that endpoint.</param>
+    /// <param name="send">Sends the probe request.</param>
+    internal H2cEndpointHealthCheck(
+        Func<string> resolveEndpointUrl,
+        string path,
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send)
+    {
+        _resolveEndpointUrl = resolveEndpointUrl;
+        _path = path;
+        _send = send;
+    }
+
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        string endpointUrl;
+        try
+        {
+            endpointUrl = _resolveEndpointUrl();
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The endpoint has no allocation yet, which is the normal state for the first polls after
+            // the AppHost starts. Reporting the failure status (rather than Healthy, and rather than
+            // letting the exception escape) is what keeps a WaitFor edge closed: Aspire releases the
+            // wait only on Healthy, so a pre-allocation poll must not pass.
+            return new HealthCheckResult(
+                context.Registration.FailureStatus,
+                "Endpoint is not allocated yet, so there is nothing to probe.",
+                ex);
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                new Uri(new Uri(endpointUrl, UriKind.Absolute), _path))
+            {
+                // h2c prior knowledge: with no TLS there is no ALPN to negotiate with, so the request
+                // has to go out as HTTP/2 and must not be allowed to fall back to HTTP/1.1, which an
+                // Http2-only Kestrel endpoint answers with GOAWAY HTTP_1_1_REQUIRED.
+                Version = HttpVersion.Version20,
+                VersionPolicy = HttpVersionPolicy.RequestVersionExact,
+            };
+
+            using var response = await _send(request, cancellationToken).ConfigureAwait(false);
+
+            var description = "Endpoint answered " + _path + " with "
+                + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + " over HTTP/2.";
+
+            if (response.IsSuccessStatusCode)
+            {
+                return HealthCheckResult.Healthy(description);
+            }
+
+            return new HealthCheckResult(context.Registration.FailureStatus, description);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or TimeoutException or InvalidOperationException or UriFormatException
+                                   && !cancellationToken.IsCancellationRequested)
+        {
+            // Unreachable, still starting, refusing HTTP/2, or slower than the probe budget. Narrow
+            // catch list (rather than a blanket Exception) so a genuine programming error still
+            // surfaces, and the cancellation guard keeps AppHost shutdown from being reported as a
+            // service fault.
+            return new HealthCheckResult(
+                context.Registration.FailureStatus,
+                "Endpoint did not answer " + _path + " over HTTP/2.",
+                ex);
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cHealthCheckExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cHealthCheckExtensions.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MMCA.Common.Aspire.Hosting;
+
+/// <summary>
+/// AppHost-side health check for a project resource whose cleartext endpoint is Http2-only (h2c,
+/// prior knowledge), so a <c>WaitFor</c> edge pointed at that resource waits for the service to be
+/// READY rather than merely started.
+/// <para>
+/// Aspire's stock <c>WithHttpHealthCheck</c> probes with a default <see cref="HttpClient"/>, which
+/// sends HTTP/1.1. A Kestrel endpoint configured <c>HttpProtocols.Http2</c> answers that with GOAWAY
+/// <c>HTTP_1_1_REQUIRED</c> rather than the health payload, so the check never turns healthy and the
+/// resource cannot be health-gated at all. Every <c>WaitFor</c> edge into it then degrades to "the
+/// process started", which is precisely the condition that lets a dependent resource race a service
+/// that has not finished migrating, seeding or warming up. This registration issues the same GET
+/// over HTTP/2 with <see cref="HttpVersionPolicy.RequestVersionExact"/>, the h2c prior-knowledge
+/// profile the framework's own gateway probes already use.
+/// </para>
+/// <para>
+/// <b>Rejected alternative, recorded so it is not re-proposed: surfacing the HTTP/1.1 health-probe
+/// listener as an Aspire endpoint.</b> A deployed service already runs a dedicated Http1-only
+/// listener for the platform probes (<c>ConfigureEndpointsWithHealthProbe</c>, driven by the
+/// <c>HealthProbe:Port</c> configuration key), so it looks tempting to inject
+/// <c>HealthProbe__Port</c> locally as well and point a stock <c>WithHttpHealthCheck</c> at it.
+/// Injecting that variable locally flips <c>ConfigureEndpointsWithHealthProbe</c> out of
+/// endpoint-defaults mode and into explicit-listener mode: its <c>Listen</c> calls then override the
+/// <c>ASPNETCORE_URLS</c> binding Aspire injects, so the service stops listening on the dynamic port
+/// Aspire allocated for it, and every co-hosted service collides on the one fixed cleartext port.
+/// The probe listener is a deployment-only construct. Locally, the answer is to speak the protocol
+/// the service already serves.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1708:Identifiers should differ by more than case",
+    Justification = "False positive: with extension(T) blocks, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
+public static class H2cHealthCheckExtensions
+{
+    /// <summary>
+    /// Default path probed. <c>/health/ready</c> rather than <c>/alive</c> on purpose: the point of
+    /// gating a <c>WaitFor</c> edge is to hold the dependent resource until the service can actually
+    /// serve, which includes its database and its own dependency checks. A gateway probing its
+    /// downstreams makes the opposite choice for the opposite reason.
+    /// </summary>
+    public const string DefaultProbePath = "/health/ready";
+
+    /// <summary>
+    /// Default Aspire endpoint name probed. The cleartext <c>http</c> endpoint is the h2c one; an
+    /// <c>https</c> endpoint negotiates the version through ALPN and needs nothing special.
+    /// </summary>
+    public const string DefaultEndpointName = "http";
+
+    /// <summary>
+    /// Probe budget, matching the gateway's downstream probes. Short on purpose: Aspire polls this
+    /// check for as long as a dependent resource is waiting, and a probe slower than the poll
+    /// interval turns the wait into a queue.
+    /// </summary>
+    internal static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Health-check key registered for one resource-and-endpoint pair. The endpoint name is part of
+    /// the key because a resource may expose more than one endpoint worth gating.
+    /// </summary>
+    /// <param name="resourceName">The Aspire resource name.</param>
+    /// <param name="endpointName">The Aspire endpoint name being probed.</param>
+    /// <returns>The health-check key.</returns>
+    internal static string CheckKey(string resourceName, string endpointName) =>
+        resourceName + "-h2c-" + endpointName;
+
+    extension(IResourceBuilder<ProjectResource> builder)
+    {
+        /// <summary>
+        /// Registers an HTTP/2 (h2c prior knowledge) health check against one of the resource's
+        /// endpoints and associates it with the resource, so <c>WaitFor</c> edges into this resource
+        /// wait for a real ready answer.
+        /// <para>
+        /// Use this instead of Aspire's <c>WithHttpHealthCheck</c> whenever the target endpoint is
+        /// Http2-only. For an endpoint that serves <c>Http1AndHttp2</c> the stock extension is fine
+        /// and this one is unnecessary.
+        /// </para>
+        /// <para>
+        /// Calling it twice for the same resource and endpoint is a no-op: the second call returns
+        /// the builder unchanged rather than registering a duplicate health-check key, which the
+        /// health-check service rejects at startup.
+        /// </para>
+        /// </summary>
+        /// <param name="path">The path to GET (defaults to <see cref="DefaultProbePath"/>).</param>
+        /// <param name="endpointName">
+        /// The Aspire endpoint to probe (defaults to <see cref="DefaultEndpointName"/>). The endpoint
+        /// is resolved lazily, so a name the resource never declares is not an error here: it
+        /// surfaces as a permanently unhealthy check, which keeps the dependent resource waiting
+        /// instead of letting it start against a service nobody verified.
+        /// </param>
+        /// <returns>The project resource builder for chaining.</returns>
+        public IResourceBuilder<ProjectResource> WithH2cHealthCheck(
+            string path = DefaultProbePath,
+            string endpointName = DefaultEndpointName)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+            ArgumentException.ThrowIfNullOrWhiteSpace(endpointName);
+
+            var services = builder.ApplicationBuilder.Services;
+            var key = CheckKey(builder.Resource.Name, endpointName);
+
+            if (!H2cHealthCheckRegistry.GetOrAdd(services).TryClaim(key))
+            {
+                return builder;
+            }
+
+            var endpoint = builder.GetEndpoint(endpointName);
+
+            services.AddHealthChecks().Add(new HealthCheckRegistration(
+                key,
+                _ => new H2cEndpointHealthCheck(endpoint, path),
+                failureStatus: HealthStatus.Unhealthy,
+                tags: null,
+                timeout: ProbeTimeout));
+
+            // WithHealthCheck only ASSOCIATES the named check with the resource; the registration
+            // above is what supplies it. Both halves are required for a WaitFor edge to gate.
+            return builder.WithHealthCheck(key);
+        }
+    }
+}
+
+/// <summary>
+/// Registration-time ledger of the resource-and-endpoint pairs already wired by
+/// <c>WithH2cHealthCheck</c>. It exists because <see cref="IServiceCollection"/> offers no way to ask
+/// which health checks are already registered, and a duplicate health-check key is a startup
+/// exception rather than a harmless second registration.
+/// <para>
+/// The ledger is attached to the AppHost's own service collection rather than kept in a static field,
+/// so two <c>DistributedApplication.CreateBuilder</c> instances in one process (which is what a test
+/// run is) never see each other's claims.
+/// </para>
+/// </summary>
+internal sealed class H2cHealthCheckRegistry
+{
+    /// <summary>
+    /// Keys already registered. A list rather than a case-insensitive <see cref="HashSet{T}"/>
+    /// because an AppHost gates a handful of resources, and the set's comparer-carrying constructor
+    /// is one of the initializer shapes IDE0028 misreports here.
+    /// </summary>
+    private readonly List<string> _keys = [];
+
+    /// <summary>
+    /// Records <paramref name="key"/> as registered, returning <see langword="false"/> when an
+    /// earlier call already claimed it (compared case-insensitively).
+    /// </summary>
+    /// <param name="key">The health-check key.</param>
+    /// <returns><see langword="true"/> when this is the first registration for the key.</returns>
+    internal bool TryClaim(string key)
+    {
+        if (_keys.Contains(key, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        _keys.Add(key);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the ledger already attached to <paramref name="services"/>, adding one if this is the
+    /// first call.
+    /// </summary>
+    /// <param name="services">The AppHost service collection being configured.</param>
+    /// <returns>The single ledger instance for this collection.</returns>
+    internal static H2cHealthCheckRegistry GetOrAdd(IServiceCollection services)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(H2cHealthCheckRegistry)
+                && descriptor.ImplementationInstance is H2cHealthCheckRegistry existing)
+            {
+                return existing;
+            }
+        }
+
+        var registry = new H2cHealthCheckRegistry();
+        services.AddSingleton(registry);
+        return registry;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/MMCA.Common.Aspire.Hosting.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/MMCA.Common.Aspire.Hosting.csproj
@@ -4,6 +4,9 @@
     <Description>MMCA framework: Aspire AppHost extension methods for the cross-cutting infrastructure (RabbitMQ broker, JWKS service discovery, gRPC project wiring) used by extracted microservice deployments</Description>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="MMCA.Common.Aspire.Hosting.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <!-- WithDataSource wires a service to its own SqlServerDatabaseResource (database per

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
 MMCA.Common.Aspire.Hosting.Extensions.extension(Aspire.Hosting.IDistributedApplicationBuilder!).AddMailDev(string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions
+MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!)
+MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!).WithH2cHealthCheck(string! path = "/health/ready", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 const MMCA.Common.Aspire.Hosting.Extensions.DefaultMailDevResourceName = "maildev" -> string!
 const MMCA.Common.Aspire.Hosting.Extensions.MailDevHttpPort = 1080 -> int
 const MMCA.Common.Aspire.Hosting.Extensions.MailDevSmtpPort = 1025 -> int
+const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultEndpointName = "http" -> string!
+const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultProbePath = "/health/ready" -> string!
 static MMCA.Common.Aspire.Hosting.Extensions.AddMailDev(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+static MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.WithH2cHealthCheck(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, string! path = "/health/ready", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!

--- a/Source/Hosting/MMCA.Common.Aspire/Gateway/DownstreamServiceHealthCheck.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Gateway/DownstreamServiceHealthCheck.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace MMCA.Common.Aspire.Gateway;
@@ -18,17 +19,40 @@ namespace MMCA.Common.Aspire.Gateway;
 /// gateway needs to know is whether the service EXISTS and is reachable at all. Probing readiness
 /// would make every rolling deployment downstream register as a gateway health failure.
 /// </para>
+/// <para>
+/// Under <see cref="DownstreamProbeVersion.Auto"/> the first probe asks for HTTP/2 and, if the
+/// downstream refuses the protocol, retries once as HTTP/1.1 within the same check, so one poll
+/// still yields one verdict. The version that answered is latched for the life of this instance,
+/// and the health-check service holds one instance per downstream, so the latch is effectively per
+/// downstream for the life of the process. That is safe because a service cannot change the
+/// protocol of its cleartext endpoint without a redeploy, and a redeploy of the topology restarts
+/// this gateway too: a stale latch cannot outlive the endpoint that justified it.
+/// </para>
 /// </summary>
 /// <param name="httpClientFactory">Factory for the named, service-discovery-wired client.</param>
 /// <param name="serviceName">The Aspire service name being probed, used for messages.</param>
 /// <param name="clientName">The named <see cref="HttpClient"/> registration to resolve.</param>
+/// <param name="probeVersion">
+/// The version profile chosen at registration. <see cref="DownstreamProbeVersion.Auto"/> negotiates
+/// on the first probe; the fixed modes never negotiate.
+/// </param>
 internal sealed class DownstreamServiceHealthCheck(
     IHttpClientFactory httpClientFactory,
     string serviceName,
-    string clientName) : IHealthCheck
+    string clientName,
+    DownstreamProbeVersion probeVersion) : IHealthCheck
 {
     /// <summary>The relative path probed on the downstream service.</summary>
     internal static readonly Uri ProbePath = new("/alive", UriKind.Relative);
+
+    /// <summary>
+    /// The version <see cref="DownstreamProbeVersion.Auto"/> has settled on, held as the underlying
+    /// value of <see cref="DownstreamProbeVersion"/> so that zero, which is
+    /// <see cref="DownstreamProbeVersion.Auto"/> itself, reads as "not settled yet". Written with
+    /// <c>Interlocked.CompareExchange</c> rather than a plain assignment because two readiness
+    /// polls can overlap on a cold gateway: the first writer wins and nothing ever unlatches.
+    /// </summary>
+    private int _latchedProbeVersion;
 
     /// <inheritdoc />
     public async Task<HealthCheckResult> CheckHealthAsync(
@@ -41,21 +65,12 @@ internal sealed class DownstreamServiceHealthCheck(
 
         try
         {
-            using var response = await client
-                .GetAsync(ProbePath, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (response.IsSuccessStatusCode)
+            if (probeVersion == DownstreamProbeVersion.Auto)
             {
-                return HealthCheckResult.Healthy(
-                    "Downstream service '" + serviceName + "' answered /alive with "
-                    + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + ".");
+                return await NegotiateAsync(client, context, cancellationToken).ConfigureAwait(false);
             }
 
-            return new HealthCheckResult(
-                context.Registration.FailureStatus,
-                "Downstream service '" + serviceName + "' answered /alive with "
-                + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + ".");
+            return await SendProbeAsync(client, context, probeVersion, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or TimeoutException or InvalidOperationException
                                    && !cancellationToken.IsCancellationRequested)
@@ -63,10 +78,120 @@ internal sealed class DownstreamServiceHealthCheck(
             // Unreachable, DNS-unresolvable, or slower than the probe timeout. Narrow catch list
             // (rather than a blanket Exception) so a genuine programming error still surfaces, and
             // the cancellation guard keeps host shutdown from being reported as a dependency fault.
+            // Nothing latches on this path on purpose: a transient outage says nothing about which
+            // protocol the endpoint speaks, and pinning the wrong one would outlive the outage.
             return new HealthCheckResult(
                 context.Registration.FailureStatus,
                 "Downstream service '" + serviceName + "' did not answer /alive.",
                 ex);
         }
     }
+
+    /// <summary>
+    /// Runs the <see cref="DownstreamProbeVersion.Auto"/> path: reuse the latched version once one
+    /// exists, otherwise ask for HTTP/2 and fall back to HTTP/1.1 on a protocol refusal.
+    /// </summary>
+    /// <param name="client">The service-discovery-wired probe client.</param>
+    /// <param name="context">The health-check context supplying the failure status.</param>
+    /// <param name="cancellationToken">The probe's cancellation token.</param>
+    /// <returns>The health result for this poll.</returns>
+    private async Task<HealthCheckResult> NegotiateAsync(
+        HttpClient client,
+        HealthCheckContext context,
+        CancellationToken cancellationToken)
+    {
+        var latched = (DownstreamProbeVersion)Volatile.Read(ref _latchedProbeVersion);
+        if (latched != DownstreamProbeVersion.Auto)
+        {
+            return await SendProbeAsync(client, context, latched, cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            var result = await SendProbeAsync(client, context, DownstreamProbeVersion.Http2, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Any HTTP response, whatever its status, proves the endpoint speaks HTTP/2. The status
+            // itself is the health verdict and has nothing to do with the protocol choice.
+            Latch(DownstreamProbeVersion.Http2);
+            return result;
+        }
+        catch (HttpRequestException ex) when (IsProtocolRefusal(ex) && !cancellationToken.IsCancellationRequested)
+        {
+            // The connection was fine and the protocol was not: a cleartext Http1AndHttp2 endpoint
+            // without ALPN answers HTTP_1_1_REQUIRED forever. Retry once inside this same check and
+            // token budget so the poll still returns a verdict. If HTTP/1.1 also fails, the caller's
+            // handler reports Unhealthy and nothing latches.
+            var result = await SendProbeAsync(client, context, DownstreamProbeVersion.Http11, cancellationToken)
+                .ConfigureAwait(false);
+
+            Latch(DownstreamProbeVersion.Http11);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Sends one <c>/alive</c> GET at the given version and maps the answer onto a health status.
+    /// </summary>
+    /// <param name="client">The service-discovery-wired probe client.</param>
+    /// <param name="context">The health-check context supplying the failure status.</param>
+    /// <param name="version">
+    /// The resolved version to send. Callers resolve <see cref="DownstreamProbeVersion.Auto"/> first.
+    /// </param>
+    /// <param name="cancellationToken">The probe's cancellation token.</param>
+    /// <returns>The health result for this attempt.</returns>
+    private async Task<HealthCheckResult> SendProbeAsync(
+        HttpClient client,
+        HealthCheckContext context,
+        DownstreamProbeVersion version,
+        CancellationToken cancellationToken)
+    {
+        var http11 = version == DownstreamProbeVersion.Http11;
+
+        // Set per request, not on the client: one client serves both attempts of a negotiation.
+        using var request = new HttpRequestMessage(HttpMethod.Get, ProbePath)
+        {
+            Version = http11 ? HttpVersion.Version11 : HttpVersion.Version20,
+            VersionPolicy = http11
+                ? HttpVersionPolicy.RequestVersionOrLower
+                : HttpVersionPolicy.RequestVersionExact,
+        };
+
+        using var response = await client
+            .SendAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return HealthCheckResult.Healthy(
+                "Downstream service '" + serviceName + "' answered /alive with "
+                + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + ".");
+        }
+
+        return new HealthCheckResult(
+            context.Registration.FailureStatus,
+            "Downstream service '" + serviceName + "' answered /alive with "
+            + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + ".");
+    }
+
+    /// <summary>
+    /// Whether the failure is the downstream refusing the HTTP VERSION rather than a connectivity
+    /// fault. Only these two errors justify retrying at a different version: DNS, a refused
+    /// connection, a TLS fault or a timeout say nothing about which protocol the endpoint speaks.
+    /// </summary>
+    /// <param name="exception">The failure to classify.</param>
+    /// <returns><see langword="true"/> when another HTTP version is worth trying.</returns>
+    private static bool IsProtocolRefusal(HttpRequestException exception) =>
+        exception.HttpRequestError is HttpRequestError.VersionNegotiationError
+            or HttpRequestError.HttpProtocolError;
+
+    /// <summary>
+    /// Records the version that answered. First writer wins, and a latched value is never replaced.
+    /// </summary>
+    /// <param name="version">The version to latch.</param>
+    private void Latch(DownstreamProbeVersion version) =>
+        Interlocked.CompareExchange(
+            ref _latchedProbeVersion,
+            (int)version,
+            (int)DownstreamProbeVersion.Auto);
 }

--- a/Source/Hosting/MMCA.Common.Aspire/Gateway/GatewayHealthCheckExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Gateway/GatewayHealthCheckExtensions.cs
@@ -1,34 +1,79 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace MMCA.Common.Aspire.Gateway;
 
 /// <summary>
+/// Which HTTP version a downstream <c>/alive</c> probe asks for.
+/// </summary>
+public enum DownstreamProbeVersion
+{
+    /// <summary>
+    /// Try HTTP/2 (h2c prior knowledge) first and, when the downstream refuses the protocol rather
+    /// than the connection, fall back to HTTP/1.1 inside the SAME check, so a single readiness poll
+    /// still produces one verdict. The version that answered is then latched for the life of the
+    /// process, making the fallback a one-time cost per downstream rather than a per-poll one.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Always send HTTP/2 over cleartext (h2c prior knowledge), with
+    /// <see cref="HttpVersionPolicy.RequestVersionExact"/> so the request never negotiates down.
+    /// Pin this only for a downstream known to be HTTP/2-only, to skip the one-time negotiation.
+    /// </summary>
+    Http2,
+
+    /// <summary>
+    /// Always send HTTP/1.1 with <see cref="HttpVersionPolicy.RequestVersionOrLower"/>, exactly the
+    /// stock <see cref="HttpClient"/> behavior. Pin this only for a downstream known to be
+    /// HTTP/1.1-only, to skip the one-time negotiation.
+    /// </summary>
+    Http11
+}
+
+/// <summary>
 /// Per-call options for <c>AddGatewayDownstreamHealthChecks</c>. One instance covers every service
-/// name passed to that call, so a gateway fronting a mix of HTTP/2-only and HTTP/1.1-only heads
-/// makes one call per profile rather than carrying a per-name map.
+/// name passed to that call, so a gateway pinning a version profile for some of its heads makes one
+/// call per profile rather than carrying a per-name map.
 /// </summary>
 public sealed class GatewayDownstreamHealthCheckOptions
 {
     /// <summary>
-    /// Whether the probe client speaks HTTP/2 over cleartext (h2c prior knowledge). Default
-    /// <see langword="true"/>.
+    /// Which HTTP version the probe requests. Default <see cref="DownstreamProbeVersion.Auto"/>,
+    /// which settles the question per downstream and needs no per-service configuration.
     /// <para>
-    /// The default exists because the services a modular-monolith gateway fronts serve h2c so that
-    /// cross-service gRPC clients can negotiate HTTP/2 without TLS/ALPN. An <c>HttpClient</c> left
-    /// on its own defaults sends HTTP/1.1, which such an endpoint refuses, so the probe fails and
-    /// the gateway reports a downstream outage that does not exist.
+    /// Negotiating is necessary because neither fixed answer is right for every head. The services
+    /// a modular-monolith gateway fronts serve h2c so cross-service gRPC clients reach HTTP/2
+    /// without TLS/ALPN, and an <see cref="HttpClient"/> left on its own defaults sends HTTP/1.1,
+    /// which an HTTP/2-only cleartext endpoint refuses. Sending HTTP/2 unconditionally has the
+    /// mirror-image failure: an HTTP/1.1-only endpoint, or a mixed <c>Http1AndHttp2</c> one serving
+    /// cleartext h2 without ALPN, answers <c>HTTP_1_1_REQUIRED</c> forever. Either way the gateway
+    /// reports a downstream outage that does not exist.
     /// </para>
     /// <para>
-    /// Set to <see langword="false"/> for a downstream whose cleartext endpoint is HTTP/1.1-only:
-    /// the probe then uses <c>1.1</c> with <see cref="HttpVersionPolicy.RequestVersionOrLower"/>,
-    /// exactly the stock <see cref="HttpClient"/> behavior. A mixed <c>Http1AndHttp2</c> endpoint
-    /// answers either way and needs no opt-out.
+    /// Pin <see cref="DownstreamProbeVersion.Http2"/> or <see cref="DownstreamProbeVersion.Http11"/>
+    /// only for a downstream whose profile is known and fixed, to skip the one-time negotiation.
     /// </para>
     /// </summary>
-    public bool ProbeOverHttp2 { get; set; } = true;
+    public DownstreamProbeVersion ProbeVersion { get; set; } = DownstreamProbeVersion.Auto;
+
+    /// <summary>
+    /// Whether the probe speaks HTTP/2 over cleartext (h2c prior knowledge). A compatibility facade
+    /// over <see cref="ProbeVersion"/>: reading it reports whether the pinned mode is
+    /// <see cref="DownstreamProbeVersion.Http2"/> (so it reads <see langword="false"/> under the
+    /// <see cref="DownstreamProbeVersion.Auto"/> default, which has not chosen a version yet), and
+    /// writing it pins <see cref="DownstreamProbeVersion.Http2"/> or
+    /// <see cref="DownstreamProbeVersion.Http11"/>, giving up the negotiation.
+    /// </summary>
+#pragma warning disable S1133 // Deprecated code should be removed: the obsoletion IS the migration mechanism; it flags every remaining consumer opt-out during the lockstep sweep, and the facade is removed once all consumers are swept.
+    [Obsolete("Use ProbeVersion; the Auto default negotiates the protocol per downstream.")]
+    public bool ProbeOverHttp2
+    {
+        get => ProbeVersion == DownstreamProbeVersion.Http2;
+        set => ProbeVersion = value ? DownstreamProbeVersion.Http2 : DownstreamProbeVersion.Http11;
+    }
+#pragma warning restore S1133
 }
 
 /// <summary>
@@ -104,12 +149,13 @@ public static class GatewayHealthCheckExtensions
 
         /// <summary>
         /// Same registration as <c>AddGatewayDownstreamHealthChecks(params string[])</c>, with the
-        /// probe client's HTTP version profile under the caller's control.
+        /// probe's HTTP version profile under the caller's control.
         /// </summary>
         /// <param name="configure">
-        /// Configures the options applied to every name in THIS call. Pass
-        /// <c>o =&gt; o.ProbeOverHttp2 = false</c> for downstreams whose cleartext endpoint is
-        /// HTTP/1.1-only.
+        /// Configures the options applied to every name in THIS call. The
+        /// <see cref="DownstreamProbeVersion.Auto"/> default fits every downstream; pass
+        /// <c>o =&gt; o.ProbeVersion = DownstreamProbeVersion.Http11</c> only to pin a head whose
+        /// profile is already known and skip its one-time negotiation.
         /// </param>
         /// <param name="serviceNames">
         /// The Aspire service names the gateway fronts. Duplicates and blanks are ignored, and a
@@ -140,12 +186,9 @@ public static class GatewayHealthCheckExtensions
         var options = new GatewayDownstreamHealthCheckOptions();
         configure?.Invoke(options);
 
-        // Captured as locals so the client-configuration closure below does not hold the mutable
-        // options object: a later call reusing the same instance must not retro-change this client.
-        var probeVersion = options.ProbeOverHttp2 ? HttpVersion.Version20 : HttpVersion.Version11;
-        var probeVersionPolicy = options.ProbeOverHttp2
-            ? HttpVersionPolicy.RequestVersionExact
-            : HttpVersionPolicy.RequestVersionOrLower;
+        // Captured as a local so the registration closure below does not hold the mutable options
+        // object: a later call reusing the same instance must not retro-change these checks.
+        var probeVersion = options.ProbeVersion;
 
         var registry = GatewayDownstreamRegistry.GetOrAdd(services);
         var healthChecks = services.AddHealthChecks();
@@ -168,11 +211,10 @@ public static class GatewayHealthCheckExtensions
                 client.BaseAddress = new Uri("http://" + name, UriKind.Absolute);
                 client.Timeout = ProbeTimeout;
 
-                // Without this the probe goes out HTTP/1.1 and an Http2-only cleartext (h2c)
-                // downstream refuses it, so a healthy service reads as an outage. See
-                // GatewayDownstreamHealthCheckOptions.ProbeOverHttp2.
-                client.DefaultRequestVersion = probeVersion;
-                client.DefaultVersionPolicy = probeVersionPolicy;
+                // The HTTP version is deliberately NOT pinned on the client. It belongs to the
+                // request, because under DownstreamProbeVersion.Auto the check discovers which
+                // version this downstream speaks and may send both on one poll. See
+                // GatewayDownstreamHealthCheckOptions.ProbeVersion.
             });
 
             healthChecks.Add(new HealthCheckRegistration(
@@ -180,7 +222,8 @@ public static class GatewayHealthCheckExtensions
                 sp => new DownstreamServiceHealthCheck(
                     sp.GetRequiredService<IHttpClientFactory>(),
                     name,
-                    clientName),
+                    clientName,
+                    probeVersion),
                 failureStatus: HealthStatus.Unhealthy,
                 tags: [HealthCheckTags.Ready],
                 timeout: ProbeTimeout));

--- a/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
@@ -1,8 +1,14 @@
 #nullable enable
+MMCA.Common.Aspire.Gateway.DownstreamProbeVersion
+MMCA.Common.Aspire.Gateway.DownstreamProbeVersion.Auto = 0 -> MMCA.Common.Aspire.Gateway.DownstreamProbeVersion
+MMCA.Common.Aspire.Gateway.DownstreamProbeVersion.Http11 = 2 -> MMCA.Common.Aspire.Gateway.DownstreamProbeVersion
+MMCA.Common.Aspire.Gateway.DownstreamProbeVersion.Http2 = 1 -> MMCA.Common.Aspire.Gateway.DownstreamProbeVersion
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.GatewayDownstreamHealthCheckOptions() -> void
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeOverHttp2.get -> bool
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeOverHttp2.set -> void
+MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeVersion.get -> MMCA.Common.Aspire.Gateway.DownstreamProbeVersion
+MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeVersion.set -> void
 MMCA.Common.Aspire.Gateway.GatewayHealthCheckExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddGatewayDownstreamHealthChecks(System.Action<MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions!>? configure, params string![]! serviceNames) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 MMCA.Common.Aspire.Logging.SerilogHostExtensions
 MMCA.Common.Aspire.Logging.SerilogHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!)

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PageExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/PageExtensions.cs
@@ -16,6 +16,10 @@ namespace MMCA.Common.Testing.E2E.Infrastructure;
     "Naming",
     "CA1708:Identifiers should differ by more than case",
     Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
+[SuppressMessage(
+    "Style",
+    "IDE0051:Remove unused private members",
+    Justification = "The private consts below are consumed only from inside the extension(T) blocks of this class. The IDE0051 analyzer in .NET SDK 10.0.201+ does not see references that cross the boundary between a C# preview extension type block and outer-scope private members of the same containing class, so it reports them as unused. Remove this suppression once Roslyn fixes the cross-block reference tracking.")]
 public static class PageExtensions
 {
     /// <summary>
@@ -24,26 +28,85 @@ public static class PageExtensions
     /// </summary>
     public const string MudDataGridRowSelector = ".mud-table-body .mud-table-row";
 
+    /// <summary>
+    /// The RUNTIME-LOADED predicate: blazor.web.js sets <c>window.Blazor</c> on load, then populates
+    /// <c>_internal</c> once the WASM CLR (or the SignalR circuit) is ready. The exact properties inside
+    /// <c>_internal</c> vary across .NET versions, so this checks for any truthy <c>_internal</c> object.
+    /// Necessary but NOT sufficient for interactivity, which is why it is only step one of
+    /// <c>WaitForBlazorAsync</c>. Shared by the wait and by <c>GotoProtectedAsync</c>'s readiness probe so
+    /// the two cannot drift.
+    /// </summary>
+    private const string BlazorRuntimeLoadedPredicate = "() => !!window.Blazor?._internal";
+
+    /// <summary>
+    /// The INTERACTIVE predicate: <c>MmcaThemeProviders</c> (MMCA.Common.UI) stamps
+    /// <c>data-mmca-interactive</c> on the document element from its first interactive render, so the
+    /// attribute appears only after components have actually attached their event handlers. Keep the
+    /// attribute name in step with that component and with <c>theme.js</c>'s <c>markInteractive</c>.
+    /// </summary>
+    private const string InteractiveMarkerPredicate =
+        "() => document.documentElement.hasAttribute('data-mmca-interactive')";
+
+    /// <summary>
+    /// The legacy settle: two animation frames plus a fixed delay, used as the fallback whenever the
+    /// interactivity marker never appears.
+    /// </summary>
+    private const string LegacySettleScript =
+        "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))";
+
+    /// <summary>A single animation frame: enough to flush the render pipeline once the marker has confirmed interactivity.</summary>
+    private const string SingleFrameSettleScript = "() => new Promise(r => requestAnimationFrame(r))";
+
+    /// <summary>Budget for the interactivity marker before falling back to the legacy settle.</summary>
+    private const float InteractiveMarkerTimeout = 3_000;
+
     extension(IPage page)
     {
         /// <summary>
         /// Waits for the Blazor runtime to finish initialising after a full page load.
         /// Without this, event handlers are not wired up and clicks/fills are silently ignored.
         /// </summary>
+        /// <remarks>
+        /// Two phases, because the runtime flag alone is a false green.
+        /// <list type="number">
+        /// <item><description><b>Runtime loaded.</b> Wait (on the caller's full budget) for
+        /// <c>window.Blazor._internal</c>. blazor.web.js sets this once the WASM CLR or the SignalR
+        /// circuit reports ready, which is necessary but happens BEFORE components have attached their
+        /// handlers, so a click issued here lands on a prerendered-but-dead control and is
+        /// swallowed.</description></item>
+        /// <item><description><b>Interactive.</b> Wait a short extra budget for the
+        /// <c>data-mmca-interactive</c> marker that <c>MmcaThemeProviders</c> (MMCA.Common.UI) stamps
+        /// from its first interactive render. That attribute exists only once a real component has
+        /// rendered interactively, so it is the honest gate; one animation frame then flushes the render
+        /// pipeline.</description></item>
+        /// </list>
+        /// The marker is best-effort by design. A page that legitimately never hydrates (the pre-auth
+        /// login page, a static error page) and a consumer still on an older MMCA.Common.UI package
+        /// never stamp it, so a marker timeout falls back to EXACTLY the legacy settle (two animation
+        /// frames plus 500 ms). The gate therefore gets stricter where the marker ships and cannot hang
+        /// or regress where it does not.
+        /// </remarks>
         public async Task WaitForBlazorAsync(float timeout = 30_000)
         {
-            // blazor.web.js sets window.Blazor on load, then populates _internal after the
-            // WASM CLR (or SignalR circuit) is ready. The exact properties inside _internal
-            // may vary across .NET versions, so we check for any truthy _internal object.
             await page.WaitForFunctionAsync(
-                "() => !!window.Blazor?._internal",
+                BlazorRuntimeLoadedPredicate,
                 new PageWaitForFunctionOptions { Timeout = timeout }).ConfigureAwait(false);
 
-            // Blazor's component rendering is asynchronous — it happens AFTER the runtime
-            // reports as ready. Wait for two animation frames + a short delay to let the
-            // render pipeline flush, event handlers get attached, and DOM settle.
-            await page.EvaluateAsync(
-                "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))").ConfigureAwait(false);
+            try
+            {
+                await page.WaitForFunctionAsync(
+                    InteractiveMarkerPredicate,
+                    new PageWaitForFunctionOptions { Timeout = InteractiveMarkerTimeout }).ConfigureAwait(false);
+
+                // Interactivity is confirmed, so only the current render batch still needs to flush.
+                await page.EvaluateAsync(SingleFrameSettleScript).ConfigureAwait(false);
+            }
+            catch (PlaywrightException)
+            {
+                // No marker on this page (never hydrates, or an older MMCA.Common.UI): settle the way
+                // this helper always did rather than failing a test the old behaviour would have passed.
+                await page.EvaluateAsync(LegacySettleScript).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -114,7 +177,7 @@ public static class PageExtensions
             bool blazorReady;
             try
             {
-                blazorReady = await page.EvaluateAsync<bool>("() => !!window.Blazor?._internal").ConfigureAwait(false);
+                blazorReady = await page.EvaluateAsync<bool>(BlazorRuntimeLoadedPredicate).ConfigureAwait(false);
             }
             catch (PlaywrightException)
             {
@@ -149,9 +212,10 @@ public static class PageExtensions
             // For full page navigations, wait for the load event. For Blazor enhanced
             // navigation (SPA-style), this resolves immediately — harmless.
             await page.WaitForLoadStateAsync(LoadState.Load).ConfigureAwait(false);
-            // Wait for Blazor render cycle — covers both full-page and enhanced navigation.
-            await page.EvaluateAsync(
-                "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 500))))").ConfigureAwait(false);
+            // Wait for Blazor render cycle (covers both full-page and enhanced navigation). This one
+            // stays on the legacy settle unconditionally: it runs after clicks that may land on a page
+            // with no marker at all, and it never asserts runtime readiness in the first place.
+            await page.EvaluateAsync(LegacySettleScript).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Source/Presentation/MMCA.Common.UI/Components/MmcaThemeProviders.razor
+++ b/Source/Presentation/MMCA.Common.UI/Components/MmcaThemeProviders.razor
@@ -1,5 +1,6 @@
 @using MMCA.Common.UI.Theme
 @inject ThemeService ThemeService
+@inject IJSRuntime JS
 @implements IDisposable
 
 @* The four Mud providers every root layout needs (theme, popover, dialog, snackbar) plus the
@@ -34,6 +35,46 @@
             await ThemeService.InitializeAsync();
             _isDarkMode = ThemeService.IsDarkMode;
             StateHasChanged();
+
+            await MarkInteractiveAsync();
+        }
+    }
+
+    // Stamps <html data-mmca-interactive="true"> once this component has actually rendered
+    // interactively. That attribute is the interactivity signal MMCA.Common.Testing.E2E's
+    // WaitForBlazorAsync waits on: blazor.web.js sets window.Blazor._internal BEFORE the WASM runtime
+    // (or the circuit) has attached event handlers, so gating a test on that alone lets it click a
+    // prerendered-but-dead control. Keep the attribute name in step with the E2E-side constant
+    // (PageExtensions.InteractiveMarkerPredicate) and with theme.js's markInteractive.
+    //
+    // The RendererInfo guard is defensive on a real host (OnAfterRenderAsync never runs during a
+    // static prerender), but bUnit DOES run it, so the guard is what keeps a test that declares
+    // SetRendererInfo(isInteractive: false) honest.
+    private async Task MarkInteractiveAsync()
+    {
+        if (!RendererInfo.IsInteractive)
+        {
+            return;
+        }
+
+        // Best-effort only: the marker is test infrastructure, so nothing here may break theme init.
+        try
+        {
+            await using var module = await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/MMCA.Common.UI/theme.js");
+            await module.InvokeVoidAsync("markInteractive");
+        }
+        catch (JSException)
+        {
+            // Asset missing or the call failed in the browser.
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit torn down between the render and this call.
+        }
+        catch (InvalidOperationException)
+        {
+            // Interop unavailable on this renderer (prerender race / disposed dispatcher).
         }
     }
 

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/theme.js
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/theme.js
@@ -33,3 +33,40 @@ export function set(value) {
 export function systemPrefersDark() {
     return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
 }
+
+// ── E2E interactivity marker ────────────────────────────────────────────────
+// Stamps the document element with the marker that MMCA.Common.Testing.E2E's WaitForBlazorAsync waits
+// on. It lives here (rather than in its own asset) because MmcaThemeProviders already imports this
+// module on its first interactive render, so the function is loaded wherever the marker can be set,
+// with no extra script tag for a consumer to remember. Keep the attribute name in step with
+// PageExtensions.InteractiveMarkerPredicate.
+const INTERACTIVE_ATTRIBUTE = 'data-mmca-interactive';
+
+let reStampAttached = false;
+
+function stampInteractive() {
+    try {
+        document.documentElement.setAttribute(INTERACTIVE_ATTRIBUTE, 'true');
+    } catch {
+        // Best-effort test infrastructure: never surface into theme initialisation.
+    }
+}
+
+export function markInteractive() {
+    stampInteractive();
+
+    if (reStampAttached) {
+        return;
+    }
+
+    try {
+        // Blazor enhanced navigation synchronises <html>'s attributes with the newly loaded document,
+        // which drops the marker even though the runtime stays interactive. Blazor raises 'enhancedload'
+        // after each of those updates, so re-stamp there instead of leaving the E2E gate to fall back to
+        // its slower legacy settle for the rest of the session.
+        document.addEventListener('enhancedload', stampInteractive);
+        reStampAttached = true;
+    } catch {
+        // No enhanced navigation on this host; the initial stamp is enough.
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/GlobalUsings.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/H2cHealthCheckExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/H2cHealthCheckExtensionsTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace MMCA.Common.Aspire.Hosting.Tests;
+
+/// <summary>
+/// Unit tests for <c>WithH2cHealthCheck</c>: what it registers on the AppHost (key, failure status,
+/// probe budget) and how it associates that check with the resource, that a repeated call does not
+/// produce the duplicate health-check key the health-check service rejects at startup, and how the
+/// probe itself maps an HTTP/2 outcome onto a health status.
+/// </summary>
+public sealed class H2cHealthCheckExtensionsTests
+{
+    [Fact]
+    public void Defaults_ProbeReadinessOnTheCleartextEndpoint()
+    {
+        H2cHealthCheckExtensions.DefaultProbePath.Should().Be("/health/ready",
+            because: "gating a WaitFor edge is about the service being able to serve, not merely being alive");
+        H2cHealthCheckExtensions.DefaultEndpointName.Should().Be("http",
+            because: "the cleartext endpoint is the h2c one; https negotiates its version through ALPN");
+    }
+
+    [Fact]
+    public void WithH2cHealthCheck_AssociatesTheCheckWithTheResource()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var service = AddService(builder);
+
+        service.WithH2cHealthCheck();
+
+        HealthCheckAnnotations(service).Single().Key.Should().Be("identity-h2c-http");
+    }
+
+    [Fact]
+    public void WithH2cHealthCheck_RegistersTheProbeInTheAppHostContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        AddService(builder).WithH2cHealthCheck();
+
+        var registration = H2cRegistrations(builder).Single();
+
+        registration.Name.Should().Be("identity-h2c-http");
+        registration.FailureStatus.Should().Be(HealthStatus.Unhealthy);
+        registration.Timeout.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    // A duplicate health-check key is a startup exception, not a harmless second registration, so a
+    // host and a helper both asking to gate the same endpoint must not compound.
+    [Fact]
+    public void WithH2cHealthCheck_IsIdempotent()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var service = AddService(builder);
+
+        var first = service.WithH2cHealthCheck();
+        var second = service.WithH2cHealthCheck();
+
+        second.Should().BeSameAs(first);
+        HealthCheckAnnotations(service).Should().ContainSingle();
+        H2cRegistrations(builder).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void WithH2cHealthCheck_KeysTheCheckByEndpointSoOneResourceCanGateTwo()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var service = AddService(builder);
+
+        service.WithH2cHealthCheck();
+        service.WithH2cHealthCheck(endpointName: "grpc");
+
+        H2cRegistrations(builder).Select(r => r.Name)
+            .Should().BeEquivalentTo("identity-h2c-http", "identity-h2c-grpc");
+    }
+
+    // The duplicate guard hangs off the app builder's own service collection rather than a static
+    // field. A test run creates many builders in one process, and a static ledger would make the
+    // second builder's registration silently disappear.
+    [Fact]
+    public void WithH2cHealthCheck_DoesNotShareItsDuplicateGuardAcrossBuilders()
+    {
+        var first = DistributedApplication.CreateBuilder([]);
+        AddService(first).WithH2cHealthCheck();
+
+        var second = DistributedApplication.CreateBuilder([]);
+        AddService(second).WithH2cHealthCheck();
+
+        H2cRegistrations(first).Should().ContainSingle();
+        H2cRegistrations(second).Should().ContainSingle();
+    }
+
+    // GetEndpoint resolves lazily, so naming an endpoint the resource never declares is NOT an error
+    // at registration time. It surfaces at probe time as a permanently unhealthy check (the endpoint
+    // never allocates, see the unallocated probe test below), which keeps the dependent resource
+    // waiting rather than letting it start against something nobody verified.
+    [Fact]
+    public void WithH2cHealthCheck_WithAnUndeclaredEndpointName_RegistersLazilyRatherThanThrowing()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var service = AddService(builder);
+
+        var act = () => service.WithH2cHealthCheck(endpointName: "does-not-exist");
+
+        act.Should().NotThrow();
+        H2cRegistrations(builder).Single().Name.Should().Be("identity-h2c-does-not-exist");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithH2cHealthCheck_RejectsABlankPath(string path)
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var service = AddService(builder);
+
+        var act = () => service.WithH2cHealthCheck(path);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithH2cHealthCheck_RejectsABlankEndpointName(string endpointName)
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var service = AddService(builder);
+
+        var act = () => service.WithH2cHealthCheck(endpointName: endpointName);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    // The whole reason this extension exists: an HttpClient on its own defaults sends HTTP/1.1, which
+    // an Http2-only cleartext endpoint answers with GOAWAY HTTP_1_1_REQUIRED, so the stock probe can
+    // never turn such a resource healthy.
+    [Fact]
+    public async Task Probe_SendsHttp2WithPriorKnowledge()
+    {
+        Version? version = null;
+        HttpVersionPolicy? versionPolicy = null;
+
+        await ProbeAsync(request =>
+        {
+            version = request.Version;
+            versionPolicy = request.VersionPolicy;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        version.Should().Be(HttpVersion.Version20);
+        versionPolicy.Should().Be(HttpVersionPolicy.RequestVersionExact,
+            because: "h2c prior knowledge means the request must go out as HTTP/2, never negotiate down");
+    }
+
+    [Fact]
+    public async Task Probe_TargetsTheConfiguredPathOnTheEndpoint()
+    {
+        Uri? requested = null;
+
+        await ProbeAsync(request =>
+        {
+            requested = request.RequestUri;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        requested.Should().Be(new Uri("http://identity:8080/health/ready"));
+    }
+
+    [Fact]
+    public async Task Probe_WhenTheServiceAnswersSuccess_ReportsHealthy()
+    {
+        var result = await ProbeAsync(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Probe_WhenTheServiceAnswersNonSuccess_ReportsUnhealthy()
+    {
+        var result = await ProbeAsync(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("503");
+    }
+
+    [Fact]
+    public async Task Probe_WhenTheServiceIsUnreachable_ReportsUnhealthyWithTheException()
+    {
+        var result = await ProbeAsync(_ => throw new HttpRequestException("connection refused"));
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().BeOfType<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task Probe_WhenTheProbeTimesOut_ReportsUnhealthy()
+    {
+        var result = await ProbeAsync(_ => throw new TaskCanceledException("probe budget exhausted"));
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    // Aspire allocates an endpoint only once the resource starts, so the first polls after the
+    // AppHost comes up resolve nothing. Failing them is correct: Aspire releases a WaitFor edge only
+    // on Healthy, so a pre-allocation poll that passed would defeat the gate entirely.
+    [Fact]
+    public async Task Probe_WhenTheEndpointIsNotAllocatedYet_ReportsUnhealthyWithoutThrowing()
+    {
+        var result = await ProbeAsync(
+            _ => new HttpResponseMessage(HttpStatusCode.OK),
+            () => throw new InvalidOperationException("The endpoint is not allocated."),
+            "/health/ready");
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().BeOfType<InvalidOperationException>();
+    }
+
+    // AddResource rather than AddProject: the extension only needs a ProjectResource in the model,
+    // and AddProject validates that the project file exists on disk, which no unit test should have
+    // to fabricate.
+    private static IResourceBuilder<ProjectResource> AddService(
+        IDistributedApplicationBuilder builder,
+        string name = "identity") =>
+        builder.AddResource(new ProjectResource(name));
+
+    private static IReadOnlyList<HealthCheckAnnotation> HealthCheckAnnotations(
+        IResourceBuilder<ProjectResource> service) =>
+        [.. service.Resource.Annotations.OfType<HealthCheckAnnotation>()];
+
+    // Filtered to this extension's own keys: the AppHost container carries health checks of Aspire's
+    // own, and this suite is not asserting anything about those.
+    private static IReadOnlyList<HealthCheckRegistration> H2cRegistrations(IDistributedApplicationBuilder builder)
+    {
+        using var provider = builder.Services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<HealthCheckServiceOptions>>();
+
+        return options is null
+            ? []
+            : [.. options.Value.Registrations.Where(r => r.Name.Contains("-h2c-", StringComparison.Ordinal))];
+    }
+
+    private static Task<HealthCheckResult> ProbeAsync(Func<HttpRequestMessage, HttpResponseMessage> respond) =>
+        ProbeAsync(respond, () => "http://identity:8080", "/health/ready");
+
+    private static async Task<HealthCheckResult> ProbeAsync(
+        Func<HttpRequestMessage, HttpResponseMessage> respond,
+        Func<string> resolveEndpointUrl,
+        string path)
+    {
+        using var handler = new StubHandler(respond);
+        using var client = new HttpClient(handler, disposeHandler: false);
+
+        var check = new H2cEndpointHealthCheck(resolveEndpointUrl, path, client.SendAsync);
+        var registration = new HealthCheckRegistration(
+            "identity-h2c-http",
+            check,
+            HealthStatus.Unhealthy,
+            tags: null);
+
+        return await check.CheckHealthAsync(
+            new HealthCheckContext { Registration = registration },
+            CancellationToken.None);
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => Task.FromResult(respond(request));
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/MMCA.Common.Aspire.Hosting.Tests.csproj
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/MMCA.Common.Aspire.Hosting.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Source\Hosting\MMCA.Common.Aspire.Hosting\MMCA.Common.Aspire.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/packages.lock.json
@@ -1,0 +1,1400 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "Meziantou.Analyzer": {
+        "type": "Direct",
+        "requested": "[3.0.190, )",
+        "resolved": "3.0.190",
+        "contentHash": "CFX3BWg27iLO78RORLAGWghpP+1afiAaijAIfhU7+JI+n6V0uVpNIr6H7LYVnRTFb2WAH/450FcvarFl7STOQA=="
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[18.7.23, )",
+        "resolved": "18.7.23",
+        "contentHash": "dyj6z8m+LFjpeH69hdnciCcRCmD0YgMlvuQEywiEshjqj/blgQ+PuWX8Vd5gkWQFoBN4e+TFxx6DvGNSv/gIKg=="
+      },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.33.0.1635, )",
+        "resolved": "10.33.0.1635",
+        "contentHash": "nOwgvMh7p64z62GTy2n4Ki51DVy4Q2ejxxfuclW6Y5u6Htk1i2RNRqxuONiZ/4aaBi8V6RwzuCcGTOFcoVoQOg=="
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "czH4MaZ2k2eLjetuN5W1fUEnNVADsTOeYxDvrqIFh04XO6H3Y8Yu1FrSy3psF1q06DZV33wftjqZVv4acwIp9Q==",
+        "dependencies": {
+          "xunit.v3.mtp-v2": "[4.0.0]"
+        }
+      },
+      "Aspire.Hosting.Azure": {
+        "type": "Transitive",
+        "resolved": "13.5.3",
+        "contentHash": "MvSl9zDtyhaqQZwFJsQMqZDy1HrTxu3i6Q05VOthDwB/CSU+wn91bnwK15rdweF9KzzlDBtMeBimye1M5mP38w==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Uris": "9.0.0",
+          "Aspire.Hosting": "13.5.3",
+          "Azure.Core": "1.57.0",
+          "Azure.Identity": "1.21.0",
+          "Azure.Provisioning": "1.5.0",
+          "Azure.Provisioning.KeyVault": "1.1.0",
+          "Azure.ResourceManager.Authorization": "1.1.6",
+          "Azure.ResourceManager.KeyVault": "1.4.0",
+          "Azure.ResourceManager.Resources": "1.11.2",
+          "Azure.Security.KeyVault.Secrets": "4.11.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.AspNetCore": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0",
+          "Grpc.Tools": "2.80.0",
+          "Humanizer.Core": "3.0.10",
+          "JsonPatch.Net": "5.0.2",
+          "KubernetesClient": "19.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.30",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Hosting": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "ModelContextProtocol": "1.3.0",
+          "Newtonsoft.Json": "13.0.4",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Polly.Core": "8.6.6",
+          "Semver": "3.0.0",
+          "StreamJsonRpc": "2.25.29",
+          "System.IO.Hashing": "10.0.8",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "Aspire.Hosting.Azure.KeyVault": {
+        "type": "Transitive",
+        "resolved": "13.5.3",
+        "contentHash": "2qPQJW5O2LLaKIfbC/3v30/qhD4ckbOdKfF4urEHv7uSw/Do2sr3jpaMzYsscSy3oIqZNTvQBcZYQVefsmxtMQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Uris": "9.0.0",
+          "Aspire.Hosting.Azure": "13.5.3",
+          "Azure.Core": "1.57.0",
+          "Azure.Identity": "1.21.0",
+          "Azure.Provisioning": "1.5.0",
+          "Azure.Provisioning.KeyVault": "1.1.0",
+          "Azure.ResourceManager.Authorization": "1.1.6",
+          "Azure.ResourceManager.KeyVault": "1.4.0",
+          "Azure.ResourceManager.Resources": "1.11.2",
+          "Azure.Security.KeyVault.Secrets": "4.11.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.AspNetCore": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0",
+          "Grpc.Tools": "2.80.0",
+          "Humanizer.Core": "3.0.10",
+          "JsonPatch.Net": "5.0.2",
+          "KubernetesClient": "19.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.30",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Hosting": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "ModelContextProtocol": "1.3.0",
+          "Newtonsoft.Json": "13.0.4",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Polly.Core": "8.6.6",
+          "Semver": "3.0.0",
+          "StreamJsonRpc": "2.25.29",
+          "System.IO.Hashing": "10.0.8",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "AspNetCore.HealthChecks.CosmosDb": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "lb1dZiZE88ipN2Ied4XsgZYorEIOvXoX2cHI4K9JhzGCAe9Av28RaXuJoqYT/7GMSiCX1lzIZpYMoSp4r/xAOQ==",
+        "dependencies": {
+          "Microsoft.Azure.Cosmos": "3.46.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
+        }
+      },
+      "AspNetCore.HealthChecks.Uris": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "XYdNlA437KeF8p9qOpZFyNqAN+c0FXt/JjTvzH/Qans0q0O3pPE8KPnn39ucQQjR/Roum1vLTP3kXiUs8VHyuA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
+          "Microsoft.Extensions.Http": "8.0.0"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.57.0",
+        "contentHash": "POStMP+rxaAEYScwGBpIUcnEpSj/3ctYmCmt2IqU3recuAjjddEgTq4q4TLImEdQCfsFr/HpEuYjiY/wKeAprQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.13.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Azure.Provisioning": {
+        "type": "Transitive",
+        "resolved": "1.5.0",
+        "contentHash": "tgjG2wh20PQpenN3R1uah5lPyDMMPo/tgBVpNR6RkOZm1dE8at4ejyit1UQ18FqyKEu053eXtAmpREzYxizH8g==",
+        "dependencies": {
+          "Azure.Core": "1.51.1"
+        }
+      },
+      "Azure.Provisioning.CosmosDB": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "Y9/AzZm5TPN5XUhRheswaZETGVqNdghScLF7XXKNeCFdjPZd4RlPT83P2IYcl/IhKkT32dtN9EoaS8Y6CKY2Zw==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Azure.Provisioning": "1.0.0",
+          "System.ClientModel": "1.2.1"
+        }
+      },
+      "Azure.Provisioning.KeyVault": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "n8SCJONrEU3w9lq/ZiQkxZ0L+Sv6RL2M95LSVYnwlYe84ww6jpo/djlfd835dh5cQvVrHgETi3UnRUcZn89J0w==",
+        "dependencies": {
+          "Azure.Core": "1.46.2",
+          "Azure.Provisioning": "1.1.0"
+        }
+      },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.14.0",
+        "contentHash": "i925pQG3EPXQ+jgTfO/26aODZ7IqWBo34nYg+kCgCPLGsMulbzjuJDiJH+PHV+xoWEjFKGvm1SBaAAXbG4887A==",
+        "dependencies": {
+          "Azure.Core": "1.51.1"
+        }
+      },
+      "Azure.ResourceManager.Authorization": {
+        "type": "Transitive",
+        "resolved": "1.1.6",
+        "contentHash": "MMkhizwHZF7EsJVSPgxMffXjzmCkC+DPAyMmjZOgpyGfkQUFqZpiGzeQDEvzj5rCyeY8SoXKF8KK1WT6ekB0mQ==",
+        "dependencies": {
+          "Azure.Core": "1.49.0",
+          "Azure.ResourceManager": "1.13.2"
+        }
+      },
+      "Azure.ResourceManager.KeyVault": {
+        "type": "Transitive",
+        "resolved": "1.4.0",
+        "contentHash": "kjEphMw5jYNmu9qjluad79gb5cCogzsJ8FEwD9JF6ou0M/KZ2TAmJO/HoR3qOyktgY0MTkb1IodG4xrjpN+WDA==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.ResourceManager": "1.14.0"
+        }
+      },
+      "Azure.ResourceManager.Resources": {
+        "type": "Transitive",
+        "resolved": "1.11.2",
+        "contentHash": "8uHC9wBM/quZotwvvJ6qBCefO3ZkKGD532lLBgpbN2NmbV1jLcN50nXzCsoo+z9FbOISHGR6CZ+/Hk6uwXF8Vg==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Azure.ResourceManager": "1.13.2"
+        }
+      },
+      "Azure.Security.KeyVault.Secrets": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "tjpVczILiXTR9bEynSL1JBU80169hGnTECtGsFjnRz9E1xoIhfUsaUTnB79k995zDkOG61hOI+YBtf5bNqgRIQ==",
+        "dependencies": {
+          "Azure.Core": "1.54.0"
+        }
+      },
+      "Fractions": {
+        "type": "Transitive",
+        "resolved": "7.3.0",
+        "contentHash": "2bETFWLBc8b7Ut2SVi+bxhGVwiSpknHYGBh2PADyGWONLkTxT7bKyDRhF8ao+XUv90tq8Fl7GTPxSI5bacIRJw=="
+      },
+      "Grpc.AspNetCore.Server": {
+        "type": "Transitive",
+        "resolved": "2.80.0",
+        "contentHash": "lbK7z1sZP5imPdQ035f/CZ61iIaBWouY6A580E9JNo7vzXYX/Qo+GQtSjOzhP9VFbxk7mtLoMhn/v1fT2U7kTw==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.80.0"
+        }
+      },
+      "Grpc.AspNetCore.Server.ClientFactory": {
+        "type": "Transitive",
+        "resolved": "2.80.0",
+        "contentHash": "7JdfxQZv/pO9qU5Ild2mrkzYA7PmVGDKVmWqKVCZNRSDN/RluRN4S4utYgBSwAcYgUBWQDHNb1Ll7wm3BdHfqw==",
+        "dependencies": {
+          "Grpc.AspNetCore.Server": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0"
+        }
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.80.0",
+        "contentHash": "i/8s+MOrYa6n7BmZ5bilcbHk+EMJDQHm2MKLhwGAT+urQqlZ6cpjvSivYvuULjebuX+UKieLYZbLRCmVQxFRkw=="
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.80.0",
+        "contentHash": "I1Aa24nTRMHqx0pmQfvthFsOpejquDjiJV6092KBqjw6EEr3wA9CMXlrdkoEgHartOiJrpKyZiQRl7n0NVlfBg==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.80.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.80.0",
+        "contentHash": "E2ERsx+9IXlry4yjBl8btx0XMIKzymGNSvX5jmBS/uSwYyYDoKIDcIREyLqFLvd8vcJdcoRlycpvn9YRXutFpQ==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.80.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "3.0.10",
+        "contentHash": "yZIhtw8sYuvsONzQbZxWpR60tMWYHXoo0DL6nyOqSFiU5POjBTSEyWFpTQtJEZuy+oqiYTXKXY/Mjx7KnqIQFw=="
+      },
+      "Json.More.Net": {
+        "type": "Transitive",
+        "resolved": "3.0.1",
+        "contentHash": "fRctF2J2SILYG6wqP21drmeEODmCVkVQ/b3MndDu2fT1swfySyUgq7ePCk+aENGlDcIm05fyfjh9vcuqDEfv3w=="
+      },
+      "JsonPatch.Net": {
+        "type": "Transitive",
+        "resolved": "5.0.2",
+        "contentHash": "q28VIShVPwsyDCFgQbLJGteUcTyixnyGHDhC3JzgTQddr9yBpbAGkuUpYinSeaSJtPju3P3AnNAamgfwuZpcjA==",
+        "dependencies": {
+          "JsonPointer.Net": "7.0.1"
+        }
+      },
+      "JsonPointer.Net": {
+        "type": "Transitive",
+        "resolved": "7.0.1",
+        "contentHash": "5C497yxfktYFsqxKG+GUQPsMvBqIjzLkqtDEdMGsnBpl3/OB8DOvTo7LEyRX7AVc1kVVj0IX5zhmLrlbvAYEnw==",
+        "dependencies": {
+          "Humanizer.Core": "3.0.10",
+          "Json.More.Net": "3.0.1"
+        }
+      },
+      "KubernetesClient": {
+        "type": "Transitive",
+        "resolved": "19.0.2",
+        "contentHash": "0m8FuzCDBygaXMbsb7qVapNZzTm4ftM7ECp/waTRh/XOUQziRF2rKJCRmsvYbBXgJkQvU+FBbkoa40hexzDC+g==",
+        "dependencies": {
+          "Fractions": "7.3.0",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "3.1.8",
+        "contentHash": "SitOtZ4tOlAZZPF7p52M7143F+Cuz7o/aU0MrtAXX0+ZkPXzDNroOFhzzE2ogMFThsoEW/E6akXVVcBFM9ZKaw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.8",
+        "contentHash": "Vm4g0cR4YRKRchEOmMJ0uVFU6yxdg7cJa2KHv3SUAHEsdYKvMpHMF5A1hZfsix89ymD5cmuzRnw9a6dKMcvq+Q=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Azure.Cosmos": {
+        "type": "Transitive",
+        "resolved": "3.61.0",
+        "contentHash": "o0lhN2nrkC2xidy0lhjnojwqgp/N6GOXAr34xQrU5Scs8MmNG9cwG6MtRJSVTWQYW3gm9Ava3pmVbuuTVQyuYg==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.HashCode": "1.1.0",
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "5T+bH3Lb1nEe8Hf/ixMxLmhlrx5wRi53wv7OhVwG2F1ZviW1ejFRS1NHur3uqPpJRGtkQwUchtY6zhVK2R+v+w=="
+      },
+      "Microsoft.Bcl.HashCode": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "J2G1k+u5unBV+aYcwxo94ip16Rkp65pgWFb0R6zwJipzWNMgvqlWeuI7/+R+e8bob66LnSG+llLJ+z8wI94cHg=="
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "rlnxc0KfwDSbE8ZHntFnl8SCgOa9QtJZblMv2zXLhRwl1Je7fsdsVzxSjzzC4JMsfAK+jXJWyezRB8SxUY4BdA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "Kue/7CF8KNT9zozfr30C94dMZVZml3atqWZvQemSXvTau76tRdypzeKiBKXadqgbOME0UiQIyVTNo5WxCRNVNg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.5.2",
+        "contentHash": "Ei+YWV9Ybnps7pR1dgjlG29gelXEwZkhLVAcWmKe6HvXS6LNBYgSdWiY3Hk9OZXYtK34rv/NtLWBQYQGOBQYPQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "vUl798SmruTqqlt/xH2gDk3tJlhk6k3HdOXAHirlRfbNKDym4g/kRpUL9S4sl6F6FsOTOMW+ZsDapqlZMOOiEw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "el1g0mBEbDBGY2bT9mcSfrTWO8QlPdq2nOCnvQugioOFwHV+bVBMeiakoI0dNOdj8d6Hi9K6HY2xzRUWJiDR3w==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "wlhRqZW8LcJPa+vk2oLAc/REXDItHtkFQdf/QcXYGZbZOO13izcsKY1pCvuFQYwUiZD+hwSZwsKASjqT+BNaVg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "rFn8RuszZn3qquPVkDytMUlPc2+rXl9MCoygwc1XmAgC5vg5/oXJ8hkOosOrLoBLsqdTy4lFwP6iQdPS9uSYOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "1KHr/1L56llwQ/yI0tAisEA31UpPsn8aasjASIwELOaN4JIUcbjuQBMdFOIzfNBBeULoUa0XfBe5QDtRRUY+fg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "KICyU3eVi5jvloKm01EXV69L97H/zkhISVtV98cIuzuFOxNx3xTUVcXqvWTz3aq7OvUuDB/MFlPFjmxRaKF7/A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "mDW7KVFB05M6jiRUyaZiOMWhS31n5HlSZwoYctHAZAucD4sMDJ70IxOmkGDt6RpstchD+keWBjhdzcMpSkWvWQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "BRliLdUowglV8GS+J1G/QsSofCJYYFg3U8QZx0ACRn+a91az/Qnpy+h6PyHS94WgV2TSazX5D/cuuk6wnCJatw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Json": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "PSmotV19c7E3lKed++uYo1kSiXFI+uTl37CBSrhq+CfLC3FCHjG7R91+xPnNehQfHS1b0Tzo/CCLPWH3qaEheg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "/a1aJz4m7ylhEDf25ugQChLQoN5XwoGjWw/BoR/ZWWKsO1v4DdJElS1uyngahz4B/eOzjFk1KNTkarRLE5wsIg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "HT70uGPxMLqqnOzKMcnQtDmeV4r0KHr4qVCLhP7SXil9jMEm8sQXwcybxVVFGXZJ1V44xV0mLqQ54aZbcR2OiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "se7Kx8QpJEt+nf26L4qIVAofGTDr1wbexxsh/Fm3Xc04xUkqUXK06KUS7FLwSQYSjqb7q9n+T7MEcXYBhI1Y5g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "fzUGzOCLquuyIxVVvvcw9h8KaUrRZ/cGTai2gBDQ1YxbdH/8eZnSyoOu+PQJYoD+RUcgTTlVe6D4+FrcaUOR9w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "5DCBP95vpklAkEfIbT2yzunianCeRtjaLrmAwoIgTf+xOJGFMmkAut/p3R2YmZL7TM1dnV81adGIg4m7Kg6wUw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "JOjac6SQQgZmdmB8WGEw61/7siqMZoWJMkmq2p1goJGxqI59lO6oB4bOl0jNsbaPBdYy5Mlkb+6U7T4+CjnD8Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Tq/UqMaczePv9yWwSsJZRgKtgA46djVR5xHj/lZBCueQ3ag8f9v5mu0EdhrNx7tXxNk+Y9OurG2oKuSKINjr0A==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "2i6rtW/B5rCnWCnhdmWWEmaM9O0HD0zsPY9eRqa++y4tclI3Uw8zvGbBvhY/LjAdtf8gUHhUPcAWj3DRlWMXmQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "eIDa/Rl+93aj17gMlFsJJx+LhBvb3CP0Mu1PeVYkDp2Y3S4Jock8UynfGQEcx7lrlq+gKW+ECQJHbro/LTPDEQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Json": "10.0.11",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.11",
+          "Microsoft.Extensions.Logging.Console": "10.0.11",
+          "Microsoft.Extensions.Logging.Debug": "10.0.11",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.11",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "pwtpF7iF/NNaOBcX+pvMZ7y2+JAVbH5KkNrH9uMZtuVxVJsFTDiWiCR7Tk3HVptsAijaetipUZVRVK2LLq+nvA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "nUOJwgFkSiLHiVGFpU22pIJtuWYewuSYQ3JVuP/gdK8ASMT807Px+TYQiRWs6uSsOmoyFTaVCwKXTasczV6BpA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Ljd0Uxoq5XpScD2Bg0nM/r3mwx7Ao5Uq24eo2ARxbGvqJ7Zht6rt2cJtwVRH4Cv+1ZVMdXz6TB43KbpmsxRrvQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "S7LvLeVHKNPaY2NMyxW7c2TBGsLgxoSUBCV5Ev5iN8kgC7EPR2UB7eW7vHsElGMcIUDwRmoxLfvGDynCn3q6EA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "dFc0yDudyD1iIg6z9XT7ofsT3hVO7Y4ylrxGHIVRR0GaZ4CUk4ujOrMoy7wWEdNHZhvJooySg6hZpOxyS8zEVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "wr+j1bjdFXhc8lKTLoq+RbwFM8M+orcMS9xrcqLmDGOxJcXpKizEeE5h6v/GKwCZV02FmhaA7OlNjoq072jZpQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Eck9GpCCpvZ3f6L7IUlN+mPtRVefnf7PsiIG5vi61QawPtLNCEAv2TPD/M3SojcU0PFaef+BxiVGPOShFHtDog==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "System.Diagnostics.EventLog": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "hs6QWECLLohi2VKqUvSGRUvrg7eXR1DqKL95Jrtz3cdD2g2nBA+yJPdRQLZ7SLmnTZWycxfMDK2s0ho+rfst5w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "eY1GAKcTfD2maP27J84X9IovT3yjHJ2dVDzPmDg6/XqYvt3jMzJhtfQCLjG9pVsZGAd+8DQ2QrjaDcs2+VQLGw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "syEhXQ/sEaSBFaqzlp9gDGHX/nk6gkQkh1sIUpBO1mlBj3Phu1rmb4ML1uCiyPW9N6Kxfxv3y5FGObC+bV01Qw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "iQWOKi3L5QStmWqDjDubcr1KlTDy88qBTe88I0etlUUo1l0zSNebGJXl1Xetyl+ACA+ujP3YUtxo3Nz54JPriw=="
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "nY8ceQyPWB9TRE1WE5Oe/sks2e10SxgPv61vBHsFYpgCeDtNwhpMZwmL29GklO3/etTdOsLdrCmNr4zJWaR2fg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "dceVNxnfTEjKnrIreLcMfkgrzzBY8kgCCJX5NAv7Lq/6vPlTP4VB5zxKeuYy0yfCoBtWuPkLjUG6qtOBMfpypA==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "ENbH4BQh9riXtOKc25KKITfiGGWhWMBJA7pZuNaF9zxzzSaVkp5AMeZxGQ6sXYaR6xb724NLz985Is6XIYqLSg=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.3.3"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Only": {
+        "type": "Transitive",
+        "resolved": "17.14.15",
+        "contentHash": "NqONyw1RXyj9P3k5e1uU2k9kc1ptwuU5NJQzG+MPq7vQVHUzBY8HLuJf/N2Rw5H/myD96CVxziDxmjawPuzntw==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Validation": "17.8.8"
+        }
+      },
+      "Microsoft.VisualStudio.Validation": {
+        "type": "Transitive",
+        "resolved": "17.13.22",
+        "contentHash": "fC20ITOxlUpGQ0ltAxITQbeFxwuB6OjLT3lByC4+/Gm46o/Mwv9hlIVrBhiUhnqdQzUUvr4EHkdiYe7WOSMLmw=="
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "ModelContextProtocol": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "WDaD6z9KkkCUHSo15xK7tYBERHy8uqP+cIUp8uIxhR0yrlpJLXTRcJcUUVqpXlBkV7MK9Eo3mTrAnctLnJuHDQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "ModelContextProtocol.Core": "1.3.0"
+        }
+      },
+      "ModelContextProtocol.Core": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "OWmdxDSwA7K9pNNg4t98MXNIssHG/wOQEr/G8pG5B7synDdw4MnmZ/IIVeb3yUdeznPqnDHvd3FBCK0jRk4IZQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.5.2",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Nerdbank.MessagePack": {
+        "type": "Transitive",
+        "resolved": "1.2.4",
+        "contentHash": "9NKlDsKkOV5zQFkZZnQmssdV6npFNs0Of1Nz5mvAJA4uANxCge2TfXQ9nCYUet58bEWQ00a/aNHdjmcXEI7iuQ==",
+        "dependencies": {
+          "Microsoft.NET.StringTools": "18.4.0",
+          "Microsoft.VisualStudio.Validation": "17.13.22",
+          "PolyType": "1.3.1"
+        }
+      },
+      "Nerdbank.Streams": {
+        "type": "Transitive",
+        "resolved": "2.13.16",
+        "contentHash": "GjifQ5M4IpQWjGNNbIrsj8M/M7ESb2328OeoGeqxk5rOJiuaAJ5zFc6CyqB+5UWKr1KEGK23hKoxA+z1gooAKA==",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading.Only": "17.13.61",
+          "Microsoft.VisualStudio.Validation": "17.8.8"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "13AKxycK+olOLe061MjliPTNBR/DUkjyRr0b9zwUhKyMjFS8lXS7G31R85rkbM55up2YFmdykWdAw2giBDJpiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.18.0"
+        }
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "io6A6PJFp3vIObRGf6oPjdHsdglkinXt/0SpTDJHrVnsLxUtOzwh/QwTsnhBJ43wJ6QcGMkyNzsSSY8XEB1Q5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.18.0"
+        }
+      },
+      "PolyType": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "GFdJvsN/VczpP0GfdPIi0jDudGH2Emk3rcIJHdqwU2SL2zQm1xSl6OTYvQSUxvzHu3ClWo096ICdWXVkpifQUA=="
+      },
+      "RabbitMQ.Client": {
+        "type": "Transitive",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
+        "dependencies": {
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "Semver": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "9jZCicsVgTebqkAujRWtC9J1A5EQVlu0TVKHcgoCuv345ve5DYf4D1MjhKEnQjdRZo6x/vdv6QQrYFs7ilGzLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "5.0.1"
+        }
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "2.25.29",
+        "contentHash": "ebP0ScWRtbd1EWayLRJ6bjM7aPwYZoJIIU1DApmn/cYl2dydR9f4p6Mj3eY77qzAywy6IbZWB9sJPSWeO5hmrg==",
+        "dependencies": {
+          "MessagePack": "2.5.302",
+          "Microsoft.VisualStudio.Threading.Only": "17.14.15",
+          "Microsoft.VisualStudio.Validation": "17.13.22",
+          "Nerdbank.MessagePack": "1.2.4",
+          "Nerdbank.Streams": "2.13.16",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.13.0",
+        "contentHash": "UneZiqYV3vmsCQJ2bO3fEzSGqK84kxEOOLN0OGDxxhAzef91gZLBQ5J8tgP0oTuwYmUSvwXGzvuq3Cvkedv8tA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "GbBrJq9S/gYpHzm7Pxx6Y5tDyfSfyxW6tlP5oiKJV38uf19Wp+GIIAnWfyL1zmNiz1+EjwVapw2WkBFvvqKQzg==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "9.0.13",
+          "System.Security.Cryptography.ProtectedData": "9.0.13"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "QTXEoQBzz00SFWbo7nAg1Ogd4f99lwqcO9uAJ7MYSLEUR28f6As32QktrqG2Fr9cfAfd1GjLyGYspE7Ipj7P6w=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "IQ4NXP/B3Ayzvw0rDQzVTYsCKyy0Jp9KI6aYcK7UnGVlR9+Awz++TIPCQtPYfLJfOpm8ajowMR09V7quD3sEHw=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "8IV+rI3xN/Mkq9MsSX7VZTv9T9Wt+tyhHLwBX9VNZBk8m8kknEs1JeTSjI2x9M2L/fSja+c2WSE5n5Yy0GXdoQ=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "t8S9IDpjJKsLpLkeBdW8cWtcPyYqrGu93Dej1RO6WwuL/lkFSqWlan3rMJfortqz1mRIh+sys2AFsSA6jWJ3Jg=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "2UtauxWDa9C6bT7MvFfZkNoFulfflb00jnDU2xeVO9Y58l4Ah2Mv/HiMs4b0zdpK/SfAxpajkgKNMN8zBKa+7Q=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "QxYfC+98lCMe7Kl9iWDUeUn+gmiPJ2Sz/r+trSdp1mvKyDMXj8S1kYdfkFNJSHyUSQ6KWomenSDgfWhGpR8zEQ=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "cjaNGmOVA5QJxcp6uuSsDhbt0lNmxezFo226mbYOuXm9E9Owq8bYTKxa9wnAMZRnbvyCmCYhAvc/+UAzf0M2vA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "2I7apws+6HPz5aYi4choAn7c8P4jPAvwbfAtLSy0JPH89oeY/z1Zqz65Cm3HJmput5l56Z1sJOinTxsAQmbyWQ==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.3",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.3",
+          "Microsoft.Testing.Platform": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3",
+          "xunit.v3.extensibility.core": "[4.0.0]",
+          "xunit.v3.runner.inproc.console": "[4.0.0]"
+        }
+      },
+      "xunit.v3.mtp-v2": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "svYjct2c3VbLyUSB2r9VWiIkYwemwXHhOgIVAor8RvupcZBFcdiGdmq8G519ZCu30yjPCr0EP3Hy4mvgEXcXpQ==",
+        "dependencies": {
+          "xunit.analyzers": "2.0.0",
+          "xunit.v3.assert": "[4.0.0]",
+          "xunit.v3.core.mtp-v2": "[4.0.0]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "1IEIAVRgnPo9nihd9D0TvxxsLKVRySa+K0wLy/m0SJ4RMdveRCUj/mICFboruO+ILUJ10fUfCCyp7MC5/y7cGw==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "System.Security.AccessControl": "[6.0.1]",
+          "xunit.v3.common": "[4.0.0]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "Sp5AALIlZUf2U5pEt2LHs+ebn18eAPSFnXEouJTltLez5p+NQvBm7kzsKSkZOM6iyoS6nuN/wKdsJt2LvixjsQ==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[4.0.0]",
+          "xunit.v3.runner.common": "[4.0.0]"
+        }
+      },
+      "YamlDotNet": {
+        "type": "Transitive",
+        "resolved": "16.3.0",
+        "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
+      },
+      "mmca.common.aspire.hosting": {
+        "type": "Project",
+        "dependencies": {
+          "Aspire.Hosting": "[13.5.3, )",
+          "Aspire.Hosting.Azure.CosmosDB": "[13.5.3, )",
+          "Aspire.Hosting.RabbitMQ": "[13.5.3, )",
+          "Aspire.Hosting.SqlServer": "[13.5.3, )",
+          "MessagePack": "[3.1.8, )",
+          "OpenTelemetry.Api": "[1.18.0, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.18.0, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.18.0, )"
+        }
+      },
+      "Aspire.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "VPsd2pgTgmwGLPTUrTD1oYR1XKMgh2ceSPBCF71NHxXSeXhSdpNHmCFDcv7tv8WgoEZDEQ76uIC6oklsEV9D/Q==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Uris": "9.0.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.AspNetCore": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0",
+          "Humanizer.Core": "3.0.10",
+          "JsonPatch.Net": "5.0.2",
+          "KubernetesClient": "19.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.30",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Hosting": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "ModelContextProtocol": "1.3.0",
+          "Newtonsoft.Json": "13.0.4",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Polly.Core": "8.6.6",
+          "Semver": "3.0.0",
+          "StreamJsonRpc": "2.25.29",
+          "System.IO.Hashing": "10.0.8",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "Aspire.Hosting.Azure.CosmosDB": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "Y3baYwnJlCv0ucBiLKQeLB13QLKw4sXXvWoCgSdAxN1cHUGLS44O+MrT0jq1HRUuTXTeAJB4Bsw0E5Mk9lshrw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.CosmosDb": "9.0.0",
+          "AspNetCore.HealthChecks.Uris": "9.0.0",
+          "Aspire.Hosting.Azure": "13.5.3",
+          "Aspire.Hosting.Azure.KeyVault": "13.5.3",
+          "Azure.Core": "1.57.0",
+          "Azure.Identity": "1.21.0",
+          "Azure.Provisioning": "1.5.0",
+          "Azure.Provisioning.CosmosDB": "1.0.0",
+          "Azure.Provisioning.KeyVault": "1.1.0",
+          "Azure.ResourceManager.Authorization": "1.1.6",
+          "Azure.ResourceManager.KeyVault": "1.4.0",
+          "Azure.ResourceManager.Resources": "1.11.2",
+          "Azure.Security.KeyVault.Secrets": "4.11.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.AspNetCore": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0",
+          "Grpc.Tools": "2.80.0",
+          "Humanizer.Core": "3.0.10",
+          "JsonPatch.Net": "5.0.2",
+          "KubernetesClient": "19.0.2",
+          "Microsoft.Azure.Cosmos": "3.61.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.30",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Hosting": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "ModelContextProtocol": "1.3.0",
+          "Newtonsoft.Json": "13.0.4",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Polly.Core": "8.6.6",
+          "Semver": "3.0.0",
+          "StreamJsonRpc": "2.25.29",
+          "System.IO.Hashing": "10.0.8",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "Aspire.Hosting.RabbitMQ": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EtjVgSO94r0Lgg/eLc9ZGUdwOdrI4OLohliE2IgPqPubR+jLboS2PzhUDk/sC1oFBomsfxA6dMjqmcCM/BiJsw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Rabbitmq": "9.0.0",
+          "AspNetCore.HealthChecks.Uris": "9.0.0",
+          "Aspire.Hosting": "13.5.3",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.AspNetCore": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0",
+          "Grpc.Tools": "2.80.0",
+          "Humanizer.Core": "3.0.10",
+          "JsonPatch.Net": "5.0.2",
+          "KubernetesClient": "19.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.30",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Hosting": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "ModelContextProtocol": "1.3.0",
+          "Newtonsoft.Json": "13.0.4",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Polly.Core": "8.6.6",
+          "RabbitMQ.Client": "7.2.1",
+          "Semver": "3.0.0",
+          "StreamJsonRpc": "2.25.29",
+          "System.IO.Hashing": "10.0.8",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "Aspire.Hosting.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "Wt5KM4vngh+V7hfPsrbdShhqu/FLf36iSQq5l4BdPNJRlU6f6ls103++oX4DIYDBeSSJncMych2asCLjmC1clA==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.SqlServer": "9.0.0",
+          "AspNetCore.HealthChecks.Uris": "9.0.0",
+          "Aspire.Hosting": "13.5.3",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.AspNetCore": "2.80.0",
+          "Grpc.Net.ClientFactory": "2.80.0",
+          "Grpc.Tools": "2.80.0",
+          "Humanizer.Core": "3.0.10",
+          "JsonPatch.Net": "5.0.2",
+          "KubernetesClient": "19.0.2",
+          "Microsoft.Data.SqlClient": "7.0.1",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.11",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Hosting": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "ModelContextProtocol": "1.3.0",
+          "Newtonsoft.Json": "13.0.4",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.15.3",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "Polly.Core": "8.6.6",
+          "Semver": "3.0.0",
+          "StreamJsonRpc": "2.25.29",
+          "System.IO.Hashing": "10.0.8",
+          "System.Security.Cryptography.Pkcs": "10.0.11",
+          "YamlDotNet": "16.3.0"
+        }
+      },
+      "AspNetCore.HealthChecks.Rabbitmq": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
+          "RabbitMQ.Client": "7.0.0"
+        }
+      },
+      "AspNetCore.HealthChecks.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "UxCf65iCF2nU1u7AcB320abjL4CRg5swCgJECY6mKk1j5lrGMfVtskWwriGs1T29pYdRig9Vra3SPnP+4G82pA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11"
+        }
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
+      "Google.Protobuf": {
+        "type": "CentralTransitive",
+        "requested": "[3.35.1, )",
+        "resolved": "3.34.1",
+        "contentHash": "212vdYxRuVopGE5bess6Jg5oXWyizA6hcLPTI7G+qA4PthQEvfeof3njT+7VSY5v/+O0P22xTydiP5fSJJpGEA=="
+      },
+      "Grpc.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.83.0, )",
+        "resolved": "2.80.0",
+        "contentHash": "ASbJbdtCUlGiKxe9NsN/QeG1PdibYoN0pEgP9U87cvS6HV0XsT+VdO/g2M6Ri8zZURfX5c7MBTaFVP/YCrC72A==",
+        "dependencies": {
+          "Google.Protobuf": "3.31.1",
+          "Grpc.AspNetCore.Server.ClientFactory": "2.80.0",
+          "Grpc.Tools": "2.80.0"
+        }
+      },
+      "Grpc.Net.ClientFactory": {
+        "type": "CentralTransitive",
+        "requested": "[2.83.0, )",
+        "resolved": "2.80.0",
+        "contentHash": "YtY1DWID2phwiGc8qBG7+wf00Do5jE7BkJgCc6nbu5b50OsD89mSd73oCE8fCnUo7IjtDAEYFOYI3NSzgn28gw==",
+        "dependencies": {
+          "Grpc.Net.Client": "2.80.0",
+          "Microsoft.Extensions.Http": "8.0.0"
+        }
+      },
+      "Grpc.Tools": {
+        "type": "CentralTransitive",
+        "requested": "[2.82.0, )",
+        "resolved": "2.80.0",
+        "contentHash": "NS1AxwVZnrdbBoMf5L5ruGjBjoLBej9avhqxWNsgfu2GU6FhpxEVJOwLJsdljlDCjvquJiAH2zf/WodIWMvf2w=="
+      },
+      "MessagePack": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.8, )",
+        "resolved": "3.1.8",
+        "contentHash": "Qk2q+9FVxnMSp+NQ9y3SLz3HqWe7Rg3KRMHhBX28FkKUoOeP9YIU86mA4pFOxDDjUIRA9e7Ssbxs/LwWUcAzPw==",
+        "dependencies": {
+          "MessagePack.Annotations": "3.1.8",
+          "MessagePackAnalyzer": "3.1.8",
+          "Microsoft.NET.StringTools": "17.11.4"
+        }
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.1",
+        "contentHash": "9jZFXAJ2ThNYK7lhj2RhH7klXVNaWSvZpQncq3bPIOjmHBrdjwgeO4c8wucUVxQwFT8rAA13Z2F2jzoYR7ICDw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "9.0.13",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "1.0.0",
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.13",
+          "System.Security.Cryptography.Pkcs": "9.0.13"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "fVi053xdpda9Em7vSkmgVxO/PtgC2m78ekReKWsgcyskqY0U82Bz/MONwxpGzI0hElYKJfw+fupqMVeKW3fSaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "nSPrT8U/cNoB4coqkmnanAMK9PsL7lsjG+LLUKEwHRFwS6E78b8S1wdv/y88EOxBhasWov1rLd7RTHmmsYPOLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "ujx8RvcKzkxPFBguwgiygbwWVHVK0P7HFlNJ6I0JBRb28tzwe42jixBoA+dGmqG9IHepPVcm04vv2IDnU93ekA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "Dhzm5oughIY9EWckt2J1yXcEbXpki5WCL2q7prJoYxzH6C7jdkfGtPMTkUVZZ4AhjJKzQnlC+kLSIlmIVwC4Vw=="
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "Et3WAviooKGObZjUZN8d6eTsdJs1YM3ZoN+KlWSAHksTmHG1nyGi9XGo2wb0fkFMWK0g80FOPdR1njg52Dm+aw==",
+        "dependencies": {
+          "OpenTelemetry": "1.18.0"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "u+JMA82H65MKwMvd2qUpL8C2qE4Jux2nvX9hmy036UK/Apv2YyIRYCttF/vlX6nMPcAKI8BXkscmL4QG3C69fw==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.18.0"
+        }
+      },
+      "Polly.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.7.0, )",
+        "resolved": "8.6.6",
+        "contentHash": "lCBL9mmhF9TZxHG3beVRkyjlLohkIC464xIAq7J7Y59C+z42hmsdUaeCKl2SIAYertOUU5TeBXyQDLDQGIKePQ=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "CentralTransitive",
+        "requested": "[8.22.0, )",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "CentralTransitive",
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "+tTe9VX2vwrUHGI48FE4ly956Ry084wPH4I/7g5D36AkAMGjQRZZDVz8eH2GwX/CLS9PDQRSca534WyrAYsyzw==",
+        "dependencies": {
+          "xunit.v3.common": "[4.0.0]"
+        }
+      }
+    }
+  }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Gateway/GatewayDownstreamHealthChecksTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Gateway/GatewayDownstreamHealthChecksTests.cs
@@ -10,11 +10,20 @@ namespace MMCA.Common.Aspire.Tests.Gateway;
 /// <summary>
 /// Unit tests for the gateway's downstream health checks: what gets registered (names, tags,
 /// failure status), that a repeated registration does not produce the duplicate check name the
-/// health-check service rejects at startup, and how the probe itself maps an HTTP outcome onto a
-/// health status.
+/// health-check service rejects at startup, how the probe itself maps an HTTP outcome onto a health
+/// status, and how it works out which HTTP version a downstream speaks (negotiate once, latch the
+/// answer, never latch on an outage).
 /// </summary>
 public sealed class GatewayDownstreamHealthChecksTests
 {
+    /// <summary>What one h2c prior-knowledge attempt looks like on the wire.</summary>
+    private static readonly ProbeAttempt Http2Attempt =
+        new(HttpVersion.Version20, HttpVersionPolicy.RequestVersionExact);
+
+    /// <summary>What one stock HTTP/1.1 attempt looks like on the wire.</summary>
+    private static readonly ProbeAttempt Http11Attempt =
+        new(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower);
+
     [Fact]
     public void AddGatewayDownstreamHealthChecks_RegistersOneCheckPerService()
     {
@@ -67,61 +76,85 @@ public sealed class GatewayDownstreamHealthChecksTests
         client.Timeout.Should().Be(TimeSpan.FromSeconds(2));
     }
 
-    // An HttpClient left on its own defaults sends HTTP/1.1, which an Http2-only cleartext (h2c)
-    // endpoint refuses outright, so the probe fails and the gateway reports a downstream outage that
-    // does not exist. The services a modular-monolith gateway fronts serve h2c precisely so that
-    // cross-service gRPC works without TLS/ALPN, which makes HTTP/2 the right default here.
+    // The probe client carries NO version pin: the version belongs to the REQUEST, because an Auto
+    // probe can put HTTP/2 and HTTP/1.1 through this one client on a single poll while it works out
+    // which one the downstream speaks.
     [Fact]
-    public void ProbeClient_SpeaksHttp2ByDefault()
+    public void ProbeClient_DoesNotPinAnHttpVersion()
     {
         var client = ProbeClientFor("catalog");
+        using var stock = new HttpClient();
 
-        client.DefaultRequestVersion.Should().Be(HttpVersion.Version20);
-        client.DefaultVersionPolicy.Should().Be(HttpVersionPolicy.RequestVersionExact,
-            because: "h2c prior knowledge means the request must go out as HTTP/2, not negotiate down");
+        client.DefaultRequestVersion.Should().Be(stock.DefaultRequestVersion);
+        client.DefaultVersionPolicy.Should().Be(stock.DefaultVersionPolicy);
     }
 
+    // The version profile is per CALL, so a gateway pinning one head's profile must not retro-change
+    // the group an earlier call registered. Driven through the REGISTRATION rather than a hand-built
+    // check, so the option is proven to travel from AddGatewayDownstreamHealthChecks onto the wire.
     [Fact]
-    public void ProbeClient_CanOptOutBackToHttp11PerDownstream()
-    {
-        var client = ProbeClientFor("legacy", configure: o => o.ProbeOverHttp2 = false);
-
-        client.DefaultRequestVersion.Should().Be(HttpVersion.Version11);
-        client.DefaultVersionPolicy.Should().Be(HttpVersionPolicy.RequestVersionOrLower);
-    }
-
-    // The opt-out is per CALL, so a gateway fronting a mix of profiles registers each group once and
-    // the second call must not retro-change the first group's client.
-    [Fact]
-    public void ProbeClient_VersionProfileIsScopedToItsOwnRegistrationCall()
+    public async Task ProbeVersion_IsScopedToItsOwnRegistrationCall()
     {
         var services = new ServiceCollection();
         services.AddGatewayDownstreamHealthChecks("catalog");
-        services.AddGatewayDownstreamHealthChecks(o => o.ProbeOverHttp2 = false, "legacy");
+        services.AddGatewayDownstreamHealthChecks(o => o.ProbeVersion = DownstreamProbeVersion.Http11, "legacy");
 
-        using var provider = services.BuildServiceProvider();
-        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        using var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
 
-        using var http2Client = factory.CreateClient(GatewayHealthCheckExtensions.ClientName("catalog"));
-        using var http11Client = factory.CreateClient(GatewayHealthCheckExtensions.ClientName("legacy"));
+        // Registered last, so it wins over the real factory AddHttpClient put in earlier.
+        services.AddSingleton<IHttpClientFactory>(new StubHttpClientFactory(client));
 
-        http2Client.DefaultRequestVersion.Should().Be(HttpVersion.Version20);
-        http11Client.DefaultRequestVersion.Should().Be(HttpVersion.Version11);
+        await using var provider = services.BuildServiceProvider();
+        var registrations = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+
+        foreach (var registration in registrations)
+        {
+            var check = registration.Factory(provider);
+            await check.CheckHealthAsync(
+                new HealthCheckContext { Registration = registration },
+                CancellationToken.None);
+        }
+
+        handler.Attempts.Should().Equal(Http2Attempt, Http11Attempt);
     }
 
     [Fact]
     public void AddGatewayDownstreamHealthChecks_WithOptions_RegistersTheSameChecks()
     {
         var services = new ServiceCollection();
-        services.AddGatewayDownstreamHealthChecks(o => o.ProbeOverHttp2 = false, "catalog", "sales");
+        services.AddGatewayDownstreamHealthChecks(
+            o => o.ProbeVersion = DownstreamProbeVersion.Http11, "catalog", "sales");
 
         Registrations(services).Select(r => r.Name)
             .Should().BeEquivalentTo("downstream-catalog", "downstream-sales");
     }
 
     [Fact]
-    public void Options_DefaultToHttp2() =>
-        new GatewayDownstreamHealthCheckOptions().ProbeOverHttp2.Should().BeTrue();
+    public void Options_DefaultToAutoNegotiation() =>
+        new GatewayDownstreamHealthCheckOptions().ProbeVersion.Should().Be(DownstreamProbeVersion.Auto);
+
+    // The bool opt-out predates ProbeVersion and survives only as a facade, so a gateway written
+    // against it keeps compiling. It maps onto the two FIXED modes, which is exactly what giving up
+    // the negotiation means.
+    [Fact]
+    public void ObsoleteProbeOverHttp2_RoundTripsOntoTheFixedModes()
+    {
+#pragma warning disable CS0618 // Obsolete on purpose: this test is what keeps the compat facade honest.
+        var options = new GatewayDownstreamHealthCheckOptions();
+
+        options.ProbeOverHttp2.Should().BeFalse(
+            because: "the Auto default has not pinned HTTP/2, it decides per downstream");
+
+        options.ProbeOverHttp2 = true;
+        options.ProbeVersion.Should().Be(DownstreamProbeVersion.Http2);
+        options.ProbeOverHttp2.Should().BeTrue();
+
+        options.ProbeOverHttp2 = false;
+        options.ProbeVersion.Should().Be(DownstreamProbeVersion.Http11);
+        options.ProbeOverHttp2.Should().BeFalse();
+#pragma warning restore CS0618
+    }
 
     private static HttpClient ProbeClientFor(
         string serviceName,
@@ -207,17 +240,161 @@ public sealed class GatewayDownstreamHealthChecksTests
             because: "probing readiness would make every downstream rolling deployment look like a gateway failure");
     }
 
+    // Auto is the default, so the first attempt of every probe goes out as h2c prior knowledge and
+    // an endpoint that answers it settles the question: later polls send one request, not two.
+    [Fact]
+    public async Task Probe_WhenAutoAndHttp2Answers_LatchesHttp2AndStopsNegotiating()
+    {
+        using var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
+
+        var first = await check.CheckHealthAsync(context, CancellationToken.None);
+        var second = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        first.Status.Should().Be(HealthStatus.Healthy);
+        second.Status.Should().Be(HealthStatus.Healthy);
+        handler.Attempts.Should().Equal(Http2Attempt, Http2Attempt);
+    }
+
+    // A cleartext Http1AndHttp2 endpoint without ALPN answers HTTP_1_1_REQUIRED forever. The check
+    // resolves that itself, inside ONE poll, which is what removes the consumer's manual opt-out.
+    [Theory]
+    [InlineData(HttpRequestError.VersionNegotiationError)]
+    [InlineData(HttpRequestError.HttpProtocolError)]
+    public async Task Probe_WhenAutoAndHttp2IsRefused_FallsBackToHttp11WithinTheSameCheck(
+        HttpRequestError error)
+    {
+        using var handler = new StubHandler(RefusesHttp2(error));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
+
+        var result = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Healthy,
+            because: "the fallback answered inside the same check, so the poll has a verdict");
+        handler.Attempts.Should().Equal(Http2Attempt, Http11Attempt);
+    }
+
+    [Fact]
+    public async Task Probe_WhenAutoHasFallenBack_GoesStraightToHttp11()
+    {
+        using var handler = new StubHandler(RefusesHttp2(HttpRequestError.VersionNegotiationError));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
+
+        await check.CheckHealthAsync(context, CancellationToken.None);
+        var later = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        later.Status.Should().Be(HealthStatus.Healthy);
+        handler.Attempts.Should().Equal(Http2Attempt, Http11Attempt, Http11Attempt);
+    }
+
+    // Latching the version that answered must not launder the answer: a 503 over the fallback is
+    // still a downstream failure.
+    [Fact]
+    public async Task Probe_WhenAutoFallbackAnswersNonSuccess_ReportsUnhealthyAndStillLatches()
+    {
+        using var handler = new StubHandler(request => request.Version == HttpVersion.Version20
+            ? throw new HttpRequestException(HttpRequestError.VersionNegotiationError, "HTTP_1_1_REQUIRED")
+            : new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
+
+        var first = await check.CheckHealthAsync(context, CancellationToken.None);
+        var later = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        first.Status.Should().Be(HealthStatus.Unhealthy);
+        first.Description.Should().Contain("503");
+        later.Status.Should().Be(HealthStatus.Unhealthy);
+        handler.Attempts.Should().Equal(Http2Attempt, Http11Attempt, Http11Attempt);
+    }
+
+    // A downstream that is simply DOWN must never pin a protocol: the outage says nothing about
+    // which version the endpoint speaks, and the wrong latch would outlive the outage.
+    [Fact]
+    public async Task Probe_WhenAutoAndTheDownstreamIsUnreachable_ReportsUnhealthyWithoutLatching()
+    {
+        var attempts = 0;
+        using var handler = new StubHandler(_ => ++attempts == 1
+            ? throw new HttpRequestException("connection refused")
+            : new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
+
+        var duringOutage = await check.CheckHealthAsync(context, CancellationToken.None);
+        var afterRecovery = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        duringOutage.Status.Should().Be(HealthStatus.Unhealthy);
+        afterRecovery.Status.Should().Be(HealthStatus.Healthy);
+        // Two attempts, both HTTP/2: a connectivity failure is not a protocol refusal, so the first
+        // check neither fell back nor latched, and the second still had the question open.
+        handler.Attempts.Should().Equal(Http2Attempt, Http2Attempt);
+    }
+
+    [Fact]
+    public async Task Probe_WhenAutoFallbackAlsoFails_ReportsUnhealthyWithoutLatching()
+    {
+        using var handler = new StubHandler(
+            _ => throw new HttpRequestException(HttpRequestError.VersionNegotiationError, "refused"));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
+
+        var first = await check.CheckHealthAsync(context, CancellationToken.None);
+        var second = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        first.Status.Should().Be(HealthStatus.Unhealthy);
+        second.Status.Should().Be(HealthStatus.Unhealthy);
+        handler.Attempts.Should().Equal(Http2Attempt, Http11Attempt, Http2Attempt, Http11Attempt);
+    }
+
+    [Fact]
+    public async Task Probe_WhenPinnedToHttp2_NeverFallsBack()
+    {
+        using var handler = new StubHandler(RefusesHttp2(HttpRequestError.VersionNegotiationError));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Http2);
+
+        var result = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        handler.Attempts.Should().Equal(Http2Attempt);
+    }
+
+    [Fact]
+    public async Task Probe_WhenPinnedToHttp11_SendsHttp11()
+    {
+        using var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Http11);
+
+        var result = await check.CheckHealthAsync(context, CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        handler.Attempts.Should().Equal(Http11Attempt);
+    }
+
+    // Stands in for a downstream that accepts the connection and refuses the VERSION: HTTP/2 throws
+    // the protocol error, HTTP/1.1 answers normally.
+    private static Func<HttpRequestMessage, HttpResponseMessage> RefusesHttp2(HttpRequestError error) =>
+        request => request.Version == HttpVersion.Version20
+            ? throw new HttpRequestException(error, "HTTP_1_1_REQUIRED")
+            : new HttpResponseMessage(HttpStatusCode.OK);
+
+    private static (DownstreamServiceHealthCheck Check, HealthCheckContext Context) CheckFor(
+        HttpClient client,
+        DownstreamProbeVersion probeVersion) =>
+        (new DownstreamServiceHealthCheck(new StubHttpClientFactory(client), "catalog", "client", probeVersion),
+            new HealthCheckContext { Registration = RegistrationFor("catalog") });
+
     private static async Task<HealthCheckResult> ProbeAsync(Func<HttpRequestMessage, HttpResponseMessage> respond)
     {
         using var handler = new StubHandler(respond);
         using var client = new HttpClient(handler) { BaseAddress = new Uri("http://catalog") };
 
-        var check = new DownstreamServiceHealthCheck(new StubHttpClientFactory(client), "catalog", "client");
-        var registration = RegistrationFor("catalog");
+        var (check, context) = CheckFor(client, DownstreamProbeVersion.Auto);
 
-        return await check.CheckHealthAsync(
-            new HealthCheckContext { Registration = registration },
-            CancellationToken.None);
+        return await check.CheckHealthAsync(context, CancellationToken.None);
     }
 
     private static HealthCheckRegistration RegistrationFor(string serviceName)
@@ -240,10 +417,25 @@ public sealed class GatewayDownstreamHealthChecksTests
         public HttpClient CreateClient(string name) => client;
     }
 
+    /// <summary>One request the check actually put on the wire, with the version profile it asked for.</summary>
+    /// <param name="Version">The HTTP version on the request.</param>
+    /// <param name="Policy">The version policy on the request.</param>
+    private sealed record ProbeAttempt(Version Version, HttpVersionPolicy Policy);
+
     private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
     {
+        private readonly List<ProbeAttempt> _attempts = [];
+
+        // Recorded in order and BEFORE respond runs, so an attempt that throws still counts. This is
+        // how a negotiation (HTTP/2 then HTTP/1.1) is told apart from a latched, single-request poll.
+        public IReadOnlyList<ProbeAttempt> Attempts => _attempts;
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
-            CancellationToken cancellationToken) => Task.FromResult(respond(request));
+            CancellationToken cancellationToken)
+        {
+            _attempts.Add(new ProbeAttempt(request.Version, request.VersionPolicy));
+            return Task.FromResult(respond(request));
+        }
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/MmcaThemeProvidersPrerenderTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/MmcaThemeProvidersPrerenderTests.cs
@@ -1,0 +1,38 @@
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using MMCA.Common.UI.Components;
+
+namespace MMCA.Common.UI.Tests.Components;
+
+/// <summary>
+/// Covers the non-interactive half of <see cref="MmcaThemeProviders"/>'s E2E interactivity marker: a
+/// renderer that reports as non-interactive must NOT stamp <c>data-mmca-interactive</c>, because
+/// MMCA.Common.Testing.E2E's <c>WaitForBlazorAsync</c> reads that attribute as proof that components
+/// have attached their event handlers. Separate from <see cref="MmcaThemeProvidersTests"/> because
+/// bUnit's <c>SetRendererInfo</c> configures the whole test context, not a single render.
+/// </summary>
+public sealed class MmcaThemeProvidersPrerenderTests : BunitTestBase
+{
+    // Must run after the base constructors' Services.Add calls (it freezes the service provider),
+    // which it does.
+    public MmcaThemeProvidersPrerenderTests()
+        => SetRendererInfo(new RendererInfo("Static", isInteractive: false));
+
+    [Fact]
+    public void NonInteractiveRender_DoesNotStampTheE2eInteractivityMarker()
+    {
+        var themeModule = JSInterop.SetupModule(MmcaThemeProvidersTests.ThemeModulePath);
+
+        var cut = RenderUnderTest<MmcaThemeProviders>(_ => { });
+
+        // ThemeService.InitializeAsync is deliberately NOT gated on RendererInfo, so its "get" call is
+        // what proves OnAfterRenderAsync has already run: without that anchor an empty marker list
+        // would only prove the assertion ran too early.
+        cut.WaitForAssertion(() => themeModule.Invocations["get"].Should().NotBeEmpty(
+            "the first render always resolves the stored theme preference"));
+
+        themeModule.Invocations["markInteractive"].Should().BeEmpty(
+            "a non-interactive renderer has attached no event handlers to advertise");
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/MmcaThemeProvidersTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/MmcaThemeProvidersTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.UI.Components;
 using MMCA.Common.UI.Services;
@@ -15,14 +16,27 @@ namespace MMCA.Common.UI.Tests.Components;
 /// MMCA theme, the first interactive render initializes <see cref="ThemeService"/> (JS interop is
 /// unavailable during SSR prerender), <c>OnChange</c> flips the theme provider's dark mode, and
 /// disposal unsubscribes so a long-lived scoped service never calls back into a dead component.
+/// The non-interactive (prerender) half of the E2E interactivity marker lives in
+/// <see cref="MmcaThemeProvidersPrerenderTests"/>, because <c>SetRendererInfo</c> is a per-context
+/// setting.
 /// </summary>
 public sealed class MmcaThemeProvidersTests : BunitTestBase
 {
+    /// <summary>The RCL module the component imports to stamp the E2E interactivity marker.</summary>
+    internal const string ThemeModulePath = "./_content/MMCA.Common.UI/theme.js";
+
     private static readonly FieldInfo OnChangeField = typeof(ThemeService)
         .GetField("OnChange", BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     private static readonly FieldInfo IsDarkModeField = typeof(MmcaThemeProviders)
         .GetField("_isDarkMode", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    // The component reads RendererInfo on its first render (it stamps the E2E interactivity marker only
+    // on an interactive one), and bUnit throws MissingRendererInfoException when nothing has declared
+    // it. Set once here so it covers every test in this class; it must run after the base constructors'
+    // Services.Add calls (it freezes the service provider), which it does.
+    public MmcaThemeProvidersTests()
+        => SetRendererInfo(new RendererInfo("Server", isInteractive: true));
 
     [Fact]
     public void Render_ProducesAllFourMudProviders_WithTheMmcaTheme()
@@ -61,6 +75,22 @@ public sealed class MmcaThemeProvidersTests : BunitTestBase
             "OnAfterRenderAsync(firstRender) must resolve the stored/OS preference"));
         themeService.IsDarkMode.Should().BeFalse(
             "loose JSInterop reports no stored value and no OS dark preference");
+    }
+
+    [Fact]
+    public void FirstInteractiveRender_StampsTheE2eInteractivityMarker()
+    {
+        // The marker (data-mmca-interactive on the document element) is what
+        // MMCA.Common.Testing.E2E's WaitForBlazorAsync gates on: blazor.web.js populates
+        // window.Blazor._internal BEFORE components attach their event handlers, so a test gated on
+        // that alone clicks prerendered-but-dead controls. Keep the identifier in step with theme.js
+        // and PageExtensions.InteractiveMarkerPredicate.
+        var themeModule = JSInterop.SetupModule(ThemeModulePath);
+
+        var cut = RenderUnderTest<MmcaThemeProviders>(_ => { });
+
+        cut.WaitForAssertion(() => themeModule.Invocations["markInteractive"].Should().ContainSingle(
+            "an interactive first render must stamp the marker the E2E interactivity gate waits on"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes the wave6/Medium-recs ledger items on the framework side.

## What

- **`WithH2cHealthCheck`** (new, `MMCA.Common.Aspire.Hosting`): health-gates a project resource whose cleartext endpoint is Kestrel Http2-only (h2c prior knowledge). Aspire's stock `WithHttpHealthCheck` probes over HTTP/1.1 and answers `HTTP_1_1_REQUIRED` forever, so ADC identity/conference/engagement and Store catalog/identity have no health check today and their `WaitFor` edges only wait for process start. The new check GETs the health path over HTTP/2 exact version against the existing endpoint: zero service/Kestrel/bicep changes. The XML docs record why surfacing the `HealthProbe:Port` HTTP/1.1 listener as an Aspire endpoint was rejected (explicit listeners override `ASPNETCORE_URLS` locally and collide on the fixed cleartext port). New test project `MMCA.Common.Aspire.Hosting.Tests` (17 tests).
- **Gateway downstream probe auto-negotiation**: `DownstreamProbeVersion { Auto, Http2, Http11 }`, `Auto` default; tries h2c exact, falls back to HTTP/1.1 on `VersionNegotiationError`/`HttpProtocolError` within the same 2s check, latches the winner per downstream for process lifetime, never latches on transient failures. `ProbeOverHttp2` becomes an `[Obsolete]` facade; both consumer gateways can collapse to one registration call in their sweep PRs.
- **E2E interactivity gate**: `MmcaThemeProviders` stamps `data-mmca-interactive` on the document root at its first interactive render (via a `theme.js` module export, re-stamped across enhanced navigations). `WaitForBlazorAsync` now waits up to 3s for the marker after the Blazor-runtime check, settling one animation frame on success; pages that never hydrate (or consumers on an older UI package) fall back to the previous 2rAF+500ms settle. Signature unchanged, so every consumer E2E suite upgrades with the pin bump.

## Verification

- Full solution: 4894 tests passed locally (Release), including the new Aspire.Hosting tests and the reworked gateway negotiation tests.
- FACTS drift gate clean; PublicAPI entries added for the new surface.

Consumer sweeps (ADC/Store/Helpdesk) follow the v1.167.0 tag per the approved wave plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jQtUMpox3zJLNv3Mecpki