### PR TITLE
feat: IToastService.ShowAction + shipped bUnit base registers UI facades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.169.0] - 2026-08-29
+
+Follow-up to the 1.168.0 facade work: the two gaps the downstream migration surfaced. Interactive
+snackbars get a contract of their own, and the shipped bUnit base registers the facades so consumer
+component tests resolve them without a local workaround.
+
+### Added
+
+- **`IToastService.ShowAction`** (`MMCA.Common.UI`). Raises a toast carrying a button
+  (`ShowAction(message, actionText, onAction, severity, requireInteraction)`): the "undo", "view it",
+  "retry" shape the facade could not express, so consumers no longer have to drop back to MudBlazor's
+  `ISnackbar` to keep an interactive snackbar. `requireInteraction: true` pins the toast open until
+  the user dismisses it and renders it filled, the same emphasis convention `ShowPersistent` uses. The
+  callback runs outside any render callback, so a caller whose work can fail guards it itself.
+- **`AddCommonUiFacades()`** (`MMCA.Common.UI`). The toast/confirm-dialog facade registration pair as
+  its own extension, so a test harness can register exactly those two over MudBlazor without the rest
+  of the shared-UI surface. `AddUIShared` calls it, so host behaviour is unchanged; TryAdd means a
+  host or test that pre-registers a substitute keeps it.
+
+### Changed
+
+- **BREAKING for implementors: `IToastService` gains a member.** `ShowAction` is a new interface
+  method, so a type outside the framework that implements `IToastService` must add it. Per the
+  [versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html) an
+  implementor-breaking interface addition ships as a MINOR release; callers and the framework's own
+  Mud-backed implementation are unaffected.
+- **`BunitComponentTestBase` registers the UI facades** (`MMCA.Common.Testing.UI`). The shipped base
+  now calls `AddCommonUiFacades()` right after `AddMudServices()`, so a consumer component test that
+  renders a page injecting `IToastService` / `IAppDialogService` resolves them from the harness.
+  Consumer test bases that added the pair locally can drop those registrations.
+- **The localized-text fitness rule covers `ShowAction`** (`MMCA.Common.Testing.Architecture`): a
+  literal first argument to it fails the gate like every other toast method (ADR-027).
+
 ## [1.168.0] - 2026-08-29
 
 Adherence release: the patterns the framework asks consumers to follow are applied to the framework

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.LocalizedText.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.LocalizedText.cs
@@ -11,7 +11,7 @@ public static partial class ArchitectureRules
 
     // Same guard for the vendor-neutral IToastService facade that replaced direct ISnackbar use:
     // a literal first argument to any toast method is a hard-coded user-visible string.
-    [GeneratedRegex(@"Toast\.(?:Success|Info|Warning|Error|Show|ShowPersistent)\(\s*\$?""", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
+    [GeneratedRegex(@"Toast\.(?:Success|Info|Warning|Error|Show|ShowPersistent|ShowAction)\(\s*\$?""", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 1000)]
     private static partial Regex LiteralToast { get; }
 
     // Matches a literal-titled page property, for example a Title property that returns the

--- a/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitComponentTestBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitComponentTestBase.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using MMCA.Common.UI;
 using MMCA.Common.UI.Services;
 using Moq;
 using MudBlazor;
@@ -43,6 +44,14 @@ public abstract class BunitComponentTestBase : BunitContext
     protected BunitComponentTestBase()
     {
         Services.AddMudServices();
+
+        // The vendor-neutral toast/confirm facades every migrated page and the shared Result helpers
+        // inject. They wrap the MudBlazor services registered on the line above, so they belong right
+        // here: without them a consumer's component test fails to resolve IToastService and each repo
+        // ends up re-registering the same pair in its own base. TryAdd inside, so a test that wants a
+        // recording double registers one afterwards (last registration wins).
+        Services.AddCommonUiFacades();
+
         JSInterop.Mode = JSRuntimeMode.Loose;
         Services.AddAuthorizationCore();
         Services.AddSingleton<IAuthorizationService, IsAuthenticatedAuthorizationService>();

--- a/Source/Presentation/MMCA.Common.UI/Common/Interfaces/IToastService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Common/Interfaces/IToastService.cs
@@ -70,4 +70,33 @@ public interface IToastService
     /// <param name="body">The already-localized body text, rendered below the title.</param>
     /// <param name="severity">The level to render at; defaults to <see cref="ToastSeverity.Info"/>.</param>
     void ShowPersistent(string title, string body, ToastSeverity severity = ToastSeverity.Info);
+
+    /// <summary>
+    /// Raises a toast carrying a button the user can click: the "undo", "view it", "retry" shape a
+    /// bare message cannot express. The toast renders a button labelled
+    /// <paramref name="actionText"/>, and <paramref name="onAction"/> runs when it is clicked.
+    /// <para>
+    /// The callback runs outside any render callback, so nothing catches what it throws: a caller
+    /// whose work can fail must guard it itself (and raise its own failure toast) rather than
+    /// letting the exception escape into the toast host.
+    /// </para>
+    /// </summary>
+    /// <param name="message">The already-localized sentence to show.</param>
+    /// <param name="actionText">The already-localized button label.</param>
+    /// <param name="onAction">
+    /// The work to run when the button is clicked. Exceptions are the caller's to handle.
+    /// </param>
+    /// <param name="severity">The level to render at; defaults to <see cref="ToastSeverity.Info"/>.</param>
+    /// <param name="requireInteraction">
+    /// When true the toast is pinned open until the user dismisses it (or takes the action) instead
+    /// of expiring on the host's default timer, and the MudBlazor implementation renders it filled:
+    /// the same emphasis convention <see cref="ShowPersistent"/> uses, because a toast that waits for
+    /// the user has to look like it is waiting.
+    /// </param>
+    void ShowAction(
+        string message,
+        string actionText,
+        Func<Task> onAction,
+        ToastSeverity severity = ToastSeverity.Info,
+        bool requireInteraction = false);
 }

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -83,13 +83,9 @@ public static class DependencyInjection
                 .AddHttpMessageHandler<AuthDelegatingHandler>()
                 .AddHttpMessageHandler<CultureDelegatingHandler>();
 
-            // Toast and confirm-dialog facades. These two implementations are the ONLY types in the
-            // framework that name MudBlazor's ISnackbar / IDialogService: every page, component and
-            // Result helper depends on IToastService / IAppDialogService instead, so the component
-            // library stays swappable and a test can record toasts without a rendered snackbar host.
-            // Scoped to match the MudBlazor services they wrap.
-            services.TryAddScoped<IToastService, MudToastService>();
-            services.TryAddScoped<IAppDialogService, MudAppDialogService>();
+            // Toast and confirm-dialog facades, factored out so a bUnit harness can register exactly
+            // these two without pulling in the whole shared-UI surface.
+            services.AddCommonUiFacades();
 
             // TryAdd prevents duplicate registration when called from multiple hosts
             services.TryAddScoped<IAuthUIService, AuthUIService>();
@@ -124,6 +120,27 @@ public static class DependencyInjection
             // MAUI/browser hosts override AFTER this call (last registration wins).
             services.AddDeviceCapabilityDefaults();
 
+            return services;
+        }
+
+        /// <summary>
+        /// Registers the vendor-neutral toast and confirm-dialog facades over MudBlazor:
+        /// <c>IToastService</c> and <c>IAppDialogService</c>. These two implementations are the ONLY
+        /// types in the framework that name MudBlazor's <c>ISnackbar</c> / <c>IDialogService</c>:
+        /// every page, component and <c>Result</c> helper depends on the contracts instead, so the
+        /// component library stays swappable and a test can record toasts without a rendered
+        /// snackbar host. Scoped, to match the MudBlazor services they wrap.
+        /// <para>
+        /// Called by <c>AddUIShared</c>, and separately by the shipped bUnit base
+        /// (<c>MMCA.Common.Testing.UI</c>) so a component test resolves the facades without the rest
+        /// of the shared-UI surface. Registered with TryAdd, so a host or test that pre-registers a
+        /// substitute keeps it.
+        /// </para>
+        /// </summary>
+        public IServiceCollection AddCommonUiFacades()
+        {
+            services.TryAddScoped<IToastService, MudToastService>();
+            services.TryAddScoped<IAppDialogService, MudAppDialogService>();
             return services;
         }
 

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -290,6 +290,7 @@ MMCA.Common.UI.Common.Interfaces.IToastService
 MMCA.Common.UI.Common.Interfaces.IToastService.Error(string! message) -> void
 MMCA.Common.UI.Common.Interfaces.IToastService.Info(string! message) -> void
 MMCA.Common.UI.Common.Interfaces.IToastService.Show(string! message, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.ShowAction(string! message, string! actionText, System.Func<System.Threading.Tasks.Task!>! onAction, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info, bool requireInteraction = false) -> void
 MMCA.Common.UI.Common.Interfaces.IToastService.ShowPersistent(string! title, string! body, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info) -> void
 MMCA.Common.UI.Common.Interfaces.IToastService.Success(string! message) -> void
 MMCA.Common.UI.Common.Interfaces.IToastService.Warning(string! message) -> void
@@ -299,3 +300,5 @@ MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info = 1 -> MMCA.Common.UI.Common
 MMCA.Common.UI.Common.Interfaces.ToastSeverity.Normal = 0 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
 MMCA.Common.UI.Common.Interfaces.ToastSeverity.Success = 2 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
 MMCA.Common.UI.Common.Interfaces.ToastSeverity.Warning = 3 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddCommonUiFacades() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static MMCA.Common.UI.DependencyInjection.AddCommonUiFacades(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/Source/Presentation/MMCA.Common.UI/Services/MudToastService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/MudToastService.cs
@@ -47,6 +47,36 @@ internal sealed class MudToastService(ISnackbar snackbar) : IToastService
                 options.SnackbarVariant = Variant.Filled;
             });
 
+    /// <inheritdoc />
+    public void ShowAction(
+        string message,
+        string actionText,
+        Func<Task> onAction,
+        ToastSeverity severity = ToastSeverity.Info,
+        bool requireInteraction = false) =>
+        snackbar.Add(
+            message,
+            Map(severity),
+            options =>
+            {
+                options.Action = actionText;
+                options.ActionColor = Color.Primary;
+
+                // MudBlazor hands the click a Snackbar instance the callback has no use for: the
+                // action is described entirely by the delegate the caller passed.
+                options.OnClick = _ => onAction();
+
+                if (requireInteraction)
+                {
+                    // Stated outright rather than left to MudBlazor's null default (which already
+                    // pins an action snackbar open): the contract promises the toast waits, so it
+                    // must not depend on a host configuration the caller cannot see. The filled
+                    // variant is the same emphasis convention ShowPersistent uses.
+                    options.RequireInteraction = true;
+                    options.SnackbarVariant = Variant.Filled;
+                }
+            });
+
     /// <summary>
     /// Projects the vendor-neutral level onto MudBlazor's own. Written out rather than cast: the
     /// two enums happen to agree numerically today, and an implicit dependency on that would break

--- a/Tests/Presentation/MMCA.Common.UI.Tests/BunitTestBase.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/BunitTestBase.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Testing.UI;
-using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Services;
 using MMCA.Common.UI.Services.Capabilities;
 using MMCA.Common.UI.Services.Capabilities.Fallbacks;
@@ -29,8 +28,9 @@ public abstract class BunitTestBase : BunitComponentTestBase
         Services.AddScoped<ICultureApplier, EndpointCultureApplier>();
 
         // Capability defaults the shared pages/layout inject (ADR-042): Login consults the
-        // external-auth broker, MainLayout renders the OfflineBanner. The Testing.UI harness
-        // cannot register these (it deliberately does not reference MMCA.Common.UI).
+        // external-auth broker, MainLayout renders the OfflineBanner. Registered here rather than in
+        // the Testing.UI harness because the head owns which capability implementations win, and a
+        // consumer's MAUI or browser head substitutes its own.
         Services.AddSingleton<IExternalAuthBroker, UnavailableExternalAuthBroker>();
         Services.AddSingleton<IConnectivityStatusService, AlwaysOnlineConnectivityStatusService>();
 
@@ -39,12 +39,9 @@ public abstract class BunitTestBase : BunitComponentTestBase
         // public-site behaviour substitutes its own builder.
         Services.AddScoped<IPublicLinkBuilder, NavigationPublicLinkBuilder>();
 
-        // Toast and confirm-dialog facades. Pages and components inject the vendor-neutral
-        // IToastService / IAppDialogService, and AddUIShared registers exactly these two Mud-backed
-        // implementations over the MudBlazor services the shared harness already added, so a
-        // component test exercises the real path. A test that asserts on toasts (or answers a
-        // confirm) registers its own double afterwards: last registration wins.
-        Services.AddScoped<IToastService, MudToastService>();
-        Services.AddScoped<IAppDialogService, MudAppDialogService>();
+        // The toast and confirm-dialog facades come from the shared harness (AddCommonUiFacades,
+        // called by BunitComponentTestBase over the MudBlazor services it registers), so a component
+        // test exercises the real Mud-backed path with no registration here. A test that asserts on
+        // toasts (or answers a confirm) registers its own double: last registration wins.
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Infrastructure/BunitComponentTestBaseFacadeTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Infrastructure/BunitComponentTestBaseFacadeTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.Testing.UI;
+using MMCA.Common.UI.Common.Interfaces;
+using MMCA.Common.UI.Services;
+
+namespace MMCA.Common.UI.Tests.Infrastructure;
+
+/// <summary>
+/// Guards the registration contract of the shipped bUnit base: a component that injects the
+/// vendor-neutral toast/dialog facades must render under <see cref="BunitComponentTestBase"/> with no
+/// per-repo setup. Deliberately derived from the SHIPPED base rather than this repo's
+/// <c>BunitTestBase</c>, because the repo-local base is exactly the layer that used to paper over the
+/// gap: every consumer that rendered a migrated page had to re-register the pair itself.
+/// </summary>
+public sealed class BunitComponentTestBaseFacadeTests : BunitComponentTestBase
+{
+    [Fact]
+    public void AComponentInjectingTheToastFacadeRendersUnderTheShippedBase()
+    {
+        var component = RenderUnderTest<ToastConsumer>(_ => { });
+
+        // The Mud-backed implementation, resolved over the ISnackbar AddMudServices registered:
+        // the real path a consumer's component test exercises.
+        component.Markup.Should().Contain(nameof(MudToastService));
+    }
+
+    [Fact]
+    public void TheConfirmDialogFacadeResolvesToo() =>
+        Services.GetRequiredService<IAppDialogService>().Should().BeOfType<MudAppDialogService>();
+
+    /// <summary>Minimal component whose only job is to prove <see cref="IToastService"/> injects.</summary>
+    private sealed class ToastConsumer : ComponentBase
+    {
+        [Inject]
+        public IToastService Toast { get; set; } = null!;
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "span");
+            builder.AddContent(1, Toast.GetType().Name);
+            builder.CloseElement();
+        }
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/MudToastServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/MudToastServiceTests.cs
@@ -1,0 +1,133 @@
+using AwesomeAssertions;
+using MMCA.Common.UI.Common.Interfaces;
+using MMCA.Common.UI.Services;
+using Moq;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="MudToastService"/>, the one place in the framework that names
+/// MudBlazor's <see cref="ISnackbar"/>. The interesting surface is <c>ShowAction</c>: it is the only
+/// method that configures the snackbar rather than just handing it a message, so what it writes into
+/// the options lambda is the whole behaviour. The lambda is captured off the mock and invoked against
+/// a real <see cref="SnackbarOptions"/>, which is what MudBlazor itself would do.
+/// </summary>
+public sealed class MudToastServiceTests
+{
+    private readonly Mock<ISnackbar> _snackbar = new();
+
+    private MudToastService Toast => new(_snackbar.Object);
+
+    [Fact]
+    public void ShowAction_RendersALabelledActionButtonOnThePrimaryColour()
+    {
+        var options = CaptureOptions(toast =>
+            toast.ShowAction("Item deleted", "Undo", () => Task.CompletedTask));
+
+        options.Action.Should().Be("Undo");
+        options.ActionColor.Should().Be(Color.Primary);
+    }
+
+    [Fact]
+    public async Task ShowAction_RunsTheCallbackWhenTheToastIsClicked()
+    {
+        var ran = false;
+        var options = CaptureOptions(toast =>
+            toast.ShowAction("Item deleted", "Undo", () =>
+            {
+                ran = true;
+                return Task.CompletedTask;
+            }));
+
+        options.OnClick.Should().NotBeNull();
+        await options.OnClick(null!);
+
+        ran.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShowAction_DoesNotSwallowACallbackFailure()
+    {
+        // Documented contract: nothing wraps the callback, so a caller whose work can fail guards it
+        // itself instead of discovering the failure as a swallowed no-op.
+        var options = CaptureOptions(toast =>
+            toast.ShowAction("Item deleted", "Undo", () => throw new InvalidOperationException("boom")));
+
+        var act = async () => await options.OnClick!(null!);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ShowAction_WithoutRequireInteraction_LeavesTheHostTimerDefaultsAlone()
+    {
+        var options = CaptureOptions(toast =>
+            toast.ShowAction("Item deleted", "Undo", () => Task.CompletedTask));
+
+        // Untouched, not written false: the host's snackbar configuration decides how long an
+        // ordinary action toast lives.
+        options.RequireInteraction.Should().BeNull();
+    }
+
+    [Fact]
+    public void ShowAction_WithRequireInteraction_PinsTheToastOpenAndFillsIt()
+    {
+        var options = CaptureOptions(toast =>
+            toast.ShowAction("Session expiring", "Stay signed in", () => Task.CompletedTask, requireInteraction: true));
+
+        options.RequireInteraction.Should().BeTrue();
+        options.SnackbarVariant.Should().Be(Variant.Filled);
+        options.Action.Should().Be("Stay signed in");
+    }
+
+    [Theory]
+    [InlineData(ToastSeverity.Normal, Severity.Normal)]
+    [InlineData(ToastSeverity.Info, Severity.Info)]
+    [InlineData(ToastSeverity.Success, Severity.Success)]
+    [InlineData(ToastSeverity.Warning, Severity.Warning)]
+    [InlineData(ToastSeverity.Error, Severity.Error)]
+    public void ShowAction_MapsTheVendorNeutralSeverity(ToastSeverity severity, Severity expected)
+    {
+        Toast.ShowAction("Message", "Action", () => Task.CompletedTask, severity);
+
+        _snackbar.Verify(
+            s => s.Add("Message", expected, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ShowAction_PassesTheMessageThroughUnchanged()
+    {
+        Toast.ShowAction("Item deleted", "Undo", () => Task.CompletedTask);
+
+        _snackbar.Verify(
+            s => s.Add("Item deleted", Severity.Info, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="act"/> against the service, captures the options lambda it handed the
+    /// snackbar, and applies it to a fresh <see cref="SnackbarOptions"/> carrying MudBlazor's own
+    /// defaults, so an assertion sees exactly what the rendered snackbar would.
+    /// </summary>
+    private SnackbarOptions CaptureOptions(Action<MudToastService> act)
+    {
+        Action<SnackbarOptions>? configure = null;
+        _snackbar
+            .Setup(s => s.Add(
+                It.IsAny<string>(),
+                It.IsAny<Severity>(),
+                It.IsAny<Action<SnackbarOptions>>(),
+                It.IsAny<string>()))
+            .Callback<string, Severity, Action<SnackbarOptions>, string>((_, _, cfg, _) => configure = cfg);
+
+        act(Toast);
+
+        configure.Should().NotBeNull("the service must configure the snackbar it raises");
+
+        var options = new SnackbarOptions(Severity.Info, new SnackbarConfiguration());
+        configure(options);
+        return options;
+    }
+}


### PR DESCRIPTION
Follow-up to the v1.168.0 wave (#303), ships as v1.169.0:

- `IToastService.ShowAction(message, actionText, onAction, severity, requireInteraction)`: interactive action toasts, restoring consumer snackbar-action parity (ADC's LiveEventListener energy-saver opt-in and poll navigation). Interface-member addition is breaking for external implementors; ships as MINOR per the versioning policy.
- `AddCommonUiFacades()` extension; `AddUIShared` delegates to it.
- `BunitComponentTestBase` (MMCA.Common.Testing.UI) now registers the UI facades, so consumer bUnit bases no longer need local registrations (gap both ADC and Store hit on 1.168.0 adoption).
- `LiteralToast` localized-text fitness regex covers `ShowAction`.

Verification: warning-free Release build; 4949/4949 tests pass (13 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw