### PR TITLE
feat: sqlite runtime migrations + tenant-write 400 mapping

### DIFF
--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/PhysicalDataSource.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DataSources/PhysicalDataSource.cs
@@ -32,4 +32,24 @@ public sealed record PhysicalDataSource(
     /// </para>
     /// </summary>
     public string? SqliteMigrationsAssembly { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this source participates in EF Core migrations, which is what
+    /// decides between <c>Migrate</c> and <c>EnsureCreated</c> at startup for this one database.
+    /// <para>
+    /// SQL Server always does: a SQL Server host has been migration-driven since the first release,
+    /// including the single-database monolith whose <c>Default</c> source names no migrations
+    /// assembly at all and lets EF look next to the context. SQLite does only once a
+    /// <c>SqliteMigrationsAssembly</c> is configured for it, because a SQLite source wired by hand
+    /// before that setting existed has no migrations to apply and must keep being created outright.
+    /// Cosmos never does: the provider has no migrations pipeline.
+    /// </para>
+    /// </summary>
+    public bool UsesMigrations => Key.Engine switch
+    {
+        DataSource.SQLServer => true,
+        DataSource.Sqlite => !string.IsNullOrEmpty(SqliteMigrationsAssembly),
+        DataSource.CosmosDB => false,
+        _ => false,
+    };
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/DbContextFactory.cs
@@ -690,14 +690,47 @@ public sealed class DbContextFactory(
     /// <inheritdoc />
     public async Task MigrateAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var key in GetSourcesInUse().Where(k => k.Engine == DataSource.SQLServer))
+        foreach (var key in GetMigrationTargets())
             await GetDbContext(key).Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The sources this host migrates: every source in use whose resolved
+    /// <see cref="PhysicalDataSource.UsesMigrations"/> says a migrations pipeline owns its schema
+    /// (every SQL Server source, plus a SQLite source with a configured migrations assembly).
+    /// <para>
+    /// A migration target that resolves no connection string is skipped unless it is SQL Server,
+    /// which keeps two behaviours intact: an optional SQLite source a test host leaves unconfigured
+    /// stays silently absent (exactly as <see cref="EnsureCreatedAsync"/> treats it), while a SQL
+    /// Server source with no connection string still fails loudly at startup rather than being
+    /// quietly skipped, because for SQL Server that is a misconfiguration, not an option.
+    /// </para>
+    /// </summary>
+    /// <returns>The keys to migrate, in source-in-use order.</returns>
+    private List<DataSourceKey> GetMigrationTargets()
+    {
+        var targets = new List<DataSourceKey>();
+
+        foreach (var key in GetSourcesInUse())
+        {
+            var physical = _dataSourceResolver.GetPhysical(key);
+
+            if (!physical.UsesMigrations)
+                continue;
+
+            if (key.Engine != DataSource.SQLServer && string.IsNullOrEmpty(physical.ConnectionString))
+                continue;
+
+            targets.Add(key);
+        }
+
+        return targets;
     }
 
     /// <inheritdoc />
     public async Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var key in GetSourcesInUse().Where(k => k.Engine == DataSource.SQLServer))
+        foreach (var key in GetMigrationTargets())
         {
             var pending = await GetDbContext(key).Database.GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
             if (pending.Any())

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IDbContextFactory.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/DbContexts/Factory/IDbContextFactory.cs
@@ -79,14 +79,17 @@ public interface IDbContextFactory : IDisposable, IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Applies pending EF Core migrations for every SQL Server physical data source in use by this
-    /// host (each with its own migrations assembly). Cosmos and SQLite sources are skipped.
+    /// Applies pending EF Core migrations for every physical data source in use whose schema a
+    /// migrations pipeline owns (each with its own migrations assembly): every SQL Server source,
+    /// plus any SQLite source with a configured <c>SqliteMigrationsAssembly</c>. Cosmos sources and
+    /// SQLite sources without a migrations assembly are skipped, and are created by
+    /// <see cref="EnsureCreatedAsync"/> instead.
     /// </summary>
     Task MigrateAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns <see langword="true"/> if any SQL Server physical data source in use has pending
-    /// migrations that have not been applied.
+    /// Returns <see langword="true"/> if any physical data source in use that
+    /// <see cref="MigrateAsync"/> would migrate has pending migrations that have not been applied.
     /// </summary>
     Task<bool> HasPendingMigrationsAsync(CancellationToken cancellationToken = default);
 }

--- a/Source/Core/MMCA.Common.Infrastructure/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Infrastructure/PublicAPI.Unshipped.txt
@@ -59,6 +59,7 @@ MMCA.Common.Infrastructure.Settings.CacheSettings.LocalCacheDuration.init -> voi
 MMCA.Common.Infrastructure.Settings.CacheSettings.PopulateLockTimeout.get -> System.TimeSpan
 MMCA.Common.Infrastructure.Settings.CacheSettings.PopulateLockTimeout.init -> void
 static readonly MMCA.Common.Infrastructure.Settings.CacheSettings.SectionName -> string!
+MMCA.Common.Infrastructure.Persistence.DataSources.PhysicalDataSource.UsesMigrations.get -> bool
 MMCA.Common.Infrastructure.Persistence.DataSources.PhysicalDataSource.SqliteMigrationsAssembly.get -> string?
 MMCA.Common.Infrastructure.Persistence.DataSources.PhysicalDataSource.SqliteMigrationsAssembly.init -> void
 MMCA.Common.Infrastructure.Settings.DataSourceEntrySettings.SqliteMigrationsAssembly.get -> string!

--- a/Source/Presentation/MMCA.Common.API/Middleware/GlobalExceptionHandler.cs
+++ b/Source/Presentation/MMCA.Common.API/Middleware/GlobalExceptionHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
 
 namespace MMCA.Common.API.Middleware;
 
@@ -9,6 +10,13 @@ namespace MMCA.Common.API.Middleware;
 /// Catch-all exception handler that converts any unhandled exception into an HTTP 500
 /// ProblemDetails response. Must be registered last in the exception handler pipeline so
 /// that more specific handlers (domain, validation, etc.) get first chance.
+/// <para>
+/// It maps one exception by type before falling back to 500: a
+/// <see cref="CrossTenantWriteException"/> is a caller fault, not a server fault, and is answered
+/// with <c>400 Bad Request</c>. The mapping lives here rather than in its own handler because the
+/// exception derives from <see cref="InvalidOperationException"/>, so nothing ahead of this handler
+/// claims it, and every other save-time invariant failure of that family still ends at the 500.
+/// </para>
 /// </summary>
 /// <param name="problemDetailsService">The service used to write RFC 9457 problem details.</param>
 /// <param name="logger">Logger for recording unhandled exceptions.</param>
@@ -17,12 +25,45 @@ public sealed class GlobalExceptionHandler(
     ILogger<GlobalExceptionHandler> logger)
     : IExceptionHandler
 {
+    /// <summary>The problem title reported for a write rejected at the tenant boundary.</summary>
+    internal const string CrossTenantWriteTitle = "Tenant write rejected";
+
+    /// <summary>
+    /// The problem detail reported for a write rejected at the tenant boundary. Deliberately free of
+    /// anything the exception carries: the entity type and both tenant ids are server-side state,
+    /// and echoing a tenant id back tells an unauthorized caller which tenant owns the row it just
+    /// tried to write. The log entry keeps the full failure for the operator.
+    /// </summary>
+    internal const string CrossTenantWriteDetail =
+        "The request did not carry a tenant that may perform this write. Supply the tenant on the "
+        + "request (the configured tenant claim or header) and retry as a tenant you belong to.";
+
     /// <inheritdoc />
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext,
         Exception exception,
         CancellationToken cancellationToken)
     {
+        if (exception is CrossTenantWriteException crossTenantWrite)
+        {
+            // Warning, not error: the request was refused exactly as designed, and a tenant-scoped
+            // API answering 400 to an untenanted write is routine rather than a server fault.
+            logger.LogWarning(crossTenantWrite, "Save rejected at the tenant boundary");
+
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+            {
+                HttpContext = httpContext,
+                Exception = exception,
+                ProblemDetails = new ProblemDetails
+                {
+                    Status = httpContext.Response.StatusCode,
+                    Title = CrossTenantWriteTitle,
+                    Detail = CrossTenantWriteDetail
+                }
+            }).ConfigureAwait(false);
+        }
+
         logger.LogError(exception, "Unhandled exception occurred");
 
         httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;

--- a/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
+++ b/Source/Presentation/MMCA.Common.API/Startup/DatabaseInitializationExtensions.cs
@@ -49,16 +49,34 @@ public static class DatabaseInitializationExtensions
 
             var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
 
-            // Cosmos and SQLite sources are optional — integration tests may omit their connection
-            // strings. Neither engine has EF Core schema migrations, so both are always created via
-            // EnsureCreated up front, independent of the SQL-Server-oriented DatabaseInitStrategy
-            // below. This is the ONLY path that creates SQLite sources under the "Migrate" and "None"
-            // strategies (which act on SQL Server alone) — without it a SQLite source in use is never
-            // created and the first repository call fails.
+            // Cosmos and SQLite sources are optional: integration tests may omit their connection
+            // strings. A Cosmos source has no EF Core migrations pipeline at all, and neither does a
+            // SQLite source with no migrations assembly configured, so both are created via
+            // EnsureCreated up front, independent of the migration-oriented DatabaseInitStrategy
+            // below. This is the ONLY path that creates them under the "Migrate" and "None"
+            // strategies; without it such a source in use is never created and the first repository
+            // call fails.
+            //
+            // A SQLite source WITH a migrations assembly is deliberately excluded here whenever the
+            // strategy migrates: EnsureCreated writes the tables without an __EFMigrationsHistory
+            // row, after which every migration is both pending and un-appliable (its CREATE TABLE
+            // hits an existing table). Under the "EnsureCreated" strategy nothing migrates, so the
+            // exclusion does not apply and every source is created outright.
+            var strategyMigrates =
+                string.Equals(applicationSettings.DatabaseInitStrategy, "Migrate", StringComparison.Ordinal)
+                || string.Equals(applicationSettings.DatabaseInitStrategy, "None", StringComparison.Ordinal);
+
             foreach (var migrationlessKey in sourcesInUse
                 .Where(k => k.Engine is DataSource.CosmosDB or DataSource.Sqlite))
             {
-                if (string.IsNullOrEmpty(resolver.GetPhysical(migrationlessKey).ConnectionString))
+                var physical = resolver.GetPhysical(migrationlessKey);
+
+                if (string.IsNullOrEmpty(physical.ConnectionString))
+                {
+                    continue;
+                }
+
+                if (strategyMigrates && physical.UsesMigrations)
                 {
                     continue;
                 }
@@ -68,7 +86,7 @@ public static class DatabaseInitializationExtensions
             }
 
             // Apply schema initialisation based on the configured strategy:
-            //   "Migrate"       — auto-apply pending EF Core migrations per SQL Server source (development/testing).
+            //   "Migrate"       — auto-apply pending EF Core migrations per migrated source (development/testing).
             //   "EnsureCreated" — legacy EnsureCreated behavior for every source in use.
             //   "None"          — production: validate no pending migrations on any source, throw if behind.
             switch (applicationSettings.DatabaseInitStrategy)
@@ -80,7 +98,7 @@ public static class DatabaseInitializationExtensions
                     await dbContextFactory.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
                     break;
                 case "None":
-                    await ThrowIfPendingMigrationsAsync(dbContextFactory, sourcesInUse, cancellationToken).ConfigureAwait(false);
+                    await ThrowIfPendingMigrationsAsync(dbContextFactory, resolver, sourcesInUse, cancellationToken).ConfigureAwait(false);
                     break;
                 default:
                     throw new InvalidOperationException(
@@ -88,7 +106,7 @@ public static class DatabaseInitializationExtensions
                         "Valid values are: Migrate, EnsureCreated, None.");
             }
 
-            await InitializeTenantDatabasesAsync(services, applicationSettings, sourcesInUse, cancellationToken)
+            await InitializeTenantDatabasesAsync(services, applicationSettings, resolver, sourcesInUse, cancellationToken)
                 .ConfigureAwait(false);
 
             // Module seeding runs on the default scope only. A seeder writes reference data an
@@ -112,6 +130,7 @@ public static class DatabaseInitializationExtensions
     private static async Task InitializeTenantDatabasesAsync(
         IServiceProvider services,
         ApplicationSettings applicationSettings,
+        IDataSourceResolver resolver,
         IReadOnlyCollection<DataSourceKey> sourcesInUse,
         CancellationToken cancellationToken)
     {
@@ -130,10 +149,15 @@ public static class DatabaseInitializationExtensions
             var factory = tenantScope.ServiceProvider.GetRequiredService<IDbContextFactory>();
             var database = factory.GetDbContext(target.Source).Database;
 
+            // The tenant's copy of a source is the same schema on a different connection, so it is
+            // migrated exactly when the shared source is. The migrations assembly is declared once,
+            // on the source, and a per-tenant override only replaces the connection string.
+            var usesMigrations = resolver.GetPhysical(target.Source).UsesMigrations;
+
             switch (applicationSettings.DatabaseInitStrategy)
             {
                 case "Migrate":
-                    if (target.Source.Engine == DataSource.SQLServer)
+                    if (usesMigrations)
                     {
                         await database.MigrateAsync(cancellationToken).ConfigureAwait(false);
                     }
@@ -147,7 +171,7 @@ public static class DatabaseInitializationExtensions
                     await database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
                     break;
                 case "None":
-                    await ThrowIfTenantPendingMigrationsAsync(database, target, cancellationToken)
+                    await ThrowIfTenantPendingMigrationsAsync(database, target, usesMigrations, cancellationToken)
                         .ConfigureAwait(false);
                     break;
                 default:
@@ -165,9 +189,10 @@ public static class DatabaseInitializationExtensions
     private static async Task ThrowIfTenantPendingMigrationsAsync(
         DatabaseFacade database,
         TenantDataSourceTarget target,
+        bool usesMigrations,
         CancellationToken cancellationToken)
     {
-        if (target.Source.Engine != DataSource.SQLServer)
+        if (!usesMigrations)
         {
             return;
         }
@@ -185,11 +210,25 @@ public static class DatabaseInitializationExtensions
     }
 
     /// <summary>
+    /// Mirrors the context factory's own migration-target rule so the breakdown this file prints
+    /// names exactly the sources the factory checked: a source a migrations pipeline owns, minus an
+    /// optional non-SQL-Server source left without a connection string.
+    /// </summary>
+    /// <param name="physical">The resolved source.</param>
+    /// <returns><see langword="true"/> when migrations are applied to this source.</returns>
+    private static bool IsMigrationTarget(PhysicalDataSource physical) =>
+        physical.UsesMigrations
+        && (physical.Key.Engine == DataSource.SQLServer || !string.IsNullOrEmpty(physical.ConnectionString));
+
+    /// <summary>
     /// Production guard for the <c>"None"</c> strategy: throws with a per-source breakdown when
-    /// any SQL Server data source in use has migrations that have not been applied.
+    /// any migrated data source in use has migrations that have not been applied. The breakdown
+    /// covers exactly the sources the factory migrates, so a SQLite source with a migrations
+    /// assembly is named here rather than reported as an empty list.
     /// </summary>
     private static async Task ThrowIfPendingMigrationsAsync(
         IDbContextFactory dbContextFactory,
+        IDataSourceResolver resolver,
         IReadOnlyCollection<DataSourceKey> sourcesInUse,
         CancellationToken cancellationToken)
     {
@@ -199,13 +238,13 @@ public static class DatabaseInitializationExtensions
         }
 
         var pendingPerSource = new List<string>();
-        foreach (var sqlKey in sourcesInUse.Where(k => k.Engine == DataSource.SQLServer))
+        foreach (var migratedKey in sourcesInUse.Where(k => IsMigrationTarget(resolver.GetPhysical(k))))
         {
-            var pending = await dbContextFactory.GetDbContext(sqlKey).Database
+            var pending = await dbContextFactory.GetDbContext(migratedKey).Database
                 .GetPendingMigrationsAsync(cancellationToken).ConfigureAwait(false);
             if (pending.Any())
             {
-                pendingPerSource.Add($"{sqlKey}: {string.Join(", ", pending)}");
+                pendingPerSource.Add($"{migratedKey}: {string.Join(", ", pending)}");
             }
         }
 

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/PhysicalDataSourceTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DataSources/PhysicalDataSourceTests.cs
@@ -1,0 +1,91 @@
+using AwesomeAssertions;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.DataSources;
+
+/// <summary>
+/// The rule that decides, per physical source, whether startup migrates the database or creates it
+/// outright. It is one property because three call sites depend on the same answer: the context
+/// factory's migrate and pending-migration passes, and the API layer's initialization strategy.
+/// </summary>
+public sealed class PhysicalDataSourceTests
+{
+    // SQL Server has been migration-driven since the first release, INCLUDING the single-database
+    // monolith whose Default source names no migrations assembly and lets EF look next to the
+    // context. Tying SQL Server to a configured assembly would stop migrating those hosts.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("App.Migrations")]
+    public void UsesMigrations_SqlServer_IsAlwaysTrue(string? migrationsAssembly)
+    {
+        var source = new PhysicalDataSource(
+            DataSourceKey.Default(DataSource.SQLServer),
+            "Server=test;Database=test",
+            migrationsAssembly,
+            string.Empty);
+
+        source.UsesMigrations.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UsesMigrations_SqliteWithAMigrationsAssembly_IsTrue()
+    {
+        var source = new PhysicalDataSource(
+            new DataSourceKey(DataSource.Sqlite, "Tickets"),
+            "Data Source=tickets.db",
+            null,
+            string.Empty)
+        {
+            SqliteMigrationsAssembly = "Tickets.Migrations.Sqlite",
+        };
+
+        source.UsesMigrations.Should().BeTrue();
+    }
+
+    // Backward compatibility: a SQLite source wired by hand before the setting existed has no
+    // migrations to apply, so it must keep being created outright rather than migrated into nothing.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void UsesMigrations_SqliteWithoutAMigrationsAssembly_IsFalse(string? migrationsAssembly)
+    {
+        var source = new PhysicalDataSource(
+            new DataSourceKey(DataSource.Sqlite, "Tickets"),
+            "Data Source=tickets.db",
+            null,
+            string.Empty)
+        {
+            SqliteMigrationsAssembly = migrationsAssembly,
+        };
+
+        source.UsesMigrations.Should().BeFalse();
+    }
+
+    // The SQL Server slot is never consulted for a SQLite source: the two are kept apart precisely
+    // so a mixed host cannot hand one engine's snapshot to the other.
+    [Fact]
+    public void UsesMigrations_SqliteCarryingOnlyTheSqlServerAssembly_IsFalse()
+    {
+        var source = new PhysicalDataSource(
+            new DataSourceKey(DataSource.Sqlite, "Tickets"),
+            "Data Source=tickets.db",
+            "Main.Migrations",
+            string.Empty);
+
+        source.UsesMigrations.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UsesMigrations_Cosmos_IsFalse()
+    {
+        var source = new PhysicalDataSource(
+            DataSourceKey.Default(DataSource.CosmosDB),
+            "AccountEndpoint=https://test;AccountKey=dGVzdA==",
+            null,
+            "AtlDevCon");
+
+        source.UsesMigrations.Should().BeFalse();
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryMigrationTargetTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/DbContextFactoryMigrationTargetTests.cs
@@ -1,0 +1,194 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Settings;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Which sources <see cref="DbContextFactory.MigrateAsync"/> acts on, over two real SQLite
+/// databases: one whose <c>DataSources</c> entry names a migrations assembly and one that names
+/// none. The distinction is what lets a SQLite host apply a later migration at startup while a
+/// SQLite source wired by hand before the setting existed keeps its EnsureCreated behaviour.
+/// </summary>
+public sealed class DbContextFactoryMigrationTargetTests : IDisposable
+{
+    private const string MigratedSourceName = "Migrated";
+    private const string CreatedSourceName = "Created";
+
+    private readonly string _migratedPath =
+        Path.Combine(Path.GetTempPath(), $"mmca-migrated-{Guid.NewGuid():N}.db");
+
+    private readonly string _createdPath =
+        Path.Combine(Path.GetTempPath(), $"mmca-created-{Guid.NewGuid():N}.db");
+
+    private readonly ServiceProvider _serviceProvider;
+    private readonly DataSourceResolver _resolver;
+    private readonly DbContextFactory _sut;
+    private readonly DataSourceKey _migratedKey;
+    private readonly DataSourceKey _createdKey;
+
+    public DbContextFactoryMigrationTargetTests()
+    {
+        var connectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "Server=unused;" };
+        var dataSources = new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            [MigratedSourceName] = new()
+            {
+                SqliteConnectionString = $"Data Source={_migratedPath}",
+
+                // The test assembly itself: it declares no migrations, which is exactly what makes
+                // the assertion below unambiguous. Migrate creates the database and the history
+                // table and nothing else, while EnsureCreated would have created the model's tables.
+                SqliteMigrationsAssembly = typeof(DbContextFactoryMigrationTargetTests).Assembly.GetName().Name!,
+            },
+            [CreatedSourceName] = new() { SqliteConnectionString = $"Data Source={_createdPath}" },
+        });
+
+        _resolver = new DataSourceResolver(connectionStrings, dataSources, NullLogger<DataSourceResolver>.Instance);
+        _migratedKey = _resolver.ResolveLogical(DataSource.Sqlite, MigratedSourceName);
+        _createdKey = _resolver.ResolveLogical(DataSource.Sqlite, CreatedSourceName);
+
+        var registry = new FixedSourcesRegistry([_migratedKey, _createdKey]);
+        var assemblyProvider = new NoConfigurationAssemblyProvider();
+
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<ILoggerFactory, NullLoggerFactory>()
+            .AddSingleton(typeof(ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<IDomainEventDispatcher>())
+            .AddSingleton<IOutboxSignal, OutboxSignal>()
+            .AddSingleton<AuditSaveChangesInterceptor>()
+            .AddSingleton<DomainEventSaveChangesInterceptor>()
+            .AddSingleton<IEntityDataSourceRegistry>(registry)
+            .AddSingleton<IDataSourceResolver>(_resolver)
+            .BuildServiceProvider();
+
+        var physicalFactory = new PhysicalDbContextFactory(_serviceProvider, _resolver, assemblyProvider);
+        _sut = new DbContextFactory(physicalFactory, registry, _resolver, Mock.Of<ICurrentUserService>());
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        _serviceProvider.Dispose();
+        SqliteConnection.ClearAllPools();
+        TryDelete(_migratedPath);
+        TryDelete(_createdPath);
+    }
+
+    [Fact]
+    public async Task MigrateAsync_SqliteSourceWithAMigrationsAssembly_IsMigrated()
+    {
+        await _sut.MigrateAsync();
+
+        File.Exists(_migratedPath).Should().BeTrue(
+            "a SQLite source with a migrations assembly is a migration target");
+        (await HistoryTableExistsAsync(_migratedKey)).Should().BeTrue(
+            "Migrate records applied migrations, which is what a later 'migrations add' builds on");
+    }
+
+    // The other half of the same act: nothing may touch the source that has no migrations assembly,
+    // because the API layer's EnsureCreated pass owns it. Migrating it would create an empty
+    // database with a history table and no tables at all.
+    [Fact]
+    public async Task MigrateAsync_SqliteSourceWithoutAMigrationsAssembly_IsSkipped()
+    {
+        await _sut.MigrateAsync();
+
+        File.Exists(_createdPath).Should().BeFalse(
+            "a SQLite source with no migrations assembly keeps its EnsureCreated behaviour");
+    }
+
+    [Fact]
+    public async Task HasPendingMigrationsAsync_ConsidersOnlyTheMigratedSource()
+    {
+        // No migrations exist in the migrations assembly, so nothing is pending. The value under
+        // test is that the call completes at all: the source with no migrations assembly is never
+        // asked, and asking it would surface as a provider failure rather than a false.
+        (await _sut.HasPendingMigrationsAsync()).Should().BeFalse();
+
+        File.Exists(_createdPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EnsureCreatedAsync_StillCoversBothSources()
+    {
+        await _sut.EnsureCreatedAsync();
+
+        File.Exists(_migratedPath).Should().BeTrue();
+        File.Exists(_createdPath).Should().BeTrue(
+            "the EnsureCreated strategy is unchanged: it creates every source in use");
+    }
+
+    /// <summary>
+    /// Whether the database behind <paramref name="key"/> carries EF's migrations history table,
+    /// which only <c>Migrate</c> creates.
+    /// </summary>
+    private async Task<bool> HistoryTableExistsAsync(DataSourceKey key)
+    {
+        var connection = _sut.GetDbContext(key).Database.GetDbConnection();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '__EFMigrationsHistory'";
+
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync();
+        }
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture) > 0;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // Best-effort temp file cleanup.
+        }
+    }
+
+    /// <summary>
+    /// Reports a fixed set of sources in use, so the test states its topology directly instead of
+    /// depending on which entity configurations happen to live in this assembly.
+    /// </summary>
+    private sealed class FixedSourcesRegistry(IReadOnlyCollection<DataSourceKey> sources) : IEntityDataSourceRegistry
+    {
+        public DataSourceKey GetDataSourceKey(Type entityType) =>
+            throw new InvalidOperationException($"No data source registered for entity type \"{entityType}\".");
+
+        public DataSourceKey GetDataSourceKey(string entityFullName) =>
+            throw new InvalidOperationException($"No data source registered for entity \"{entityFullName}\".");
+
+        public bool TryGetDataSourceKey(string entityFullName, out DataSourceKey key)
+        {
+            key = default;
+            return false;
+        }
+
+        public IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse() => sources;
+    }
+
+    /// <summary>
+    /// Supplies no configuration assemblies, keeping each context's model to what the framework
+    /// itself declares. The question under test is source SELECTION, not schema.
+    /// </summary>
+    private sealed class NoConfigurationAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Middleware/ExceptionHandlerTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Middleware/ExceptionHandlerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.API.Middleware;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Shared.Exceptions;
 using Moq;
 
@@ -51,6 +52,103 @@ public sealed class ExceptionHandlerTests
         capturedContext.Should().NotBeNull();
         capturedContext!.ProblemDetails.Title.Should().Be("Internal Server Error");
         capturedContext.ProblemDetails.Detail.Should().Be("An error occurred while processing your request. Please try again");
+    }
+
+    // ── GlobalExceptionHandler: the one exception it maps by type ──
+    [Fact]
+    public async Task GlobalExceptionHandler_WithCrossTenantWriteException_Returns400()
+    {
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService.Setup(x => x.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .ReturnsAsync(true);
+        var sut = new GlobalExceptionHandler(
+            problemDetailsService.Object,
+            NullLogger<GlobalExceptionHandler>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+
+        bool handled = await sut.TryHandleAsync(
+            httpContext,
+            new CrossTenantWriteException(),
+            CancellationToken.None);
+
+        handled.Should().BeTrue();
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest,
+            "a write the caller may not perform is a caller fault, not a server fault");
+    }
+
+    [Fact]
+    public async Task GlobalExceptionHandler_WithCrossTenantWriteException_WritesTenantProblemDetails()
+    {
+        ProblemDetailsContext? capturedContext = null;
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService.Setup(x => x.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Callback<ProblemDetailsContext>(ctx => capturedContext = ctx)
+            .ReturnsAsync(true);
+        var sut = new GlobalExceptionHandler(
+            problemDetailsService.Object,
+            NullLogger<GlobalExceptionHandler>.Instance);
+
+        await sut.TryHandleAsync(
+            new DefaultHttpContext(),
+            new CrossTenantWriteException(),
+            CancellationToken.None);
+
+        capturedContext.Should().NotBeNull();
+        capturedContext!.ProblemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        capturedContext.ProblemDetails.Title.Should().Be(GlobalExceptionHandler.CrossTenantWriteTitle);
+        capturedContext.ProblemDetails.Detail.Should().Be(GlobalExceptionHandler.CrossTenantWriteDetail);
+        capturedContext.ProblemDetails.Detail.Should().Contain("tenant",
+            "the caller has to be told what to fix about the request");
+    }
+
+    // The exception message names the entity type and both tenant ids so an operator can read the
+    // log. None of that may reach the caller: a tenant id echoed back tells an unauthorized caller
+    // which tenant owns the row it just tried to write.
+    [Fact]
+    public async Task GlobalExceptionHandler_WithCrossTenantWriteException_DoesNotLeakTheExceptionMessage()
+    {
+        ProblemDetailsContext? capturedContext = null;
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService.Setup(x => x.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Callback<ProblemDetailsContext>(ctx => capturedContext = ctx)
+            .ReturnsAsync(true);
+        var sut = new GlobalExceptionHandler(
+            problemDetailsService.Object,
+            NullLogger<GlobalExceptionHandler>.Instance);
+
+        var exception = new CrossTenantWriteException(
+            "The update of \"SecretWidget\" was rejected: the entity belongs to tenant "
+            + "\"acme-corp\" but this scope resolved tenant \"contoso\".");
+
+        await sut.TryHandleAsync(new DefaultHttpContext(), exception, CancellationToken.None);
+
+        capturedContext.Should().NotBeNull();
+        capturedContext!.ProblemDetails.Detail.Should().NotContain("SecretWidget");
+        capturedContext.ProblemDetails.Detail.Should().NotContain("acme-corp");
+        capturedContext.ProblemDetails.Detail.Should().NotContain("contoso");
+        capturedContext.ProblemDetails.Title.Should().NotContain("SecretWidget");
+    }
+
+    [Fact]
+    public async Task GlobalExceptionHandler_WithOtherInvalidOperationException_StillReturns500()
+    {
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService.Setup(x => x.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .ReturnsAsync(true);
+        var sut = new GlobalExceptionHandler(
+            problemDetailsService.Object,
+            NullLogger<GlobalExceptionHandler>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+
+        await sut.TryHandleAsync(
+            httpContext,
+            new InvalidOperationException("some other save-time invariant"),
+            CancellationToken.None);
+
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError,
+            "only the cross-tenant write is mapped; its base type is not");
     }
 
     // ── DomainExceptionHandler ──

--- a/Tests/Presentation/MMCA.Common.API.Tests/Startup/DatabaseInitializationExtensionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Startup/DatabaseInitializationExtensionsTests.cs
@@ -31,6 +31,9 @@ public sealed class DatabaseInitializationExtensionsTests : IDisposable
     private readonly string _sqliteDbPath =
         Path.Combine(Path.GetTempPath(), $"mmca-init-sqlite-{Guid.NewGuid():N}.db");
 
+    private readonly string _sqliteMigratedDbPath =
+        Path.Combine(Path.GetTempPath(), $"mmca-init-sqlite-migrated-{Guid.NewGuid():N}.db");
+
     [Fact]
     public async Task InitializeDatabaseAsync_MigrateStrategy_CreatesSqliteSource()
     {
@@ -78,12 +81,107 @@ public sealed class DatabaseInitializationExtensionsTests : IDisposable
         (await context.Set<InitTestWidget>().CountAsync()).Should().Be(0);
     }
 
+    // A SQLite source that DOES name a migrations assembly is the small-app shape: its schema is
+    // owned by a migrations project, so startup must migrate it and must NOT EnsureCreated it first
+    // (EnsureCreated writes the tables with no __EFMigrationsHistory row, after which every
+    // migration is both pending and un-appliable). Both sources are in use in this one host, so the
+    // choice is made per source rather than per host.
+    [Fact]
+    public async Task InitializeDatabaseAsync_MigrateStrategy_MigratesTheSqliteSourceThatHasAMigrationsAssembly()
+    {
+        var connectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "Server=unused;" };
+        var dataSources = new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["TestSqlite"] = new() { SqliteConnectionString = $"Data Source={_sqliteDbPath}" },
+            ["TestSqliteMigrated"] = new()
+            {
+                SqliteConnectionString = $"Data Source={_sqliteMigratedDbPath}",
+
+                // The test assembly declares no migrations, so Migrate creates the database and the
+                // history table and nothing else: the absence of the entity's table is what proves
+                // EnsureCreated did not run against this source.
+                SqliteMigrationsAssembly = typeof(DatabaseInitializationExtensionsTests).Assembly.GetName().Name!,
+            },
+        });
+
+        var resolver = new DataSourceResolver(connectionStrings, dataSources, NullLogger<DataSourceResolver>.Instance);
+        var assemblyProvider = new FixedAssemblyProvider();
+        var registry = new EntityDataSourceRegistry(assemblyProvider, resolver);
+
+        await using var provider = BuildProvider(resolver, registry, assemblyProvider);
+
+        await provider.InitializeDatabaseAsync(
+            new ApplicationSettings { DatabaseInitStrategy = "Migrate" },
+            new ModuleLoader());
+
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
+
+        var migrated = factory.GetDbContext(resolver.ResolveLogical(DataSource.Sqlite, "TestSqliteMigrated"));
+        (await CountTablesAsync(migrated, "__EFMigrationsHistory")).Should().Be(1,
+            "a SQLite source with a migrations assembly goes through Migrate");
+        (await CountTablesAsync(migrated, nameof(InitTestMigratedWidget))).Should().Be(0,
+            "EnsureCreated must not run first: it would leave the schema outside migration control");
+
+        var created = factory.GetDbContext(resolver.ResolveLogical(DataSource.Sqlite, "TestSqlite"));
+        (await CountTablesAsync(created, nameof(InitTestWidget))).Should().Be(1,
+            "the source with no migrations assembly keeps its EnsureCreated behaviour");
+        (await CountTablesAsync(created, "__EFMigrationsHistory")).Should().Be(0);
+    }
+
+    /// <summary>Counts the tables of the given name in a SQLite context's database.</summary>
+    private static async Task<int> CountTablesAsync(DbContext context, string tableName)
+    {
+        var connection = context.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync();
+        }
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = $name";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = tableName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(
+            await command.ExecuteScalarAsync(),
+            System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static ServiceProvider BuildProvider(
+        DataSourceResolver resolver,
+        EntityDataSourceRegistry registry,
+        IEntityConfigurationAssemblyProvider assemblyProvider) =>
+        new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<ILoggerFactory, NullLoggerFactory>()
+            .AddSingleton(typeof(ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<IDomainEventDispatcher>())
+            .AddSingleton<IOutboxSignal, OutboxSignal>()
+            .AddSingleton<AuditSaveChangesInterceptor>()
+            .AddSingleton<DomainEventSaveChangesInterceptor>()
+            .AddSingleton(Mock.Of<ICurrentUserService>())
+            .AddSingleton(assemblyProvider)
+            .AddSingleton<IDataSourceResolver>(resolver)
+            .AddSingleton<IEntityDataSourceRegistry>(registry)
+            .AddSingleton<IPhysicalDbContextFactory, PhysicalDbContextFactory>()
+            .AddScoped<IDbContextFactory, DbContextFactory>()
+            .BuildServiceProvider();
+
     public void Dispose()
     {
         Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        TryDelete(_sqliteDbPath);
+        TryDelete(_sqliteMigratedDbPath);
+    }
+
+    private static void TryDelete(string path)
+    {
         try
         {
-            File.Delete(_sqliteDbPath);
+            File.Delete(path);
         }
         catch (IOException)
         {
@@ -104,4 +202,13 @@ public sealed class DatabaseInitializationExtensionsTests : IDisposable
 
     [UseDatabase("TestSqlite")]
     private sealed class InitTestWidgetConfiguration : EntityTypeConfigurationSqlite<InitTestWidget, int>;
+
+    public sealed class InitTestMigratedWidget : AuditableAggregateRootEntity<int>
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [UseDatabase("TestSqliteMigrated")]
+    private sealed class InitTestMigratedWidgetConfiguration
+        : EntityTypeConfigurationSqlite<InitTestMigratedWidget, int>;
 }


### PR DESCRIPTION
## Summary

Two framework fixes closing small-app wave follow-ups (ships as v1.171.0):

- **SQLite runtime migrations**: migration targets are selected by the new `PhysicalDataSource.UsesMigrations` rule (SQL Server always; SQLite only when `SqliteMigrationsAssembly` is configured; Cosmos never), so a generated small-app's `.Migrations.Sqlite.*` project now applies at startup and later migrations auto-apply. Sqlite sources without a configured assembly keep EnsureCreated (back-compat), and a migrating source is never EnsureCreated first (ordering guard: no orphaned schema without `__EFMigrationsHistory`). SQL Server single-DB monoliths (null migrations assembly on the Default source) provably unchanged.
- **`CrossTenantWriteException` maps to 400 ProblemDetails** ("Tenant write rejected") instead of an unmapped 500; the message's entity/tenant details are logged at Warning and never echoed to the caller.

The third planned fix (gateway h2c health probes) was found **already shipped** in v1.167/168 (`DownstreamProbeVersion.Auto`: h2c prior-knowledge first, HTTP/1.1 fallback, per-downstream latching, 24 tests) - no change made.

## Verification

- Debug + Release builds warning-free; FACTS check clean.
- Infrastructure 1329, API 698, Aspire 156, Architecture 159 - all green via test exes.
- New tests: migration-target selection (real sqlite files, `__EFMigrationsHistory` asserted), per-source Migrate-vs-EnsureCreated strategy, 400 mapping shape + no-leak + plain InvalidOperationException still 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jQtUMpox3zJLNv3Mecpki