### PR TITLE
release: v1.173.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
-## [Unreleased]
+## [1.173.0] - 2026-08-30
 
 One way to do everything. This release removes the dual code paths that existed only for
 compatibility with earlier package versions; supporting older consumers is a non-goal, so each pair


### PR DESCRIPTION
v1.173.0 ships the collapse-dual-paths wave merged in #316: every backward-compat dual path removed (If-Match-only concurrency with 428 on a missing token, permission-only authz, IOptions-only settings, DataSources-sufficient configuration, RS256 default) while the monolith-vs-extraction duals stay. This PR only retitles the CHANGELOG Unreleased section; the tag follows on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw