### PR TITLE
Build filter concurrency responses through ProblemDetailsFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.173.1] - 2026-08-30
+
+### Fixed
+
+- **Filter-built concurrency responses satisfy the problem-details contract.** The 428 (no
+  precondition), 400 (malformed If-Match) and exception-path 412 responses from
+  `SupportsIfMatchAttribute` are now built through the registered `ProblemDetailsFactory` (stamping
+  `traceId`/`requestId` like every other problem response) and carry the standard `errors`
+  extension (`Concurrency.PreconditionRequired`, `Concurrency.MalformedIfMatch`,
+  `Concurrency.PreconditionFailed`). v1.173.0 answered them with a bare body, which failed the
+  consumers' RFC 9457 contract tests.
+
 ## [1.173.0] - 2026-08-30
 
 One way to do everything. This release removes the dual code paths that existed only for

--- a/Source/Presentation/MMCA.Common.API/Concurrency/SupportsIfMatchAttribute.cs
+++ b/Source/Presentation/MMCA.Common.API/Concurrency/SupportsIfMatchAttribute.cs
@@ -1,7 +1,12 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MMCA.Common.API.Localization;
+using MMCA.Common.API.Middleware;
+using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.Http;
 
 namespace MMCA.Common.API.Concurrency;
@@ -104,13 +109,13 @@ public sealed class SupportsIfMatchAttribute : Attribute, IAsyncActionFilter
         if (string.IsNullOrWhiteSpace(headerValue)
             || string.Equals(headerValue.Trim(), ConcurrencyETag.Wildcard, StringComparison.Ordinal))
         {
-            context.Result = PreconditionRequiredResult();
+            context.Result = PreconditionRequiredResult(context.HttpContext);
             return false;
         }
 
         if (!ConcurrencyETag.TryParse(headerValue, out var rowVersion))
         {
-            context.Result = MalformedIfMatchResult();
+            context.Result = MalformedIfMatchResult(context.HttpContext);
             return false;
         }
 
@@ -128,7 +133,7 @@ public sealed class SupportsIfMatchAttribute : Attribute, IAsyncActionFilter
         {
             // The global handler would map this to 409 like any other DbUpdateException. Under an
             // explicit precondition it is a failed precondition, so it is answered here instead.
-            executed.Result = PreconditionFailedResult();
+            executed.Result = PreconditionFailedResult(executed.HttpContext);
             executed.ExceptionHandled = true;
             return;
         }
@@ -154,38 +159,63 @@ public sealed class SupportsIfMatchAttribute : Attribute, IAsyncActionFilter
     }
 
     /// <summary>The response for a conditional write that stated no precondition at all.</summary>
-    private static ObjectResult PreconditionRequiredResult() =>
-        new(new ProblemDetails
-        {
-            Status = StatusCodes.Status428PreconditionRequired,
-            Title = "If-Match header required",
-            Detail = "This write is conditional. Send the entity tag from your last read in the If-Match header, for example W/\"AAAAAAAAB9E=\".",
-        })
-        {
-            StatusCode = StatusCodes.Status428PreconditionRequired,
-        };
+    private static ObjectResult PreconditionRequiredResult(HttpContext httpContext) =>
+        Problem(
+            httpContext,
+            StatusCodes.Status428PreconditionRequired,
+            "If-Match header required",
+            "This write is conditional. Send the entity tag from your last read in the If-Match header, for example W/\"AAAAAAAAB9E=\".",
+            Error.Validation(
+                "Concurrency.PreconditionRequired",
+                "This write is conditional; the If-Match header is required.",
+                nameof(SupportsIfMatchAttribute)));
 
     /// <summary>The response for an <c>If-Match</c> value that is not a decodable entity tag.</summary>
-    private static ObjectResult MalformedIfMatchResult() =>
-        new(new ProblemDetails
-        {
-            Status = StatusCodes.Status400BadRequest,
-            Title = "Invalid If-Match header",
-            Detail = "The If-Match header must be an entity tag returned by a previous read, for example W/\"AAAAAAAAB9E=\".",
-        })
-        {
-            StatusCode = StatusCodes.Status400BadRequest,
-        };
+    private static ObjectResult MalformedIfMatchResult(HttpContext httpContext) =>
+        Problem(
+            httpContext,
+            StatusCodes.Status400BadRequest,
+            "Invalid If-Match header",
+            "The If-Match header must be an entity tag returned by a previous read, for example W/\"AAAAAAAAB9E=\".",
+            Error.Validation(
+                "Concurrency.MalformedIfMatch",
+                "The If-Match header is not a decodable entity tag.",
+                nameof(SupportsIfMatchAttribute)));
 
     /// <summary>The response for a concurrency conflict on a request that stated a precondition.</summary>
-    private static ObjectResult PreconditionFailedResult() =>
-        new(new ProblemDetails
-        {
-            Status = StatusCodes.Status412PreconditionFailed,
-            Title = "Precondition failed",
-            Detail = "The resource changed since the version named in the If-Match header. Re-read it and retry.",
-        })
-        {
-            StatusCode = StatusCodes.Status412PreconditionFailed,
-        };
+    private static ObjectResult PreconditionFailedResult(HttpContext httpContext) =>
+        Problem(
+            httpContext,
+            StatusCodes.Status412PreconditionFailed,
+            "Precondition failed",
+            "The resource changed since the version named in the If-Match header. Re-read it and retry.",
+            Error.Conflict(
+                "Concurrency.PreconditionFailed",
+                "The resource changed since the version named in the If-Match header.",
+                nameof(SupportsIfMatchAttribute)));
+
+    /// <summary>
+    /// Builds the problem response the same way the rest of the API surface does: through the
+    /// registered <see cref="ProblemDetailsFactory"/> (which stamps the diagnostic extensions such
+    /// as <c>traceId</c>), with the error carried in the standard <c>errors</c> extension. The
+    /// factory can be absent only in a host that never called the framework's API registration; the
+    /// response then still carries the <c>errors</c> extension.
+    /// </summary>
+    private static ObjectResult Problem(HttpContext httpContext, int statusCode, string title, string detail, Error error)
+    {
+        var services = httpContext.RequestServices;
+        var problemDetails = services?.GetService<ProblemDetailsFactory>()
+                ?.CreateProblemDetails(httpContext, statusCode, title: title, detail: detail)
+            ?? new ProblemDetails
+            {
+                Status = statusCode,
+                Title = title,
+                Detail = detail,
+            };
+
+        problemDetails.Extensions["errors"] =
+            ErrorHttpMapping.BuildErrorsExtension([error], services?.GetService<IErrorLocalizer>());
+
+        return new ObjectResult(problemDetails) { StatusCode = statusCode };
+    }
 }

--- a/Tests/Presentation/MMCA.Common.API.Tests/Concurrency/SupportsIfMatchAttributeTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Concurrency/SupportsIfMatchAttributeTests.cs
@@ -71,7 +71,11 @@ public sealed class SupportsIfMatchAttributeTests
 
         var objectResult = result.Should().BeOfType<ObjectResult>().Which;
         objectResult.StatusCode.Should().Be(StatusCodes.Status428PreconditionRequired);
-        objectResult.Value.Should().BeOfType<ProblemDetails>().Which.Title.Should().Be("If-Match header required");
+        var problemDetails = objectResult.Value.Should().BeOfType<ProblemDetails>().Which;
+        problemDetails.Title.Should().Be("If-Match header required");
+        problemDetails.Extensions.Should().ContainKey(
+            "errors",
+            because: "the problem-details contract carries every failure in the errors extension");
     }
 
     [Fact]
@@ -172,6 +176,11 @@ public sealed class SupportsIfMatchAttributeTests
         executedContext.ExceptionHandled.Should().BeTrue("the global 409 handler must not also answer this");
         var objectResult = executedContext.Result.Should().BeOfType<ObjectResult>().Which;
         objectResult.StatusCode.Should().Be(StatusCodes.Status412PreconditionFailed);
+
+        var problemDetails = objectResult.Value.Should().BeOfType<ProblemDetails>().Which;
+        problemDetails.Extensions.Should().ContainKey(
+            "errors",
+            because: "a filter-built 412 must satisfy the same problem-details contract as a handler-built conflict");
     }
 
     /// <summary>Runs the filter over an action that threw, returning the executed context itself.</summary>


### PR DESCRIPTION
## Summary

Fixes the v1.173.0 regression caught by the consumer integration tiers (ADC + Store `PreconditionFailed_412_HasProblemDetailsShape`): the 428/400/412 responses `SupportsIfMatchAttribute` builds itself carried a bare `ProblemDetails` with none of the diagnostic extensions the RFC 9457 contract requires. They are now built through the registered `ProblemDetailsFactory` (stamps `traceId`/`requestId`) and carry the standard `errors` extension with stable codes (`Concurrency.PreconditionRequired` / `Concurrency.MalformedIfMatch` / `Concurrency.PreconditionFailed`). Includes the v1.173.1 CHANGELOG entry so the tag can follow the merge directly.

## Test plan
- [x] `SupportsIfMatchAttributeTests` extended to pin the `errors` extension on the 428 and exception-412 paths; 10/10 green locally
- [ ] CI required checks
- [ ] Consumer integration tiers re-run on the bumped consumer PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw