### PR TITLE
feat: v1.174.0 riders: drop legacy HMAC verify, /alive default probe, MAUI token freshness, CapturedRequest.Headers, send-page scope caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [Unreleased]
+
+Five framework riders feeding the consumer wave: one credential-verification path, one startup-gate
+default, the MAUI token pipeline, a testing affordance and a send-page caption. Three of them are
+breaking; each is listed below with the exact call site a consumer has to touch.
+
+### Removed (breaking)
+
+- **The legacy HMAC-SHA512 verification branch** (`MMCA.Common.Infrastructure`).
+  `PasswordHasher.VerifyPassword` derives every candidate digest with PBKDF2-HMAC-SHA512: the
+  128-byte-salt discriminator, the `ComputeLegacyHash` path and the `LegacyHmacSaltSize` constant are
+  gone. A credential still stored in the pre-PBKDF2 shape now fails verification instead of
+  authenticating through an unsalted single-round digest, so it needs a password reset. Both
+  production databases were verified clean (every stored salt is 32 bytes) before the branch was
+  removed; a consumer on an older data set should run the same check before taking this version.
+  `PasswordHasherSecurityTests` pins the removal with a test asserting a legacy-shaped digest is
+  rejected.
+
+### Changed (breaking)
+
+- **`WithH2cHealthCheck` defaults to `/alive`** (`MMCA.Common.Aspire.Hosting`). `DefaultProbePath`
+  moves from `/health/ready` to `/alive`, because a startup `WaitFor` gate must probe liveness: a
+  readiness endpoint aggregates downstream and warmup checks, so gating startup on it can deadlock the
+  dependency graph when the warmup path runs back through the resource that is waiting. An AppHost
+  that passes `/alive` explicitly can drop the argument; one that relied on the old default changes
+  behavior silently, so check every `WithH2cHealthCheck` call site during the bump. Pass an explicit
+  path where a stricter gate is genuinely wanted and no cycle exists.
+- **`DirectApiTokenRefresher` takes `ISecureTokenStore`** (`MMCA.Common.UI`). Its second constructor
+  parameter changes from `ITokenStorageService` to the new raw-storage interface. Hosts that wire the
+  MAUI token pipeline through `AddCommonMauiTokenStorage()` need no change (it registers both halves);
+  a host that constructs the refresher by hand, or registers its own storage, supplies an
+  `ISecureTokenStore` instead.
+
+### Added
+
+- **`ISecureTokenStore`** (`MMCA.Common.UI`): raw token persistence with no freshness semantics,
+  splitting storage from the freshness-checking layer above it. `MauiSecureTokenStore`
+  (`MMCA.Common.UI.Maui`) implements it over OS SecureStorage with the same per-call guards the old
+  storage type carried, and `AddCommonMauiTokenStorage()` registers it alongside the storage service.
+- **`CapturedRequest.Headers`** (`MMCA.Common.Testing.UI`): every request header plus the content
+  headers when the request had a body, keyed case-insensitively with multi-values comma-joined, so a
+  test can assert `If-Match` or `Content-Type` directly. Additive and non-positional: the record's
+  constructor and `Deconstruct` are unchanged, and `Authorization` still works as before.
+- **`INotificationScopeProvider.GetCurrentScopeDisplayNameAsync`** (`MMCA.Common.UI`): a default
+  interface method returning null, so existing implementations compile untouched. An application that
+  scopes its notifications overrides it to name the current scope, and the send page captions the
+  auto-applied target ("Targeting: {name}") instead of leaving the operator to infer who a broadcast
+  reaches. Same never-throw contract as `GetCurrentScopeKeyAsync`; failing closed here means returning
+  null, since a missing caption only hides information while a wrong one would state the wrong
+  audience.
+
+### Fixed
+
+- **MAUI reads its access token through an expiry check.** `MauiTokenStorageService` now mirrors
+  `WasmTokenStorageService`: a 30-second skew, `JwtTokenInfo.IsFresh`, and a single-flight refresh
+  through `ITokenRefresher`, delegating raw reads and writes to `ISecureTokenStore`. It previously
+  returned whatever the secure enclave held, so a token that expired while the app was backgrounded
+  was handed to the delegating handler, the auth-state provider and SignalR alike, and the resulting
+  401 read to the user as a random sign-out. The split also breaks the DI cycle that a freshness check
+  would otherwise have introduced: storage depends on the refresher, and the refresher depends on the
+  raw store rather than back on storage.
+
 ## [1.173.1] - 2026-08-30
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,9 +29,10 @@ fix before public disclosure.
 - **Password hashing:** PBKDF2-SHA512 with a high iteration count and constant-time comparison. Both
   are build-failing invariants, not conventions: `PasswordHasherSecurityTests` recomputes the digest
   independently (known-answer tests, plus a negative one proving the work factor participates in
-  verification) and pins the iteration count, salt size, digest size and legacy-salt discriminator by
-  reflection, while `PasswordHashingFitnessTests` asserts structurally that the hasher still depends on
-  a slow key derivation function and on the fixed-time comparison.
+  verification) and pins the iteration count, salt size and digest size by reflection, while
+  `PasswordHashingFitnessTests` asserts structurally that the hasher still depends on a slow key
+  derivation function and on the fixed-time comparison. PBKDF2 is the only verification path: there is
+  no legacy HMAC fallback.
 - **Field encryption:** AES-256-GCM via `EncryptedStringConverter` for sensitive columns.
 - **Authorization:** server-side; `Result` → HTTP status mapping never leaks internal detail.
 - **CORS:** the permissive `AllowAnyOrigin` policy is **development-only**; production uses an

--- a/Source/Core/MMCA.Common.Infrastructure/Services/PasswordHasher.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Services/PasswordHasher.cs
@@ -6,8 +6,8 @@ namespace MMCA.Common.Infrastructure.Services;
 
 /// <summary>
 /// Hashes and verifies passwords using PBKDF2-HMAC-SHA512 with 600,000 iterations
-/// (OWASP-recommended). Backward-compatible with legacy HMAC-SHA512 hashes: detects
-/// the algorithm from the salt length (32 bytes = PBKDF2, 128 bytes = legacy HMAC-SHA512).
+/// (OWASP-recommended). PBKDF2 is the only supported algorithm: every stored hash is
+/// derived and verified through it.
 /// </summary>
 public sealed class PasswordHasher : IPasswordHasher
 {
@@ -22,9 +22,6 @@ public sealed class PasswordHasher : IPasswordHasher
     /// High iteration count makes brute-force attacks computationally expensive.
     /// </summary>
     private const int Iterations = 600_000;
-
-    /// <summary>Legacy HMAC-SHA512 salt size (the HMAC key length).</summary>
-    private const int LegacyHmacSaltSize = 128;
 
     /// <inheritdoc />
     public (byte[] Hash, byte[] Salt) HashPassword(string password)
@@ -49,9 +46,7 @@ public sealed class PasswordHasher : IPasswordHasher
         ArgumentNullException.ThrowIfNull(hash);
         ArgumentNullException.ThrowIfNull(salt);
 
-        var computedHash = salt.Length == LegacyHmacSaltSize
-            ? ComputeLegacyHash(password, salt)
-            : ComputePbkdf2Hash(password, salt, hash.Length);
+        var computedHash = ComputePbkdf2Hash(password, salt, hash.Length);
 
         // FixedTimeEquals prevents timing side-channel attacks by always comparing
         // the full length regardless of where the first difference occurs.
@@ -66,11 +61,4 @@ public sealed class PasswordHasher : IPasswordHasher
             Iterations,
             HashAlgorithmName.SHA512,
             outputLength);
-
-    /// <summary>Computes a legacy HMAC-SHA512 hash for backward compatibility with existing passwords.</summary>
-    private static byte[] ComputeLegacyHash(string password, byte[] salt)
-    {
-        using var hmac = new HMACSHA512(salt);
-        return hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
-    }
 }

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cHealthCheckExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cHealthCheckExtensions.cs
@@ -41,12 +41,16 @@ namespace MMCA.Common.Aspire.Hosting;
 public static class H2cHealthCheckExtensions
 {
     /// <summary>
-    /// Default path probed. <c>/health/ready</c> rather than <c>/alive</c> on purpose: the point of
-    /// gating a <c>WaitFor</c> edge is to hold the dependent resource until the service can actually
-    /// serve, which includes its database and its own dependency checks. A gateway probing its
-    /// downstreams makes the opposite choice for the opposite reason.
+    /// Default path probed. <c>/alive</c> rather than <c>/health/ready</c> on purpose: a startup
+    /// <c>WaitFor</c> gate must probe LIVENESS, never readiness. A readiness endpoint aggregates
+    /// downstream and warmup checks, so gating startup on it can deadlock the dependency graph: the
+    /// gateway waits for a service to report ready, that service's readiness includes a check that
+    /// warms up through the gateway, and neither side can complete first. Liveness answers as soon as
+    /// the process can serve a request, which is exactly what a dependent resource needs to know
+    /// before it starts. Pass an explicit path when a specific resource genuinely needs a stricter
+    /// gate and no cycle exists.
     /// </summary>
-    public const string DefaultProbePath = "/health/ready";
+    public const string DefaultProbePath = "/alive";
 
     /// <summary>
     /// Default Aspire endpoint name probed. The cleartext <c>http</c> endpoint is the h2c one; an
@@ -76,11 +80,18 @@ public static class H2cHealthCheckExtensions
         /// <summary>
         /// Registers an HTTP/2 (h2c prior knowledge) health check against one of the resource's
         /// endpoints and associates it with the resource, so <c>WaitFor</c> edges into this resource
-        /// wait for a real ready answer.
+        /// wait for a real answer over the protocol the endpoint actually speaks.
         /// <para>
         /// Use this instead of Aspire's <c>WithHttpHealthCheck</c> whenever the target endpoint is
         /// Http2-only. For an endpoint that serves <c>Http1AndHttp2</c> the stock extension is fine
         /// and this one is unnecessary.
+        /// </para>
+        /// <para>
+        /// <b>Probe liveness, not readiness.</b> The default path is <c>/alive</c> for that reason: a
+        /// readiness endpoint rolls up downstream and warmup checks, and a startup gate pointed at one
+        /// can deadlock the dependency graph when the warmup path runs back through the resource that
+        /// is doing the waiting. Only override <paramref name="path"/> when the stricter gate is
+        /// genuinely required and no such cycle exists.
         /// </para>
         /// <para>
         /// Calling it twice for the same resource and endpoint is a no-op: the second call returns

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -2,11 +2,11 @@
 MMCA.Common.Aspire.Hosting.Extensions.extension(Aspire.Hosting.IDistributedApplicationBuilder!).AddMailDev(string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
 MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions
 MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!)
-MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!).WithH2cHealthCheck(string! path = "/health/ready", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!).WithH2cHealthCheck(string! path = "/alive", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 const MMCA.Common.Aspire.Hosting.Extensions.DefaultMailDevResourceName = "maildev" -> string!
 const MMCA.Common.Aspire.Hosting.Extensions.MailDevHttpPort = 1080 -> int
 const MMCA.Common.Aspire.Hosting.Extensions.MailDevSmtpPort = 1025 -> int
 const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultEndpointName = "http" -> string!
-const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultProbePath = "/health/ready" -> string!
+const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultProbePath = "/alive" -> string!
 static MMCA.Common.Aspire.Hosting.Extensions.AddMailDev(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
-static MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.WithH2cHealthCheck(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, string! path = "/health/ready", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.WithH2cHealthCheck(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, string! path = "/alive", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!

--- a/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/CapturingHttpMessageHandler.cs
+++ b/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/CapturingHttpMessageHandler.cs
@@ -13,7 +13,8 @@ namespace MMCA.Common.Testing.UI;
 /// responder when one was supplied, otherwise 404 with an empty body, which mirrors the WebAPI's
 /// not-found behavior and keeps incidental refresh calls out of each test's setup. Responses are
 /// built fresh per request so a Polly retry pipeline never reuses a consumed
-/// <see cref="HttpContent"/>. Every request is recorded (method, URI, Authorization header, body).
+/// <see cref="HttpContent"/>. Every request is recorded (method, URI, Authorization header, every
+/// request and content header, body).
 /// </summary>
 public sealed class CapturingHttpMessageHandler : HttpMessageHandler
 {
@@ -84,7 +85,35 @@ public sealed class CapturingHttpMessageHandler : HttpMessageHandler
             uri?.AbsolutePath ?? string.Empty,
             uri?.PathAndQuery ?? string.Empty,
             request.Headers.Authorization?.ToString(),
-            body);
+            body)
+        {
+            Headers = CaptureHeaders(request),
+        };
+    }
+
+    /// <summary>
+    /// Flattens the request headers and, when present, the content headers into one case-insensitive
+    /// lookup. Both halves are needed: <c>If-Match</c> lives on the request while <c>Content-Type</c>
+    /// lives on the content, and a caller asserting either should not have to know which.
+    /// </summary>
+    private static Dictionary<string, string> CaptureHeaders(HttpRequestMessage request)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var header in request.Headers)
+        {
+            headers[header.Key] = string.Join(", ", header.Value);
+        }
+
+        if (request.Content is not null)
+        {
+            foreach (var header in request.Content.Headers)
+            {
+                headers[header.Key] = string.Join(", ", header.Value);
+            }
+        }
+
+        return headers;
     }
 
     private HttpResponseMessage Respond(HttpRequestMessage request)
@@ -132,4 +161,21 @@ public sealed record CapturedRequest(
     string Path,
     string PathAndQuery,
     string? Authorization,
-    string? Body);
+    string? Body)
+{
+    /// <summary>
+    /// Every request header, plus the content headers when the request carried a body, keyed by
+    /// header name (case-insensitive) with multiple values comma-joined. This is what makes headers
+    /// the service layer sets itself assertable: <c>If-Match</c> is a request header and
+    /// <c>Content-Type</c> is a content header, and a test that pins optimistic concurrency needs the
+    /// first while a test that pins the payload shape needs the second.
+    /// <para>
+    /// It is a non-positional init member on purpose: adding a seventh positional parameter would
+    /// rewrite the record's primary constructor and <c>Deconstruct</c>, breaking every consumer that
+    /// constructs or deconstructs a captured request. <see cref="Authorization"/> stays as it is, so
+    /// existing assertions keep working; it is also present here.
+    /// </para>
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Headers { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}

--- a/Source/Hosting/MMCA.Common.Testing.UI/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.UI/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ MMCA.Common.Testing.UI.ErrorSummaryExtensions.extension<TComponent>(Bunit.IRende
 MMCA.Common.Testing.UI.ErrorSummaryExtensions.extension<TComponent>(Bunit.IRenderedComponent<TComponent>!).ErrorSummaryMessages() -> System.Collections.Generic.IReadOnlyList<string!>!
 const MMCA.Common.Testing.UI.ErrorSummaryExtensions.ErrorSummaryTitleClass = "mmca-error-summary-title" -> string!
 static MMCA.Common.Testing.UI.ErrorSummaryExtensions.ErrorSummaryMessages<TComponent>(this Bunit.IRenderedComponent<TComponent>! cut) -> System.Collections.Generic.IReadOnlyList<string!>!
+MMCA.Common.Testing.UI.CapturedRequest.Headers.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+MMCA.Common.Testing.UI.CapturedRequest.Headers.init -> void

--- a/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/DependencyInjection.cs
@@ -62,16 +62,27 @@ public static class DependencyInjection
         }
 
         /// <summary>
-        /// Registers the OS-SecureStorage token storage (<see cref="MauiTokenStorageService"/> as
-        /// the scoped <c>ITokenStorageService</c>): the platform secure enclave holds both tokens,
-        /// and every read/write is guarded so an OS-invalidated keystore entry degrades to one
-        /// clean re-login instead of an unhandled throw on launch. The browser-host equivalents are
-        /// <c>AddCommonServerTokenStorage()</c> (MMCA.Common.UI.Web) and the WASM
-        /// <c>WasmTokenStorageService</c> (MMCA.Common.UI). Scoped rather than singleton to match
-        /// those siblings, so component code can depend on one lifetime across every head.
+        /// Registers the MAUI token pipeline: <see cref="MauiSecureTokenStore"/> as the scoped
+        /// <c>ISecureTokenStore</c> (the platform secure enclave holds both tokens, and every
+        /// read/write is guarded so an OS-invalidated keystore entry degrades to one clean re-login
+        /// instead of an unhandled throw on launch) and <see cref="MauiTokenStorageService"/> as the
+        /// scoped <c>ITokenStorageService</c> on top of it, which checks expiry and refreshes
+        /// proactively rather than handing callers a stale bearer.
+        /// <para>
+        /// Both halves are required. The split is what keeps the graph acyclic: storage depends on
+        /// the refresher, and the refresher depends on the raw store rather than back on storage.
+        /// </para>
+        /// <para>
+        /// The browser-host equivalents are <c>AddCommonServerTokenStorage()</c> (MMCA.Common.UI.Web)
+        /// and the WASM <c>WasmTokenStorageService</c> (MMCA.Common.UI). Scoped rather than singleton
+        /// to match those siblings, so component code can depend on one lifetime across every head.
+        /// </para>
         /// </summary>
-        public IServiceCollection AddCommonMauiTokenStorage() =>
-            services.AddScoped<ITokenStorageService, MauiTokenStorageService>();
+        public IServiceCollection AddCommonMauiTokenStorage()
+        {
+            services.AddScoped<ISecureTokenStore, MauiSecureTokenStore>();
+            return services.AddScoped<ITokenStorageService, MauiTokenStorageService>();
+        }
 
         /// <summary>
         /// Registers this platform's credentialed <see cref="IPushDeviceTokenProvider"/> (ADR-044):

--- a/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiSecureTokenStore.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiSecureTokenStore.cs
@@ -1,0 +1,121 @@
+using MMCA.Common.UI.Services.Auth;
+
+namespace MMCA.Common.UI.Maui.Services;
+
+/// <summary>
+/// Raw MAUI token store backed by <see cref="SecureStorage"/>, which leverages platform-specific
+/// secure enclaves (Android Keystore, iOS Keychain, Windows DPAPI) to protect tokens at rest.
+/// Every call is guarded: the OS invalidates keystore entries on its own schedule (an Android
+/// backup/restore onto a new device, a security patch that rotates the master key, a biometric
+/// enrolment change), and the raw APIs then throw a platform exception instead of returning
+/// nothing. An unhandled throw here bricks the app on launch until it is reinstalled, so a read
+/// failure degrades to "no token stored" (which <see cref="ISecureTokenStore"/> already documents)
+/// and drops the unreadable entry, forcing one clean re-login. A write failure clears BOTH entries
+/// before it propagates, so the app can never be left holding a stale pair it believes is current:
+/// the outcome of any failed write is the clean signed-out state.
+/// <para>
+/// This is the raw half of the MAUI token pipeline. <see cref="MauiTokenStorageService"/> sits above
+/// it and adds the expiry check plus the single-flight refresh; both are registered together by
+/// <c>AddCommonMauiTokenStorage()</c>.
+/// </para>
+/// </summary>
+public sealed class MauiSecureTokenStore : ISecureTokenStore
+{
+    private const string AccessTokenKey = "auth_access_token";
+    private const string RefreshTokenKey = "auth_refresh_token";
+
+    /// <inheritdoc />
+    public Task<string?> GetAccessTokenAsync() => GetAsync(AccessTokenKey);
+
+    /// <inheritdoc />
+    public Task<string?> GetRefreshTokenAsync() => GetAsync(RefreshTokenKey);
+
+    /// <inheritdoc />
+    public async Task SetTokensAsync(string accessToken, string refreshToken)
+    {
+        // Refresh first, both writes under the SAME guard: whichever one fails, drop both so storage
+        // is a clean signed-out state. A failing refresh write used to escape before the guard was
+        // entered, leaving the OLD pair in place: the app then held a stale access token it believed
+        // was current, and only a manual sign-out cleared it.
+        try
+        {
+            await SetAsync(RefreshTokenKey, refreshToken);
+            await SetAsync(AccessTokenKey, accessToken);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; rethrown after the cleanup
+        catch
+#pragma warning restore CA1031
+        {
+            TryRemove(AccessTokenKey);
+            TryRemove(RefreshTokenKey);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task ClearTokensAsync()
+    {
+        // Logout must always succeed: an entry we cannot delete is one the OS already
+        // invalidated, which is the outcome the caller asked for.
+        TryRemove(AccessTokenKey);
+        TryRemove(RefreshTokenKey);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Reads one entry, degrading a corrupt or undecryptable entry to <see langword="null"/> and
+    /// dropping it so the next write starts from a clean key.
+    /// </summary>
+    private static async Task<string?> GetAsync(string key)
+    {
+        try
+        {
+            return await SecureStorage.Default.GetAsync(key);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - the platform exception type differs per OS and none of them are recoverable here
+        catch
+#pragma warning restore CA1031
+        {
+            // No logging facility exists in this host (nothing in the MAUI head takes an ILogger),
+            // so the swallow is documented here rather than reported: the user sees the normal
+            // signed-out state and logs in again.
+            TryRemove(key);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes one entry, retrying once against a freshly removed key. A second failure propagates:
+    /// the caller must never believe a token was persisted when it was not.
+    /// </summary>
+    private static async Task SetAsync(string key, string value)
+    {
+        try
+        {
+            await SecureStorage.Default.SetAsync(key, value);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; the retry below is the recovery
+        catch
+#pragma warning restore CA1031
+        {
+            TryRemove(key);
+            await SecureStorage.Default.SetAsync(key, value);
+        }
+    }
+
+    /// <summary>Best-effort delete of one entry; a delete that itself throws is already the goal.</summary>
+    private static void TryRemove(string key)
+    {
+        try
+        {
+            SecureStorage.Default.Remove(key);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync
+        catch
+#pragma warning restore CA1031
+        {
+            // Nothing left to do: the entry is unreadable and undeletable, and the next
+            // SetAsync overwrites it anyway.
+        }
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Services/MauiTokenStorageService.cs
@@ -3,119 +3,78 @@ using MMCA.Common.UI.Services.Auth;
 namespace MMCA.Common.UI.Maui.Services;
 
 /// <summary>
-/// MAUI token storage using <see cref="SecureStorage"/>, which leverages platform-specific
-/// secure enclaves (Android Keystore, iOS Keychain, Windows DPAPI) to protect tokens at rest.
-/// Every call is guarded: the OS invalidates keystore entries on its own schedule (an Android
-/// backup/restore onto a new device, a security patch that rotates the master key, a biometric
-/// enrolment change), and the raw APIs then throw a platform exception instead of returning
-/// nothing. An unhandled throw here bricks the app on launch until it is reinstalled, so a read
-/// failure degrades to "no token stored" (which <see cref="ITokenStorageService"/> already
-/// documents) and drops the unreadable entry, forcing one clean re-login. A write failure clears
-/// BOTH entries before it propagates, so the app can never be left holding a stale pair it believes
-/// is current: the outcome of any failed write is the clean signed-out state.
+/// MAUI token storage: the freshness-checking layer over <see cref="ISecureTokenStore"/>. Raw
+/// persistence lives in <see cref="MauiSecureTokenStore"/> (OS SecureStorage); this type adds what a
+/// long-lived mobile session needs, exactly as <c>WasmTokenStorageService</c> does for the browser.
+/// A token read back from the enclave can be hours or days old, so returning it verbatim hands every
+/// caller (the delegating handler, the auth-state provider, SignalR) an expired bearer and produces a
+/// 401 the user experiences as a random sign-out. Reading through the expiry check instead refreshes
+/// proactively, <see cref="ExpirySkew"/> ahead of the actual expiry.
 /// <para>
-/// Register with <c>AddCommonMauiTokenStorage()</c>; the browser-host siblings are
-/// <c>WasmTokenStorageService</c> (MMCA.Common.UI) and <c>ServerTokenStorageService</c>
-/// (MMCA.Common.UI.Web).
+/// Register with <c>AddCommonMauiTokenStorage()</c>, which wires the raw store alongside it; the
+/// browser-host siblings are <c>WasmTokenStorageService</c> (MMCA.Common.UI) and
+/// <c>ServerTokenStorageService</c> (MMCA.Common.UI.Web).
 /// </para>
 /// </summary>
-public sealed class MauiTokenStorageService : ITokenStorageService
+public sealed class MauiTokenStorageService(
+    ISecureTokenStore store,
+    ITokenRefresher tokenRefresher) : ITokenStorageService
 {
-    private const string AccessTokenKey = "auth_access_token";
-    private const string RefreshTokenKey = "auth_refresh_token";
+    private static readonly TimeSpan ExpirySkew = TimeSpan.FromSeconds(30);
+
+    private readonly Lock _hydrateSync = new();
+
+    private Task<string?>? _hydrateInFlight;
 
     /// <inheritdoc />
-    public Task<string?> GetAccessTokenAsync() => GetAsync(AccessTokenKey);
+    public async Task<string?> GetAccessTokenAsync()
+    {
+        var stored = await store.GetAccessTokenAsync();
+        if (JwtTokenInfo.IsFresh(stored, ExpirySkew))
+        {
+            return stored;
+        }
+
+        // Single-flight: concurrent callers (delegating handler, auth-state, SignalR) share one
+        // acquisition. The lock is what makes it single: an unguarded "??=" lets two callers each
+        // start a refresh, and every extra refresh rotates the refresh token again, invalidating the
+        // pair the other caller is still holding. HydrateAsync reaches its first await immediately,
+        // so nothing slow runs under the lock.
+        Task<string?> inFlight;
+        lock (_hydrateSync)
+        {
+            _hydrateInFlight ??= HydrateAsync();
+            inFlight = _hydrateInFlight;
+        }
+
+        try
+        {
+            return await inFlight.ConfigureAwait(false);
+        }
+        finally
+        {
+            // Only clear our own task: an unguarded clear can drop a NEWER hydrate started after
+            // this one completed, splitting the next set of callers again.
+            lock (_hydrateSync)
+            {
+                if (ReferenceEquals(_hydrateInFlight, inFlight))
+                {
+                    _hydrateInFlight = null;
+                }
+            }
+        }
+    }
 
     /// <inheritdoc />
-    public Task<string?> GetRefreshTokenAsync() => GetAsync(RefreshTokenKey);
+    public Task<string?> GetRefreshTokenAsync() => store.GetRefreshTokenAsync();
 
     /// <inheritdoc />
-    public async Task SetTokensAsync(string accessToken, string refreshToken)
-    {
-        // Refresh first, both writes under the SAME guard: whichever one fails, drop both so storage
-        // is a clean signed-out state. A failing refresh write used to escape before the guard was
-        // entered, leaving the OLD pair in place: the app then held a stale access token it believed
-        // was current, and only a manual sign-out cleared it.
-        try
-        {
-            await SetAsync(RefreshTokenKey, refreshToken);
-            await SetAsync(AccessTokenKey, accessToken);
-        }
-#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; rethrown after the cleanup
-        catch
-#pragma warning restore CA1031
-        {
-            TryRemove(AccessTokenKey);
-            TryRemove(RefreshTokenKey);
-            throw;
-        }
-    }
+    public Task SetTokensAsync(string accessToken, string refreshToken) =>
+        store.SetTokensAsync(accessToken, refreshToken);
 
     /// <inheritdoc />
-    public Task ClearTokensAsync()
-    {
-        // Logout must always succeed: an entry we cannot delete is one the OS already
-        // invalidated, which is the outcome the caller asked for.
-        TryRemove(AccessTokenKey);
-        TryRemove(RefreshTokenKey);
-        return Task.CompletedTask;
-    }
+    public Task ClearTokensAsync() => store.ClearTokensAsync();
 
-    /// <summary>
-    /// Reads one entry, degrading a corrupt or undecryptable entry to <see langword="null"/> and
-    /// dropping it so the next write starts from a clean key.
-    /// </summary>
-    private static async Task<string?> GetAsync(string key)
-    {
-        try
-        {
-            return await SecureStorage.Default.GetAsync(key);
-        }
-#pragma warning disable CA1031 // Do not catch general exception types - the platform exception type differs per OS and none of them are recoverable here
-        catch
-#pragma warning restore CA1031
-        {
-            // No logging facility exists in this host (nothing in the MAUI head takes an ILogger),
-            // so the swallow is documented here rather than reported: the user sees the normal
-            // signed-out state and logs in again.
-            TryRemove(key);
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Writes one entry, retrying once against a freshly removed key. A second failure propagates:
-    /// the caller must never believe a token was persisted when it was not.
-    /// </summary>
-    private static async Task SetAsync(string key, string value)
-    {
-        try
-        {
-            await SecureStorage.Default.SetAsync(key, value);
-        }
-#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync; the retry below is the recovery
-        catch
-#pragma warning restore CA1031
-        {
-            TryRemove(key);
-            await SecureStorage.Default.SetAsync(key, value);
-        }
-    }
-
-    /// <summary>Best-effort delete of one entry; a delete that itself throws is already the goal.</summary>
-    private static void TryRemove(string key)
-    {
-        try
-        {
-            SecureStorage.Default.Remove(key);
-        }
-#pragma warning disable CA1031 // Do not catch general exception types - see GetAsync
-        catch
-#pragma warning restore CA1031
-        {
-            // Nothing left to do: the entry is unreadable and undeletable, and the next
-            // SetAsync overwrites it anyway.
-        }
-    }
+    private async Task<string?> HydrateAsync() =>
+        await tokenRefresher.AcquireAccessTokenAsync().ConfigureAwait(false);
 }

--- a/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationSend.razor
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationSend.razor
@@ -17,6 +17,14 @@
             <MudText Typo="Typo.body2" Color="Color.Tertiary">
                 @L["Notif.Send.Description"]
             </MudText>
+            @* Only rendered when the app supplies a scope display name: a scoped send is targeted
+               automatically, and the operator should see that target rather than infer it. *@
+            @if (_scopeCaption is not null)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Primary" Class="mmca-send-scope">
+                    @_scopeCaption
+                </MudText>
+            }
         </CardHeaderContent>
     </MudCardHeader>
     <MudCardContent>

--- a/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationSend.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationSend.razor.cs
@@ -22,6 +22,7 @@ public partial class NotificationSend : IDisposable
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private IToastService Toast { get; set; } = default!;
     [Inject] private IStringLocalizer<SharedResource> L { get; set; } = default!;
+    [Inject] private INotificationScopeProvider ScopeProvider { get; set; } = default!;
 
     private readonly CancellationTokenSource _cts = new();
 
@@ -44,6 +45,13 @@ public partial class NotificationSend : IDisposable
     // model's own DataAnnotations decide the outcome, so no rule is written twice.
     private Func<object, string, IEnumerable<string>> _validate = default!;
 
+    /// <summary>
+    /// The caption naming the scope this send will be auto-targeted at, already localized. Null when
+    /// the application runs unscoped or the provider has no display name, in which case the page
+    /// renders no caption at all rather than an empty line.
+    /// </summary>
+    private string? _scopeCaption;
+
     protected override void OnInitialized()
     {
         // Built here (not in a field initializer) so the injected localizer is available (ADR-027).
@@ -56,6 +64,26 @@ public partial class NotificationSend : IDisposable
 
         // The model's ErrorMessage values are resource keys; the localizer resolves them (ADR-027).
         _validate = ModelValidation.For(_model, new DataAnnotationsModelValidator(L));
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        // A scoped application applies its scope to the send automatically, so without a caption the
+        // operator is composing a broadcast with no visible statement of who receives it. The
+        // localized string is built here rather than in a field initializer because it needs the
+        // injected localizer (ADR-027).
+        try
+        {
+            var scopeName = await ScopeProvider.GetCurrentScopeDisplayNameAsync(_cts.Token);
+            if (!string.IsNullOrWhiteSpace(scopeName))
+            {
+                _scopeCaption = L["Notif.Send.Targeting", scopeName].Value;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during component disposal or InteractiveAuto render mode transition
+        }
     }
 
     private async Task SendNotificationAsync()

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -303,3 +303,12 @@ static MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.Co
 MMCA.Common.UI.Common.NavItem.Deconstruct(out string! Title, out string! Href, out string! Icon, out System.Type! TitleResource, out string? RequiredRole, out string? RequiredClaim, out MMCA.Common.UI.Common.NavSection Section, out string? Group) -> void
 MMCA.Common.UI.Common.NavItem.NavItem(string! Title, string! Href, string! Icon, System.Type! TitleResource, string? RequiredRole = null, string? RequiredClaim = null, MMCA.Common.UI.Common.NavSection Section = MMCA.Common.UI.Common.NavSection.General, string? Group = null) -> void
 MMCA.Common.UI.Common.NavItem.TitleResource.get -> System.Type!
+*REMOVED*MMCA.Common.UI.Services.Auth.DirectApiTokenRefresher.DirectApiTokenRefresher(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService) -> void
+MMCA.Common.UI.Services.Auth.DirectApiTokenRefresher.DirectApiTokenRefresher(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ISecureTokenStore! tokenStore) -> void
+MMCA.Common.UI.Services.Auth.ISecureTokenStore
+MMCA.Common.UI.Services.Auth.ISecureTokenStore.ClearTokensAsync() -> System.Threading.Tasks.Task!
+MMCA.Common.UI.Services.Auth.ISecureTokenStore.GetAccessTokenAsync() -> System.Threading.Tasks.Task<string?>!
+MMCA.Common.UI.Services.Auth.ISecureTokenStore.GetRefreshTokenAsync() -> System.Threading.Tasks.Task<string?>!
+MMCA.Common.UI.Services.Auth.ISecureTokenStore.SetTokensAsync(string! accessToken, string! refreshToken) -> System.Threading.Tasks.Task!
+MMCA.Common.UI.Services.Notifications.INotificationScopeProvider.GetCurrentScopeDisplayNameAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+override MMCA.Common.UI.Pages.Notifications.NotificationSend.OnInitializedAsync() -> System.Threading.Tasks.Task!

--- a/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.es.resx
@@ -448,6 +448,9 @@
   <data name="Nav.ToggleMenu.Aria" xml:space="preserve">
     <value>Alternar el menú de navegación</value>
   </data>
+  <data name="Notif.Send.Targeting" xml:space="preserve">
+    <value>Destinatario: {0}</value>
+  </data>
   <data name="Notif.Send.SentTo" xml:space="preserve">
     <value>Notificación enviada a {0} destinatarios.</value>
   </data>

--- a/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.resx
+++ b/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.resx
@@ -448,6 +448,9 @@
   <data name="Nav.ToggleMenu.Aria" xml:space="preserve">
     <value>Toggle navigation menu</value>
   </data>
+  <data name="Notif.Send.Targeting" xml:space="preserve">
+    <value>Targeting: {0}</value>
+  </data>
   <data name="Notif.Send.SentTo" xml:space="preserve">
     <value>Notification sent to {0} recipients.</value>
   </data>

--- a/Source/Presentation/MMCA.Common.UI/Services/Auth/DirectApiTokenRefresher.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Auth/DirectApiTokenRefresher.cs
@@ -7,17 +7,24 @@ namespace MMCA.Common.UI.Services.Auth;
 /// MAUI token refresher. Exchanges the refresh token held in OS SecureStorage directly against the API's
 /// cross-origin <c>auth/refresh</c> endpoint and persists the rotated pair back to SecureStorage. Used on
 /// the MAUI host, which has no browser/DOM (and thus no XSS surface) so direct token handling is acceptable.
+/// <para>
+/// It depends on <see cref="ISecureTokenStore"/> rather than <see cref="ITokenStorageService"/> on
+/// purpose: every operation it performs is a raw read or write, and taking the raw store keeps the
+/// dependency graph acyclic (the freshness-checking storage depends on this refresher, which depends
+/// on the raw store). Taking the storage service instead would close that loop and let a refresh
+/// re-enter the very acquisition that started it.
+/// </para>
 /// </summary>
 public sealed class DirectApiTokenRefresher(
     IHttpClientFactory httpClientFactory,
-    ITokenStorageService tokenStorageService) : ITokenRefresher
+    ISecureTokenStore tokenStore) : ITokenRefresher
 {
     private const string ApiClientName = "APIClient";
 
     public async Task<string?> AcquireAccessTokenAsync(CancellationToken cancellationToken = default)
     {
-        var accessToken = await tokenStorageService.GetAccessTokenAsync();
-        var refreshToken = await tokenStorageService.GetRefreshTokenAsync();
+        var accessToken = await tokenStore.GetAccessTokenAsync();
+        var refreshToken = await tokenStore.GetRefreshTokenAsync();
 
         if (string.IsNullOrWhiteSpace(accessToken) || string.IsNullOrWhiteSpace(refreshToken))
         {
@@ -39,7 +46,7 @@ public sealed class DirectApiTokenRefresher(
             return null;
         }
 
-        await tokenStorageService.SetTokensAsync(result.AccessToken, result.RefreshToken);
+        await tokenStore.SetTokensAsync(result.AccessToken, result.RefreshToken);
         return result.AccessToken;
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/Auth/ISecureTokenStore.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Auth/ISecureTokenStore.cs
@@ -1,0 +1,29 @@
+namespace MMCA.Common.UI.Services.Auth;
+
+/// <summary>
+/// Raw token persistence, with no freshness semantics: it reads back exactly what was written and
+/// never triggers a refresh. It exists to split storage from the freshness-checking layer above it,
+/// which is what keeps the MAUI wiring acyclic. <see cref="ITokenStorageService"/> (the layer callers
+/// consume) depends on <see cref="ITokenRefresher"/>; the refresher in turn depends on THIS interface,
+/// so the graph is storage to refresher to raw store, with no loop and no re-entrancy hazard at
+/// runtime.
+/// <para>
+/// Only hosts that persist tokens themselves implement it: MAUI backs it with OS SecureStorage. The
+/// browser hosts hold the access token in memory and keep the refresh token in an HttpOnly cookie, so
+/// they have no raw store to expose.
+/// </para>
+/// </summary>
+public interface ISecureTokenStore
+{
+    /// <summary>Reads the stored access token verbatim, or <see langword="null"/> if none exists.</summary>
+    Task<string?> GetAccessTokenAsync();
+
+    /// <summary>Reads the stored refresh token verbatim, or <see langword="null"/> if none exists.</summary>
+    Task<string?> GetRefreshTokenAsync();
+
+    /// <summary>Persists both tokens, replacing whatever was stored before.</summary>
+    Task SetTokensAsync(string accessToken, string refreshToken);
+
+    /// <summary>Removes both tokens (used on logout).</summary>
+    Task ClearTokensAsync();
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/INotificationScopeProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/INotificationScopeProvider.cs
@@ -20,4 +20,21 @@ public interface INotificationScopeProvider
     /// <param name="ct">A cancellation token.</param>
     /// <returns>The scope key (for example <c>"event:2"</c>), or null for no scoping.</returns>
     Task<string?> GetCurrentScopeKeyAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a human-readable name for the scope currently in force (the conference event's title, the
+    /// tenant's name), or null when there is nothing to show. The send page uses it to caption who a
+    /// notification will actually reach, so an operator can see the auto-applied target rather than
+    /// infer it.
+    /// <para>
+    /// It is a default interface method returning null: an application that has no display name, and
+    /// every existing implementation, keeps compiling untouched. The same never-throw, fail-closed
+    /// contract as <see cref="GetCurrentScopeKeyAsync"/> applies, except that failing closed here
+    /// means returning null: a missing caption hides information, while a wrong one would state the
+    /// wrong audience.
+    /// </para>
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>The scope display name, or null when none is available.</returns>
+    Task<string?> GetCurrentScopeDisplayNameAsync(CancellationToken ct = default) => Task.FromResult<string?>(null);
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PasswordHasherSecurityTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PasswordHasherSecurityTests.cs
@@ -20,7 +20,6 @@ public sealed class PasswordHasherSecurityTests
     private const int PinnedIterations = 600_000;
     private const int PinnedSaltSize = 32;
     private const int PinnedHashSize = 64;
-    private const int PinnedLegacyHmacSaltSize = 128;
 
     private readonly PasswordHasher _sut = new();
 
@@ -103,10 +102,17 @@ public sealed class PasswordHasherSecurityTests
             "the stored digest must keep the full 512-bit output of the KDF, not a truncation of it");
 
     [Fact]
-    public void LegacyHmacSaltSize_IsPinnedTo128Bytes() =>
-        ReadPrivateConstant("LegacyHmacSaltSize").Should().Be(PinnedLegacyHmacSaltSize,
-            "this length is the discriminator that routes a credential to the weak legacy HMAC path: "
-            + "moving it to 32 would send every current PBKDF2 credential down the unsalted-HMAC branch");
+    public void VerifyPassword_RejectsALegacyHmacDigest()
+    {
+        const string password = "LegacyPassword";
+        using var hmac = new HMACSHA512();
+        var legacySalt = hmac.Key; // 128 bytes, the length the removed legacy branch keyed on
+        var legacyDigest = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
+
+        _sut.VerifyPassword(password, legacyDigest, legacySalt).Should().BeFalse(
+            "the HMAC-SHA512 verification branch is gone: a credential still stored in the legacy shape "
+            + "must fail verification rather than authenticate through an unsalted, single-round digest");
+    }
 
     private static byte[] DeterministicSalt()
     {

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PasswordHasherTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Services/PasswordHasherTests.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using AwesomeAssertions;
 using MMCA.Common.Infrastructure.Services;
 
@@ -60,30 +58,6 @@ public sealed class PasswordHasherTests
     {
         var (hash, salt) = _sut.HashPassword("MyPassword");
         _sut.VerifyPassword("WrongPassword", hash, salt).Should().BeFalse();
-    }
-
-    // ── Legacy HMAC-SHA512 backward compatibility ──
-    [Fact]
-    public void VerifyPassword_LegacyHmacSha512Hash_ReturnsTrue()
-    {
-        // Simulate a password hashed with the old HMAC-SHA512 algorithm (128-byte salt).
-        const string password = "LegacyPassword";
-        using var hmac = new HMACSHA512();
-        var legacySalt = hmac.Key; // 128 bytes
-        var legacyHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
-
-        _sut.VerifyPassword(password, legacyHash, legacySalt).Should().BeTrue();
-    }
-
-    [Fact]
-    public void VerifyPassword_LegacyHmacSha512Hash_WrongPassword_ReturnsFalse()
-    {
-        const string password = "LegacyPassword";
-        using var hmac = new HMACSHA512();
-        var legacySalt = hmac.Key;
-        var legacyHash = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
-
-        _sut.VerifyPassword("WrongPassword", legacyHash, legacySalt).Should().BeFalse();
     }
 
     // ── Argument validation ──

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/H2cHealthCheckExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/H2cHealthCheckExtensionsTests.cs
@@ -17,10 +17,12 @@ namespace MMCA.Common.Aspire.Hosting.Tests;
 public sealed class H2cHealthCheckExtensionsTests
 {
     [Fact]
-    public void Defaults_ProbeReadinessOnTheCleartextEndpoint()
+    public void Defaults_ProbeLivenessOnTheCleartextEndpoint()
     {
-        H2cHealthCheckExtensions.DefaultProbePath.Should().Be("/health/ready",
-            because: "gating a WaitFor edge is about the service being able to serve, not merely being alive");
+        H2cHealthCheckExtensions.DefaultProbePath.Should().Be("/alive",
+            because: "a startup WaitFor gate must probe liveness: a readiness endpoint aggregates downstream "
+                + "and warmup checks, so gating startup on it can deadlock the dependency graph when the "
+                + "warmup path runs back through the resource that is waiting");
         H2cHealthCheckExtensions.DefaultEndpointName.Should().Be("http",
             because: "the cleartext endpoint is the h2c one; https negotiates its version through ALPN");
     }

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/GalleryHost.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/GalleryHost.cs
@@ -79,6 +79,11 @@ public static class GalleryHost
         builder.Services.AddScoped<INotificationInboxUIService, StubNotificationInboxUIService>();
         builder.Services.AddScoped<IPushNotificationUIService, StubPushNotificationUIService>();
 
+        // The send page injects the scope provider to caption its auto-applied target. The gallery is
+        // unscoped, so the null provider is the right stand-in: it keeps the page rendering and the
+        // caption absent, which is exactly the framework-default look the scan should measure.
+        builder.Services.AddScoped<INotificationScopeProvider, NullNotificationScopeProvider>();
+
         // One empty UI module whose Assembly is the gallery, so the shared Router (Routes.razor)
         // discovers the gallery's own /components page alongside the real Login/Register pages, and
         // contributes a few nav links so the host is browsable when run interactively.

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Infrastructure/CapturingHttpMessageHandlerTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Infrastructure/CapturingHttpMessageHandlerTests.cs
@@ -194,6 +194,43 @@ public sealed class CapturingHttpMessageHandlerTests
     }
 
     [Fact]
+    public async Task CapturedHeaders_CarryRequestHeaders_SoIfMatchIsAssertable()
+    {
+        using var handler = new CapturingHttpMessageHandler();
+        handler.SetResponse(HttpMethod.Put, "/orders/42", HttpStatusCode.NoContent);
+        using var client = CreateClient(handler);
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, new Uri("/orders/42", UriKind.Relative));
+        request.Headers.TryAddWithoutValidation("If-Match", "\"v7\"");
+        using var response = await client.SendAsync(request);
+
+        var captured = handler.RequestsFor(HttpMethod.Put, "/orders/42").Should().ContainSingle().Subject;
+        captured.Headers.Should().ContainKey("if-match",
+            "the lookup is case-insensitive, matching how HTTP treats header names");
+        captured.Headers["If-Match"].Should().Be("\"v7\"",
+            "an optimistic-concurrency test asserts the exact entity tag the service sent");
+    }
+
+    [Fact]
+    public async Task CapturedHeaders_AlsoCarryContentHeaders_AndAreEmptyWhenNoneWereSet()
+    {
+        using var handler = new CapturingHttpMessageHandler();
+        handler.SetResponse(HttpMethod.Post, "/orders", HttpStatusCode.Created);
+        handler.SetResponse(HttpMethod.Get, "/orders", HttpStatusCode.OK);
+        using var client = CreateClient(handler);
+
+        using var content = new StringContent(/*lang=json,strict*/ """{"productId":7}""");
+        using var post = await client.PostAsync(new Uri("/orders", UriKind.Relative), content);
+        using var get = await client.GetAsync(new Uri("/orders", UriKind.Relative));
+
+        handler.Requests[0].Headers.Should().ContainKey("Content-Type",
+            "a content header belongs in the same lookup: the caller should not have to know which "
+            + "collection HTTP files a given header under");
+        handler.Requests[1].Headers.Should().NotContainKey("Content-Type",
+            "the GET carried no content, and the default is an empty lookup rather than null");
+    }
+
+    [Fact]
     public async Task RequestsFor_FiltersByMethodAndPath_CaseInsensitively()
     {
         using var handler = new CapturingHttpMessageHandler();

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Notifications/NotificationSendTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Notifications/NotificationSendTests.cs
@@ -15,11 +15,25 @@ namespace MMCA.Common.UI.Tests.Pages.Notifications;
 /// <summary>
 /// bUnit tests for the <see cref="NotificationSend"/> compose page: form validation gating,
 /// successful submit wiring (service call + toast + navigation), the failed-send surface (one
-/// toast, no navigation, the wording repeated inline by the shared <c>ErrorSummary</c>), and
-/// cancel navigation.
+/// toast, no navigation, the wording repeated inline by the shared <c>ErrorSummary</c>), the
+/// auto-target caption, and cancel navigation.
 /// </summary>
 public sealed class NotificationSendTests : BunitTestBase
 {
+    /// <summary>
+    /// Scope provider that supplies a display name, standing in for a scoped application. It relies
+    /// on the interface's default implementation of nothing: the display-name member is overridden
+    /// here while the key member is implemented explicitly, which is the shape a real app has.
+    /// </summary>
+    private sealed class NamedScopeProvider(string? displayName) : INotificationScopeProvider
+    {
+        public Task<string?> GetCurrentScopeKeyAsync(CancellationToken ct = default) =>
+            Task.FromResult<string?>("event:2");
+
+        public Task<string?> GetCurrentScopeDisplayNameAsync(CancellationToken ct = default) =>
+            Task.FromResult(displayName);
+    }
+
     private readonly Mock<IPushNotificationUIService> _service = new();
     private readonly Mock<IToastService> _toast = new();
 
@@ -29,6 +43,9 @@ public sealed class NotificationSendTests : BunitTestBase
         // Registered after the base class's default facade, so this wins and the page's toast
         // surface can be counted without rendering a snackbar provider.
         Services.AddSingleton<IToastService>(_toast.Object);
+        // The framework default. A test that needs a captioned scope registers its own provider
+        // after this one, and the later registration is the one resolved.
+        Services.AddSingleton<INotificationScopeProvider>(new NullNotificationScopeProvider());
     }
 
     private static Result<PushNotificationDTO> Accepted(int recipientCount)
@@ -101,6 +118,42 @@ public sealed class NotificationSendTests : BunitTestBase
         _service.Verify(
             x => x.SendAsync(It.IsAny<SendPushNotificationRequest>(), It.IsAny<CancellationToken>()),
             Times.Never());
+    }
+
+    // ── Auto-target caption ──
+    [Fact]
+    public void WithAScopedProvider_CaptionsTheAutoAppliedTarget()
+    {
+        // The send is scoped automatically by the notification service; without this caption the
+        // operator composes a broadcast with no statement of who receives it.
+        Services.AddSingleton<INotificationScopeProvider>(new NamedScopeProvider("ADC 2026"));
+
+        var cut = RenderUnderTest<NotificationSend>(_ => { });
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Targeting: ADC 2026"));
+    }
+
+    [Fact]
+    public void WithAnUnscopedProvider_RendersNoCaption()
+    {
+        // The null provider is the framework default, and an unscoped app must not gain a caption
+        // with nothing in it.
+        var cut = RenderUnderTest<NotificationSend>(_ => { });
+
+        cut.Markup.Should().NotContain("Targeting:");
+        cut.FindAll(".mmca-send-scope").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithAScopedProviderThatHasNoDisplayName_RendersNoCaption()
+    {
+        // A provider that scopes but cannot name the scope fails closed to no caption rather than
+        // printing a bare label.
+        Services.AddSingleton<INotificationScopeProvider>(new NamedScopeProvider(displayName: null));
+
+        var cut = RenderUnderTest<NotificationSend>(_ => { });
+
+        cut.FindAll(".mmca-send-scope").Should().BeEmpty();
     }
 
     [Fact]

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Auth/DirectApiTokenRefresherTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Auth/DirectApiTokenRefresherTests.cs
@@ -19,7 +19,7 @@ public sealed class DirectApiTokenRefresherTests
     private sealed record Mocks(
         StubHttpMessageHandler Handler,
         StubHttpClientFactory Factory,
-        Mock<ITokenStorageService> TokenStorage);
+        Mock<ISecureTokenStore> TokenStore);
 
     private static (DirectApiTokenRefresher Sut, Mocks Mocks) CreateSut(
         Func<HttpRequestMessage, HttpResponseMessage> responder,
@@ -28,10 +28,10 @@ public sealed class DirectApiTokenRefresherTests
     {
         var handler = new StubHttpMessageHandler(responder);
         var factory = new StubHttpClientFactory(handler);
-        var tokenStorage = new Mock<ITokenStorageService>();
-        tokenStorage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync(accessToken);
-        tokenStorage.Setup(s => s.GetRefreshTokenAsync()).ReturnsAsync(refreshToken);
-        return (new DirectApiTokenRefresher(factory, tokenStorage.Object), new Mocks(handler, factory, tokenStorage));
+        var tokenStore = new Mock<ISecureTokenStore>();
+        tokenStore.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync(accessToken);
+        tokenStore.Setup(s => s.GetRefreshTokenAsync()).ReturnsAsync(refreshToken);
+        return (new DirectApiTokenRefresher(factory, tokenStore.Object), new Mocks(handler, factory, tokenStore));
     }
 
     private static HttpResponseMessage TokenResponse(string accessToken, string refreshToken) =>
@@ -54,7 +54,7 @@ public sealed class DirectApiTokenRefresherTests
         mocks.Handler.LastRequest.Method.Should().Be(HttpMethod.Post);
         mocks.Handler.LastRequest.Uri!.AbsolutePath.Should().Be("/auth/refresh");
         mocks.Handler.LastRequest.Body.Should().Contain("old-access").And.Contain("old-refresh");
-        mocks.TokenStorage.Verify(s => s.SetTokensAsync("new-access", "new-refresh"), Times.Once);
+        mocks.TokenStore.Verify(s => s.SetTokensAsync("new-access", "new-refresh"), Times.Once);
     }
 
     // == Missing credentials: no HTTP round-trip at all ==
@@ -73,7 +73,7 @@ public sealed class DirectApiTokenRefresherTests
 
         result.Should().BeNull();
         mocks.Handler.CallCount.Should().Be(0);
-        mocks.TokenStorage.Verify(s => s.SetTokensAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        mocks.TokenStore.Verify(s => s.SetTokensAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     // == Failure paths ==
@@ -85,7 +85,7 @@ public sealed class DirectApiTokenRefresherTests
         var result = await sut.AcquireAccessTokenAsync(TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
-        mocks.TokenStorage.Verify(s => s.SetTokensAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        mocks.TokenStore.Verify(s => s.SetTokensAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public sealed class DirectApiTokenRefresherTests
         var result = await sut.AcquireAccessTokenAsync(TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
-        mocks.TokenStorage.Verify(s => s.SetTokensAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        mocks.TokenStore.Verify(s => s.SetTokensAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Five framework riders feeding the v1.174.0 release and the ADC/Store consumer wave. Three are breaking.

## Item 1: drop the PasswordHasher legacy-HMAC verify branch (BREAKING)

`PasswordHasher.VerifyPassword` derives every candidate digest with PBKDF2-HMAC-SHA512. The 128-byte-salt discriminator, `ComputeLegacyHash` and the `LegacyHmacSaltSize` constant are gone, and the class doc no longer claims backward compatibility. `SECURITY.md` drops the legacy-salt-discriminator phrase.

Tests: the two legacy round-trip tests are deleted. `PasswordHasherSecurityTests` loses its reflection pin on the removed constant (which would have failed hard) and gains `VerifyPassword_RejectsALegacyHmacDigest` in its place, so the removal itself is pinned rather than just unpinned. `ReadPrivateConstant` is kept (three other pins use it). `PasswordHashingFitnessTests` was unaffected.

Both production databases were verified clean (all 32-byte salts) before this landed.

## Item 2: WithH2cHealthCheck defaults to /alive (BREAKING)

`DefaultProbePath` moves from `/health/ready` to `/alive`. Both the constant's doc and the extension method's doc now state the readiness-cycle rule: a startup `WaitFor` gate must probe liveness, because a readiness endpoint aggregates downstream and warmup checks and gating startup on one can deadlock the dependency graph when the warmup path runs back through the resource that is waiting. The idempotency and lazy-endpoint-resolution paragraphs are unchanged.

PublicAPI: all three `"/health/ready"` literals in Aspire.Hosting's `PublicAPI.Unshipped.txt` updated in place (still unshipped, so a plain edit).

Test: `Defaults_ProbeReadinessOnTheCleartextEndpoint` renamed to `Defaults_ProbeLivenessOnTheCleartextEndpoint` and re-pinned with a because-text carrying the liveness rule. The probe tests that pass `/health/ready` explicitly are left alone: they exercise an explicit override, which still works.

## Item 3: MAUI token freshness plus DI-cycle break (BREAKING)

New `ISecureTokenStore` (MMCA.Common.UI): the four raw members, no freshness semantics. `MauiSecureTokenStore` (new, MMCA.Common.UI.Maui) is the old `MauiTokenStorageService` body verbatim, keeping every per-call SecureStorage guard. `MauiTokenStorageService` is reworked to mirror `WasmTokenStorageService`: primary constructor `(ISecureTokenStore, ITokenRefresher)`, 30s `ExpirySkew`, `JwtTokenInfo.IsFresh`, single-flight hydrate behind a `Lock`, raw operations delegated to the store.

`DirectApiTokenRefresher`'s second constructor parameter changes from `ITokenStorageService` to `ISecureTokenStore`. Every operation it performs is a raw read or write, so this is the right dependency and it breaks the cycle: storage to refresher to raw store, no loop, and the runtime re-entrancy hazard goes with it.

`AddCommonMauiTokenStorage()` now registers both halves (scoped). The WASM and Server implementations are untouched.

Verified: `dotnet build Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj` succeeds across all four TFMs locally.

## Item 4: CapturedRequest.Headers (additive)

`CapturedRequest` gains a non-positional `public IReadOnlyDictionary<string, string> Headers { get; init; }` defaulting to an empty case-insensitive dictionary. Deliberately not a seventh positional parameter: that would rewrite the shipped constructor and `Deconstruct` and break consumers. `CaptureAsync` populates it from `request.Headers` plus `request.Content?.Headers` (values comma-joined), so `If-Match` and content headers are both assertable. `Authorization` is unchanged.

Tests: `CapturedHeaders_CarryRequestHeaders_SoIfMatchIsAssertable` (round-trips an `If-Match`, and asserts the case-insensitive lookup) and `CapturedHeaders_AlsoCarryContentHeaders_AndAreEmptyWhenNoneWereSet`.

## Item 10b (framework half): NotificationSend auto-target caption

`INotificationScopeProvider` gains `GetCurrentScopeDisplayNameAsync` as a default interface method returning null, so `NullNotificationScopeProvider` and both existing test stubs compile untouched. Its doc records the never-throw, fail-closed contract, and that failing closed here means returning null (a missing caption hides information, a wrong one would state the wrong audience).

`NotificationSend` injects the provider, fetches the name in `OnInitializedAsync` and builds the localized caption there rather than in a field initializer (ADR-027), rendering it in the `MudCardHeader` only when non-null. New key `Notif.Send.Targeting` added to both `SharedResource.resx` ("Targeting: {0}") and `SharedResource.es.resx` ("Destinatario: {0}").

Tests: three added (captioned scope, null provider, scoped-but-unnamed provider), with the null provider registered in the fixture as the default. `GalleryHost` now registers `NullNotificationScopeProvider` so the send page still renders for the axe/render E2E scan; it previously registered no provider and the new injection would have failed there.

## Breaking changes for consumers

1. Legacy-HMAC verify removal: a credential still in the pre-PBKDF2 shape needs a reset. Both prods verified clean.
2. `WithH2cHealthCheck` default: check every AppHost call site. One that passes `/alive` explicitly can drop the argument; one that relied on the old default changes behavior silently.
3. `DirectApiTokenRefresher` constructor: hosts wiring through `AddCommonMauiTokenStorage()` need no change; a host constructing the refresher by hand supplies an `ISecureTokenStore`.

## Deviations from the plan

- **PublicAPI for the refresher ctor**: the plan said to edit `MMCA.Common.UI/PublicAPI.Shipped.txt:360`. The repo's own convention (see the `NotificationInboxService` ctor pair already in `PublicAPI.Unshipped.txt`) is a `*REMOVED*` line plus the new line in Unshipped, leaving Shipped for the release to regenerate. Followed the repo convention.
- **PublicAPI for the new MAUI surface**: `MMCA.Common.UI.Maui` has no PublicAPI files, and `Directory.Build.props:82-86` excludes it from the analyzer by design (it builds only on the windows `build-maui` job). Nothing to add there.
- **Added test rather than only deleting**: `PasswordHasherSecurityTests` gained a rejection test in place of the deleted constant pin, so the security file does not lose coverage of the legacy path.

## Verification

- `dotnet build MMCA.Common.slnx`: clean (Debug and Release).
- `dotnet test --solution MMCA.Common.slnx`: 5052 passed, 0 failed (Debug and Release). No zero-discovery recurrence this run.
- `dotnet build Source/Presentation/MMCA.Common.UI.Maui/MMCA.Common.UI.Maui.csproj`: succeeded (pre-existing unrelated `NativeThemeSync.razor` path warnings only).
- `dotnet build Tests/Presentation/MMCA.Common.UI.Gallery` and `Tests/Presentation/MMCA.Common.UI.E2E.Tests` (both out of slnx): clean.
- `dotnet run --project build/facts -- . --check`: up to date.
- MMCA.Helpdesk (the consumer-source-build canary) references none of the changed APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jQtUMpox3zJLNv3Mecpki
