### PR TITLE
feat: adopt [EventName] on OutputCacheEvictionRequested

### DIFF
--- a/Source/Core/MMCA.Common.Domain/IntegrationEvents/OutputCacheEvictionRequested.cs
+++ b/Source/Core/MMCA.Common.Domain/IntegrationEvents/OutputCacheEvictionRequested.cs
@@ -1,3 +1,4 @@
+using MMCA.Common.Domain.Attributes;
 using MMCA.Common.Domain.DomainEvents;
 
 namespace MMCA.Common.Domain.IntegrationEvents;
@@ -24,6 +25,7 @@ namespace MMCA.Common.Domain.IntegrationEvents;
 /// queues drain (ADR-090).
 /// </para>
 /// </summary>
+[EventName("Common.OutputCacheEvictionRequested.v1")]
 public sealed record class OutputCacheEvictionRequested : BaseIntegrationEvent
 {
     /// <summary>


### PR DESCRIPTION
Adopts the [EventName] stable serialization identity (ADR-003) on this repo's integration events, naming shape Module.EventName.v1. First adoption anywhere: the attribute shipped in the v1.168/v1.169 adherence wave but no event had opted in. Semantics: only NEW outbox/inbox rows store the declared name; rows already written under CLR names keep resolving through the unchanged CLR-name-first path, so in-flight rows are unaffected. The inbox dedup key changes once per event across the deploy boundary (short name to declared name); consumers are idempotent, absorbing any redelivery in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jQtUMpox3zJLNv3Mecpki