### PR TITLE
fix + wave (scorecard 8/19/23/25/26/34): h2c probe keep-alive + six-front implementation lift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,11 +440,25 @@ jobs:
   # repos are checked out as siblings so Helpdesk's local.props path (..\MMCA.Common\Source)
   # resolves to this PR's checkout. Promoted to a required merge gate 2026-07-16 after 9
   # consecutive green runs since introduction (2026-07-14); its context is in branch protection.
+  # It also proves the framework's MIGRATION path end to end (rubric #8): the consumer's real EF
+  # migrations are applied to an ephemeral SQL Server, so a framework change that breaks
+  # `dotnet ef database update` fails here instead of at a consumer's deploy.
   consumer-source-build:
     name: Consumer source build (Helpdesk)
     needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 20 covered the build+test pair; the SQL container, its readiness poll and the migration apply
+    # add a few minutes on a cold cache.
+    timeout-minutes: 30
+    env:
+      # Throwaway SA password for a container that lives and dies with this job. Not a secret:
+      # keeping it inline (as ADC's integration job does) means no secret is needed to run the gate
+      # from a fork, and there is nothing to rotate.
+      MSSQL_SA_PASSWORD: "Helpdesk_Canary!Test1"
+      # The database the Helpdesk design-time factory targets. Its DesignTimeSQLServerDbContextFactory
+      # reads HELPDESK_TICKETS_SQL and falls back to a Trusted_Connection localhost string, which
+      # cannot work on a Linux runner, so the apply step below overrides it.
+      HELPDESK_TICKETS_DB: HelpdeskMigrationCanary
     steps:
       - name: Checkout MMCA.Common (this PR)
         uses: actions/checkout@v7
@@ -493,6 +507,20 @@ jobs:
             **/packages.lock.json
             Directory.Packages.props
 
+      # Started BEFORE the build so SQL Server warms up (~30-60s) while the solution compiles; the
+      # readiness poll below then usually returns on its first try. A guarded STEP rather than a
+      # job-level `services:` block, so a docs-only PR pays no SQL cost while this job still posts
+      # its required status green.
+      - name: Start SQL Server (ephemeral, for the migration apply)
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          docker run -d --name sqlserver \
+            -e ACCEPT_EULA=Y \
+            -e MSSQL_SA_PASSWORD="$MSSQL_SA_PASSWORD" \
+            -e MSSQL_PID=Developer \
+            -p 1433:1433 \
+            mcr.microsoft.com/mssql/server:2022-latest
+
       - name: Build Helpdesk against Common source (UseLocalMMCA)
         if: needs.changes.outputs.code == 'true'
         working-directory: MMCA.Helpdesk
@@ -506,6 +534,92 @@ jobs:
         # Helpdesk's suite is ~91 tests; floor at 40 so a discovery/filter regression fails
         # instead of passing green with near-zero tests discovered.
         run: dotnet test --solution MMCA.Helpdesk.slnx -c Release --no-build --minimum-expected-tests 40
+
+      # go-sqlcmd (the Go rewrite) rather than the mssql-tools deb: a single static binary with no
+      # apt source and no EULA prompt. Used by the readiness poll and by the post-apply assertions.
+      - name: Install sqlcmd
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          curl -sL https://github.com/microsoft/go-sqlcmd/releases/latest/download/sqlcmd-linux-amd64.tar.bz2 \
+            | sudo tar -xjC /usr/local/bin/
+
+      # The container reports "running" long before the engine accepts logins, so poll a real query
+      # rather than docker state. 30 x 5s covers a cold image pull on a slow runner.
+      - name: Wait for SQL Server
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          for i in $(seq 1 30); do
+            if sqlcmd -S localhost,1433 -U sa -P "$MSSQL_SA_PASSWORD" -C -Q "SELECT 1" >/dev/null 2>&1; then
+              echo "SQL Server is ready"
+              exit 0
+            fi
+            echo "Waiting for SQL Server ($i/30)..."
+            sleep 5
+          done
+          echo "::error::SQL Server did not become ready in time"
+          docker logs sqlserver || true
+          exit 1
+
+      # Pinned to the same version ADC and Store deploy with, so the canary exercises the tool the
+      # consumers actually run their migrations through.
+      - name: Install EF Core tools
+        if: needs.changes.outputs.code == 'true'
+        run: dotnet tool install --global dotnet-ef --version 10.0.8
+
+      # The point of the whole SQL half of this job: apply a REAL consumer's committed migrations,
+      # built against THIS PR's framework source, to a real SQL Server. `migrations add` and the
+      # model-drift gate never open a connection, so neither notices a framework change that breaks
+      # the generated DDL, the history table, or the design-time context wiring. `database update`
+      # does, and it creates the database as its first act.
+      # --no-build is safe: the Release build above covers MMCA.Helpdesk.slnx, which includes the
+      # migrations project. The project IS the startup project (it ships its own
+      # DesignTimeSQLServerDbContextFactory), and SQLServerDbContext is the framework's single
+      # per-engine context class (ADR-006), not a per-module subclass.
+      - name: Apply Helpdesk Tickets migrations to SQL Server
+        if: needs.changes.outputs.code == 'true'
+        working-directory: MMCA.Helpdesk
+        env:
+          HELPDESK_TICKETS_SQL: "Server=localhost,1433;Database=${{ env.HELPDESK_TICKETS_DB }};User Id=sa;Password=${{ env.MSSQL_SA_PASSWORD }};TrustServerCertificate=True;Encrypt=False;MultipleActiveResultSets=True"
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet ef database update \
+            --project Source/Hosting/MMCA.Helpdesk.Migrations.SqlServer.Tickets \
+            --startup-project Source/Hosting/MMCA.Helpdesk.Migrations.SqlServer.Tickets \
+            --context SQLServerDbContext \
+            --configuration Release \
+            --no-build
+
+      # `dotnet ef database update` exits 0 on a no-op, so a wiring mistake that applied nothing
+      # would pass the step above silently. Assert the outcome instead: migrations recorded in the
+      # history table, plus one module table and one framework table actually present. The framework
+      # table (dbo.OutboxMessages) is the half that belongs to MMCA.Common, so a change that stops
+      # the framework's own tables reaching a consumer's schema fails right here.
+      - name: Assert migrations were recorded and the schema exists
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          db='${{ env.HELPDESK_TICKETS_DB }}'
+          query() {
+            sqlcmd -S localhost,1433 -U sa -P "$MSSQL_SA_PASSWORD" -C -d "$db" -h -1 -W \
+              -Q "SET NOCOUNT ON; $1"
+          }
+
+          applied=$(query "SELECT COUNT(*) FROM __EFMigrationsHistory")
+          echo "Applied migrations: $applied"
+          if [ "${applied:-0}" -lt 1 ]; then
+            echo "::error::No rows in __EFMigrationsHistory: the migration apply was a silent no-op"
+            exit 1
+          fi
+
+          for table in "Tickets.Ticket" "dbo.OutboxMessages"; do
+            schema="${table%%.*}"
+            name="${table##*.}"
+            found=$(query "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '$schema' AND TABLE_NAME = '$name'")
+            if [ "${found:-0}" -lt 1 ]; then
+              echo "::error::Table $table is missing after the migration apply"
+              exit 1
+            fi
+            echo "Table $table exists"
+          done
 
   # Package-mode consumption canary: pack every slnx package into a local folder feed, then
   # restore + build a minimal throwaway consumer against those nupkgs. Catches pack breaks (NU5xxx)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,10 @@ jobs:
         if: github.repository_owner == 'ivanball'
         run: dotnet nuget push ./nupkgs/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
 
-  # MMCA.Common.UI.Maui (the 15th package) cannot build on ubuntu — its four TFMs need the MAUI
-  # workloads — so it packs on windows, versioned from the same tag so the lockstep release stays
-  # whole. Same SBOM hard gate as the main job, scoped to this project.
+  # MMCA.Common.UI.Maui (the one MAUI-TFM package; the full id list lives in FACTS.md) cannot
+  # build on ubuntu (its four TFMs need the MAUI workloads), so it packs on windows, versioned
+  # from the same tag so the lockstep release stays whole. Same SBOM hard gate as the main job,
+  # scoped to this project.
   publish-maui:
     runs-on: windows-latest
     timeout-minutes: 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,79 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [Unreleased]
+
+A six-front implementation-lift wave (scorecard categories 8, 19, 23, 25, 26, 34): migrations proven
+in CI, cascade soft-delete enforced, a complete default CSP with a nonce path, an explicit client-side
+staleness policy, opt-in desktop grid virtualization, and a typed notification deep link. Three
+constructor signatures change shape (binary-breaking, source-compatible via optional parameters);
+each is listed with the call site a consumer has to touch.
+
+### Changed (breaking)
+
+- **`EntityServiceBase` constructor gains an optional `IUiReadCache? readCache = null`**
+  (`MMCA.Common.UI`). Source-compatible (existing subclasses compile unchanged) but binary-breaking:
+  recompile during the bump. Passing `null` keeps read behavior byte-identical; passing the
+  DI-registered cache opts that service's reads into the staleness policy below. `AuthUIService` and
+  `NotificationState` change the same way (`IUiReadCache?` and `TimeProvider?` respectively, both
+  optional and defaulted).
+- **The default static Content-Security-Policy now carries `script-src` and `style-src`**
+  (`MMCA.Common.Aspire`). `SecurityHeadersSettings.ContentSecurityPolicy` defaults to
+  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'`,
+  the strength Blazor and MudBlazor require, so a host on the static default gets a complete policy
+  instead of one missing both directives. A host that loads third-party scripts or stylesheets from
+  another origin must now name them in a configured policy; everything same-origin keeps working.
+- **`BlazorCspPolicyProvider` fails closed on a missing or unparseable API endpoint**
+  (`MMCA.Common.UI.Web`). The fallback was `connect-src 'self' https: wss:` in Report-Only mode
+  (permissive and unenforced); it is now `connect-src 'self'`, enforced. A misconfigured endpoint
+  surfaces as blocked API calls in the browser console instead of a silently unenforced policy; fix
+  the `ApiEndpoint`/`WasmApiEndpoint` setting rather than relaxing the policy.
+- **`NotificationBell` reads its cadence from configuration** (`MMCA.Common.UI`). The hardcoded 30s
+  poll moves to `NotificationBellOptions` (`NotificationBell` section: `PollInterval`,
+  `NavigationRefreshMaxAge`, both defaulting to 30s), and navigating no longer refetches the unread
+  count unless it is stale by that policy. Defaults preserve today's cadence; hosts tune via config.
+
+### Added
+
+- **Client-side staleness policy** (`MMCA.Common.UI`): `IUiReadCache` (scoped, per circuit) with
+  `UiReadCacheOptions` (`UiReadCache` section: `Enabled`, `DefaultTtl` 60s, longest-prefix
+  `RoutePrefixTtls`). Keys are the relative URL (path plus full query), the same shape as the server
+  output cache's `QueryKeys="*"` (ADR-040), so client and server agree on what "the same read" means.
+  Reads through `EntityServiceBase` route via `GetCachedAsync` (successes only, explicit
+  `bypassCache` available); writes invalidate their endpoint prefix; logout clears the cache. Opt-in
+  per service via the constructor parameter above.
+- **Per-request CSP nonce path** (`MMCA.Common.Aspire`): a `{nonce}` placeholder anywhere in a
+  configured policy is replaced per request with `'nonce-<base64>'`, and `CspNonce.Get(HttpContext)`
+  exposes the value for the host layout to stamp onto its script and style tags. This is the
+  supported path off `style-src 'unsafe-inline'` for hosts that can nonce their tags.
+- **Cascade soft-delete fitness rule** (`MMCA.Common.Testing.Architecture`):
+  `CascadeSoftDeleteConventionTestsBase` fails the build when an aggregate declaring a collection of
+  auditable children has no `Delete()` override that cascades (`DeleteChildren` or per-child
+  `Delete()`; a bare `base.Delete()` cannot satisfy the rule). Subclass with your map and move each
+  reported aggregate to a fix or a justified exemption. Common now also runs the shipped hard-delete
+  gate over its own assemblies, so a new framework eraser fails here rather than downstream.
+- **Migrations proven in CI**: the `consumer-source-build` job applies MMCA.Helpdesk's real SQL
+  Server migrations against an ephemeral SQL Server 2022 container with pinned `dotnet-ef`, and an
+  in-repo fixture migration proves the `Migrate`/`None` startup strategies against real migration
+  files in the unit tier.
+- **Opt-in desktop grid row virtualization** (`MMCA.Common.UI`): override `VirtualizeGrid` on
+  `DataGridListPageBase` and bind `Virtualize`/`Height`/`ItemSize`/`VirtualizeServerData` to the new
+  `LoadVirtualizedServerDataAsync` funnel (the viewport window maps onto the existing paged API; a
+  grid binds `ServerData` or `VirtualizeServerData`, never both). Scroll persistence follows the
+  grid's inner container; the pager-restore machinery is inert for virtualized grids. Defaults off;
+  existing grids are untouched.
+- **Typed notification deep link** (`MMCA.Common.UI`): `/notifications/inbox/{Id:int}` highlights
+  and scrolls to one notification (`NotificationRoutePaths.NotificationInboxItem(id)` builds the
+  link); a malformed id renders `NotFound` via the route constraint, an absent id degrades to the
+  plain inbox. A new navigation-contract fact requires every future route parameter to carry a type
+  constraint.
+
+### Fixed
+
+- **`FACTS.md` names both registries**: the generated packages line now reads "Released in lockstep
+  to nuget.org and GitHub Packages (dual-registry, ADR-053)", ending a seven-cycle drift between the
+  generator prose and the actual release pipeline.
+
 ## [1.174.0] - 2026-08-30
 
 Five framework riders feeding the consumer wave: one credential-verification path, one startup-gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ build as the final word.
 ## Releases are separate
 
 Do **not** bump versions in a feature PR. A release is cut after merge by the maintainer via the
-`/push-release` flow: tag `vX.Y.Z` on the merged `main` (publishes all 15 packages in lockstep),
+`/push-release` flow: tag `vX.Y.Z` on the merged `main` (publishes every package in lockstep),
 then a follow-up FACTS-regen PR and one lockstep version-bump PR per consumer. See
 [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html).
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,7 +65,7 @@
   </PropertyGroup>
 
   <!-- The icon referenced by PackageIcon above must itself be packed. Done once here rather than
-       in fifteen csproj files (each of which still packs README.md individually). The changelog rides
+       in every packable csproj (each of which still packs README.md individually). The changelog rides
        along in every package for the same reason: a consumer inspecting a .nupkg gets the version
        history without leaving the package. -->
   <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('Source'))">

--- a/FACTS.md
+++ b/FACTS.md
@@ -17,7 +17,7 @@ _As of: 2026-08-31 (framework v1.174.0) — **generated from source by `build/fa
   rollout).
 
 ## Published packages — **17**
-Released in lockstep to GitHub Packages (the packable projects under `Source/` carrying a `<PackageId>`):
+Released in lockstep to nuget.org and GitHub Packages (dual-registry, ADR-053; the packable projects under `Source/` carrying a `<PackageId>`):
 
 1. `MMCA.Common.Application`
 2. `MMCA.Common.Domain`

--- a/FACTS.md
+++ b/FACTS.md
@@ -43,10 +43,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **121 test methods across 45 abstract `*TestsBase` classes**, shipped once in the
+- **122 test methods across 46 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **178** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **186** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/FACTS.md
+++ b/FACTS.md
@@ -46,7 +46,7 @@ it owns the range/count and the one-line summaries. Do not restate the `(001-NNN
 - **122 test methods across 46 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **186** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **187** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/MMCA.Common.slnx
+++ b/MMCA.Common.slnx
@@ -34,6 +34,7 @@
     <Project Path="Tests/Core/MMCA.Common.Domain.Tests/MMCA.Common.Domain.Tests.csproj" />
     <Project Path="Tests/Core/MMCA.Common.Application.Tests/MMCA.Common.Application.Tests.csproj" />
     <Project Path="Tests/Core/MMCA.Common.Infrastructure.Tests/MMCA.Common.Infrastructure.Tests.csproj" />
+    <Project Path="Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/MMCA.Common.Infrastructure.Tests.MigrationsFixture.csproj" />
   </Folder>
   <Folder Name="/Tests/Presentation/">
     <Project Path="Tests/Presentation/MMCA.Common.API.Tests/MMCA.Common.API.Tests.csproj" />

--- a/NavigationFlow.md
+++ b/NavigationFlow.md
@@ -18,13 +18,25 @@
 | `/auth/oauth-complete` | `Auth/OAuthComplete` | Anonymous | External-login callback landing. |
 | `/notifications` | `Notifications/NotificationList` | Authenticated | Push-notification history. Route carries `[Authorize]`. |
 | `/notifications/inbox` | `Notifications/NotificationInbox` | Authenticated | Per-user durable inbox (paged). Route carries `[Authorize]`. |
+| `/notifications/inbox/{Id:int}` | `Notifications/NotificationInbox` | Authenticated | Typed deep link to one notification: highlights it and scrolls it into view. The `:int` constraint is the validation boundary (a malformed id renders `NotFound`); an id that is valid but absent from the loaded page degrades silently to the plain inbox. Route carries `[Authorize]`. |
 | `/notifications/send` | `Notifications/NotificationSend` | Authenticated | Admin/sender surface. Route carries `[Authorize]`; the sender role/claim gate is consumer-declared (NavItem filter) and enforced server-side by the send API. |
 | `/profile/sessions` | `Auth/Sessions` | Authenticated | Signed-in devices: one row per live refresh session, with a per-device sign-out and a sign-out-everywhere. Route carries `[Authorize]`; reachable from the shared nav menu's account section. |
 | `/not-found` | `NotFound` | Any | 404 within the app shell (`Router.NotFoundPage`). |
 | `/forbidden` | `Forbidden` | Any | 403 within the app shell (see below); rendered for authenticated-but-unauthorized hits via `AuthorizeRouteView`, but the route itself is open (a direct anonymous visit just shows the 403 page). |
 
+The table covers `MMCA.Common.UI` only. `MMCA.Common.UI.Web`'s `/Error` page is a server-rendered
+host page (the ASP.NET exception-handler landing, no interactive render mode), so it is deliberately
+outside this contract and outside the drift gate's reflection anchor.
+
 ## Guards & wayfinding (the §25 contract)
 
+- **Typed route parameters, not free-form strings.** Every route parameter carries a type constraint
+  (`/notifications/inbox/{Id:int}`), so validation happens at the router: a malformed id never
+  reaches a page and renders `NotFound` instead of failing somewhere downstream. A deep link whose id
+  is well-formed but not present (a later page, a deleted row, another user's notification) degrades
+  to the plain page silently, because the user cannot act on a toast about it. Build these links from
+  the `*RoutePaths` helpers (`NotificationRoutePaths.NotificationInboxItem`), never by string
+  concatenation, so the URL always matches the constraint.
 - **Route-level authorization, not UI hiding.** `Routes.razor` wraps routing in
   `AuthorizeRouteView`. Hiding a nav item is convenience only; the route itself is the boundary, and
   the API re-validates server-side (ADR-022/ADR-004) — UI hiding is never the security control.

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cEndpointHealthCheck.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/H2cEndpointHealthCheck.cs
@@ -25,8 +25,31 @@ internal sealed class H2cEndpointHealthCheck : IHealthCheck
     /// <summary>
     /// Proxy detection is off: the probe target is a sibling process on the developer's own machine
     /// (or a sibling replica inside the deployment network), never something a proxy should see.
+    /// <para>
+    /// <b>The keep-alive ping trio is load-bearing, not tuning.</b> The client below is shared for
+    /// the process lifetime, and HTTP/2 pools ONE connection per origin. Aspire's endpoint proxy
+    /// listens before the target Kestrel does, so the first probe of a starting resource can open a
+    /// connection that is accepted and then never answered: the TCP connect succeeds, the HTTP/2
+    /// handshake never completes, and the proxy holds that socket open for the life of the AppHost.
+    /// Without the pings, every later probe queues onto that one zombie connection and times out at
+    /// <see cref="H2cHealthCheckExtensions.ProbeTimeout"/> forever, even after the service is up:
+    /// the resource can never turn healthy and every WaitFor edge into it wedges the stack (the
+    /// 2026-08-31 apphost-smoke wedge, nightly runs 33392642362/33399413579). The pings bound the
+    /// zombie's life instead: a connection that stops answering pings is torn down, and the next
+    /// probe opens a fresh one to the now-listening service. Verified against a held-open
+    /// accepted-but-unanswered socket: without pings the client never recovers; with them it
+    /// recovers on the first probe after the service binds. ConnectTimeout does NOT cover this case
+    /// (the connect itself succeeds) and is deliberately absent: the request timeout already bounds
+    /// the connect phase.
+    /// </para>
     /// </summary>
-    private static readonly SocketsHttpHandler ProbeHandler = new() { UseProxy = false };
+    internal static readonly SocketsHttpHandler ProbeHandler = new()
+    {
+        UseProxy = false,
+        KeepAlivePingDelay = TimeSpan.FromSeconds(1),
+        KeepAlivePingTimeout = TimeSpan.FromSeconds(1),
+        KeepAlivePingPolicy = HttpKeepAlivePingPolicy.Always,
+    };
 
     /// <summary>
     /// One process-lifetime client for every probe. Static rather than per-registration so a handful
@@ -121,16 +144,19 @@ internal sealed class H2cEndpointHealthCheck : IHealthCheck
 
             return new HealthCheckResult(context.Registration.FailureStatus, description);
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or TimeoutException or InvalidOperationException or UriFormatException
-                                   && !cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or TimeoutException or InvalidOperationException or UriFormatException)
         {
             // Unreachable, still starting, refusing HTTP/2, or slower than the probe budget. Narrow
             // catch list (rather than a blanket Exception) so a genuine programming error still
-            // surfaces, and the cancellation guard keeps AppHost shutdown from being reported as a
-            // service fault.
+            // surfaces. No cancellation guard: the registration's own timeout cancels the SAME token
+            // this method receives, so a probe that outlives ProbeTimeout used to slip past the
+            // filter and be logged by the health service as an unhandled exception rather than
+            // reported here. The status is Unhealthy either way; catching it just keeps the report
+            // honest. The one other canceller is AppHost shutdown, where an Unhealthy result goes
+            // nowhere and costs nothing.
             return new HealthCheckResult(
                 context.Registration.FailureStatus,
-                "Endpoint did not answer " + _path + " over HTTP/2.",
+                "Endpoint did not answer " + _path + " over HTTP/2 within the probe budget.",
                 ex);
         }
     }

--- a/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
@@ -18,3 +18,6 @@ static MMCA.Common.Aspire.Logging.SerilogHostExtensions.CreateBootstrapLoggerFac
 *REMOVED*static MMCA.Common.Aspire.Extensions.AddInfrastructureHealthChecks<TBuilder>(this TBuilder builder, bool requireSqlServer = false) -> TBuilder
 MMCA.Common.Aspire.Extensions.extension<TBuilder>(TBuilder).AddInfrastructureHealthChecks(bool requireDatabase = false) -> TBuilder
 static MMCA.Common.Aspire.Extensions.AddInfrastructureHealthChecks<TBuilder>(this TBuilder builder, bool requireDatabase = false) -> TBuilder
+MMCA.Common.Aspire.Security.CspNonce
+const MMCA.Common.Aspire.Security.CspNonce.ItemKey = "MMCA.CspNonce" -> string!
+static MMCA.Common.Aspire.Security.CspNonce.Get(Microsoft.AspNetCore.Http.HttpContext! context) -> string?

--- a/Source/Hosting/MMCA.Common.Aspire/Security/SecurityHeaders.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Security/SecurityHeaders.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -37,15 +38,21 @@ public sealed class SecurityHeadersSettings
 
     /// <summary>
     /// Static Content-Security-Policy used by the default <see cref="ICspPolicyProvider"/>. Set to
-    /// <see langword="null"/>/empty to emit no CSP. The default is a conservative hardened baseline —
-    /// <c>default-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'</c>
-    /// — safe for the JSON / WebSocket / static responses of API and Gateway hosts. It deliberately omits
-    /// <c>script-src</c>/<c>style-src</c> so it does not break an HTML/Blazor host that forgot to register a
-    /// provider (Blazor needs <c>script-src 'wasm-unsafe-eval'</c> and MudBlazor needs <c>style-src 'unsafe-inline'</c>);
-    /// HTML hosts register their own <see cref="ICspPolicyProvider"/> for a full resource policy.
+    /// <see langword="null"/>/empty to emit no CSP. The default is a complete hardened baseline:
+    /// <code>
+    /// default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+    /// </code>
+    /// It ships <c>script-src</c> and <c>style-src</c> at exactly the strength Blazor
+    /// (<c>'wasm-unsafe-eval'</c>) and MudBlazor (<c>'unsafe-inline'</c> styles) require, so an HTML host that never registers a
+    /// provider still gets a functional policy instead of one silently missing both directives, while
+    /// the JSON / WebSocket / static responses of API and Gateway hosts are unaffected.
+    /// A host needing a stricter or looser policy configures the <c>"SecurityHeaders"</c> section or
+    /// registers its own <see cref="ICspPolicyProvider"/>; the <c>{nonce}</c> placeholder (see
+    /// <see cref="CspNonce"/>) is the supported path off <c>'unsafe-inline'</c>.
     /// </summary>
     public string? ContentSecurityPolicy { get; set; } =
-        "default-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
+        "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; " +
+        "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
 
     /// <summary>When <see langword="true"/> the static CSP is enforced; otherwise it is emitted Report-Only.</summary>
     public bool EnforceContentSecurityPolicy { get; set; } = true;
@@ -86,6 +93,38 @@ internal sealed class StaticCspPolicyProvider : ICspPolicyProvider
 }
 
 /// <summary>
+/// Per-request Content-Security-Policy nonce produced by <see cref="SecurityHeadersMiddleware"/>.
+/// </summary>
+/// <remarks>
+/// A policy that wants a nonce writes the literal token <c>{nonce}</c> as a source-list entry, e.g.
+/// <c>script-src 'self' {nonce}</c>. For every request whose resolved policy contains that token the
+/// middleware generates a fresh random value, replaces each occurrence with the quoted source-list form
+/// <c>'nonce-&lt;value&gt;'</c>, and stashes the raw value under <see cref="ItemKey"/> before the rest of
+/// the pipeline runs, so the page render can read it. A host layout stamps it onto its own tags:
+/// <code>
+/// @inject Microsoft.AspNetCore.Http.IHttpContextAccessor Http
+/// &lt;script nonce="@CspNonce.Get(Http.HttpContext!)" src="app.js"&gt;&lt;/script&gt;
+/// </code>
+/// A policy with no placeholder generates no nonce and stores nothing.
+/// </remarks>
+public static class CspNonce
+{
+    /// <summary>Key under which the raw (unquoted, Base64) nonce is stored in <see cref="HttpContext.Items"/>.</summary>
+    public const string ItemKey = "MMCA.CspNonce";
+
+    /// <summary>
+    /// Returns the nonce generated for the current request, or <see langword="null"/> when the resolved
+    /// policy carried no <c>{nonce}</c> placeholder (or the middleware did not run).
+    /// </summary>
+    /// <param name="context">The current request.</param>
+    public static string? Get(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Items.TryGetValue(ItemKey, out var value) ? value as string : null;
+    }
+}
+
+/// <summary>
 /// Adds hardened security response headers to every response: <c>X-Content-Type-Options</c>,
 /// <c>X-Frame-Options</c>, <c>Referrer-Policy</c>, <c>Permissions-Policy</c>, HSTS (outside Development),
 /// and a Content-Security-Policy resolved from <see cref="ICspPolicyProvider"/>. Centralizes what each
@@ -93,6 +132,12 @@ internal sealed class StaticCspPolicyProvider : ICspPolicyProvider
 /// </summary>
 public sealed class SecurityHeadersMiddleware
 {
+    /// <summary>Literal token a policy uses to request a per-request nonce (see <see cref="CspNonce"/>).</summary>
+    private const string NoncePlaceholder = "{nonce}";
+
+    /// <summary>Nonce entropy in bytes; 16 bytes (128 bits) is the CSP specification's recommendation.</summary>
+    private const int NonceByteCount = 16;
+
     private readonly RequestDelegate _next;
     private readonly ICspPolicyProvider _cspPolicyProvider;
     private readonly SecurityHeadersSettings _settings;
@@ -132,13 +177,24 @@ public sealed class SecurityHeadersMiddleware
         var csp = _cspPolicyProvider.GetPolicy(context);
         if (csp is not null)
         {
+            // A policy carrying the {nonce} token gets a fresh value per request. The raw value lands in
+            // HttpContext.Items BEFORE the pipeline runs, because the page render is what stamps it onto
+            // its script/style tags; the header carries the quoted 'nonce-<value>' source-list form.
+            var value = csp.Value;
+            if (value.Contains(NoncePlaceholder, StringComparison.Ordinal))
+            {
+                var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(NonceByteCount));
+                context.Items[CspNonce.ItemKey] = nonce;
+                value = value.Replace(NoncePlaceholder, $"'nonce-{nonce}'", StringComparison.Ordinal);
+            }
+
             if (csp.Enforce)
             {
-                headers.ContentSecurityPolicy = csp.Value;
+                headers.ContentSecurityPolicy = value;
             }
             else
             {
-                headers.ContentSecurityPolicyReportOnly = csp.Value;
+                headers.ContentSecurityPolicyReportOnly = value;
             }
         }
 

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.CascadeSoftDelete.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.CascadeSoftDelete.cs
@@ -1,0 +1,252 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace MMCA.Common.Testing.Architecture;
+
+public static partial class ArchitectureRules
+{
+    /// <summary>The aggregate-root base, without Cecil's generic-arity marker.</summary>
+    private const string AggregateRootBaseFullName = "MMCA.Common.Domain.Entities.AuditableAggregateRootEntity";
+
+    /// <summary>The auditable-entity base every child of an aggregate derives from, arity stripped.</summary>
+    private const string AuditableEntityBaseFullName = "MMCA.Common.Domain.Entities.AuditableBaseEntity";
+
+    /// <summary>The framework helper that cascades a soft-delete across a child collection.</summary>
+    private const string CascadeHelperName = "DeleteChildren";
+
+    /// <summary>The soft-delete member on the entity base.</summary>
+    private const string DeleteMemberName = "Delete";
+
+    /// <summary>
+    /// The generic collection types a child collection is declared as. A child collection held in
+    /// anything else (a dictionary, a custom collection type) is out of scope rather than
+    /// mis-reported.
+    /// </summary>
+    private static readonly string[] ChildCollectionTypeNames =
+    [
+        "System.Collections.Generic.ICollection`1",
+        "System.Collections.Generic.IReadOnlyCollection`1",
+        "System.Collections.Generic.List`1",
+        "System.Collections.Generic.IList`1",
+        "System.Collections.Generic.IReadOnlyList`1",
+        "System.Collections.Generic.HashSet`1",
+    ];
+
+    /// <summary>
+    /// Soft-delete does not cascade by itself. Setting <c>IsDeleted = true</c> on an aggregate root
+    /// hides the root behind the global query filter and leaves every child row ACTIVE: an order line
+    /// of a deleted order, a session of a deleted event. Nothing reads those rows through the root any
+    /// more, so the orphans are invisible until a report, an export or a per-child query surfaces them,
+    /// and an erasure request that walks the child table finds data whose owner was "deleted" months
+    /// ago. The database cannot help either, because a soft delete is an ordinary UPDATE: there is no
+    /// <c>ON DELETE CASCADE</c> to fire.
+    /// <para>
+    /// This rule fails when an aggregate root that OWNS children does not cascade the delete to them:
+    /// every type deriving from <c>AuditableAggregateRootEntity&lt;T&gt;</c> that declares a collection
+    /// of <c>AuditableBaseEntity&lt;T&gt;</c> children must declare a <c>Delete()</c> override whose
+    /// body deletes those children, either through the framework's
+    /// <c>DeleteChildren&lt;TChild, TChildId&gt;</c> helper or by calling the child's own
+    /// <c>Delete()</c>.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>How it looks.</b> Neither NetArchTest nor reflection can see a CALL inside a method body, so
+    /// the rule reads the IL of every assembly the map registers (through the Mono.Cecil already
+    /// carried by NetArchTest) and inspects the <c>Delete()</c> override's <c>call</c>/<c>callvirt</c>
+    /// operands. Bases and callees are matched by full NAME with the generic arity stripped, so the
+    /// package keeps its deliberate zero-reference stance toward the framework it governs, and an
+    /// aggregate whose base lives in an assembly the map does not register is still recognized.
+    /// </para>
+    /// <para>
+    /// <b>What counts as a child collection.</b> An instance field declared on the aggregate whose type
+    /// is one of <see cref="ChildCollectionTypeNames"/> over an element type deriving from
+    /// <c>AuditableBaseEntity&lt;T&gt;</c>. Auto-properties are covered by the same pass, because an
+    /// auto-property IS a compiler-generated instance field (the backing field's name is normalized
+    /// back to the property name for the report). The aggregate's own <c>_domainEvents</c> is not a
+    /// child collection twice over: it is declared on the base rather than on the aggregate, and
+    /// <c>IDomainEvent</c> is not an entity.
+    /// </para>
+    /// <para>
+    /// <b>What counts as cascading.</b> A direct call, inside the <c>Delete()</c> override, to
+    /// <c>DeleteChildren</c> (the helper on the aggregate base), or to a zero-argument <c>Delete</c> on
+    /// something other than <see langword="this"/>. The second form is what a hand-rolled
+    /// <c>foreach (var line in _lines) line.Delete();</c> compiles to. <c>base.Delete()</c> is
+    /// deliberately NOT accepted: C# emits it as a non-virtual <c>call</c> to a virtual method, which
+    /// nothing else in C# produces, so the rule can tell "delete myself" from "delete my children"
+    /// without guessing.
+    /// </para>
+    /// <para>
+    /// <b>Allowlist entries</b> are type full names (<c>Some.Ns.Domain.Basket</c>) or namespaces
+    /// (<c>Some.Ns.Domain.Legacy</c>); a namespace entry covers everything under it. Matching is
+    /// ordinal and case-sensitive, exactly as <see cref="HardDeletesOnlyInAllowedTypes"/> matches.
+    /// </para>
+    /// <para>
+    /// <b>Limits.</b> (1) Only DIRECT calls in the override are read, the same visibility limit the
+    /// hard-delete rule documents: an aggregate that delegates the loop to a private helper is
+    /// reported, and inlining the loop (or calling <c>DeleteChildren</c>) is the fix. (2) The rule
+    /// proves that a cascade EXISTS, not that it covers every collection: an aggregate with two child
+    /// collections that cascades only one passes here, and a unit test on the aggregate is what pins
+    /// the second. (3) Only fields declared ON the aggregate are inspected, so a collection inherited
+    /// from an intermediate abstract entity is out of scope. (4) Children reached by navigation from a
+    /// child (grandchildren) are the child's own cascade to own.
+    /// </para>
+    /// </remarks>
+    /// <param name="map">The repo's architecture map.</param>
+    /// <param name="allowedTypes">
+    /// Type full names or namespace prefixes where NOT cascading is the deliberate, reviewed choice.
+    /// An empty list requires every child-bearing aggregate to cascade.
+    /// </param>
+    public static void AggregatesCascadeSoftDeleteToChildren(
+        IArchitectureMap map,
+        IReadOnlyCollection<string> allowedTypes)
+    {
+        ArgumentNullException.ThrowIfNull(map);
+        ArgumentNullException.ThrowIfNull(allowedTypes);
+
+        var modules = new List<ModuleDefinition>();
+        try
+        {
+            foreach (var location in ScannableAssemblyLocations(map))
+            {
+                modules.Add(ModuleDefinition.ReadModule(location));
+            }
+
+            var index = new CallGraphIndex(modules);
+
+            var violations = index.Types
+                .Where(type => type is { IsClass: true, IsAbstract: false }
+                    && !IsAllowed(type.FullName, allowedTypes)
+                    && DerivesFrom(index, type, AggregateRootBaseFullName))
+                .Select(type => (Aggregate: type, Collections: ChildCollectionsOf(type, index)))
+                .Where(found => found.Collections.Count > 0)
+                .Select(found => DescribeCascadeGap(found.Aggregate, found.Collections))
+                .OfType<string>()
+                .Order(StringComparer.Ordinal)
+                .ToList();
+
+            ArchitectureAssert.NoViolations(violations,
+                "a soft-delete is an ordinary UPDATE, so it does not cascade: an aggregate root that "
+                    + "owns children must delete them in its own Delete() override, through "
+                    + "DeleteChildren<TChild, TChildId>(...) or by calling each child's Delete(). "
+                    + "Without it the root disappears behind the query filter and its child rows stay "
+                    + "active and orphaned, invisible to every read through the root but still present "
+                    + "for exports, reports and erasure requests");
+        }
+        finally
+        {
+            foreach (var module in modules)
+            {
+                module.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The violation line for an aggregate that owns children, or null when it cascades correctly.
+    /// </summary>
+    private static string? DescribeCascadeGap(TypeDefinition aggregate, IReadOnlyCollection<string> collections)
+    {
+        var names = string.Join(", ", collections);
+
+        var deleteOverride = aggregate.Methods.FirstOrDefault(m =>
+            !m.IsStatic
+            && m.HasBody
+            && m.Parameters.Count == 0
+            && string.Equals(m.Name, DeleteMemberName, StringComparison.Ordinal));
+
+        if (deleteOverride is null)
+        {
+            return $"  - {aggregate.FullName}: no Delete() override, so its children ({names}) stay active";
+        }
+
+        return CascadesToChildren(deleteOverride)
+            ? null
+            : $"  - {aggregate.FullName}: Delete() never deletes a child, so its children ({names}) stay active";
+    }
+
+    /// <summary>
+    /// True when the override's own IL cascades: a call to the <c>DeleteChildren</c> helper, or a
+    /// zero-argument <c>Delete</c> invoked on something other than <see langword="this"/>.
+    /// </summary>
+    private static bool CascadesToChildren(MethodDefinition deleteOverride) =>
+        deleteOverride.Body.Instructions.Any(instruction =>
+            instruction.Operand is MethodReference callee
+            && (string.Equals(callee.Name, CascadeHelperName, StringComparison.Ordinal)
+                || IsChildDeleteCall(instruction, callee)));
+
+    /// <summary>
+    /// True when the instruction deletes a CHILD: a zero-argument <c>Delete</c> reached virtually.
+    /// <c>base.Delete()</c> is the one thing C# compiles to a non-virtual <c>call</c> on a virtual
+    /// member, so excluding that opcode separates "delete myself" from "delete my children" exactly.
+    /// </summary>
+    private static bool IsChildDeleteCall(Instruction instruction, MethodReference callee) =>
+        string.Equals(callee.Name, DeleteMemberName, StringComparison.Ordinal)
+        && callee.Parameters.Count == 0
+        && instruction.OpCode == OpCodes.Callvirt;
+
+    /// <summary>
+    /// The names of the aggregate's own child-entity collections, with auto-property backing fields
+    /// reported under their property name.
+    /// </summary>
+    private static IReadOnlyCollection<string> ChildCollectionsOf(TypeDefinition aggregate, CallGraphIndex index) =>
+        [.. aggregate.Fields
+            .Where(field => !field.IsStatic && IsChildEntityCollection(field.FieldType, index))
+            .Select(field => DeclaredMemberName(field.Name))
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)];
+
+    /// <summary>True when the type is a generic collection over an auditable child entity.</summary>
+    private static bool IsChildEntityCollection(TypeReference fieldType, CallGraphIndex index)
+    {
+        if (fieldType is not GenericInstanceType collection
+            || collection.GenericArguments.Count != 1
+            || !ChildCollectionTypeNames.Contains(collection.ElementType.FullName, StringComparer.Ordinal))
+        {
+            return false;
+        }
+
+        var element = index.Find(collection.GenericArguments[0]);
+        return element is not null && DerivesFrom(index, element, AuditableEntityBaseFullName);
+    }
+
+    /// <summary>
+    /// True when any base type of <paramref name="type"/> carries the given full name once the
+    /// generic-arity marker is stripped. The comparison is by NAME, so a base declared in an assembly
+    /// outside the scan is still recognized; only the walk THROUGH such a base stops.
+    /// </summary>
+    private static bool DerivesFrom(CallGraphIndex index, TypeDefinition type, string baseFullName)
+    {
+        for (var current = type; current?.BaseType is not null; current = index.Find(current.BaseType))
+        {
+            if (string.Equals(WithoutArity(CallGraphIndex.ElementFullName(current.BaseType)), baseFullName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>A full name with Cecil's generic-arity marker removed (<c>Foo`1</c> to <c>Foo</c>).</summary>
+    private static string WithoutArity(string fullName)
+    {
+        var tick = fullName.IndexOf('`', StringComparison.Ordinal);
+        return tick >= 0 ? fullName[..tick] : fullName;
+    }
+
+    /// <summary>
+    /// The source-level member name behind a field: an auto-property's backing field is named
+    /// <c>&lt;Lines&gt;k__BackingField</c> in metadata and is reported as <c>Lines</c>.
+    /// </summary>
+    private static string DeclaredMemberName(string fieldName)
+    {
+        if (!fieldName.StartsWith('<'))
+        {
+            return fieldName;
+        }
+
+        var close = fieldName.IndexOf('>', StringComparison.Ordinal);
+        return close > 1 ? fieldName[1..close] : fieldName;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/CascadeSoftDeleteConventionTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/CascadeSoftDeleteConventionTestsBase.cs
@@ -1,0 +1,32 @@
+namespace MMCA.Common.Testing.Architecture;
+
+/// <summary>
+/// Cascade-soft-delete fitness function: an aggregate root that owns child entities must delete them
+/// in its own <c>Delete()</c> override. A soft delete is an ordinary UPDATE, so nothing cascades for
+/// free: the root vanishes behind the global query filter while its child rows stay ACTIVE, orphaned
+/// and unreachable through the root, yet still present for exports, reports and erasure requests.
+/// The framework's <c>DeleteChildren&lt;TChild, TChildId&gt;(...)</c> helper is the one-line fix; a
+/// hand-rolled loop over the children counts too.
+/// <para>
+/// Adoption in a repo with existing aggregates: subclass, run once, and move each reported type into
+/// a fix (add or extend the <c>Delete()</c> override) or into
+/// <see cref="AllowedCascadeExemptTypes"/> with a comment saying why the children are meant to
+/// outlive the root. The exemption list is the point of the rule: it turns "delete cascades, mostly"
+/// into a reviewed inventory of every aggregate that leaves children behind on purpose.
+/// </para>
+/// </summary>
+public abstract class CascadeSoftDeleteConventionTestsBase
+{
+    protected abstract IArchitectureMap Map { get; }
+
+    /// <summary>
+    /// Type full names (<c>MMCA.X.Catalog.Domain.Basket</c>) or namespace prefixes
+    /// (<c>MMCA.X.Catalog.Domain.Legacy</c>) whose child entities deliberately survive the root's
+    /// soft-delete. Empty by default, which requires every child-bearing aggregate to cascade.
+    /// </summary>
+    protected virtual IReadOnlyCollection<string> AllowedCascadeExemptTypes => [];
+
+    [Fact]
+    public void AggregatesWithChildCollections_MustCascadeSoftDelete_InDelete() =>
+        ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(Map, AllowedCascadeExemptTypes);
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
@@ -5,6 +5,9 @@ MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AnonymousEndpointTes
 MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AnonymousEndpoints() -> System.Collections.Generic.IEnumerable<string!>!
 MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AnonymousEndpoints_AreAllowListed() -> void
 MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.ScannedEndpointSet_IsNotEmpty() -> void
+MMCA.Common.Testing.Architecture.CascadeSoftDeleteConventionTestsBase
+MMCA.Common.Testing.Architecture.CascadeSoftDeleteConventionTestsBase.AggregatesWithChildCollections_MustCascadeSoftDelete_InDelete() -> void
+MMCA.Common.Testing.Architecture.CascadeSoftDeleteConventionTestsBase.CascadeSoftDeleteConventionTestsBase() -> void
 MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase
 MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.CommandInventory_ShouldNotBe_Empty() -> void
 MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.CommandValidatorCoverageTestsBase() -> void
@@ -40,6 +43,7 @@ MMCA.Common.Testing.Architecture.SortableColumnConventionTestsBase.SortableColum
 MMCA.Common.Testing.Architecture.SortableColumnConventionTestsBase.SortableColumns_ShouldNotBe_TemplateColumns() -> void
 abstract MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.AllowedAnonymousEndpoints.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 abstract MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.TargetAssemblies.get -> System.Collections.Generic.IReadOnlyCollection<System.Reflection.Assembly!>!
+abstract MMCA.Common.Testing.Architecture.CascadeSoftDeleteConventionTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
 abstract MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
 abstract MMCA.Common.Testing.Architecture.ConcurrencyConventionTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
 abstract MMCA.Common.Testing.Architecture.ContractImplementationTestsBase.Map.get -> MMCA.Common.Testing.Architecture.IArchitectureMap!
@@ -53,6 +57,7 @@ const MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractAttribut
 static MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.IsController(System.Type! type) -> bool
 static MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.IsRoutableComponent(System.Type! type) -> bool
 static MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.IsScannedEndpointType(System.Type! type) -> bool
+static MMCA.Common.Testing.Architecture.ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedTypes) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.CommandsHaveValidators(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedTypesAndNamespaces) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.DistinctErrorCodeCount(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> int
 static MMCA.Common.Testing.Architecture.ArchitectureRules.DomainEventHandlersDoNotSave(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedTypesAndNamespaces, int maxCallDepth = 6) -> void
@@ -69,6 +74,7 @@ static MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractsDoNotD
 static MMCA.Common.Testing.Architecture.ArchitectureRules.SortableGridColumnsUsePropertyColumn(System.Collections.Generic.IReadOnlyCollection<string!>! markupRoots) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.UpdateRequestsAreNotConcurrencyAware(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 virtual MMCA.Common.Testing.Architecture.AnonymousEndpointTestsBase.MinimumScannedTypes.get -> int
+virtual MMCA.Common.Testing.Architecture.CascadeSoftDeleteConventionTestsBase.AllowedCascadeExemptTypes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 virtual MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.AllowedUnvalidatedCommands.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 virtual MMCA.Common.Testing.Architecture.CommandValidatorCoverageTestsBase.MinimumCommands.get -> int
 virtual MMCA.Common.Testing.Architecture.ContractImplementationTestsBase.AllowedPublicImplementations.get -> System.Collections.Generic.IReadOnlyCollection<string!>!

--- a/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitComponentTestBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.UI/Infrastructure/BunitComponentTestBase.cs
@@ -62,6 +62,12 @@ public abstract class BunitComponentTestBase : BunitContext
         // resources in the component's own assembly) without per-test setup.
         Services.AddLogging();
         Services.AddLocalization();
+
+        // The clock components measure staleness against (the notification bell's poll interval and
+        // navigation-refresh window, §19). TryAdd so a test that drives time deterministically
+        // registers a FakeTimeProvider of its own; AddLogging above already brought in the options
+        // infrastructure, so IOptions<T> of an unconfigured settings class resolves to its defaults.
+        Services.TryAddSingleton(TimeProvider.System);
     }
 
     /// <summary>

--- a/Source/Presentation/MMCA.Common.UI.Web/Security/BlazorCspPolicyProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI.Web/Security/BlazorCspPolicyProvider.cs
@@ -13,8 +13,11 @@ namespace MMCA.Common.UI.Web.Security;
 /// configured API/Gateway origin (https + wss) from <see cref="ApiSettings"/>
 /// (<c>WasmApiEndpoint</c> ?? <c>ApiEndpoint</c>): <c>'self'</c> covers the Blazor Server interactive
 /// circuit's same-origin WebSocket; the Gateway origin covers cross-origin API calls and the SignalR
-/// notification hub. If the endpoint cannot be resolved/parsed, the CSP degrades to a permissive
-/// <c>Report-Only</c> policy so a misconfiguration can never hard-break the app in production.
+/// notification hub. If the endpoint cannot be resolved/parsed, the policy <b>fails closed</b>: the rest
+/// of the policy is unchanged but <c>connect-src</c> narrows to <c>'self'</c> and the policy is still
+/// enforced. A misconfigured endpoint therefore surfaces immediately as blocked API calls in the browser
+/// console, instead of as a permissive Report-Only header that protects nothing and that nobody notices;
+/// a security response header that quietly stops being enforced is the worse failure mode.
 /// Hoisted from the app Blazor Web hosts (byte-identical there); register via
 /// <c>AddCommonBlazorCsp()</c> BEFORE <c>AddCommonSecurityHeaders</c>.
 /// </summary>
@@ -33,8 +36,8 @@ internal sealed class BlazorCspPolicyProvider : ICspPolicyProvider
     /// <inheritdoc />
     public CspPolicy? GetPolicy(HttpContext context) => _policy;
 
-    // Builds the CSP. When the API/Gateway origin can be pinned, the policy is enforced; otherwise it
-    // degrades to a permissive Report-Only policy (never enforce a CSP we can't construct correctly).
+    // Builds the CSP. When the API/Gateway origin can be pinned, connect-src carries it; otherwise the
+    // policy fails closed on the strictest connect-src we can be sure of ('self') and stays enforced.
     private static CspPolicy BuildCsp(ApiSettings api, bool isDevelopment)
     {
         var endpoint = api.WasmApiEndpoint ?? api.ApiEndpoint;
@@ -46,7 +49,9 @@ internal sealed class BlazorCspPolicyProvider : ICspPolicyProvider
             !string.Equals(apiUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
             !string.Equals(apiUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
-            return new CspPolicy(BuildPolicy("connect-src 'self' https: wss:", isDevelopment), Enforce: false);
+            // Fail closed: an endpoint we cannot parse is a misconfiguration, and the honest signal is
+            // blocked cross-origin calls in the console rather than a policy that is emitted but inert.
+            return new CspPolicy(BuildPolicy("connect-src 'self'", isDevelopment), Enforce: true);
         }
 
         // scheme://host:port for the API/Gateway, plus its WebSocket origin (SignalR notification hub).

--- a/Source/Presentation/MMCA.Common.UI/Common/NotificationRoutePaths.cs
+++ b/Source/Presentation/MMCA.Common.UI/Common/NotificationRoutePaths.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace MMCA.Common.UI.Common;
 
 /// <summary>
@@ -8,4 +10,14 @@ public static class NotificationRoutePaths
     public static readonly string Notifications = "/notifications";
     public static readonly string NotificationSend = "/notifications/send";
     public static readonly string NotificationInbox = "/notifications/inbox";
+
+    /// <summary>
+    /// Builds the typed deep link to one notification in the inbox
+    /// (<c>/notifications/inbox/{Id:int}</c>). The route's <c>:int</c> constraint is the validation
+    /// boundary, so this formats invariantly: a culture that renders digit groups or non-ASCII
+    /// digits would produce a URL the constraint rejects.
+    /// </summary>
+    /// <param name="id">The user notification to open.</param>
+    public static string NotificationInboxItem(UserNotificationIdentifierType id) =>
+        string.Create(CultureInfo.InvariantCulture, $"{NotificationInbox}/{id}");
 }

--- a/Source/Presentation/MMCA.Common.UI/Common/Settings/NotificationBellOptions.cs
+++ b/Source/Presentation/MMCA.Common.UI/Common/Settings/NotificationBellOptions.cs
@@ -1,0 +1,30 @@
+namespace MMCA.Common.UI.Common.Settings;
+
+/// <summary>
+/// Strongly-typed options bound to the <c>"NotificationBell"</c> configuration section: how often the
+/// unread badge re-reads the API, and how old its count may be before a navigation re-reads it.
+/// <para>
+/// Both numbers used to be compiled in (a hardcoded thirty-second timer, and a refresh on EVERY
+/// navigation). Stating them here makes the badge's staleness a host decision: a deployment paying
+/// per API call widens the poll, a deployment where an unread count must feel instant narrows it.
+/// </para>
+/// </summary>
+public sealed class NotificationBellOptions
+{
+    /// <summary>Configuration section name used for binding.</summary>
+    public static readonly string SectionName = "NotificationBell";
+
+    /// <summary>
+    /// How often the single active bell re-reads the authoritative unread count. The periodic read is
+    /// the backstop behind the real-time push, not the primary path, so this is the budget for "how
+    /// long a missed push may go unnoticed".
+    /// </summary>
+    public TimeSpan PollInterval { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How old the count may be for a navigation to accept it. A page change used to force an
+    /// unconditional read, so a user clicking through five pages in ten seconds issued five reads for
+    /// a number that had not moved; within this window the badge now keeps the count it has.
+    /// </summary>
+    public TimeSpan NavigationRefreshMaxAge { get; init; } = TimeSpan.FromSeconds(30);
+}

--- a/Source/Presentation/MMCA.Common.UI/Common/Settings/UiReadCacheOptions.cs
+++ b/Source/Presentation/MMCA.Common.UI/Common/Settings/UiReadCacheOptions.cs
@@ -1,0 +1,42 @@
+namespace MMCA.Common.UI.Common.Settings;
+
+/// <summary>
+/// Strongly-typed options bound to the <c>"UiReadCache"</c> configuration section: the explicit
+/// client-side staleness policy for <see cref="MMCA.Common.UI.Services.Caching.IUiReadCache"/>.
+/// <para>
+/// The point of stating it in configuration is that staleness becomes a decision a host records
+/// rather than an accident of how often a component happens to re-render. A host that wants every
+/// read to hit the API sets <see cref="Enabled"/> to <see langword="false"/>; a host with reference
+/// data that changes hourly gives that route prefix its own, much longer, TTL.
+/// </para>
+/// </summary>
+public sealed class UiReadCacheOptions
+{
+    /// <summary>Configuration section name used for binding.</summary>
+    public static readonly string SectionName = "UiReadCache";
+
+    /// <summary>
+    /// Whether the read cache serves and stores anything. <see langword="false"/> turns every lookup
+    /// into a miss and every store into a no-op, so the services behave exactly as they did before a
+    /// cache was registered (the framework's own escape hatch for a host that wants no client-side
+    /// staleness at all).
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Freshness budget applied to any read whose URL matches no entry in
+    /// <see cref="RoutePrefixTtls"/>. Sixty seconds is short enough that a stale list corrects itself
+    /// within one user's attention span, and long enough to collapse the burst of identical reads a
+    /// page issues while it mounts.
+    /// </summary>
+    public TimeSpan DefaultTtl { get; init; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Per-route-prefix TTL overrides, keyed by the leading part of the relative URL (e.g.
+    /// <c>countries</c>). The LONGEST matching prefix wins, so a specific child route can state a
+    /// different budget than the endpoint it sits under. Getter-only so the configuration binder
+    /// populates the instance the defaults created, which is how the other settings classes in this
+    /// namespace shape their bindable collections.
+    /// </summary>
+    public Dictionary<string, TimeSpan> RoutePrefixTtls { get; } = [];
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationBell.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationBell.razor.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using MMCA.Common.UI.Common;
+using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Resources;
 using MMCA.Common.UI.Services.Notifications;
 
@@ -10,6 +12,12 @@ namespace MMCA.Common.UI.Components.Notifications;
 /// Code-behind for the notification bell: renders the unread badge from the scoped
 /// <see cref="NotificationState"/>, and one instance at a time holds the single active-poller slot
 /// (periodic + on-navigation refresh) so duplicate bell placements never duplicate API calls.
+/// <para>
+/// Its staleness policy is explicit and configurable (<see cref="NotificationBellOptions"/>): the
+/// first read and the periodic tick are unconditional, a navigation reads only when the count is
+/// older than the configured window, and a real-time push marks the count stale and reads
+/// regardless. Both the timer and the age comparison run off the injected <see cref="TimeProvider"/>.
+/// </para>
 /// </summary>
 /// <remarks>
 /// Hosts commonly render the bell twice (a desktop app bar and a mobile nav) inside
@@ -21,12 +29,12 @@ namespace MMCA.Common.UI.Components.Notifications;
 /// </remarks>
 public partial class NotificationBell : IDisposable
 {
-    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
-
     [Inject] private NotificationState State { get; set; } = default!;
     [Inject] private INotificationInboxUIService InboxService { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
     [Inject] private IStringLocalizer<SharedResource> L { get; set; } = default!;
+    [Inject] private IOptions<NotificationBellOptions> Options { get; set; } = default!;
+    [Inject] private TimeProvider Clock { get; set; } = default!;
 
     private readonly CancellationTokenSource _cts = new();
     private PeriodicTimer? _pollTimer;
@@ -66,9 +74,13 @@ public partial class NotificationBell : IDisposable
 
         _isActivePoller = true;
         NavigationManager.LocationChanged += OnLocationChanged;
+
+        // The first read is unconditional: nothing has established the count yet.
         await RefreshUnreadCountAsync();
 
-        _pollTimer = new PeriodicTimer(PollInterval);
+        // The TimeProvider overload rather than the ambient system clock, so a test drives the loop
+        // deterministically instead of waiting out a real interval.
+        _pollTimer = new PeriodicTimer(Options.Value.PollInterval, Clock);
         _ = PollLoopAsync();
     }
 
@@ -114,18 +126,39 @@ public partial class NotificationBell : IDisposable
         }
     }
 
-    // Event-handler signature; the refresh task observes its own failures internally (catch-all),
-    // so the explicit discard is safe and avoids the async-void crash-the-process mode (VSTHRD100).
-    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e) =>
-        _ = RefreshUnreadCountAsync();
+    /// <summary>
+    /// Navigation is an ambient trigger, not evidence that the count moved: it fires on every page
+    /// change, and a user clicking through a menu used to issue one API read per click for a number
+    /// that had not changed. The read now happens only when the count is actually old enough
+    /// (<see cref="NotificationBellOptions.NavigationRefreshMaxAge"/>).
+    /// </summary>
+    /// <remarks>
+    /// Event-handler signature; the refresh task observes its own failures internally (catch-all),
+    /// so the explicit discard is safe and avoids the async-void crash-the-process mode (VSTHRD100).
+    /// </remarks>
+    private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        if (State.IsStale(Options.Value.NavigationRefreshMaxAge))
+        {
+            _ = RefreshUnreadCountAsync();
+        }
+    }
 
     /// <summary>
     /// Called when NotificationListener receives a SignalR push and requests an API refresh.
     /// This provides a second chance to update the badge if the optimistic IncrementUnreadCount
     /// didn't trigger a re-render (e.g., cross-component InvokeAsync dispatch was dropped).
+    /// <para>
+    /// Unconditional, and it marks the count stale first: the server has just said the data changed,
+    /// so the age of the number carries no information any more. This is the one path that must never
+    /// be throttled by the navigation window.
+    /// </para>
     /// </summary>
-    private void HandleRefreshRequested(object? sender, EventArgs e) =>
+    private void HandleRefreshRequested(object? sender, EventArgs e)
+    {
+        State.MarkStale();
         _ = RefreshUnreadCountAsync();
+    }
 
     private async Task RefreshUnreadCountAsync()
     {

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -9,6 +9,7 @@ using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Globalization;
 using MMCA.Common.UI.Services;
 using MMCA.Common.UI.Services.Auth;
+using MMCA.Common.UI.Services.Caching;
 using MMCA.Common.UI.Services.Capabilities;
 using MMCA.Common.UI.Services.Navigation;
 
@@ -37,6 +38,23 @@ public static class DependencyInjection
             // Bind layout settings (footer text, etc.) — optional, defaults to empty values
             services.AddOptions<LayoutSettings>()
                 .Bind(configuration.GetSection(LayoutSettings.SectionName));
+
+            // Client-side staleness policy (§19). Both sections are optional: an absent section leaves
+            // the compiled-in defaults, which is the behaviour a host gets without configuring anything.
+            services.AddOptions<UiReadCacheOptions>()
+                .Bind(configuration.GetSection(UiReadCacheOptions.SectionName));
+
+            services.AddOptions<NotificationBellOptions>()
+                .Bind(configuration.GetSection(NotificationBellOptions.SectionName));
+
+            // The clock the staleness policy is measured against. TryAdd, because a host that already
+            // registered one (AddInfrastructure does) keeps it, and a test substitutes a FakeTimeProvider.
+            services.TryAddSingleton(TimeProvider.System);
+
+            // Read-through cache over the API client, scoped so it is per-circuit on Blazor Server.
+            // On WebAssembly and MAUI the scope is the app lifetime, which is why the sign-out path
+            // clears it (AuthUIService.LogoutAsync): otherwise one account's reads outlive its session.
+            services.TryAddScoped<IUiReadCache, UiReadCache>();
 
             // Resource-based localization for IStringLocalizer<T> across all UI hosts (ADR-027).
             services.AddLocalization();

--- a/Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs
@@ -83,6 +83,10 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
     // back to an empty grid that the first interactive ServerData call refills.
     private const int PrerenderFetchTimeoutMs = 5000;
 
+    // MudDataGrid v9 puts its height-bound scroll viewport on `.mud-table-container`. A virtualized
+    // grid scrolls THERE, not on the document, so scroll tracking and restore have to follow it.
+    private const string VirtualizedScrollContainerSelector = ".mud-table-container";
+
     private CancellationTokenSource? _cts;
     private bool _disposed;
     private IJSObjectReference? _scrollModule;
@@ -121,6 +125,35 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
     /// (e.g., mobile-only pages).
     /// </summary>
     protected virtual MudDataGrid<TDto>? GridRef => null;
+
+    /// <summary>
+    /// Opt-in switch for MudDataGrid row virtualization. Defaults to <see langword="false"/>, so every
+    /// existing page keeps its pager and its <c>ServerData</c> binding untouched. A page that overrides
+    /// this to <see langword="true"/> binds <c>Virtualize="true"</c>, <c>Height="@VirtualizedGridHeight"</c>,
+    /// <c>ItemSize="VirtualizedItemSize"</c> and <c>VirtualizeServerData</c> (wired to
+    /// <see cref="LoadVirtualizedServerDataAsync"/>) in its markup INSTEAD of <c>ServerData</c>: MudBlazor
+    /// v9 accepts only one of the two funnels, and binding both leaves the grid fetching through the
+    /// pager it no longer renders. Turning this on also disables the pager-restore machinery
+    /// (rows-per-page / current-page restoration and the <c>p</c>/<c>ps</c> URL mirror), which has no
+    /// meaning without a pager; sort, filter and density persistence still apply.
+    /// </summary>
+    protected virtual bool VirtualizeGrid => false;
+
+    /// <summary>
+    /// The CSS height bound to <c>Height</c> on a virtualized grid. MudDataGrid v9 virtualizes only when
+    /// <c>Height</c> is set (the scroll viewport is what bounds the rendered window), so this is
+    /// mandatory rather than cosmetic. Defaults to <c>70vh</c>, which leaves room for the page header and
+    /// toolbar on a laptop viewport; override for a page whose chrome is taller or shorter.
+    /// </summary>
+    protected virtual string VirtualizedGridHeight => "70vh";
+
+    /// <summary>
+    /// The row height in pixels bound to <c>ItemSize</c> on a virtualized grid. MudBlazor sizes the
+    /// spacer elements above and below the rendered window from this number, so a value far from the
+    /// real rendered row height makes the scrollbar drift and the fetch window overshoot. Defaults to
+    /// <c>52</c>, the comfortable-density MudDataGrid row height; a dense grid is nearer <c>36</c>.
+    /// </summary>
+    protected virtual int VirtualizedItemSize => 52;
 
     /// <summary>
     /// Reads URL query string as the source of truth for paging, sort, and filter state,
@@ -245,7 +278,13 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
         {
             if (GridRef is { } grid)
             {
-                ApplyCurrentPageFromUrl(grid, urlState.Page);
+                // A virtualized grid renders no pager, so there is no CurrentPage to re-apply; the
+                // reload alone re-reads the restored sort/filters.
+                if (!VirtualizeGrid)
+                {
+                    ApplyCurrentPageFromUrl(grid, urlState.Page);
+                }
+
                 await grid.ReloadServerData();
             }
             StateHasChanged();
@@ -321,7 +360,8 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
                 "enableScrollTracking",
                 _dotNetRef,
                 _scrollTrackerId,
-                150);
+                150,
+                ScrollContainerSelector);
 
             await RestoreGridStateAsync(needsSessionRestore);
 
@@ -335,11 +375,18 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
         if (_pendingScrollRestore is { } pending && !IsLoading && _scrollModule is not null)
         {
             _pendingScrollRestore = null;
-            await _scrollModule.InvokeVoidAsync("setScrollPosition", pending);
+            await _scrollModule.InvokeVoidAsync("setScrollPosition", pending, ScrollContainerSelector);
         }
 
         await base.OnAfterRenderAsync(firstRender);
     }
+
+    /// <summary>
+    /// The element whose <c>scrollTop</c> is tracked and restored: the grid's own scroll viewport when
+    /// virtualization is on (the document itself does not scroll then, because the grid is height-bound),
+    /// otherwise <see langword="null"/> for the document scroller.
+    /// </summary>
+    private string? ScrollContainerSelector => VirtualizeGrid ? VirtualizedScrollContainerSelector : null;
 
     /// <summary>
     /// Invoked from JS by the debounced scroll listener whenever the user scrolls.
@@ -394,6 +441,20 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
     /// </summary>
     private async Task RestoreGridStateAsync(bool needsReload)
     {
+        // Single entry point for the pager-restore machinery, so opting into virtualization skips it
+        // in ONE place instead of guarding each step: a virtualized grid renders no pager, so
+        // RowsPerPage and CurrentPage carry no meaning there. A session-driven reload is still needed
+        // (sort/filters were restored after the first fetch returned defaults).
+        if (VirtualizeGrid)
+        {
+            if (needsReload && GridRef is { } virtualizedGrid)
+            {
+                await virtualizedGrid.ReloadServerData();
+            }
+
+            return;
+        }
+
         // SAFETY NET: even though we pass RowsPerPage as a parameter (so the pager init sees
         // the saved size), MudDataGrid v9's parameter setter is one-shot and queues an
         // InvokeAsync that may not propagate the value to _rowsPerPage in time for the first
@@ -455,7 +516,7 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
             _persistedGridData = null;
             _lastSuccessfulGridData = cached;
 
-            var (sc, sd) = ResolveSortParameters(state);
+            var (sc, sd) = ResolveSortParameters(state.SortDefinitions);
             SaveCurrentState(state.Page, state.PageSize, sc, string.Equals(sd, "desc", StringComparison.OrdinalIgnoreCase));
             return cached;
         }
@@ -468,17 +529,18 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
         // backend can't block prerendering — and therefore the page load / navigation — indefinitely (the
         // dominant cause of E2E navigation timeouts). On timeout the fetch throws OperationCanceledException
         // and we return an empty grid; the first INTERACTIVE ServerData call then loads the real data.
-        using var fetchCts = CreateFetchCts();
+        // No extra token to link: the paged funnel has no per-request token of its own.
+        using var fetchCts = CreateFetchCts(CancellationToken.None);
 
         // Filter and sort extraction run INSIDE the try: the caller's additionalFilters callback is
         // arbitrary page code, and a throw from it (or from the extraction itself) used to escape
         // past the finally, stranding IsLoading at true and leaving the grid spinning forever.
         try
         {
-            var filters = ExtractGridFilters(state);
+            var filters = ExtractGridFilters(state.FilterDefinitions);
             additionalFilters?.Invoke(filters);
 
-            var (sortColumn, sortDirection) = ResolveSortParameters(state);
+            var (sortColumn, sortDirection) = ResolveSortParameters(state.SortDefinitions);
 
             var fetched = await fetchAsync(filters, state.Page + 1, state.PageSize, sortColumn, sortDirection, fetchCts.Token);
             if (!fetched.TryGetValue(out var page))
@@ -517,14 +579,139 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
     }
 
     /// <summary>
+    /// The <c>VirtualizeServerData</c> counterpart of <see cref="LoadServerDataAsync"/>: it manages the
+    /// <see cref="CancellationTokenSource"/>, loading/failure state and error toast identically, but maps
+    /// the row window MudBlazor asks for (<c>[StartIndex, StartIndex + Count)</c>) onto the same
+    /// page-based fetch delegate, so a page can switch to virtualization without a second API contract.
+    /// </summary>
+    /// <param name="state">Virtualized grid state provided by MudDataGrid.</param>
+    /// <param name="fetchAsync">
+    /// Delegate that performs the actual data fetch. Receives: filters, pageNumber, pageSize,
+    /// sortColumn, sortDirection, cancellationToken. Called twice when the requested window straddles
+    /// two pages (see <see cref="ComputeVirtualWindow"/>).
+    /// </param>
+    /// <param name="additionalFilters">
+    /// Optional action to inject extra filters (e.g., search string, status dropdown) before the fetch.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// The token MudBlazor hands the <c>VirtualizeServerData</c> callback (it cancels a window that the
+    /// user has already scrolled past). Forward it so a superseded fetch stops at the API boundary too;
+    /// omitting it still works, because the base class supersedes its own previous fetch on every call.
+    /// </param>
+    /// <remarks>
+    /// Cancellation is ALWAYS silent here, unlike the paged path: a virtualized grid supersedes its own
+    /// in-flight fetch on every scroll burst, so a cancel toast would fire continuously during normal
+    /// scrolling and say nothing the user needs to act on.
+    /// </remarks>
+    protected async Task<GridData<TDto>> LoadVirtualizedServerDataAsync(
+        GridStateVirtualize<TDto> state,
+        Func<Dictionary<string, (string Operator, string Value)>, int, int, string?, string?, CancellationToken, Task<Result<(IReadOnlyList<TDto> Items, int TotalItems)>>> fetchAsync,
+        Action<Dictionary<string, (string Operator, string Value)>>? additionalFilters = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(fetchAsync);
+
+        await ResetCancellationTokenAsync();
+
+        IsLoading = true;
+        LoadFailed = false;
+        StateHasChanged();
+
+        using var fetchCts = CreateFetchCts(cancellationToken);
+
+        try
+        {
+            var filters = ExtractGridFilters(state.FilterDefinitions);
+            additionalFilters?.Invoke(filters);
+
+            var (sortColumn, sortDirection) = ResolveSortParameters(state.SortDefinitions);
+            var window = ComputeVirtualWindow(state.StartIndex, state.Count);
+
+            var fetched = await fetchAsync(filters, window.FirstPage, window.PageSize, sortColumn, sortDirection, fetchCts.Token);
+            if (!fetched.TryGetValue(out var page))
+            {
+                fetched.NotifyOnFailure(Toast, Localizer);
+                LoadFailed = true;
+                return new GridData<TDto> { Items = [], TotalItems = 0 };
+            }
+
+            var items = page.Items;
+            if (window.NeedsSecondPage)
+            {
+                var continued = await fetchAsync(filters, window.FirstPage + 1, window.PageSize, sortColumn, sortDirection, fetchCts.Token);
+                if (!continued.TryGetValue(out var nextPage))
+                {
+                    continued.NotifyOnFailure(Toast, Localizer);
+                    LoadFailed = true;
+                    return new GridData<TDto> { Items = [], TotalItems = 0 };
+                }
+
+                items = [.. items, .. nextPage.Items];
+            }
+
+            // Trim to exactly the requested window; the tail of the data set legitimately yields fewer.
+            var slice = items.Skip(window.Offset).Take(Math.Max(state.Count, 0)).ToList();
+            SaveCurrentState(0, 0, sortColumn, string.Equals(sortDirection, "desc", StringComparison.OrdinalIgnoreCase));
+            return new GridData<TDto> { Items = slice, TotalItems = page.TotalItems };
+        }
+        catch (OperationCanceledException)
+        {
+            // Deliberately silent — see the remarks above.
+            return new GridData<TDto> { Items = [], TotalItems = 0 };
+        }
+        catch (Exception ex)
+        {
+            Toast.Error(ErrorMessages.LoadError(Title, ex));
+            LoadFailed = true;
+            return new GridData<TDto> { Items = [], TotalItems = 0 };
+        }
+        finally
+        {
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Maps a virtualization row window onto the page-based fetch contract. The window's own size
+    /// becomes the page size, so an aligned window (<paramref name="startIndex"/> a multiple of
+    /// <paramref name="count"/>) is exactly one page and needs one fetch; an unaligned window spills
+    /// into the following page, which is fetched too and concatenated before the caller slices
+    /// <c>Offset</c> rows off the front.
+    /// </summary>
+    /// <param name="startIndex">Zero-based index of the first requested row.</param>
+    /// <param name="count">Number of requested rows. Zero or less is clamped to a page size of 1.</param>
+    /// <returns>
+    /// The 1-based first page to fetch, the page size to fetch it with, how many leading rows of that
+    /// page fall before the window, and whether the following page is needed as well.
+    /// </returns>
+    internal static (int FirstPage, int PageSize, int Offset, bool NeedsSecondPage) ComputeVirtualWindow(int startIndex, int count)
+    {
+        var pageSize = Math.Max(count, 1);
+        var start = Math.Max(startIndex, 0);
+        var offset = start % pageSize;
+
+        var firstPage = start / pageSize + 1;
+
+        return (firstPage, pageSize, offset, offset > 0);
+    }
+
+    /// <summary>
     /// Builds the cancellation token source for a <c>ServerData</c> fetch. Always linked to the active
     /// request token; during SSR pre-render (non-interactive) it additionally times out after
     /// <see cref="PrerenderFetchTimeoutMs"/> so a cold or unreachable backend cannot block prerendering
     /// (and therefore the page load) indefinitely. The caller owns disposal via a <see langword="using"/> statement.
     /// </summary>
-    private CancellationTokenSource CreateFetchCts()
+    /// <param name="additionalToken">
+    /// An extra token to link in (the virtualized path forwards MudBlazor's own per-window token).
+    /// <see cref="CancellationToken.None"/> links nothing extra.
+    /// </param>
+    private CancellationTokenSource CreateFetchCts(CancellationToken additionalToken)
     {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(_cts!.Token);
+        var cts = additionalToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(_cts!.Token, additionalToken)
+            : CancellationTokenSource.CreateLinkedTokenSource(_cts!.Token);
         if (!RendererInfo.IsInteractive)
         {
             cts.CancelAfter(PrerenderFetchTimeoutMs);
@@ -613,8 +800,14 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
     /// delegate takes. MudDataGrid lets the user add several filter rows on the SAME column, which
     /// a dictionary cannot carry, so the newest row wins instead of the projection throwing.
     /// </summary>
-    private static Dictionary<string, (string Operator, string Value)> ExtractGridFilters(GridState<TDto> state) =>
-        state.FilterDefinitions?
+    /// <remarks>
+    /// Takes the definition collection rather than the state object so the paged
+    /// (<see cref="GridState{T}"/>) and virtualized (<see cref="GridStateVirtualize{T}"/>) funnels
+    /// share one implementation; MudBlazor v9 exposes the same definition types on both.
+    /// </remarks>
+    private static Dictionary<string, (string Operator, string Value)> ExtractGridFilters(
+        IEnumerable<IFilterDefinition<TDto>>? filterDefinitions) =>
+        filterDefinitions?
             .Where(f => !string.IsNullOrWhiteSpace(f.Column?.PropertyName))
             .GroupBy(f => f.Column!.PropertyName!, StringComparer.Ordinal)
             .ToDictionary(
@@ -627,9 +820,10 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
                 StringComparer.Ordinal
             ) ?? [];
 
-    private static (string? SortColumn, string? SortDirection) ExtractSortParameters(GridState<TDto> state)
+    private static (string? SortColumn, string? SortDirection) ExtractSortParameters(
+        IEnumerable<SortDefinition<TDto>>? sortDefinitions)
     {
-        var sort = state.SortDefinitions?.FirstOrDefault();
+        var sort = sortDefinitions?.FirstOrDefault();
         return (sort?.SortBy, sort?.Descending == true ? "desc" : "asc");
     }
 
@@ -638,9 +832,10 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
     /// SortDefinition (typical on initial load with a URL-driven sort), the sort restored from the
     /// query string is used instead, so the data lands sorted from the very first request.
     /// </summary>
-    private (string? SortColumn, string? SortDirection) ResolveSortParameters(GridState<TDto> state)
+    private (string? SortColumn, string? SortDirection) ResolveSortParameters(
+        IEnumerable<SortDefinition<TDto>>? sortDefinitions)
     {
-        var (sortColumn, sortDirection) = ExtractSortParameters(state);
+        var (sortColumn, sortDirection) = ExtractSortParameters(sortDefinitions);
 
         if (string.IsNullOrEmpty(sortColumn) && !string.IsNullOrEmpty(_savedSortColumn))
         {

--- a/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationInbox.razor
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationInbox.razor
@@ -1,4 +1,5 @@
 @page "/notifications/inbox"
+@page "/notifications/inbox/{Id:int}"
 @using Microsoft.AspNetCore.Authorization
 @using MMCA.Common.Shared.Notifications.UserNotifications
 @attribute [Authorize]
@@ -33,9 +34,10 @@ else
     <MudStack Spacing="2">
         @foreach (var notification in _notifications)
         {
-            <MudCard Elevation="@(notification.IsRead ? 0 : 1)"
-                     Class="@($"notification-card {(notification.IsRead ? "read" : "unread")}")"
-                     Style="@(notification.IsRead ? "" : "border-left: 4px solid var(--mud-palette-primary);")">
+            <MudCard id="@CardElementId(notification)"
+                     Elevation="@CardElevation(notification)"
+                     Class="@CardClass(notification)"
+                     Style="@CardStyle(notification)">
                 <MudCardContent Class="py-2">
                     <div class="d-flex align-center justify-space-between">
                         <div class="flex-grow-1">

--- a/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationInbox.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Notifications/NotificationInbox.razor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 using MMCA.Common.Shared.Notifications.UserNotifications;
@@ -14,6 +15,13 @@ namespace MMCA.Common.UI.Pages.Notifications;
 /// Displays the current user's notifications with read/unread state and pagination.
 /// Reloads the current page when a real-time push requests a refresh via
 /// <see cref="NotificationState.OnRefreshRequested"/>.
+/// <para>
+/// The page is also the target of a typed deep link (<c>/notifications/inbox/{Id:int}</c>, rubric
+/// §25): a push payload or an email can point straight at one notification. The route constraint is
+/// the validation boundary, so a malformed id never reaches this component (the router renders
+/// <c>NotFound</c> instead), and an id that is simply not on the loaded page degrades silently to
+/// the plain inbox rather than raising an error the user can do nothing about.
+/// </para>
 /// </summary>
 public partial class NotificationInbox : IDisposable
 {
@@ -23,6 +31,16 @@ public partial class NotificationInbox : IDisposable
     [Inject] private NotificationState NotificationState { get; set; } = default!;
     [Inject] private IToastService Toast { get; set; } = default!;
     [Inject] private IStringLocalizer<SharedResource> L { get; set; } = default!;
+    [Inject] private IScrollManager ScrollManager { get; set; } = default!;
+
+    /// <summary>
+    /// The deep-linked notification to highlight and scroll to, from the
+    /// <c>/notifications/inbox/{Id:int}</c> route. Declared as <see cref="int"/> because
+    /// <c>UserNotificationIdentifierType</c> is an <see cref="int"/> alias and a route parameter's
+    /// type must be written out for the <c>:int</c> constraint to bind to it. Null on the
+    /// parameterless route, which renders exactly the plain inbox.
+    /// </summary>
+    [Parameter] public int? Id { get; set; }
 
     private readonly CancellationTokenSource _cts = new();
 
@@ -40,6 +58,18 @@ public partial class NotificationInbox : IDisposable
     /// <summary>A push arrived while a load was in flight and still owes the list one reload.</summary>
     private bool _refreshPending;
 
+    /// <summary>The deep-linked notification found on the loaded page, or null when there is none.</summary>
+    private UserNotificationIdentifierType? _highlightedId;
+
+    /// <summary>The id the next <see cref="OnAfterRenderAsync"/> owes a scroll, or null when none is due.</summary>
+    private UserNotificationIdentifierType? _pendingScrollId;
+
+    /// <summary>The id already scrolled to, so a re-render (or a push-driven reload) never scrolls twice.</summary>
+    private UserNotificationIdentifierType? _scrolledId;
+
+    /// <summary>The <see cref="Id"/> the deep-link state was last computed for, to detect a re-navigation.</summary>
+    private UserNotificationIdentifierType? _appliedId;
+
     protected override async Task OnInitializedAsync()
     {
         // Breadcrumbs are built here (not in a field initializer) so the injected localizer is
@@ -53,6 +83,103 @@ public partial class NotificationInbox : IDisposable
         NotificationState.OnRefreshRequested += HandleRefreshRequested;
 
         await LoadNotificationsAsync();
+    }
+
+    /// <summary>
+    /// Recomputes the deep-link highlight whenever the route id changes. Navigating from
+    /// <c>/notifications/inbox/5</c> to <c>/notifications/inbox/9</c> reuses this component instance,
+    /// so the "already scrolled" latch is cleared here and nowhere else: without that, the second
+    /// deep link would highlight but never move the viewport.
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        if (_appliedId != Id)
+        {
+            _appliedId = Id;
+            _scrolledId = null;
+        }
+
+        ApplyDeepLinkTarget();
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_pendingScrollId is not { } id || _disposed)
+        {
+            return;
+        }
+
+        // Cleared before the await so a re-entrant render cannot queue the same scroll twice.
+        _pendingScrollId = null;
+        _scrolledId = id;
+
+        await ScrollManager.ScrollIntoViewAsync(CardSelector(id), ScrollBehavior.Smooth);
+    }
+
+    /// <summary>
+    /// Matches the route id against what the loaded page actually holds. An id that is absent (a
+    /// later page, a deleted notification, or another user's) leaves the highlight off and queues no
+    /// scroll: the plain inbox renders, with no toast, because a deep link the user cannot act on is
+    /// not an error they caused.
+    /// </summary>
+    private void ApplyDeepLinkTarget()
+    {
+        if (Id is not { } id || id <= 0 || !_notifications.Exists(n => n.Id == id))
+        {
+            _highlightedId = null;
+            _pendingScrollId = null;
+            return;
+        }
+
+        _highlightedId = id;
+        if (_scrolledId != id)
+        {
+            _pendingScrollId = id;
+        }
+    }
+
+    private bool IsDeepLinkTarget(UserNotificationDTO notification) => _highlightedId == notification.Id;
+
+    private static string CardElementId(UserNotificationDTO notification) => CardElementId(notification.Id);
+
+    private static string CardElementId(UserNotificationIdentifierType id) =>
+        string.Create(CultureInfo.InvariantCulture, $"notification-{id}");
+
+    private static string CardSelector(UserNotificationIdentifierType id) => "#" + CardElementId(id);
+
+    /// <summary>Lifts the deep-linked card off the stack; unread stays at 1 and read stays flat.</summary>
+    private int CardElevation(UserNotificationDTO notification)
+    {
+        if (IsDeepLinkTarget(notification))
+        {
+            return 4;
+        }
+
+        return notification.IsRead ? 0 : 1;
+    }
+
+    private string CardClass(UserNotificationDTO notification)
+    {
+        var state = notification.IsRead ? "read" : "unread";
+        return IsDeepLinkTarget(notification)
+            ? "notification-card " + state + " deep-linked"
+            : "notification-card " + state;
+    }
+
+    /// <summary>
+    /// Card chrome, built from MudBlazor palette tokens only so both themes stay legible. The unread
+    /// marker is a primary left border; the deep-link marker is a secondary-colored ring plus a faint
+    /// surface tint, so the two read as different things when a deep-linked card is also unread.
+    /// </summary>
+    private string CardStyle(UserNotificationDTO notification)
+    {
+        var unread = notification.IsRead
+            ? string.Empty
+            : "border-left: 4px solid var(--mud-palette-primary);";
+        return IsDeepLinkTarget(notification)
+            ? unread + "box-shadow: 0 0 0 2px var(--mud-palette-secondary);background-color: var(--mud-palette-action-default-hover);"
+            : unread;
     }
 
     private void HandleRefreshRequested(object? sender, EventArgs e)
@@ -98,6 +225,11 @@ public partial class NotificationInbox : IDisposable
                 {
                     _totalPages = 1;
                 }
+
+                // Only a successful load can decide whether the deep-linked id is present, so the
+                // highlight is recomputed here rather than on the failure path, which deliberately
+                // leaves the previous list (and therefore the previous highlight) untouched.
+                ApplyDeepLinkTarget();
             }
             else
             {

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -312,3 +312,34 @@ MMCA.Common.UI.Services.Auth.ISecureTokenStore.GetRefreshTokenAsync() -> System.
 MMCA.Common.UI.Services.Auth.ISecureTokenStore.SetTokensAsync(string! accessToken, string! refreshToken) -> System.Threading.Tasks.Task!
 MMCA.Common.UI.Services.Notifications.INotificationScopeProvider.GetCurrentScopeDisplayNameAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
 override MMCA.Common.UI.Pages.Notifications.NotificationSend.OnInitializedAsync() -> System.Threading.Tasks.Task!
+*REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.AuthUIService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Auth.ITokenRefresher! tokenRefresher, Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider! authStateProvider, MMCA.Common.UI.Services.Capabilities.IPushRegistrationService! pushRegistration) -> void
+*REMOVED*MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.EntityServiceBase(string! endpoint, System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService) -> void
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.NotificationState() -> void
+MMCA.Common.UI.Common.Settings.NotificationBellOptions
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.get -> System.TimeSpan
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.init -> void
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.NotificationBellOptions() -> void
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.PollInterval.get -> System.TimeSpan
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.PollInterval.init -> void
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.DefaultTtl.get -> System.TimeSpan
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.DefaultTtl.init -> void
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.Enabled.get -> bool
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.Enabled.init -> void
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.RoutePrefixTtls.get -> System.Collections.Generic.Dictionary<string!, System.TimeSpan>!
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.UiReadCacheOptions() -> void
+MMCA.Common.UI.Services.Auth.AuthUIService.AuthUIService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Auth.ITokenRefresher! tokenRefresher, Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider! authStateProvider, MMCA.Common.UI.Services.Capabilities.IPushRegistrationService! pushRegistration, MMCA.Common.UI.Services.Caching.IUiReadCache? readCache = null) -> void
+MMCA.Common.UI.Services.Caching.IUiReadCache
+MMCA.Common.UI.Services.Caching.IUiReadCache.Clear() -> void
+MMCA.Common.UI.Services.Caching.IUiReadCache.InvalidatePrefix(string! routePrefix) -> void
+MMCA.Common.UI.Services.Caching.IUiReadCache.Set<T>(string! url, T value) -> void
+MMCA.Common.UI.Services.Caching.IUiReadCache.TryGetFresh<T>(string! url, out T? value) -> bool
+MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.EntityServiceBase(string! endpoint, System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Caching.IUiReadCache? readCache = null) -> void
+MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetCachedAsync<T>(string! url, System.Threading.CancellationToken cancellationToken, bool bypassCache = false) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!
+MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.ReadCache.get -> MMCA.Common.UI.Services.Caching.IUiReadCache?
+MMCA.Common.UI.Services.Notifications.NotificationState.IsStale(System.TimeSpan maxAge) -> bool
+MMCA.Common.UI.Services.Notifications.NotificationState.LastFetchedUtc.get -> System.DateTimeOffset?
+MMCA.Common.UI.Services.Notifications.NotificationState.MarkStale() -> void
+MMCA.Common.UI.Services.Notifications.NotificationState.NotificationState(System.TimeProvider? timeProvider = null) -> void
+static readonly MMCA.Common.UI.Common.Settings.NotificationBellOptions.SectionName -> string!
+static readonly MMCA.Common.UI.Common.Settings.UiReadCacheOptions.SectionName -> string!

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -343,3 +343,7 @@ MMCA.Common.UI.Services.Notifications.NotificationState.MarkStale() -> void
 MMCA.Common.UI.Services.Notifications.NotificationState.NotificationState(System.TimeProvider? timeProvider = null) -> void
 static readonly MMCA.Common.UI.Common.Settings.NotificationBellOptions.SectionName -> string!
 static readonly MMCA.Common.UI.Common.Settings.UiReadCacheOptions.SectionName -> string!
+MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadVirtualizedServerDataAsync(MudBlazor.GridStateVirtualize<TDto>! state, System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MudBlazor.GridData<TDto>!>!
+virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizeGrid.get -> bool
+virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizedGridHeight.get -> string!
+virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizedItemSize.get -> int

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -347,3 +347,8 @@ MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadVirtualizedServerData
 virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizeGrid.get -> bool
 virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizedGridHeight.get -> string!
 virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizedItemSize.get -> int
+MMCA.Common.UI.Pages.Notifications.NotificationInbox.Id.get -> int?
+MMCA.Common.UI.Pages.Notifications.NotificationInbox.Id.set -> void
+override MMCA.Common.UI.Pages.Notifications.NotificationInbox.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override MMCA.Common.UI.Pages.Notifications.NotificationInbox.OnParametersSet() -> void
+static MMCA.Common.UI.Common.NotificationRoutePaths.NotificationInboxItem(int id) -> string!

--- a/Source/Presentation/MMCA.Common.UI/Services/Auth/AuthUIService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Auth/AuthUIService.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.Shared.Auth;
 using MMCA.Common.Shared.Http;
+using MMCA.Common.UI.Services.Caching;
 using MMCA.Common.UI.Services.Capabilities;
 
 namespace MMCA.Common.UI.Services.Auth;
@@ -20,12 +21,23 @@ namespace MMCA.Common.UI.Services.Auth;
 /// <see cref="TokenStorageUnavailableCode"/> rather than swallowed into a null.
 /// </para>
 /// </summary>
+/// <param name="httpClientFactory">Factory for the named <c>"APIClient"</c> HttpClient.</param>
+/// <param name="tokenStorageService">Store the access/refresh tokens are persisted in.</param>
+/// <param name="tokenRefresher">Host-specific refresher used to renew an expired access token.</param>
+/// <param name="authStateProvider">Blazor's auth-state provider, notified on sign-in and sign-out.</param>
+/// <param name="pushRegistration">Native push registration, unregistered on sign-out (ADR-044).</param>
+/// <param name="readCache">
+/// Optional client-side read cache, emptied on sign-out. It matters most where the DI scope outlives
+/// the session (WebAssembly and MAUI resolve one scope for the app's lifetime): without the clear, the
+/// next account signing in on the same client could be served the previous account's cached reads.
+/// </param>
 public sealed class AuthUIService(
     IHttpClientFactory httpClientFactory,
     ITokenStorageService tokenStorageService,
     ITokenRefresher tokenRefresher,
     AuthenticationStateProvider authStateProvider,
-    IPushRegistrationService pushRegistration) : IAuthUIService
+    IPushRegistrationService pushRegistration,
+    IUiReadCache? readCache = null) : IAuthUIService
 {
     /// <summary>
     /// Error code reported when the authentication succeeded but the tokens could not be persisted
@@ -109,6 +121,11 @@ public sealed class AuthUIService(
             // JS interop not available
         }
 
+        // Everything the previous session read is now another user's data. The scope that holds the
+        // cache outlives the session on WebAssembly and MAUI, so leaving entries behind would show
+        // them to whoever signs in next on this client.
+        readCache?.Clear();
+
         if (authStateProvider is JwtAuthenticationStateProvider jwtProvider)
         {
             jwtProvider.NotifyUserLogout();
@@ -133,6 +150,10 @@ public sealed class AuthUIService(
             {
                 // JS interop not available (SSR prerender / disconnected circuit)
             }
+
+            // The same reasoning as LogoutAsync: an unrefreshable session IS a sign-out, and the
+            // cached reads belong to the session that just ended.
+            readCache?.Clear();
 
             if (authStateProvider is JwtAuthenticationStateProvider jwtProvider)
             {

--- a/Source/Presentation/MMCA.Common.UI/Services/Caching/IUiReadCache.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Caching/IUiReadCache.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace MMCA.Common.UI.Services.Caching;
+
+/// <summary>
+/// Per-circuit read-through cache over the API client: the client half of the framework's caching
+/// policy, so a page that re-reads the same list twice inside a few seconds (a grid re-mounted by
+/// navigation, a lookup rendered in two components) does not pay for two round trips.
+/// <para>
+/// <b>Keys are the relative URL, path plus the FULL query string</b>, which is deliberately the same
+/// key shape the server's authenticated output cache uses (ADR-040: its policy sets
+/// <c>CacheVaryByRules.QueryKeys = "*"</c>, so every query-string variant is its own entry). Mirroring
+/// that shape means the two tiers agree on what "the same read" is: a filter, page or sort change
+/// misses on both sides rather than serving a stale answer on one of them.
+/// </para>
+/// <para>
+/// Freshness comes from <see cref="MMCA.Common.UI.Common.Settings.UiReadCacheOptions"/>: a default
+/// TTL, plus optional per-route-prefix overrides for reads whose staleness budget genuinely differs
+/// (reference data can hold for minutes, a live queue for seconds). Only successful reads are stored:
+/// a failure is never cached, so a transient outage cannot pin an error in front of the user.
+/// </para>
+/// <para>
+/// Registered scoped, which is one instance per Blazor Server circuit and one per app lifetime on
+/// WebAssembly and MAUI. Because the WASM scope outlives a sign-out, the sign-out path calls
+/// <see cref="Clear"/> so one account's reads can never be served to the next.
+/// </para>
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "The parameter is a cache KEY that happens to be spelled as a relative URL: it is compared by ordinal prefix and stored verbatim so it matches the server-side output-cache key shape (path + full query, ADR-040). System.Uri would re-encode and re-normalize the string, which is exactly what must not happen to a key, and every call site already holds the same string it puts on the wire.")]
+public interface IUiReadCache
+{
+    /// <summary>
+    /// Reads a cached value that is still within its TTL.
+    /// </summary>
+    /// <typeparam name="T">The cached value's type; a hit stored under a different type reads as a miss.</typeparam>
+    /// <param name="url">The relative request URL (path plus the full query string), used verbatim as the key.</param>
+    /// <param name="value">The cached value on a hit; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> on a fresh hit, <see langword="false"/> on a miss, an expired
+    /// entry, or when caching is disabled.</returns>
+    bool TryGetFresh<T>(string url, out T? value);
+
+    /// <summary>
+    /// Stores a successfully read value under <paramref name="url"/>, stamped with the current time.
+    /// A no-op when caching is disabled.
+    /// </summary>
+    /// <typeparam name="T">The value's type.</typeparam>
+    /// <param name="url">The relative request URL (path plus the full query string), used verbatim as the key.</param>
+    /// <param name="value">The value to cache. Only ever a success value: failures are not stored.</param>
+    void Set<T>(string url, T value);
+
+    /// <summary>
+    /// Drops every entry whose key starts with <paramref name="routePrefix"/> (ordinal), which is how
+    /// a successful write invalidates the reads it just made stale: one endpoint's create, update or
+    /// delete clears that endpoint's list, paged, lookup and by-id entries in one call.
+    /// </summary>
+    /// <param name="routePrefix">The endpoint's relative route prefix, e.g. <c>products</c>.</param>
+    void InvalidatePrefix(string routePrefix);
+
+    /// <summary>
+    /// Drops every entry. Called on sign-out, where the scope can outlive the session (WebAssembly and
+    /// MAUI resolve one scope for the app's lifetime) and a surviving entry would be one account's data
+    /// shown to the next.
+    /// </summary>
+    void Clear();
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Caching/UiReadCache.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Caching/UiReadCache.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.Options;
+using MMCA.Common.UI.Common.Settings;
+
+namespace MMCA.Common.UI.Services.Caching;
+
+/// <summary>
+/// Default <see cref="IUiReadCache"/>: an in-memory dictionary keyed by the relative request URL,
+/// guarded by a lock because circuit code is not single-threaded (a periodic poll, a SignalR push
+/// handler and a user-driven page load can all reach the same instance).
+/// </summary>
+/// <remarks>
+/// Expiry is lazy: an entry past its TTL is removed when it is next read, not by a timer. A UI cache
+/// holds tens of entries for the life of a circuit, so a sweeping timer would cost more than the
+/// entries it reclaims, and a stale entry that is never read again is never served either.
+/// </remarks>
+/// <param name="timeProvider">Clock used for the stored-at stamp and every freshness comparison.</param>
+/// <param name="options">The staleness policy: enablement, default TTL, per-prefix overrides.</param>
+internal sealed class UiReadCache(TimeProvider timeProvider, IOptions<UiReadCacheOptions> options) : IUiReadCache
+{
+    private readonly Lock _sync = new();
+
+    // Keys are relative URLs, and a Dictionary<string, ...> compares them ordinally by default, which
+    // is the comparison every prefix check below also uses: two URLs that differ only in case are two
+    // different requests to the server, so they must be two different entries here.
+    private readonly Dictionary<string, (object Value, DateTimeOffset StoredAt)> _entries = [];
+    private readonly TimeProvider _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    private readonly UiReadCacheOptions _options = (options ?? throw new ArgumentNullException(nameof(options))).Value;
+
+    /// <inheritdoc />
+    public bool TryGetFresh<T>(string url, out T? value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+
+        value = default;
+
+        if (!_options.Enabled)
+        {
+            return false;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        lock (_sync)
+        {
+            if (!_entries.TryGetValue(url, out var entry))
+            {
+                return false;
+            }
+
+            if (now - entry.StoredAt > ResolveTtl(url))
+            {
+                _entries.Remove(url);
+                return false;
+            }
+
+            if (entry.Value is not T typed)
+            {
+                // The same URL read back as a different type means the caller changed shape; the
+                // stored value can no longer answer the question, so drop it and let the read run.
+                _entries.Remove(url);
+                return false;
+            }
+
+            value = typed;
+            return true;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Set<T>(string url, T value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+
+        if (!_options.Enabled || value is null)
+        {
+            return;
+        }
+
+        var storedAt = _timeProvider.GetUtcNow();
+
+        lock (_sync)
+        {
+            _entries[url] = (value, storedAt);
+        }
+    }
+
+    /// <inheritdoc />
+    public void InvalidatePrefix(string routePrefix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(routePrefix);
+
+        lock (_sync)
+        {
+            var doomed = _entries.Keys
+                .Where(key => key.StartsWith(routePrefix, StringComparison.Ordinal))
+                .ToList();
+
+            foreach (var key in doomed)
+            {
+                _entries.Remove(key);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        lock (_sync)
+        {
+            _entries.Clear();
+        }
+    }
+
+    /// <summary>
+    /// The freshness budget for one URL: the TTL of the LONGEST configured route prefix it starts
+    /// with, or <see cref="UiReadCacheOptions.DefaultTtl"/> when it matches none. Longest-match rather
+    /// than first-match so a nested route can state a stricter budget than the endpoint above it,
+    /// whatever order the configuration happens to enumerate in.
+    /// </summary>
+    private TimeSpan ResolveTtl(string url)
+    {
+        var ttl = _options.DefaultTtl;
+        var matchedLength = -1;
+
+        foreach (var (prefix, prefixTtl) in _options.RoutePrefixTtls)
+        {
+            if (prefix.Length > matchedLength && url.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                matchedLength = prefix.Length;
+                ttl = prefixTtl;
+            }
+        }
+
+        return ttl;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/EntityServiceBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/EntityServiceBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Http.Json;
 using MMCA.Common.Shared.Abstractions;
@@ -5,6 +6,7 @@ using MMCA.Common.Shared.DTOs;
 using MMCA.Common.Shared.Http;
 using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Services.Auth;
+using MMCA.Common.UI.Services.Caching;
 
 namespace MMCA.Common.UI.Services;
 
@@ -29,14 +31,31 @@ namespace MMCA.Common.UI.Services;
 /// </summary>
 /// <typeparam name="TEntityDTO">DTO type returned by the API.</typeparam>
 /// <typeparam name="TIdentifierType">Primary key type of the entity.</typeparam>
+/// <param name="endpoint">The service's relative endpoint, e.g. <c>products</c>.</param>
+/// <param name="httpClientFactory">Factory for the named <c>"APIClient"</c> HttpClient.</param>
+/// <param name="tokenStorageService">Circuit-scoped store the bearer token is read from.</param>
+/// <param name="readCache">
+/// Optional per-circuit read cache (ADR-040's client half). Supplied, the four read methods become
+/// read-through with the TTL policy in <c>UiReadCacheOptions</c>, and every successful write
+/// invalidates this endpoint's entries. Left <see langword="null"/>, every read goes to the API and
+/// the class behaves exactly as it did before the cache existed.
+/// </param>
 public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
     string endpoint,
     IHttpClientFactory httpClientFactory,
-    ITokenStorageService tokenStorageService) : AuthenticatedServiceBase(httpClientFactory, tokenStorageService), IEntityService<TEntityDTO, TIdentifierType>
+    ITokenStorageService tokenStorageService,
+    IUiReadCache? readCache = null) : AuthenticatedServiceBase(httpClientFactory, tokenStorageService), IEntityService<TEntityDTO, TIdentifierType>
     where TEntityDTO : IBaseDTO<TIdentifierType>
     where TIdentifierType : notnull
 {
     protected string Endpoint { get; } = endpoint;
+
+    /// <summary>
+    /// The read cache this service reads through, or <see langword="null"/> when the host registered
+    /// none. A derived service reaches for it directly only to invalidate a route prefix its own
+    /// custom write touches; the CRUD verbs below already invalidate <see cref="Endpoint"/>.
+    /// </summary>
+    protected IUiReadCache? ReadCache { get; } = readCache;
 
     /// <inheritdoc />
     public virtual async Task<Result<IReadOnlyList<TEntityDTO>>> GetAllAsync(
@@ -51,10 +70,7 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         };
 
         var url = $"{Endpoint}?{string.Join("&", queryParams)}";
-        var wrapper = await SendRequestAsync<PagedCollectionResult<TEntityDTO>>(
-            httpClient => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
-            cancellationToken
-        );
+        var wrapper = await GetCachedAsync<PagedCollectionResult<TEntityDTO>>(url, cancellationToken);
 
         return wrapper.Map(page => AsReadOnlyList(page.Items));
     }
@@ -92,10 +108,7 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         }
 
         var url = $"{Endpoint}/paged?{string.Join("&", queryParams)}";
-        var result = await SendRequestAsync<PagedCollectionResult<TEntityDTO>>(
-            httpClient => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
-            cancellationToken
-        );
+        var result = await GetCachedAsync<PagedCollectionResult<TEntityDTO>>(url, cancellationToken);
 
         // The pagination metadata still travels with the page; only its shape is flattened, so a
         // grid keeps binding to (Items, TotalItems) exactly as before.
@@ -109,10 +122,7 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         CancellationToken cancellationToken = default)
     {
         var url = $"{Endpoint}/lookup?nameProperty={Uri.EscapeDataString(nameProperty)}";
-        var result = await SendRequestAsync<CollectionResult<BaseLookup<TIdentifierType>>>(
-            httpClient => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
-            cancellationToken
-        );
+        var result = await GetCachedAsync<CollectionResult<BaseLookup<TIdentifierType>>>(url, cancellationToken);
 
         return result.Map(collection => AsReadOnlyList(collection.Items));
     }
@@ -132,11 +142,8 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
 
         // A missing entity is a NotFound failure rather than a null value: the caller can tell it
         // apart from a transport failure (ResultUiExtensions.IsNotFound) instead of both arriving
-        // as the same null.
-        return await SendRequestAsync<TEntityDTO>(
-            httpClient => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
-            cancellationToken
-        );
+        // as the same null. A failure is never cached, so a 404 is re-asked every time.
+        return await GetCachedAsync<TEntityDTO>(url, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -149,11 +156,14 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         // Creates are the one CRUD verb that is not naturally idempotent: a retried POST whose
         // first attempt actually reached the server would create a second record. The key makes the
         // server collapse the duplicate; reads, updates (full PUT) and deletes need no key.
-        return await SendRequestAsync<TEntityDTO>(
+        var result = await SendRequestAsync<TEntityDTO>(
             httpClient => httpClient.PostAsJsonAsync(new Uri(url, UriKind.Relative), entity, cancellationToken),
             cancellationToken,
             idempotencyKey: NewIdempotencyKey()
         );
+
+        InvalidateOnSuccess(result);
+        return result;
     }
 
     /// <inheritdoc />
@@ -168,11 +178,14 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         CancellationToken cancellationToken = default)
     {
         var url = $"{Endpoint}/{GetEntityId(entity)}";
-        return await SendRequestAsync(
+        var result = await SendRequestAsync(
             httpClient => httpClient.PutAsJsonAsync(new Uri(url, UriKind.Relative), entity, cancellationToken),
             cancellationToken,
             ifMatch: ConcurrencyTagOf(entity)
         );
+
+        InvalidateOnSuccess(result);
+        return result;
     }
 
     /// <summary>
@@ -192,14 +205,86 @@ public abstract class EntityServiceBase<TEntityDTO, TIdentifierType>(
         CancellationToken cancellationToken = default)
     {
         var url = $"{Endpoint}/{id}";
-        return await SendRequestAsync(
+        var result = await SendRequestAsync(
             httpClient => httpClient.DeleteAsync(new Uri(url, UriKind.Relative), cancellationToken),
             cancellationToken
         );
+
+        InvalidateOnSuccess(result);
+        return result;
     }
 
     protected virtual TIdentifierType GetEntityId(TEntityDTO entity)
         => entity.Id;
+
+    /// <summary>
+    /// A read that goes through <see cref="ReadCache"/> when the host registered one: a fresh entry
+    /// answers without a round trip, a miss fetches and stores, and a failure is returned without
+    /// being stored. With no cache registered (or with <paramref name="bypassCache"/> set) this is
+    /// exactly the plain GET the read methods used to issue.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize the response body into, and the cached type.</typeparam>
+    /// <param name="url">The relative URL, path plus the full query string. It IS the cache key, so
+    /// two reads that differ by a single query parameter are two entries, matching the server-side
+    /// output cache's <c>QueryKeys = "*"</c> rule (ADR-040).</param>
+    /// <param name="cancellationToken">Cancellation token; caller cancellation still propagates as an exception.</param>
+    /// <param name="bypassCache">
+    /// Forces a round trip and leaves the cache untouched. For a read the user explicitly asked to be
+    /// current (a refresh button, a re-poll after a push), where serving a fresh-by-the-clock entry
+    /// would answer a question the user did not ask.
+    /// </param>
+    /// <returns>The value, from cache or from the API, or the failure the API described.</returns>
+    [SuppressMessage(
+        "Design",
+        "CA1054:URI-like parameters should not be strings",
+        Justification = "The string IS the cache key as well as the request path: it must be stored and compared verbatim so it matches the server-side output-cache key shape (path + full query, ADR-040), and a System.Uri round trip would re-encode it. The read methods above already build this exact string, and the sibling SendRequestAsync overloads take the same shape.")]
+    protected async Task<Result<T>> GetCachedAsync<T>(
+        string url,
+        CancellationToken cancellationToken,
+        bool bypassCache = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+
+        if (ReadCache is null || bypassCache)
+        {
+            return await SendGetAsync<T>(url, cancellationToken);
+        }
+
+        if (ReadCache.TryGetFresh<T>(url, out var cached) && cached is not null)
+        {
+            return Result.Success(cached);
+        }
+
+        var result = await SendGetAsync<T>(url, cancellationToken);
+
+        // Only a success is stored: caching a failure would pin a transient outage in front of the
+        // user for the whole TTL, and a 404 would survive the create that fixed it.
+        if (result is { IsSuccess: true, Value: not null })
+        {
+            ReadCache.Set(url, result.Value);
+        }
+
+        return result;
+    }
+
+    private Task<Result<T>> SendGetAsync<T>(string url, CancellationToken cancellationToken) =>
+        SendRequestAsync<T>(
+            httpClient => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
+            cancellationToken);
+
+    /// <summary>
+    /// Drops this endpoint's cached reads after a write actually succeeded. Only on success: a
+    /// rejected write changed nothing, and invalidating there would throw away entries that are
+    /// still accurate.
+    /// </summary>
+    /// <param name="result">The write's outcome.</param>
+    private void InvalidateOnSuccess(Result result)
+    {
+        if (result.IsSuccess)
+        {
+            ReadCache?.InvalidatePrefix(Endpoint);
+        }
+    }
 
     /// <summary>
     /// Presents a deserialized <c>Items</c> collection as an <see cref="IReadOnlyList{T}"/> without

--- a/Source/Presentation/MMCA.Common.UI/Services/ListPageStateService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/ListPageStateService.cs
@@ -17,7 +17,12 @@ public sealed record ListPageState
     /// <summary>Mobile card list 1-indexed page number.</summary>
     public int MobilePage { get; init; } = 1;
 
-    /// <summary>Document scroll offset in pixels (from <c>document.scrollingElement.scrollTop</c>).</summary>
+    /// <summary>
+    /// Scroll offset in pixels of whichever element the page actually scrolls. For a normal paged list
+    /// page that is the document (<c>document.scrollingElement.scrollTop</c>); for a page that opts into
+    /// grid virtualization it is the grid's own height-bound viewport
+    /// (<c>.mud-table-container</c>), because the document itself does not scroll there.
+    /// </summary>
     public double ScrollPosition { get; init; }
 
     /// <summary>

--- a/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationState.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Notifications/NotificationState.cs
@@ -4,10 +4,21 @@ namespace MMCA.Common.UI.Services.Notifications;
 /// Shared state for notification unread count. Components subscribe to <see cref="OnChange"/>
 /// to react when the count changes (e.g., new notification received, notification marked as read).
 /// Registered as scoped so each Blazor circuit gets its own instance.
+/// <para>
+/// It also records WHEN the count was last established (<see cref="LastFetchedUtc"/>), which is the
+/// state half of the client's staleness policy: a subscriber can ask <see cref="IsStale"/> instead of
+/// re-fetching on every trigger it sees, and a subscriber that knows the data moved calls
+/// <see cref="MarkStale"/> to force the next read.
+/// </para>
 /// </summary>
-public sealed class NotificationState
+/// <param name="timeProvider">
+/// Clock used to stamp and age <see cref="LastFetchedUtc"/>; defaults to
+/// <see cref="TimeProvider.System"/> so an existing host keeps the previous constructor shape.
+/// </param>
+public sealed class NotificationState(TimeProvider? timeProvider = null)
 {
     private readonly Lock _pollerSync = new();
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     /// <summary>
     /// The component that currently holds the single active-poller slot, or <see langword="null"/>
@@ -19,6 +30,15 @@ public sealed class NotificationState
 
     /// <summary>Gets the current unread notification count.</summary>
     public int UnreadCount { get; private set; }
+
+    /// <summary>
+    /// When the count was last established from the API, or <see langword="null"/> when it never has
+    /// been (or <see cref="MarkStale"/> discarded the stamp). Stamped by every
+    /// <see cref="SetUnreadCount"/> call, INCLUDING one that re-confirms the value already held: the
+    /// question the stamp answers is "how old is this number", and a confirmed number is fresh even
+    /// though nothing changed.
+    /// </summary>
+    public DateTimeOffset? LastFetchedUtc { get; private set; }
 
     /// <summary>Raised when <see cref="UnreadCount"/> changes.</summary>
     public event EventHandler? OnChange;
@@ -37,8 +57,14 @@ public sealed class NotificationState
     public event EventHandler? OnPollerSlotFreed;
 
     /// <summary>Sets the unread count to an absolute value (e.g., after fetching from API).</summary>
+    /// <param name="count">The authoritative count just read.</param>
     public void SetUnreadCount(int count)
     {
+        // Stamped BEFORE the unchanged-count early return: an API read that came back with the same
+        // number is still a read, and treating it as one is what stops a subscriber from re-fetching
+        // forever on a quiet inbox (the count almost never changes, so almost every read is this one).
+        LastFetchedUtc = _timeProvider.GetUtcNow();
+
         if (UnreadCount == count)
         {
             return;
@@ -47,6 +73,23 @@ public sealed class NotificationState
         UnreadCount = count;
         OnChange?.Invoke(this, EventArgs.Empty);
     }
+
+    /// <summary>
+    /// Whether the count is older than <paramref name="maxAge"/>, or was never established at all.
+    /// A subscriber that fires on an ambient trigger (navigation, a re-render) asks this instead of
+    /// re-reading the API every time the trigger happens to fire.
+    /// </summary>
+    /// <param name="maxAge">How old the count may be before it counts as stale.</param>
+    /// <returns><see langword="true"/> when the count should be re-read.</returns>
+    public bool IsStale(TimeSpan maxAge) =>
+        LastFetchedUtc is not { } lastFetched || _timeProvider.GetUtcNow() - lastFetched > maxAge;
+
+    /// <summary>
+    /// Discards the freshness stamp, so the next <see cref="IsStale"/> answers <see langword="true"/>
+    /// whatever the clock says. Called by a subscriber that learned the data moved (a real-time push),
+    /// where age is no longer evidence of freshness.
+    /// </summary>
+    public void MarkStale() => LastFetchedUtc = null;
 
     /// <summary>Increments the unread count by one (e.g., real-time notification received).</summary>
     public void IncrementUnreadCount()

--- a/Source/Presentation/MMCA.Common.UI/wwwroot/list-page-scroll.js
+++ b/Source/Presentation/MMCA.Common.UI/wwwroot/list-page-scroll.js
@@ -1,28 +1,50 @@
 // Scroll-position helpers for DataGridListPageBase.
-// Captures the document's scrollTop on a debounced scroll listener and pushes
-// it back into Blazor via a DotNetObjectReference. Restores via double-RAF so
-// the scroll target lands AFTER MudDataGrid's row layout pass on first render.
+// Captures the scrollTop on a debounced scroll listener and pushes it back into Blazor via a
+// DotNetObjectReference. Restores via double-RAF so the scroll target lands AFTER MudDataGrid's row
+// layout pass on first render.
+//
+// The scroll target is the document by default. A virtualized grid is height-bound and scrolls inside
+// its own viewport instead, so every exported function takes an OPTIONAL trailing containerSelector:
+// when supplied AND it matches an element, that element is tracked/restored; otherwise the document
+// behavior is unchanged, which keeps the pre-existing call shapes working untouched.
 
 const trackers = new Map();
 
-function getScroller() {
+function getScroller(containerSelector) {
+    if (containerSelector) {
+        const container = document.querySelector(containerSelector);
+        if (container) {
+            return container;
+        }
+    }
+
     return document.scrollingElement || document.documentElement;
 }
 
-export function getScrollPosition() {
-    return getScroller().scrollTop || 0;
+export function getScrollPosition(containerSelector) {
+    return getScroller(containerSelector).scrollTop || 0;
 }
 
-export function setScrollPosition(top) {
+export function setScrollPosition(top, containerSelector) {
     requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-            getScroller().scrollTo(0, top);
+            // Resolved inside the double-RAF: a virtualized grid's container may not exist yet when
+            // the restore is queued, but it does once the layout pass has run.
+            const scroller = getScroller(containerSelector);
+            if (scroller === document.scrollingElement || scroller === document.documentElement) {
+                scroller.scrollTo(0, top);
+            } else {
+                scroller.scrollTop = top;
+            }
         });
     });
 }
 
-export function enableScrollTracking(dotNetRef, id, debounceMs) {
+export function enableScrollTracking(dotNetRef, id, debounceMs, containerSelector) {
     disableScrollTracking(id);
+
+    const container = containerSelector ? document.querySelector(containerSelector) : null;
+    const target = container || window;
 
     let timeoutId = null;
     const handler = () => {
@@ -31,21 +53,21 @@ export function enableScrollTracking(dotNetRef, id, debounceMs) {
         }
         timeoutId = setTimeout(() => {
             timeoutId = null;
-            const top = getScroller().scrollTop || 0;
+            const top = (container || getScroller()).scrollTop || 0;
             dotNetRef.invokeMethodAsync('OnScrollPositionChanged', top).catch(() => {
                 // Circuit may have torn down between scroll and dispatch — ignore.
             });
         }, debounceMs);
     };
 
-    window.addEventListener('scroll', handler, { passive: true });
-    trackers.set(id, { handler, timeoutId: () => timeoutId });
+    target.addEventListener('scroll', handler, { passive: true });
+    trackers.set(id, { handler, target, timeoutId: () => timeoutId });
 }
 
 export function disableScrollTracking(id) {
     const entry = trackers.get(id);
     if (entry) {
-        window.removeEventListener('scroll', entry.handler);
+        (entry.target || window).removeEventListener('scroll', entry.handler);
         trackers.delete(id);
     }
 }

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/CascadeFixtures/CascadeFixtures.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/CascadeFixtures/CascadeFixtures.cs
@@ -1,0 +1,104 @@
+using MMCA.Common.Domain.Entities;
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.Architecture.Tests.CascadeFixtures;
+
+/// <summary>
+/// Compiled aggregates for <c>CascadeSoftDeleteFitnessTests</c>. The cascade rule reads the IL of a
+/// <c>Delete()</c> override, so the only honest way to test it is to compile the cascading and the
+/// non-cascading shapes side by side in this assembly and point a map at it.
+/// <para>
+/// Every fixture is internal and lives in its own namespace, so it is invisible to the framework
+/// rules that run over <c>CommonArchitectureMap</c> (the <c>Source/</c> assemblies, never this test
+/// assembly) and to the other self-tests, which each point their own fixture map at their own
+/// namespace or at type shapes these fixtures do not have.
+/// </para>
+/// </summary>
+internal sealed class CascadeChildFixture : AuditableBaseEntity<int>
+{
+    public string Label { get; init; } = string.Empty;
+}
+
+/// <summary>Cascades through the framework helper. The rule must stay silent about this type.</summary>
+internal sealed class HelperCascadingFixture : AuditableAggregateRootEntity<int>
+{
+    private readonly List<CascadeChildFixture> _children = [];
+
+    public IReadOnlyCollection<CascadeChildFixture> Children => _children;
+
+    public override Result Delete() =>
+        Result.Combine(DeleteChildren<CascadeChildFixture, int>(_children), base.Delete());
+}
+
+/// <summary>
+/// Cascades with a hand-rolled loop over the children, which is what every aggregate did before the
+/// helper existed. The rule must accept it too.
+/// </summary>
+internal sealed class LoopCascadingFixture : AuditableAggregateRootEntity<int>
+{
+    private readonly List<CascadeChildFixture> _items = [];
+
+    public IReadOnlyCollection<CascadeChildFixture> Items => _items;
+
+    public override Result Delete()
+    {
+        foreach (var item in _items)
+        {
+            _ = item.Delete();
+        }
+
+        return base.Delete();
+    }
+}
+
+/// <summary>
+/// Owns children and never overrides <c>Delete()</c>, so deleting the root leaves every child row
+/// active. The rule must report it, naming the collection.
+/// </summary>
+internal sealed class MissingOverrideFixture : AuditableAggregateRootEntity<int>
+{
+    private readonly List<CascadeChildFixture> _orphans = [];
+
+    public IReadOnlyCollection<CascadeChildFixture> Orphans => _orphans;
+}
+
+/// <summary>
+/// Overrides <c>Delete()</c>, even touches the collection, and still leaves every child row active:
+/// detaching the children from the in-memory list is not a soft-delete. This is the shape a naive
+/// "does it override Delete" check would pass, which is why the rule reads the body.
+/// </summary>
+internal sealed class SelfOnlyDeleteFixture : AuditableAggregateRootEntity<int>
+{
+    private readonly List<CascadeChildFixture> _ignored = [];
+
+    public IReadOnlyCollection<CascadeChildFixture> Ignored => _ignored;
+
+    public override Result Delete()
+    {
+        _ignored.Clear();
+
+        return base.Delete();
+    }
+}
+
+/// <summary>
+/// The same shape as <see cref="MissingOverrideFixture"/>, kept separate so one self-test can
+/// allowlist it and prove an exemption silences exactly the type it names.
+/// </summary>
+internal sealed class ExemptedOffenderFixture : AuditableAggregateRootEntity<int>
+{
+    private readonly List<CascadeChildFixture> _exempt = [];
+
+    public IReadOnlyCollection<CascadeChildFixture> Exempt => _exempt;
+}
+
+/// <summary>
+/// An aggregate with no child ENTITY collection: a list of strings is not an aggregate's children,
+/// so the rule must ignore this type even though it never overrides <c>Delete()</c>.
+/// </summary>
+internal sealed class ChildlessFixture : AuditableAggregateRootEntity<int>
+{
+    private readonly List<string> _tags = [];
+
+    public IReadOnlyCollection<string> Tags => _tags;
+}

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/CascadeSoftDeleteConventionTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/CascadeSoftDeleteConventionTests.cs
@@ -1,0 +1,17 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Cascade-soft-delete convention (an aggregate root that owns children deletes them in its own
+/// <c>Delete()</c> override), driven by the shared
+/// <see cref="CascadeSoftDeleteConventionTestsBase"/>. MMCA.Common's <c>Source/</c> declares no
+/// child-bearing aggregate today, so the framework run is a ratchet rather than an assertion: it
+/// fails the moment the framework itself grows an aggregate whose children would be left active by
+/// a delete, and it is the same rule Store and ADC subclass over their own modules. The rule's own
+/// behaviour is proven against compiled fixtures in <c>CascadeSoftDeleteFitnessTests</c>.
+/// </summary>
+public sealed class CascadeSoftDeleteConventionTests : CascadeSoftDeleteConventionTestsBase
+{
+    protected override IArchitectureMap Map { get; } = new CommonArchitectureMap();
+}

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/CascadeSoftDeleteFitnessTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/CascadeSoftDeleteFitnessTests.cs
@@ -1,0 +1,106 @@
+using MMCA.Common.Architecture.Tests.CascadeFixtures;
+using MMCA.Common.Testing.Architecture;
+using Xunit.Sdk;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Self-test for the cascade-soft-delete fitness rule shipped in
+/// <c>MMCA.Common.Testing.Architecture</c> (<see cref="CascadeSoftDeleteConventionTestsBase"/>). A
+/// rule that reads IL cannot be verified by reading it, so this points a map at THIS assembly, which
+/// compiles the cascading and the non-cascading aggregate shapes side by side in
+/// <c>CascadeFixtures</c>, and pins all five behaviours: both cascade forms pass, a missing override
+/// and an override that only deletes itself are reported with their reason and their child
+/// collection, an aggregate with no child entities is ignored, and an exemption silences exactly the
+/// type it names.
+/// </summary>
+public sealed class CascadeSoftDeleteFitnessTests
+{
+    private const string FixtureNamespace = "MMCA.Common.Architecture.Tests.CascadeFixtures";
+
+    private readonly FixtureAssemblyMap _map = new();
+
+    [Fact]
+    public void AggregateWithoutDeleteOverride_IsFlagged_WithItsChildCollection()
+    {
+        var act = () => ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(_map, []);
+
+        var message = act.Should().Throw<XunitException>().Which.Message;
+
+        message.Should().Contain(nameof(MissingOverrideFixture), "it owns children and never overrides Delete()");
+        message.Should().Contain("no Delete() override", "the report must say WHY the aggregate is offending");
+        message.Should().Contain("_orphans", "the report must name the child collection that stays active");
+    }
+
+    [Fact]
+    public void DeleteOverrideThatOnlyDeletesItself_IsFlagged_WithItsChildCollection()
+    {
+        var act = () => ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(_map, []);
+
+        var message = act.Should().Throw<XunitException>().Which.Message;
+
+        message.Should().Contain(nameof(SelfOnlyDeleteFixture), "base.Delete() deletes the root, not its children");
+        message.Should().Contain("Delete() never deletes a child", "the report must distinguish this from a missing override");
+        message.Should().Contain("_ignored", "the report must name the child collection that stays active");
+    }
+
+    [Fact]
+    public void BothCascadeForms_AreAccepted()
+    {
+        var act = () => ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(_map, []);
+
+        var message = act.Should().Throw<XunitException>().Which.Message;
+
+        message.Should().NotContain(
+            nameof(HelperCascadingFixture),
+            "DeleteChildren<TChild, TChildId>(...) is the framework's cascade helper");
+        message.Should().NotContain(
+            nameof(LoopCascadingFixture),
+            "a hand-rolled foreach calling each child's Delete() cascades just as well");
+    }
+
+    [Fact]
+    public void AggregateWithNoChildEntities_IsIgnored()
+    {
+        var act = () => ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(_map, []);
+
+        act.Should().Throw<XunitException>()
+            .Which.Message.Should().NotContain(
+                nameof(ChildlessFixture),
+                "a List<string> is not a child-entity collection, so there is nothing to cascade to");
+    }
+
+    [Fact]
+    public void AllowlistedType_SilencesOnlyThatType()
+    {
+        var allowed = $"{FixtureNamespace}.{nameof(ExemptedOffenderFixture)}";
+
+        var act = () => ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(_map, [allowed]);
+
+        var message = act.Should().Throw<XunitException>(
+            "the other offenders are still outside the exemption list").Which.Message;
+
+        message.Should().NotContain(nameof(ExemptedOffenderFixture));
+        message.Should().Contain(nameof(MissingOverrideFixture));
+    }
+
+    [Fact]
+    public void AllowlistedNamespace_SilencesTheRule()
+    {
+        var act = () => ArchitectureRules.AggregatesCascadeSoftDeleteToChildren(_map, [FixtureNamespace]);
+
+        act.Should().NotThrow(
+            "a namespace entry covers the aggregates under it, which is how a repo records the roots whose children deliberately outlive them");
+    }
+
+    /// <summary>A map whose single layer is this test assembly, so the rule scans the fixtures above.</summary>
+    private sealed class FixtureAssemblyMap : ArchitectureMapBase
+    {
+        public override string RepoToken => "MMCA.Common";
+
+        protected override IEnumerable<LayerRef> DefineLayers() =>
+        [
+            Framework(Layer.Domain, typeof(CascadeChildFixture).Assembly),
+        ];
+    }
+}

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/NavigationContractTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/NavigationContractTests.cs
@@ -13,6 +13,8 @@ namespace MMCA.Common.Architecture.Tests;
 /// moving in the same change fails the build, and so does an auth-posture lie in either direction:
 /// a route the doc calls Authenticated must carry <see cref="AuthorizeAttribute"/>, and a route the
 /// doc calls Anonymous (or Any) must not. A minimum-route floor keeps the reflection non-vacuous.
+/// The same gate also holds the typed-deep-link half of §25: every route parameter must carry a type
+/// constraint, so the router validates the value before any page sees it.
 /// </summary>
 public sealed partial class NavigationContractTests
 {
@@ -76,6 +78,27 @@ public sealed partial class NavigationContractTests
             because: "the documented auth posture is the §25 route-guard contract; the RouteAttribute/AuthorizeAttribute reality must match it exactly");
     }
 
+    [Fact]
+    public void RouteTemplateParameters_AllCarryTypeConstraints()
+    {
+        var violations = new List<string>();
+        foreach (var template in DiscoverRoutedPages().Keys.Order(StringComparer.Ordinal))
+        {
+            foreach (Match segment in RouteParameterRegex.Matches(template))
+            {
+                var body = segment.Groups["param"].Value;
+                if (!body.Contains(':', StringComparison.Ordinal))
+                {
+                    violations.Add(
+                        $"{template}: route parameter '{{{body}}}' carries no type constraint, so it accepts arbitrary strings and the page, not the router, becomes the validation boundary; a typed deep link must constrain its parameter (e.g. '{{{body}:int}}') so a malformed value renders NotFound instead of reaching the component (rubric §25)");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            because: "every route parameter shipped by MMCA.Common.UI must be type-constrained; an unconstrained parameter bypasses the typed deep-link validation the §25 navigation contract promises");
+    }
+
     private static Dictionary<string, bool> DiscoverRoutedPages()
     {
         var pages = new Dictionary<string, bool>(StringComparer.Ordinal);
@@ -115,4 +138,7 @@ public sealed partial class NavigationContractTests
 
     [GeneratedRegex(@"^\|\s*`(?<route>/[^`]*)`\s*\|[^|]*\|\s*(?<auth>[^|]+)\|", RegexOptions.Multiline | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 2000)]
     private static partial Regex RouteRowRegex { get; }
+
+    [GeneratedRegex(@"\{(?<param>[^{}]+)\}", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 2000)]
+    private static partial Regex RouteParameterRegex { get; }
 }

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/SoftDeleteEnforcementTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/SoftDeleteEnforcementTests.cs
@@ -1,0 +1,48 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Soft-delete enforcement guard (ADR-005), driven by the shared
+/// <see cref="SoftDeleteEnforcementTestsBase"/>: the framework deletes by setting
+/// <c>IsDeleted = true</c>, so EF Core's row-erasing members are banned outside the reviewed types
+/// listed in <see cref="AllowedHardDeleteTypes"/>.
+/// <para>
+/// This is the rule turned back on its own author. Store and ADC subclass the same base and
+/// allowlist exactly these four framework types, because no module of theirs erases a row of its
+/// own; running it here is what keeps that list honest, since a NEW framework eraser would
+/// otherwise land in the packages and fail downstream instead of in this repo. Each entry is named
+/// individually rather than exempting a namespace, so a fifth eraser under
+/// <c>MMCA.Common.Infrastructure.Persistence</c> still fails here and gets reviewed.
+/// </para>
+/// </summary>
+public sealed class SoftDeleteEnforcementTests : SoftDeleteEnforcementTestsBase
+{
+    protected override IArchitectureMap Map { get; } = new CommonArchitectureMap();
+
+    /// <inheritdoc />
+    protected override IReadOnlyCollection<string> AllowedHardDeleteTypes =>
+    [
+        // The framework's own set-based delete escape hatch: the ONE place the abstraction can be
+        // reached from, so the rule catches it at the implementation and leaves IRepository free to
+        // be used everywhere else. Erasing is the caller's explicit ask here (the method is named
+        // ExecuteDeleteAsync), and the calling convention is that it targets derived rows the caller
+        // is about to rewrite, never user data that carries an audit or erasure obligation.
+        "MMCA.Common.Infrastructure.Persistence.Repositories.EFRepository`2",
+
+        // Outbox and inbox retention (PurgeAsync, PurgeInboxAsync, SweepDeadLettersAsync). These
+        // rows are delivery plumbing with a bounded lifetime, and the sweep IS the retention policy;
+        // soft-deleting them would grow the table the job exists to bound.
+        "MMCA.Common.Infrastructure.Persistence.Outbox.OutboxCleanupService",
+
+        // Audit-trail retention. Erasing past the retention window IS the requirement (keeping an
+        // audit row forever is the privacy defect, not the safeguard).
+        "MMCA.Common.Infrastructure.Persistence.AuditTrail.AuditTrailCleanupJob",
+
+        // Refresh-session retention. A session row is framework bookkeeping, not an aggregate: it
+        // carries no IsDeleted flag and no audit stamps, and its content is a credential digest plus
+        // the IP and user-agent of a device. Flagging it instead of erasing it would keep a growing
+        // record of a data subject's devices past any use for it (ADR-005).
+        "MMCA.Common.Infrastructure.Persistence.Auth.RefreshSessionCleanupService",
+    ];
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/CreateMigrationProofTable.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/CreateMigrationProofTable.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+
+namespace MMCA.Common.Infrastructure.Tests.MigrationsFixture;
+
+/// <summary>
+/// A real EF Core migration for the framework's single SQLite context, kept in this tiny library
+/// so that the migration-apply proof runs against something a consumer would actually commit.
+/// </summary>
+/// <remarks>
+/// It lives OUTSIDE the test assembly on purpose. EF selects migrations by the
+/// <see cref="DbContextAttribute"/> they carry and the framework declares exactly one SQLite
+/// context class (ADR-006), so a migration compiled into
+/// <c>MMCA.Common.Infrastructure.Tests</c> would immediately be "pending" for every other test that
+/// names the test assembly as its migrations assembly, notably
+/// <c>DbContextFactoryMigrationTargetTests</c>, whose whole argument rests on that assembly
+/// declaring none. Only the tests that opt in by naming THIS assembly ever see this migration.
+/// No Designer file and no model snapshot accompany it: neither is needed to apply a migration at
+/// run time, and both exist only to let <c>dotnet ef migrations add</c> diff the next one.
+/// </remarks>
+[DbContext(typeof(SqliteDbContext))]
+[Migration(MigrationId)]
+public sealed class CreateMigrationProofTable : Migration
+{
+    /// <summary>The migration identifier, as recorded in <c>__EFMigrationsHistory</c>.</summary>
+    public const string MigrationId = "20260831000001_CreateMigrationProofTable";
+
+    /// <summary>The table this migration creates, and the evidence that it was applied.</summary>
+    public const string TableName = "MigrationProof";
+
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+        // Column types are stated explicitly rather than inferred: with no model snapshot the
+        // migration carries an empty target model, so nothing else would supply them.
+        migrationBuilder.CreateTable(
+            name: TableName,
+            columns: table => new
+            {
+                Id = table.Column<long>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                Name = table.Column<string>(type: "TEXT", nullable: false),
+            },
+            constraints: table => table.PrimaryKey($"PK_{TableName}", x => x.Id));
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+        migrationBuilder.DropTable(name: TableName);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/MMCA.Common.Infrastructure.Tests.MigrationsFixture.csproj
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/MMCA.Common.Infrastructure.Tests.MigrationsFixture.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Source\Core\MMCA.Common.Infrastructure\MMCA.Common.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests.MigrationsFixture/packages.lock.json
@@ -1,0 +1,1031 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Meziantou.Analyzer": {
+        "type": "Direct",
+        "requested": "[3.0.190, )",
+        "resolved": "3.0.190",
+        "contentHash": "CFX3BWg27iLO78RORLAGWghpP+1afiAaijAIfhU7+JI+n6V0uVpNIr6H7LYVnRTFb2WAH/450FcvarFl7STOQA=="
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[18.7.23, )",
+        "resolved": "18.7.23",
+        "contentHash": "dyj6z8m+LFjpeH69hdnciCcRCmD0YgMlvuQEywiEshjqj/blgQ+PuWX8Vd5gkWQFoBN4e+TFxx6DvGNSv/gIKg=="
+      },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "+J5kR/naCd62IwY2BG9P0QoHnJM8liBUFFAk6jga1t9s61JC3M+ofb3AY3wc73/pdROyKFCURqctQh8WRCIT/w=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.33.0.1635, )",
+        "resolved": "10.33.0.1635",
+        "contentHash": "nOwgvMh7p64z62GTy2n4Ki51DVy4Q2ejxxfuclW6Y5u6Htk1i2RNRqxuONiZ/4aaBi8V6RwzuCcGTOFcoVoQOg=="
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Azure.Core.Amqp": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "AY1ZM4WwLBb9L2WwQoWs7wS2XKYg83tp3yVVdgySdebGN0FuIszuEqCy3Nhv6qHpbkjx/NGuOTsUbF/oNGBgwA==",
+        "dependencies": {
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "System.Memory.Data": "1.0.2"
+        }
+      },
+      "Azure.Messaging.ServiceBus": {
+        "type": "Transitive",
+        "resolved": "7.20.1",
+        "contentHash": "DxCkedWPQuiXrIyFcriOhsQcZmDZW+j9d55Ev4nnK3yjMUFjlVe4Hj37fuZTJlNhC3P+7EumqBTt33R6DfOxGA==",
+        "dependencies": {
+          "Azure.Core": "1.46.2",
+          "Azure.Core.Amqp": "1.3.1",
+          "Microsoft.Azure.Amqp": "2.7.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "FluentValidation": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "MassTransit.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.5.10",
+        "contentHash": "nZnm2YNH+NcVwY6yC114sJy8J9LtKdFjfKUm/A5HfmzOlZ8ksjgHaPBg5XCG1VAqKDRDFnaudIcesVultKJD7g=="
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "3.1.8",
+        "contentHash": "SitOtZ4tOlAZZPF7p52M7143F+Cuz7o/aU0MrtAXX0+ZkPXzDNroOFhzzE2ogMFThsoEW/E6akXVVcBFM9ZKaw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.8",
+        "contentHash": "Vm4g0cR4YRKRchEOmMJ0uVFU6yxdg7cJa2KHv3SUAHEsdYKvMpHMF5A1hZfsix89ymD5cmuzRnw9a6dKMcvq+Q=="
+      },
+      "Microsoft.Azure.Amqp": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "gm/AEakujttMzrDhZ5QpRz3fICVkYDn/oDG9SmxDP+J7R8JDBXYU9WWG7hr6wQy40mY+wjUF0yUGXDPRDRNJwQ=="
+      },
+      "Microsoft.Azure.Cosmos": {
+        "type": "Transitive",
+        "resolved": "3.61.0",
+        "contentHash": "o0lhN2nrkC2xidy0lhjnojwqgp/N6GOXAr34xQrU5Scs8MmNG9cwG6MtRJSVTWQYW3gm9Ava3pmVbuuTVQyuYg==",
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.HashCode": "1.1.0",
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Bcl.HashCode": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "J2G1k+u5unBV+aYcwxo94ip16Rkp65pgWFb0R6zwJipzWNMgvqlWeuI7/+R+e8bob66LnSG+llLJ+z8wI94cHg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "hubA20AGenQ4Sx0ElWaPpB8DISjXpdx463+1zOGRslsT0e/t/06ITv+pHsop8CcJ0d8PZLfgnT7juCDVD79Dkw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "VOSGU8en6HZJs8t7UMFN+9vGcRgVOOn6fA44Ngcg2NyvJ3P1KE94iAb0XzaVaGhXGtt+qaM/VtEn0/hzluQJeg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "6auJR+9+9VunznKfH7WGrHMrnrmA0F7JZ22EXzwXvVhjfnbu9Xq7NSIWaOf3KJsOanM2qf5ajJ2JR5TlcPZTLA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Bv7X4wSSnzCQED9WYXKJ8fwgyvKwf0xZM1GO8xkf6CF9zl+UBnvjxmcPnokJRy0JKjc1SlHSzzhx1HcL4jitTQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "grznnTJgEYxaWpdKAsTzg6j+89jHgCXWYp+QGtlX5O92+w/VuhWM6JLPYb+uw8M9VhGUvOTsO76dYOy9vNPd5Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "ywTQKt32xnVhCzjEQAqFufpEyXkOUfvW/EC/s4xnS8Xaor2xXE+TMUyzhgACqXtZEU5IR95y94RDzHto55Fx7w==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyModel": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "BX45SeAjP6sz9Djg6Gm0/IruBuWkyUKxtr4pn9sLAuprnuRn+VBPZVH2XxpzbaT7cVCPim3+Dkijl6yhLHjBOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "vUl798SmruTqqlt/xH2gDk3tJlhk6k3HdOXAHirlRfbNKDym4g/kRpUL9S4sl6F6FsOTOMW+ZsDapqlZMOOiEw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "el1g0mBEbDBGY2bT9mcSfrTWO8QlPdq2nOCnvQugioOFwHV+bVBMeiakoI0dNOdj8d6Hi9K6HY2xzRUWJiDR3w==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "tuSqNuiJxlln43sZ8c1EDA4WXit1eX4foGadylXso3DnMVc+DtKfaNEwvHuiFXfPsEUZ6Z3GnF0Bfk9vvOsE4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.ObjectPool": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "wlhRqZW8LcJPa+vk2oLAc/REXDItHtkFQdf/QcXYGZbZOO13izcsKY1pCvuFQYwUiZD+hwSZwsKASjqT+BNaVg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "rFn8RuszZn3qquPVkDytMUlPc2+rXl9MCoygwc1XmAgC5vg5/oXJ8hkOosOrLoBLsqdTy4lFwP6iQdPS9uSYOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "mDW7KVFB05M6jiRUyaZiOMWhS31n5HlSZwoYctHAZAucD4sMDJ70IxOmkGDt6RpstchD+keWBjhdzcMpSkWvWQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "PSmotV19c7E3lKed++uYo1kSiXFI+uTl37CBSrhq+CfLC3FCHjG7R91+xPnNehQfHS1b0Tzo/CCLPWH3qaEheg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "/a1aJz4m7ylhEDf25ugQChLQoN5XwoGjWw/BoR/ZWWKsO1v4DdJElS1uyngahz4B/eOzjFk1KNTkarRLE5wsIg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "hO/IpudHBl+EMXm1Ag8+7ersCN7VuiR6ech1+cVk8I+o7ssPRKdTozIAO4HGPt49G/lY6lo7G2kY5Q00biMHew==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "PJPtFYsZ+r+uz9qqXWUTEyKeJ1EiBGIJtqavkg9ZXijjGSFAk4Fgi5sqIxj+uAyLZwEKgexDUQXhWhvU6l3+og=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "HT70uGPxMLqqnOzKMcnQtDmeV4r0KHr4qVCLhP7SXil9jMEm8sQXwcybxVVFGXZJ1V44xV0mLqQ54aZbcR2OiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "se7Kx8QpJEt+nf26L4qIVAofGTDr1wbexxsh/Fm3Xc04xUkqUXK06KUS7FLwSQYSjqb7q9n+T7MEcXYBhI1Y5g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "Cyp36W6/XHD6sSDnbc6Ss7M+qOcjrer400Dx4Tfkb5OHcKV6bp9uMqZ4Y8PAoSwTfS8a/3lB9xCF+CLf0JGUig==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "4x6y2Uy+g9Ou93eBCVkG/3JCwnc2AMKhrE1iuEhXT/MzNN7co/Zt6yL+q1Srt0CnOe3iLX+sVqpJI4ZGlOPfug==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "JOjac6SQQgZmdmB8WGEw61/7siqMZoWJMkmq2p1goJGxqI59lO6oB4bOl0jNsbaPBdYy5Mlkb+6U7T4+CjnD8Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Tq/UqMaczePv9yWwSsJZRgKtgA46djVR5xHj/lZBCueQ3ag8f9v5mu0EdhrNx7tXxNk+Y9OurG2oKuSKINjr0A==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "2i6rtW/B5rCnWCnhdmWWEmaM9O0HD0zsPY9eRqa++y4tclI3Uw8zvGbBvhY/LjAdtf8gUHhUPcAWj3DRlWMXmQ=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "pwtpF7iF/NNaOBcX+pvMZ7y2+JAVbH5KkNrH9uMZtuVxVJsFTDiWiCR7Tk3HVptsAijaetipUZVRVK2LLq+nvA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "jxxGX3bUe0ZZFtkMaigIJG44aGK6toE0EFhQwPYfTGLHw4EgXgceO8+RAdXZakK4BezpeDhR//6cxqmtae0I9Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Microsoft.Extensions.Telemetry": "10.9.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "nUOJwgFkSiLHiVGFpU22pIJtuWYewuSYQ3JVuP/gdK8ASMT807Px+TYQiRWs6uSsOmoyFTaVCwKXTasczV6BpA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Ljd0Uxoq5XpScD2Bg0nM/r3mwx7Ao5Uq24eo2ARxbGvqJ7Zht6rt2cJtwVRH4Cv+1ZVMdXz6TB43KbpmsxRrvQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "S7LvLeVHKNPaY2NMyxW7c2TBGsLgxoSUBCV5Ev5iN8kgC7EPR2UB7eW7vHsElGMcIUDwRmoxLfvGDynCn3q6EA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "p76ztQFROBOlHgdV1vXfmTjRyu073Av7ZlsiLR93ka6+nzkLCeV2ONXq0DO/BGf71REqGW29Uy/20fzQHAjB7Q=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "eY1GAKcTfD2maP27J84X9IovT3yjHJ2dVDzPmDg6/XqYvt3jMzJhtfQCLjG9pVsZGAd+8DQ2QrjaDcs2+VQLGw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "syEhXQ/sEaSBFaqzlp9gDGHX/nk6gkQkh1sIUpBO1mlBj3Phu1rmb4ML1uCiyPW9N6Kxfxv3y5FGObC+bV01Qw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "LXMTKZGNzs3fsjKytTVeIEdp+yssJon7PW3VbxERZeqALA2Za/AQzt2h6K64PZ2NzgfFnX4rCJp6aTe+ocX83A==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.9.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.9.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "RpV3VzPa1YoHqvE2Q4uOuVjioVJhLOhaz4FXIE3XAEvla4qujnM+wFB7QnTAmIJxlg7lbBslkIHJQzpI8yHDQQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.9.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.9.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.11",
+          "Microsoft.Extensions.ObjectPool": "10.0.11",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.9.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.9.0",
+        "contentHash": "rCyM64XvBNi2IY/5noMVsJjt22zVmnI+8tGrb6JnPRW/75Nyv9Hi+7gkxb7zQcR0+2mzS1sAqPXz2PsdHZCqHg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.9.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.ObjectPool": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Broker": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "928ySLeGz1xtvydwq6h9tv7TbxrtA4ZzavLKUqRJh0PW6BGcEJwpI8W8vf2PlQdYemGm/oyGjdzYzdY/I8r/4A==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.NativeInterop": "0.20.6"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "3Izi75UCUssvo8LPx3OVnEeZay58qaFicrtSnbtUt7q8qQi0gy46gh4V8VUTkMVMKXV6VMyjBVmeNNgeCUJuIw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "BZNgSq/o8gsKExdYoBKPR65fdsxW0cTF8PsdqB8y011AGUJJW300S/ZIsEUD0+sOmGc003Gwv3FYbjrVjvsLNQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "h+fHHBGokepmCX+QZXJk4Ij8OApCb2n2ktoDkNX5CXteXsOxTHMNgjPGpAwdJMFvAL7TtGarUnk3o97NmBq2QQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "yT2Hdj8LpPbcT9C9KlLVxXl09C8zjFaVSaApdOwuecMuoV4s6Sof/mnTDz/+F/lILPIBvrWugR9CC7iRVZgbfQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "7.7.1",
+          "System.IdentityModel.Tokens.Jwt": "7.7.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "7.7.1",
+        "contentHash": "fQ0VVCba75lknUHGldi3iTKAYUQqbzp1Un8+d9cm9nON0Gs8NAkXddNg8iaUB0qi/ybtAmNWizTR4avdkCJ9pQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.7.1"
+        }
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.11.4",
+        "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA=="
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "RabbitMQ.Client": {
+        "type": "Transitive",
+        "resolved": "7.2.1",
+        "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg==",
+        "dependencies": {
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "RESPite": {
+        "type": "Transitive",
+        "resolved": "3.1.31",
+        "contentHash": "u+MFK6FzGWngKaY3wJ/V9vQSVe/NSqpk0IYYw6ACwmlPq5eTnsyZGlzEa3YMifJGVs3omrl5MkgigB1jZYNnGg=="
+      },
+      "SQLite": {
+        "type": "Transitive",
+        "resolved": "3.53.4",
+        "contentHash": "KN7jeWqgUPeBRe1FlcpZURzxomuKKEKHmBBQfg+Nx7NkY1LjKhzHvH+3ASkNvhayESE34nMBinL9CV21JfPRJw=="
+      },
+      "SQLitePCLRaw.config.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "aSk8WE5tF2MybESMgtZAEyMVCAWA0nBqOMc48HFoa9UoSdtm3goDXVzNRnefeKIwE6bV9NaNXptn1F9ReMQI0Q==",
+        "dependencies": {
+          "SQLitePCLRaw.provider.e_sqlite3": "3.0.5"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "k81AYXXRCw3Zj8rOhyBoCsx/U97KYDFI2CSKr/ijl5BwpsW/hX/4kBiDmerFaoust8nxBwa0IHQFw8MmSHRtnQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "3.0.5",
+        "contentHash": "um8YSWduhhuskTG2bHfZrBqMNQOydfU8pcseT+cu5RivOGyoUbCrGXxgoRNTmRYw2VbMWnEZVVFcneZT/5dsBg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "3.0.5"
+        }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "9.0.11",
+        "contentHash": "vPinosRgEk1CGjohbv0pDuz6gPprkWo5xvBTjOJjks5JOgOEWvPndq5NngGxiTcBcy1+k9GwzZ1c3Bp2fU5ezw==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "9.0.11",
+          "System.Security.Cryptography.ProtectedData": "9.0.11"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "9.0.11",
+        "contentHash": "2Us/NchH6SM69NYWzf8NRyeftdv3ILso8LMiMdAjT7ECTiZKzddiXWhAyQj6ZzbddoAOHS9GdlPbAAkwCPID3Q=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8IBJWcCT9+e4Bmevm4T7+fQEiAh133KGiz4oiVTgJckd3Q76OFdR1falgn9lpz7+C4HJvogCDJeAa2QmvbeVtg=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "9.0.11",
+        "contentHash": "YS2YqtN6fFjlTDIQI+ucjbbrEvwMn796r+VLTQRr/5Oy6g+i+m7nIou83KnJCnAcKna2I+5eVJRks6SoHSpetQ=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "9.0.11",
+        "contentHash": "s8yUYuYYu+PAwvBdhLG1KyrGrk9gkYeuPxfAsXsTqqWyepwSyEw8hAaflW4nO98NG52YpYI1am2+9o+79h2RtQ=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "mmca.common.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "MMCA.Common.Domain": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Json": "[10.0.11, )",
+          "Microsoft.FeatureManagement": "[4.7.0, )",
+          "MiniProfiler.Shared": "[4.5.4, )",
+          "Scrutor": "[7.0.0, )",
+          "System.Linq.Dynamic.Core": "[1.7.3, )"
+        }
+      },
+      "mmca.common.domain": {
+        "type": "Project",
+        "dependencies": {
+          "MMCA.Common.Shared": "[1.0.0, )"
+        }
+      },
+      "mmca.common.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
+          "Azure.Storage.Blobs": "[12.29.2, )",
+          "Cronos": "[0.13.0, )",
+          "MMCA.Common.Application": "[1.0.0, )",
+          "MassTransit": "[8.5.10, )",
+          "MassTransit.Azure.ServiceBus.Core": "[8.5.10, )",
+          "MassTransit.RabbitMQ": "[8.5.10, )",
+          "MessagePack": "[3.1.8, )",
+          "Microsoft.AspNetCore.SignalR.StackExchangeRedis": "[10.0.11, )",
+          "Microsoft.Azure.NotificationHubs": "[4.2.0, )",
+          "Microsoft.EntityFrameworkCore.Cosmos": "[10.0.11, )",
+          "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.11, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.11, )",
+          "Microsoft.Extensions.Caching.Hybrid": "[10.9.0, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
+          "MiniProfiler.EntityFrameworkCore": "[4.5.4, )",
+          "Polly.Core": "[8.7.0, )",
+          "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
+          "SixLabors.ImageSharp": "[3.1.12, )",
+          "StackExchange.Redis": "[3.1.31, )"
+        }
+      },
+      "mmca.common.shared": {
+        "type": "Project"
+      },
+      "Azure.Identity": {
+        "type": "CentralTransitive",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "CentralTransitive",
+        "requested": "[12.29.2, )",
+        "resolved": "12.29.2",
+        "contentHash": "NeZmk7bphspT2BYn8XaNCTV4/9vQG+ea79F85MBTi2o2WiXIIJNsRBtFyeBrzK2HIk476rfSqLNwPt4vXgOEkQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.13.0, )",
+        "resolved": "0.13.0",
+        "contentHash": "Nkve+Yi0+ol3ntSBRHeW0ka9cJQ8vndSUvvkXqF9LVqwpoqWueyxu/HS275r98RDOmF7/mzRnZW5XXUBXob+TA=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "MassTransit": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "TGi34UA8RftBIpYCHEdoIP5uSu2/pLWZRen4RUcg4CV1nr8MmCZMuFYjzvXXUyFcj0ZuRQxZZNhG7fB5/raSOg==",
+        "dependencies": {
+          "MassTransit.Abstractions": "8.5.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "MassTransit.Azure.ServiceBus.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "pXA+Vk/VB+s/0PeL4iht3q3VzxirbLNuSWnDDvEIFBfQdZpY28ZD/l2+6PTcVj6KvJH9nkqzlI7mnMw2pEYKPQ==",
+        "dependencies": {
+          "Azure.Identity": "1.21.0",
+          "Azure.Messaging.ServiceBus": "7.20.1",
+          "MassTransit": "8.5.10"
+        }
+      },
+      "MassTransit.RabbitMQ": {
+        "type": "CentralTransitive",
+        "requested": "[8.5.10, )",
+        "resolved": "8.5.10",
+        "contentHash": "5aQGpJpeqRhRv+htkXfi6MfWu0dj/4Lcf1c6h2J3tYZClupGklqB1ixlP3IRdZExrH9BI/60uYoxR+7pg3s1oQ==",
+        "dependencies": {
+          "MassTransit": "8.5.10",
+          "RabbitMQ.Client": "7.2.1"
+        }
+      },
+      "MessagePack": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.8, )",
+        "resolved": "3.1.8",
+        "contentHash": "Qk2q+9FVxnMSp+NQ9y3SLz3HqWe7Rg3KRMHhBX28FkKUoOeP9YIU86mA4pFOxDDjUIRA9e7Ssbxs/LwWUcAzPw==",
+        "dependencies": {
+          "MessagePack.Annotations": "3.1.8",
+          "MessagePackAnalyzer": "3.1.8",
+          "Microsoft.NET.StringTools": "17.11.4"
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "bo7fagrKzIkwBTnzYXwPSqkV/JLALw22QYSwVnizsrHkiV7txWmIrsWxm8Qe3uRTZbxnykBUOnnC3ZavGtlqRg==",
+        "dependencies": {
+          "MessagePack": "2.5.302",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
+      "Microsoft.Azure.NotificationHubs": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "LOCxFB/sB1frfuXjecdDRDKEHkH+I1qKRatS5NyWIgYhpKhIcAlPNIJajcwLgQBShckdc3hMG9E+75CnL3qDhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "6.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.2, )",
+        "resolved": "6.1.6",
+        "contentHash": "6abRPXrjjEWxcNkTomBIzBdGolYnwD0ykP+6YAynaEEfKlGe94ZSQd58pggucusp28xUA7wLo9XcvzU92ZuF6Q==",
+        "dependencies": {
+          "Azure.Core": "1.50.0",
+          "Azure.Identity": "1.17.1",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "9.0.11",
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.Broker": "4.84.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.7.1",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.11",
+          "System.IdentityModel.Tokens.Jwt": "7.7.1",
+          "System.Security.Cryptography.Pkcs": "9.0.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Cosmos": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "Bx8MAu44K23LK7UQvG+iwkYcgHIUnd/G1cFeQX5sk9JzNO9E1fZebGWfLjfk90ii08MUilMmP5wcDOSlkJwFqw==",
+        "dependencies": {
+          "Microsoft.Azure.Cosmos": "3.61.0",
+          "Microsoft.EntityFrameworkCore": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Newtonsoft.Json": "13.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "jc7iVrhQyInR3loraMESfEFaFOtQOB1mRKHjX6QYC9o7YDbfMNbAPnIwlpffnFwhXd6/27FKaaV+sWSoLd4F1g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyModel": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.12",
+          "SQLitePCLRaw.core": "2.1.12"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "LClSs5cNN6za2Uk7IeH7RAP4Qe5EMXxFsD9i53ncPx21TVg04IEjoFyxvvsSNkq2/Ux9HyJsJ2qEO8Tl7Gcrrg==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.6",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.Hybrid": {
+        "type": "CentralTransitive",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "D0tHRbUCliInxTfPgN9K6RxrCVaWu9kyIT66vbIJ/YwA6BV2xa8vTqoE3JQXA2Rf2vRdgd29+HR6Ay6KmzDslw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "fVi053xdpda9Em7vSkmgVxO/PtgC2m78ekReKWsgcyskqY0U82Bz/MONwxpGzI0hElYKJfw+fupqMVeKW3fSaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "nSPrT8U/cNoB4coqkmnanAMK9PsL7lsjG+LLUKEwHRFwS6E78b8S1wdv/y88EOxBhasWov1rLd7RTHmmsYPOLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.11",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "ujx8RvcKzkxPFBguwgiygbwWVHVK0P7HFlNJ6I0JBRb28tzwe42jixBoA+dGmqG9IHepPVcm04vv2IDnU93ekA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "loWrGc0mZt6N91IV+PZQeNU4uvb2vHdKgU9pUo8i2SGix9edTNCVhwzBp3gWJeaXeoPMph6F9xXcXF4W2ePpRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.9.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.11",
+          "Microsoft.Extensions.Resilience": "10.9.0"
+        }
+      },
+      "Microsoft.FeatureManagement": {
+        "type": "CentralTransitive",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "f+XutOuZZLNq6OJV8z7nys+k89W3PUsoJJgrbYTXd20GvDyJfQ9A8o2MSU8FZT7DY6jQOq3I4KO/+NHsXHdACw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
+        }
+      },
+      "MiniProfiler.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.4, )",
+        "resolved": "4.5.4",
+        "contentHash": "SSOuBYtNbM8AMmsYMP6Edr7iBfVYzswVt/yoIDboBRLLUgkA4SyROCJuTTtZ8eJSzlNuq5DIR+BLCCcigaV/vw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.11",
+          "MiniProfiler.Shared": "4.5.4"
+        }
+      },
+      "MiniProfiler.Shared": {
+        "type": "CentralTransitive",
+        "requested": "[4.5.4, )",
+        "resolved": "4.5.4",
+        "contentHash": "f8ckFm/xTS8C2Bn4BdVc94dNvg+tRfk0e4XFaETOqRi6r0PUOyn3Z9jTQCVpB3R1pP5WiRsEIrqqxux95BVpTA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.0.0"
+        }
+      },
+      "Polly.Core": {
+        "type": "CentralTransitive",
+        "requested": "[8.7.0, )",
+        "resolved": "8.7.0",
+        "contentHash": "BS2t+nsBer16PIebCEPNBK5fgMisADQyRCd7K+BgkMWpFmSaiYE+rVVNpFhGRqUkJmNSLmw0uCNzHHWfgml28Q=="
+      },
+      "Scrutor": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "wHWaroody48jnlLoq/REwUltIFLxplXyHTP+sttrc8P7+jkiVqf38afDidJNv4qgD/6zz2NKOYg06xLZ1bG7wQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0"
+        }
+      },
+      "SixLabors.ImageSharp": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.12, )",
+        "resolved": "3.1.12",
+        "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.5, )",
+        "resolved": "3.0.5",
+        "contentHash": "SW8iASIyWMrLzqabUHYQRvALhvD4ylSBsj4PgEVGwc36kQjc9xT5kSV/XQ9rU7nIpBWD+LPyX3Hlw5FzyUzGeQ==",
+        "dependencies": {
+          "SQLite": "3.53.4",
+          "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[3.1.31, )",
+        "resolved": "3.1.31",
+        "contentHash": "QillloeZxgw9+IWmnowTrjrn+JV7JIMVzr1JiUpCa7pJQI48rtcqG9yy6u5UBRiTuCiKU5909aRu67Ch6gWVMg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "RESPite": "3.1.31",
+          "System.IO.Hashing": "10.0.5"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "CentralTransitive",
+        "requested": "[8.22.0, )",
+        "resolved": "7.7.1",
+        "contentHash": "rQkO1YbAjLwnDJSMpRhRtrc6XwIcEOcUvoEcge+evurpzSZM3UNK+MZfD3sKyTlYsvknZ6eJjSBfnmXqwOsT9Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
+          "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "System.Linq.Dynamic.Core": {
+        "type": "CentralTransitive",
+        "requested": "[1.7.3, )",
+        "resolved": "1.7.3",
+        "contentHash": "0m52+B4Jce/9AXLXPZnnFW7NeLotHBuYvbsVF3D/DTvvbCGJZdskPn5xjr5sjnnFI3XekNdPqG2djyJE3UU7SA=="
+      }
+    }
+  }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/MMCA.Common.Infrastructure.Tests.csproj
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/MMCA.Common.Infrastructure.Tests.csproj
@@ -19,5 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Source\Core\MMCA.Common.Infrastructure\MMCA.Common.Infrastructure.csproj" />
+    <!-- Holds the one committed EF migration MigrationApplyProofTests applies. Kept in its own
+         assembly so it is invisible to the tests that name THIS assembly as their migrations
+         assembly precisely because it declares none. -->
+    <ProjectReference Include="..\MMCA.Common.Infrastructure.Tests.MigrationsFixture\MMCA.Common.Infrastructure.Tests.MigrationsFixture.csproj" />
   </ItemGroup>
 </Project>

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/MigrationApplyProofTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/MigrationApplyProofTests.cs
@@ -1,0 +1,225 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Interfaces;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts.Factory;
+using MMCA.Common.Infrastructure.Persistence.Interceptors;
+using MMCA.Common.Infrastructure.Persistence.Outbox;
+using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.MigrationsFixture;
+using Moq;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// End-to-end proof that the framework applies a REAL migration: a committed
+/// <see cref="CreateMigrationProofTable"/> in a separate fixture assembly is run against a real
+/// SQLite file through <see cref="DbContextFactory"/>, the same call
+/// <c>DatabaseInitializationExtensions</c> makes for the <c>"Migrate"</c> strategy.
+/// </summary>
+/// <remarks>
+/// Its sibling <c>DbContextFactoryMigrationTargetTests</c> proves which SOURCES the factory selects,
+/// using a migrations assembly that declares nothing so that only the history table can appear.
+/// This class proves the other half, that a declared migration actually reaches the schema, which is
+/// why the migration lives in its own assembly: the two tests would otherwise contradict each other.
+/// The pending-migration assertions below are the primitive the <c>"None"</c> strategy guard is
+/// built on; the guard itself is covered where it lives, in
+/// <c>MMCA.Common.API.Tests.Startup.DatabaseInitializationExtensionsTests</c>.
+/// </remarks>
+public sealed class MigrationApplyProofTests : IDisposable
+{
+    private const string SourceName = "MigrationProof";
+
+    private static readonly string MigrationsAssemblyName =
+        typeof(CreateMigrationProofTable).Assembly.GetName().Name!;
+
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"mmca-migration-proof-{Guid.NewGuid():N}.db");
+
+    private readonly ServiceProvider _serviceProvider;
+    private readonly DataSourceResolver _resolver;
+    private readonly DbContextFactory _sut;
+    private readonly DataSourceKey _key;
+
+    public MigrationApplyProofTests()
+    {
+        var connectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "Server=unused;" };
+        var dataSources = new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            [SourceName] = new()
+            {
+                SqliteConnectionString = $"Data Source={_databasePath}",
+                SqliteMigrationsAssembly = MigrationsAssemblyName,
+            },
+        });
+
+        _resolver = new DataSourceResolver(Options.Create(connectionStrings), dataSources, NullLogger<DataSourceResolver>.Instance);
+        _key = _resolver.ResolveLogical(DataSource.Sqlite, SourceName);
+
+        var registry = new FixedSourcesRegistry([_key]);
+        var assemblyProvider = new NoConfigurationAssemblyProvider();
+
+        _serviceProvider = new ServiceCollection()
+            .AddSingleton(TimeProvider.System)
+            .AddSingleton<ILoggerFactory, NullLoggerFactory>()
+            .AddSingleton(typeof(ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<IDomainEventDispatcher>())
+            .AddSingleton<IOutboxSignal, OutboxSignal>()
+            .AddSingleton<AuditSaveChangesInterceptor>()
+            .AddSingleton<DomainEventSaveChangesInterceptor>()
+            .AddSingleton<IEntityDataSourceRegistry>(registry)
+            .AddSingleton<IDataSourceResolver>(_resolver)
+            .BuildServiceProvider();
+
+        var physicalFactory = new PhysicalDbContextFactory(_serviceProvider, _resolver, assemblyProvider);
+        _sut = new DbContextFactory(physicalFactory, registry, _resolver, Mock.Of<ICurrentUserService>(), Mock.Of<ITenantContext>(), Options.Create(new TenancySettings()));
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+        _serviceProvider.Dispose();
+        SqliteConnection.ClearAllPools();
+        TryDelete(_databasePath);
+    }
+
+    [Fact]
+    public async Task MigrateAsync_AppliesTheCommittedMigration()
+    {
+        await _sut.MigrateAsync();
+
+        (await AppliedMigrationsAsync()).Should().ContainSingle()
+            .Which.Should().Be(CreateMigrationProofTable.MigrationId,
+                "the applied migration is recorded in the history table by its id");
+        (await TableExistsAsync(CreateMigrationProofTable.TableName)).Should().BeTrue(
+            "the migration's CreateTable reached the schema, not just the history table");
+        (await _sut.HasPendingMigrationsAsync()).Should().BeFalse(
+            "nothing is left pending once the only migration is applied");
+    }
+
+    // The other side of the same fact, and the one a production host depends on: before anything is
+    // applied, the migration is reported as pending BY NAME. The "None" strategy turns exactly this
+    // into a startup failure, so a host is never allowed to serve traffic against a schema that is
+    // behind its code.
+    [Fact]
+    public async Task HasPendingMigrationsAsync_NamesTheMigrationBeforeItIsApplied()
+    {
+        (await _sut.HasPendingMigrationsAsync()).Should().BeTrue();
+
+        var pending = await _sut.GetDbContext(_key).Database.GetPendingMigrationsAsync();
+        pending.Should().ContainSingle().Which.Should().Be(CreateMigrationProofTable.MigrationId);
+
+        (await TableExistsAsync(CreateMigrationProofTable.TableName)).Should().BeFalse(
+            "asking what is pending must not apply anything");
+    }
+
+    // Startup runs on every boot and every replica, so a second Migrate over an up-to-date database
+    // has to be a no-op rather than a re-apply (whose CREATE TABLE would hit the existing table).
+    [Fact]
+    public async Task MigrateAsync_RunTwice_IsANoOp()
+    {
+        await _sut.MigrateAsync();
+        await _sut.MigrateAsync();
+
+        (await AppliedMigrationsAsync()).Should().ContainSingle(
+            "a migration already recorded in the history table is not applied again");
+        (await TableExistsAsync(CreateMigrationProofTable.TableName)).Should().BeTrue();
+    }
+
+    /// <summary>The migration ids recorded in the database's <c>__EFMigrationsHistory</c> table.</summary>
+    private async Task<IReadOnlyList<string>> AppliedMigrationsAsync()
+    {
+        if (!await TableExistsAsync("__EFMigrationsHistory"))
+        {
+            return [];
+        }
+
+        var connection = await OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT MigrationId FROM __EFMigrationsHistory ORDER BY MigrationId";
+
+        var applied = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            applied.Add(reader.GetString(0));
+        }
+
+        return applied;
+    }
+
+    /// <summary>Whether a table of the given name exists in the database under test.</summary>
+    private async Task<bool> TableExistsAsync(string tableName)
+    {
+        var connection = await OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = $name";
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = tableName;
+        command.Parameters.Add(parameter);
+
+        return Convert.ToInt32(
+            await command.ExecuteScalarAsync(),
+            System.Globalization.CultureInfo.InvariantCulture) > 0;
+    }
+
+    private async Task<System.Data.Common.DbConnection> OpenConnectionAsync()
+    {
+        var connection = _sut.GetDbContext(_key).Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+        {
+            await connection.OpenAsync();
+        }
+
+        return connection;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // Best-effort temp file cleanup.
+        }
+    }
+
+    /// <summary>
+    /// Reports the single source under test, so the topology is stated here rather than inferred
+    /// from whichever entity configurations happen to live in this assembly.
+    /// </summary>
+    private sealed class FixedSourcesRegistry(IReadOnlyCollection<DataSourceKey> sources) : IEntityDataSourceRegistry
+    {
+        public DataSourceKey GetDataSourceKey(Type entityType) =>
+            throw new InvalidOperationException($"No data source registered for entity type \"{entityType}\".");
+
+        public DataSourceKey GetDataSourceKey(string entityFullName) =>
+            throw new InvalidOperationException($"No data source registered for entity \"{entityFullName}\".");
+
+        public bool TryGetDataSourceKey(string entityFullName, out DataSourceKey key)
+        {
+            key = default;
+            return false;
+        }
+
+        public IReadOnlyCollection<DataSourceKey> GetPhysicalSourcesInUse() => sources;
+    }
+
+    /// <summary>
+    /// Supplies no configuration assemblies: the schema under test comes from the migration, which
+    /// is the whole point, so the context's own model must contribute nothing.
+    /// </summary>
+    private sealed class NoConfigurationAssemblyProvider : IEntityConfigurationAssemblyProvider
+    {
+        public IReadOnlyList<System.Reflection.Assembly> GetConfigurationAssemblies() => [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/packages.lock.json
@@ -897,6 +897,12 @@
           "StackExchange.Redis": "[3.1.31, )"
         }
       },
+      "mmca.common.infrastructure.tests.migrationsfixture": {
+        "type": "Project",
+        "dependencies": {
+          "MMCA.Common.Infrastructure": "[1.0.0, )"
+        }
+      },
       "mmca.common.shared": {
         "type": "Project"
       },

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/H2cHealthCheckExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/H2cHealthCheckExtensionsTests.cs
@@ -207,6 +207,50 @@ public sealed class H2cHealthCheckExtensionsTests
         result.Status.Should().Be(HealthStatus.Unhealthy);
     }
 
+    // The registration's own timeout cancels the SAME token CheckHealthAsync receives. A probe that
+    // outlives ProbeTimeout therefore arrives here with a cancelled token, and it must still come
+    // back as an Unhealthy RESULT: letting it escape gets it logged by the health service as an
+    // unhandled exception on every poll (the 2026-08-31 apphost-smoke logs were full of exactly
+    // that noise).
+    [Fact]
+    public async Task Probe_WhenTheRegistrationTimeoutHasCancelledTheToken_StillReportsUnhealthyRatherThanThrowing()
+    {
+        using var handler = new StubHandler(_ => throw new TaskCanceledException("probe budget exhausted"));
+        using var client = new HttpClient(handler, disposeHandler: false);
+        var check = new H2cEndpointHealthCheck(() => "http://identity:8080", "/alive", client.SendAsync);
+        var registration = new HealthCheckRegistration("identity-h2c-http", check, HealthStatus.Unhealthy, tags: null);
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        var result = await check.CheckHealthAsync(
+            new HealthCheckContext { Registration = registration },
+            cancelled.Token);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().BeOfType<TaskCanceledException>();
+    }
+
+    // Pins the poisoned-connection guard on the shared probe handler. HTTP/2 pools one connection
+    // per origin, and the Aspire endpoint proxy listens before the target Kestrel does, so the first
+    // probe of a starting resource can open a connection that is accepted and never answered. The
+    // keep-alive ping trio is what tears that zombie down so a later probe can open a fresh
+    // connection; without it the shared client queues every probe onto the zombie forever and the
+    // resource can never turn healthy (the 2026-08-31 apphost-smoke wedge). Verified empirically
+    // against a held-open unanswered socket; this test pins the settings so a refactor cannot
+    // silently drop them.
+    [Fact]
+    public void ProbeHandler_KeepsTheKeepAlivePingGuardAgainstPoisonedConnections()
+    {
+        var handler = H2cEndpointHealthCheck.ProbeHandler;
+
+        handler.KeepAlivePingPolicy.Should().Be(
+            HttpKeepAlivePingPolicy.Always,
+            because: "a zombie connection carries no active streams, so a WithActiveRequests policy would never ping it down");
+        handler.KeepAlivePingDelay.Should().Be(TimeSpan.FromSeconds(1));
+        handler.KeepAlivePingTimeout.Should().Be(TimeSpan.FromSeconds(1));
+        handler.UseProxy.Should().BeFalse();
+    }
+
     // Aspire allocates an endpoint only once the resource starts, so the first polls after the
     // AppHost comes up resolve nothing. Failing them is correct: Aspire releases a WaitFor edge only
     // on Healthy, so a pre-allocation poll that passed would defeat the gate entirely.

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Security/SecurityHeadersMiddlewareTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Security/SecurityHeadersMiddlewareTests.cs
@@ -91,13 +91,97 @@ public sealed class SecurityHeadersMiddlewareTests
         headers.ContentSecurityPolicyReportOnly.ToString().Should().BeEmpty();
     }
 
-    // The framework default (used when a host registers no custom ICspPolicyProvider) must be a
-    // conservative hardened baseline — safe for API/Gateway JSON responses, and deliberately omitting
-    // script-src/style-src so an HTML host that forgot a provider isn't broken (§26, R18).
+    // The framework default (used when a host registers no custom ICspPolicyProvider) is a COMPLETE
+    // hardened baseline: script-src and style-src ship at exactly the strength Blazor ('wasm-unsafe-eval')
+    // and MudBlazor ('unsafe-inline' styles) require, so an HTML host that never registers a provider
+    // still gets a functional policy rather than one silently missing both directives (§26, R18).
     [Fact]
     public void DefaultSettings_ContentSecurityPolicy_IsHardenedBaseline() =>
         new SecurityHeadersSettings().ContentSecurityPolicy.Should().Be(
-            "default-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'");
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; " +
+            "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'");
+
+    // == Per-request {nonce} placeholder ==
+    private static async Task<(IHeaderDictionary Headers, HttpContext Context)> RunWithContextAsync(CspPolicy? policy)
+    {
+        var context = new DefaultHttpContext();
+        var middleware = new SecurityHeadersMiddleware(
+            _ => Task.CompletedTask,
+            Options.Create(new SecurityHeadersSettings()),
+            new StubCspProvider(policy),
+            new StubWebHostEnvironment(Environments.Production));
+
+        await middleware.InvokeAsync(context);
+        return (context.Response.Headers, context);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PolicyWithNoncePlaceholder_SubstitutesQuotedNonceIntoTheHeader()
+    {
+        var (headers, context) = await RunWithContextAsync(
+            new CspPolicy("script-src 'self' {nonce}; style-src 'self' {nonce}", Enforce: true));
+
+        var nonce = CspNonce.Get(context);
+        nonce.Should().NotBeNullOrWhiteSpace();
+        Convert.TryFromBase64String(nonce!, new byte[nonce!.Length], out var written)
+            .Should().BeTrue("the nonce is valid Base64");
+        written.Should().Be(16, "the nonce carries 128 bits of entropy");
+
+        var value = headers.ContentSecurityPolicy.ToString();
+        value.Should().NotContain("{nonce}", "every occurrence of the placeholder is replaced");
+        value.Should().Be(
+            $"script-src 'self' 'nonce-{nonce}'; style-src 'self' 'nonce-{nonce}'",
+            "one nonce is generated per request, not per occurrence, and it is emitted in quoted source-list form");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PolicyWithNoncePlaceholder_StoresTheSameValueCspNonceGetReturns()
+    {
+        var (headers, context) = await RunWithContextAsync(new CspPolicy("script-src 'self' {nonce}", Enforce: true));
+
+        var stored = CspNonce.Get(context);
+        stored.Should().NotBeNullOrWhiteSpace();
+        context.Items[CspNonce.ItemKey].Should().Be(stored);
+        headers.ContentSecurityPolicy.ToString().Should().Be($"script-src 'self' 'nonce-{stored}'");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PolicyWithNoncePlaceholder_GeneratesADifferentNoncePerRequest()
+    {
+        var policy = new CspPolicy("script-src 'self' {nonce}", Enforce: true);
+
+        var (_, first) = await RunWithContextAsync(policy);
+        var (_, second) = await RunWithContextAsync(policy);
+
+        CspNonce.Get(second).Should().NotBe(CspNonce.Get(first));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PolicyWithNoncePlaceholder_WorksInReportOnlyMode()
+    {
+        var (headers, context) = await RunWithContextAsync(new CspPolicy("script-src 'self' {nonce}", Enforce: false));
+
+        var stored = CspNonce.Get(context);
+        stored.Should().NotBeNullOrWhiteSpace();
+        headers.ContentSecurityPolicyReportOnly.ToString().Should().Be($"script-src 'self' 'nonce-{stored}'");
+        headers.ContentSecurityPolicy.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PolicyWithoutNoncePlaceholder_EmitsTheconfiguredStringAndStoresNoNonce()
+    {
+        const string configured = "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'";
+
+        var (headers, context) = await RunWithContextAsync(new CspPolicy(configured, Enforce: true));
+
+        headers.ContentSecurityPolicy.ToString().Should().Be(configured);
+        context.Items.ContainsKey(CspNonce.ItemKey).Should().BeFalse();
+        CspNonce.Get(context).Should().BeNull();
+    }
+
+    [Fact]
+    public void CspNonce_Get_WithNoMiddlewareRun_ReturnsNull() =>
+        CspNonce.Get(new DefaultHttpContext()).Should().BeNull();
 
     private sealed class StubCspProvider(CspPolicy? policy) : ICspPolicyProvider
     {

--- a/Tests/Presentation/MMCA.Common.API.Tests/MMCA.Common.API.Tests.csproj
+++ b/Tests/Presentation/MMCA.Common.API.Tests/MMCA.Common.API.Tests.csproj
@@ -20,5 +20,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Source\Presentation\MMCA.Common.API\MMCA.Common.API.csproj" />
+    <!-- Supplies the one committed EF migration the "None" strategy guard is tested against; see
+         the fixture project's own remarks for why it is not compiled into a test assembly. -->
+    <ProjectReference Include="..\..\Core\MMCA.Common.Infrastructure.Tests.MigrationsFixture\MMCA.Common.Infrastructure.Tests.MigrationsFixture.csproj" />
   </ItemGroup>
 </Project>

--- a/Tests/Presentation/MMCA.Common.API.Tests/Startup/DatabaseInitializationExtensionsTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Startup/DatabaseInitializationExtensionsTests.cs
@@ -18,6 +18,7 @@ using MMCA.Common.Infrastructure.Persistence.Interceptors;
 using MMCA.Common.Infrastructure.Persistence.Outbox;
 using MMCA.Common.Infrastructure.Services;
 using MMCA.Common.Infrastructure.Settings;
+using MMCA.Common.Infrastructure.Tests.MigrationsFixture;
 using Moq;
 
 namespace MMCA.Common.API.Tests.Startup;
@@ -131,6 +132,46 @@ public sealed class DatabaseInitializationExtensionsTests : IDisposable
         (await CountTablesAsync(created, nameof(InitTestWidget))).Should().Be(1,
             "the source with no migrations assembly keeps its EnsureCreated behaviour");
         (await CountTablesAsync(created, "__EFMigrationsHistory")).Should().Be(0);
+    }
+
+    // The production guard, against a REAL committed migration rather than an empty migrations
+    // assembly: "None" is what a deployed host runs, and its whole job is to refuse to start when
+    // the schema is behind the code. The failure has to NAME the migration, because the operator
+    // reading it needs to know what to apply. Nothing may be applied on the way out either: "None"
+    // means none.
+    [Fact]
+    public async Task InitializeDatabaseAsync_NoneStrategy_FailsStartupNamingThePendingMigration()
+    {
+        var connectionStrings = new ConnectionStringSettings { SQLServerConnectionString = "Server=unused;" };
+        var dataSources = new DataSourcesSettings(new Dictionary<string, DataSourceEntrySettings>(StringComparer.Ordinal)
+        {
+            ["TestSqlite"] = new() { SqliteConnectionString = $"Data Source={_sqliteDbPath}" },
+            ["TestSqliteMigrated"] = new()
+            {
+                SqliteConnectionString = $"Data Source={_sqliteMigratedDbPath}",
+                SqliteMigrationsAssembly =
+                    typeof(CreateMigrationProofTable).Assembly.GetName().Name!,
+            },
+        });
+
+        var resolver = new DataSourceResolver(Options.Create(connectionStrings), dataSources, NullLogger<DataSourceResolver>.Instance);
+        var assemblyProvider = new FixedAssemblyProvider();
+        var registry = new EntityDataSourceRegistry(assemblyProvider, resolver);
+
+        await using var provider = BuildProvider(resolver, registry, assemblyProvider);
+
+        var act = () => provider.InitializeDatabaseAsync(
+            new ApplicationSettings { DatabaseInitStrategy = "None" },
+            new ModuleLoader());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{CreateMigrationProofTable.MigrationId}*");
+
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory>();
+        var context = factory.GetDbContext(resolver.ResolveLogical(DataSource.Sqlite, "TestSqliteMigrated"));
+        (await CountTablesAsync(context, CreateMigrationProofTable.TableName)).Should().Be(0,
+            "the 'None' strategy reports what is pending and applies nothing");
     }
 
     // The strategy names exactly two behaviours. A value outside that set is a configuration mistake

--- a/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.API.Tests/packages.lock.json
@@ -1031,6 +1031,12 @@
           "StackExchange.Redis": "[3.1.31, )"
         }
       },
+      "mmca.common.infrastructure.tests.migrationsfixture": {
+        "type": "Project",
+        "dependencies": {
+          "MMCA.Common.Infrastructure": "[1.0.0, )"
+        }
+      },
       "mmca.common.shared": {
         "type": "Project"
       },

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/GridPageE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/GridPageE2ETests.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+using Microsoft.Playwright;
+using MMCA.Common.Testing.E2E.Infrastructure;
+using MMCA.Common.UI.E2E.Tests.Infrastructure;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace MMCA.Common.UI.E2E.Tests;
+
+/// <summary>
+/// Real-browser coverage for the opt-in virtualized list page (<c>/grid</c> in the gallery): that the
+/// windowing is actually happening (the DOM holds a small fraction of the 1,000-row data set), that the
+/// grid scrolls inside its own height-bound viewport rather than the document, and that the virtualized
+/// markup still passes the same WCAG 2.1 AA scan as every other gallery page.
+/// </summary>
+public sealed class GridPageE2ETests : GalleryAxeTestBase
+{
+    /// <summary>Row count of the gallery's generated data set (see <c>SampleGridData.RowCount</c>).</summary>
+    private const int DataSetRowCount = 1000;
+
+    /// <summary>
+    /// Ceiling on rendered body rows. A 70vh viewport at 52px per row plus MudBlazor's overscan lands
+    /// well under 50 on any CI viewport; 200 leaves generous headroom while still being a fifth of the
+    /// data set, so a regression that renders everything cannot slip through.
+    /// </summary>
+    private const int MaxRenderedRows = 200;
+
+    public GridPageE2ETests(PlaywrightFixture playwright, GalleryHostFixture gallery)
+        : base(playwright, gallery)
+    {
+    }
+
+    [Fact]
+    public async Task GridPage_RendersFarFewerRowsThanTheDataSet()
+    {
+        await Page.GotoAndWaitForBlazorAsync("/grid");
+
+        await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Virtualized Grid Gallery" })).ToBeVisibleAsync();
+        await Expect(Page.GetByText("Row 0001")).ToBeVisibleAsync();
+
+        var rendered = await Page.Locator("tbody tr").CountAsync();
+
+        Assert.True(
+            rendered < MaxRenderedRows,
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"Expected a virtualized window under {MaxRenderedRows} rows out of {DataSetRowCount}, but {rendered} rows were rendered."));
+        Assert.True(rendered > 0, "The grid rendered no rows at all, so the window assertion proves nothing.");
+    }
+
+    [Fact]
+    public async Task GridPage_ScrollsInsideItsOwnViewport_AndKeepsTheWindowSmall()
+    {
+        await Page.GotoAndWaitForBlazorAsync("/grid");
+        await Expect(Page.GetByText("Row 0001")).ToBeVisibleAsync();
+
+        // The height-bound container is what scrolls (and what the base class tracks for scroll
+        // restore); the document itself does not.
+        var container = Page.Locator(".mud-table-container");
+        await Expect(container).ToBeVisibleAsync();
+
+        await container.EvaluateAsync("el => { el.scrollTop = 5000; }");
+        var scrollTop = await container.EvaluateAsync<double>("el => el.scrollTop");
+        Assert.True(scrollTop > 0, "The grid container did not scroll, so it is not the virtualization viewport.");
+
+        // The window moves with the scroll; it must not accumulate.
+        await Expect(Page.Locator("tbody tr").First).ToBeVisibleAsync();
+        var rendered = await Page.Locator("tbody tr").CountAsync();
+        Assert.True(
+            rendered < MaxRenderedRows,
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"After scrolling, {rendered} rows were rendered; the window must stay under {MaxRenderedRows}."));
+    }
+
+    [Fact]
+    public async Task GridPage_HasNoWcag21AaViolations()
+    {
+        await Page.GotoAndWaitForBlazorAsync("/grid");
+        await Expect(Page.GetByText("Row 0001")).ToBeVisibleAsync();
+
+        await Page.AssertNoAccessibilityViolationsAsync(AxeOptions.Wcag21Aa);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/NotificationPagesE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/NotificationPagesE2ETests.cs
@@ -45,6 +45,36 @@ public sealed class NotificationPagesE2ETests : GalleryAxeTestBase
     }
 
     [Fact]
+    public async Task NotificationInboxDeepLink_ToAnUnknownNotification_DegradesToThePlainInbox()
+    {
+        // The typed deep link /notifications/inbox/{Id:int} (rubric §25). The gallery's stub inbox
+        // holds ids 1 and 2, so 123 is a well-formed id that is simply not on the loaded page: the
+        // page must render the ordinary inbox, with nothing highlighted and no error surface, since
+        // the user can do nothing about a stale link.
+        await SeedSignedInCookieAsync();
+        await Page.GotoAndWaitForBlazorAsync("/notifications/inbox/123");
+
+        await Expect(Page.GetByRole(AriaRole.Button, new() { Name = "Mark All as Read" })).ToBeVisibleAsync();
+        await Expect(Page.GetByText("Welcome to MMCA").First).ToBeVisibleAsync();
+        await Expect(Page.Locator(".notification-card.deep-linked")).ToHaveCountAsync(0);
+
+        await Page.AssertNoAccessibilityViolationsAsync(AxeOptions.Wcag21Aa);
+    }
+
+    [Fact]
+    public async Task NotificationInboxDeepLink_ToAKnownNotification_HighlightsThatCard()
+    {
+        await SeedSignedInCookieAsync();
+        await Page.GotoAndWaitForBlazorAsync("/notifications/inbox/2");
+
+        var highlighted = Page.Locator(".notification-card.deep-linked");
+        await Expect(highlighted).ToHaveCountAsync(1);
+        await Expect(highlighted).ToHaveAttributeAsync("id", "notification-2");
+
+        await Page.AssertNoAccessibilityViolationsAsync(AxeOptions.Wcag21Aa);
+    }
+
+    [Fact]
     public async Task NotificationCompose_Renders_AndHasNoWcag21AaViolations()
     {
         await SeedSignedInCookieAsync();

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/WebVitalsE2ETests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/WebVitalsE2ETests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using MMCA.Common.Testing.E2E.Infrastructure;
 using MMCA.Common.UI.E2E.Tests.Infrastructure;
 using Xunit;
@@ -19,29 +18,53 @@ public sealed class WebVitalsE2ETests : GalleryAxeTestBase
     private const double TtfbBudgetMs = 4000;
     private const double ClsBudget = 0.25;
 
+    /// <summary>
+    /// The measurement flow lives in the shipped <c>MeasureWebVitalsAsync</c> extension (install the
+    /// observers BEFORE the navigation, load, collect, write the artifact, assert), so this suite no
+    /// longer hand-rolls it. FCP is pinned to the LCP ceiling rather than left on the package default:
+    /// FCP always precedes LCP, so this keeps the effective gate exactly the three metrics the suite has
+    /// always gated on and its CI history comparable. INP stays on the default and is skipped anyway,
+    /// since neither case drives an interaction.
+    /// </summary>
+    private static readonly WebVitalsBudget Budget =
+        new(Lcp: LcpBudgetMs, Fcp: LcpBudgetMs, Ttfb: TtfbBudgetMs, Cls: ClsBudget);
+
     public WebVitalsE2ETests(PlaywrightFixture playwright, GalleryHostFixture gallery)
         : base(playwright, gallery)
     {
     }
 
     [Fact]
-    public async Task LoginPage_CoreWebVitals_WithinBudget() =>
-        await MeasureAsync("gallery-login", "/login");
+    public async Task LoginPage_CoreWebVitals_WithinBudget()
+    {
+        var sample = await Page.MeasureWebVitalsAsync("gallery-login", "/login", Budget);
+
+        AssertSomethingWasMeasured(sample);
+    }
 
     [Fact]
-    public async Task ComponentsPage_CoreWebVitals_WithinBudget() =>
-        await MeasureAsync("gallery-components", "/components");
-
-    private async Task MeasureAsync(string label, string path)
+    public async Task ComponentsPage_CoreWebVitals_WithinBudget()
     {
-        await WebVitalsCollector.InstallAsync(Page);
-        await Page.GotoAndWaitForBlazorAsync(path);
+        var sample = await Page.MeasureWebVitalsAsync("gallery-components", "/components", Budget);
 
-        var sample = await WebVitalsCollector.CollectAsync(Page);
-        await WebVitalsCollector.WriteArtifactAsync(label, path, sample);
-
-        Assert.True(sample.Lcp <= LcpBudgetMs, string.Create(CultureInfo.InvariantCulture, $"LCP {sample.Lcp:F0}ms exceeded budget {LcpBudgetMs}ms on {path}"));
-        Assert.True(sample.Ttfb <= TtfbBudgetMs, string.Create(CultureInfo.InvariantCulture, $"TTFB {sample.Ttfb:F0}ms exceeded budget {TtfbBudgetMs}ms on {path}"));
-        Assert.True(sample.Cls <= ClsBudget, string.Create(CultureInfo.InvariantCulture, $"CLS {sample.Cls:F3} exceeded budget {ClsBudget} on {path}"));
+        AssertSomethingWasMeasured(sample);
     }
+
+    [Fact]
+    public async Task GridPage_CoreWebVitals_WithinBudget()
+    {
+        var sample = await Page.MeasureWebVitalsAsync("gallery-grid", "/grid", Budget);
+
+        AssertSomethingWasMeasured(sample);
+    }
+
+    /// <summary>
+    /// Guards against a vacuous pass. An all-zero sample (collector never installed, navigation never
+    /// happened) is inside every ceiling, so the budget alone cannot tell "fast" from "not measured".
+    /// LCP and CLS are Chromium-only, so the cross-engine floor is TTFB or FCP.
+    /// </summary>
+    private static void AssertSomethingWasMeasured(WebVitalsSample sample) =>
+        Assert.True(
+            sample.Ttfb > 0 || sample.Fcp > 0,
+            "No TTFB or FCP was recorded, so the budget assertion measured nothing.");
 }

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/Pages/GridGallery.razor
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/Pages/GridGallery.razor
@@ -1,0 +1,89 @@
+@page "/grid"
+@using MMCA.Common.Shared.Abstractions
+@using MMCA.Common.UI.Pages.Common
+@inherits DataGridListPageBase<SampleGridRow>
+
+<PageTitle>Virtualized grid</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    <PageHeader Title="Virtualized Grid Gallery" />
+
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-2 mb-4">
+        @SampleGridData.RowCount.ToString("N0", System.Globalization.CultureInfo.InvariantCulture) rows served through
+        <c>VirtualizeServerData</c>. Only the visible window is rendered and fetched, so the row
+        count in the DOM stays a small fraction of the data set no matter how far you scroll.
+    </MudText>
+
+    <MudDataGrid T="SampleGridRow"
+                 @ref="_grid"
+                 Virtualize="true"
+                 Height="@VirtualizedGridHeight"
+                 ItemSize="VirtualizedItemSize"
+                 FixedHeader="true"
+                 Dense="@DenseGrid"
+                 Hover="true"
+                 SortMode="SortMode.Single"
+                 VirtualizeServerData="LoadRowsAsync">
+        <Columns>
+            <PropertyColumn Property="x => x.Id" Title="Id" />
+            <PropertyColumn Property="x => x.Name" Title="Name" />
+            <PropertyColumn Property="x => x.Category" Title="Category" />
+            <PropertyColumn Property="x => x.CreatedOn" Title="Created" Format="yyyy-MM-dd" />
+            <PropertyColumn Property="x => x.Amount" Title="Amount" Format="F2" />
+        </Columns>
+    </MudDataGrid>
+</MudContainer>
+
+@code {
+    private MudDataGrid<SampleGridRow>? _grid;
+
+    protected override string Title => "Virtualized Grid Gallery";
+
+    // The opt-in switch under test: it turns off the pager-restore machinery in the base class and
+    // moves scroll tracking onto the grid's own viewport.
+    protected override bool VirtualizeGrid => true;
+
+    protected override MudDataGrid<SampleGridRow>? GridRef => _grid;
+
+    private Task<GridData<SampleGridRow>> LoadRowsAsync(
+        GridStateVirtualize<SampleGridRow> state, CancellationToken cancellationToken) =>
+        LoadVirtualizedServerDataAsync(state, FetchPageAsync, cancellationToken: cancellationToken);
+
+    // Stands in for IEntityService.GetPagedAsync: same delegate shape, same 1-based page contract, so
+    // the base class maps the virtualization window onto it exactly as it would onto a real API.
+    private static Task<Result<(IReadOnlyList<SampleGridRow> Items, int TotalItems)>> FetchPageAsync(
+        Dictionary<string, (string Operator, string Value)> filters,
+        int pageNumber,
+        int pageSize,
+        string? sortColumn,
+        string? sortDirection,
+        CancellationToken cancellationToken)
+    {
+        var descending = string.Equals(sortDirection, "desc", StringComparison.OrdinalIgnoreCase);
+        var rows = SampleGridData.All;
+
+        IEnumerable<SampleGridRow> ordered = sortColumn switch
+        {
+            nameof(SampleGridRow.Name) => descending
+                ? rows.OrderByDescending(r => r.Name, StringComparer.Ordinal)
+                : rows.OrderBy(r => r.Name, StringComparer.Ordinal),
+            nameof(SampleGridRow.Category) => descending
+                ? rows.OrderByDescending(r => r.Category, StringComparer.Ordinal)
+                : rows.OrderBy(r => r.Category, StringComparer.Ordinal),
+            nameof(SampleGridRow.CreatedOn) => descending
+                ? rows.OrderByDescending(r => r.CreatedOn)
+                : rows.OrderBy(r => r.CreatedOn),
+            nameof(SampleGridRow.Amount) => descending
+                ? rows.OrderByDescending(r => r.Amount)
+                : rows.OrderBy(r => r.Amount),
+            _ => descending
+                ? rows.OrderByDescending(r => r.Id)
+                : rows.OrderBy(r => r.Id),
+        };
+
+        var page = ordered.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();
+
+        return Task.FromResult(
+            Result.Success<(IReadOnlyList<SampleGridRow> Items, int TotalItems)>((page, rows.Count)));
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/Pages/SampleGridRow.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/Pages/SampleGridRow.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+
+namespace MMCA.Common.UI.Gallery.Pages;
+
+/// <summary>
+/// The row DTO behind the virtualized-grid gallery page. Deliberately plain: the point of
+/// <c>/grid</c> is the windowing behaviour of <c>DataGridListPageBase</c>, not the shape of the data.
+/// </summary>
+public sealed record SampleGridRow(int Id, string Name, string Category, DateTime CreatedOn, decimal Amount);
+
+/// <summary>
+/// The gallery's in-memory stand-in for a paged API. The rows are generated once from fixed inputs
+/// (no randomness, no clock), so every E2E run, on every engine, scrolls over an identical data set
+/// and a row assertion can name an exact value.
+/// </summary>
+internal static class SampleGridData
+{
+    /// <summary>The row count the E2E windowing assertion is written against.</summary>
+    public const int RowCount = 1000;
+
+    private static readonly string[] Categories = ["Hardware", "Software", "Services", "Training", "Support"];
+
+    private static readonly DateTime Epoch = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public static IReadOnlyList<SampleGridRow> All { get; } = Build();
+
+    private static SampleGridRow[] Build()
+    {
+        var rows = new SampleGridRow[RowCount];
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var id = i + 1;
+            rows[i] = new SampleGridRow(
+                id,
+                string.Create(CultureInfo.InvariantCulture, $"Row {id:D4}"),
+                Categories[i % Categories.Length],
+                Epoch.AddHours(i),
+                id * 37 % 10000 / 100m);
+        }
+
+        return rows;
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Gallery/Stubs/GalleryUIModule.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Gallery/Stubs/GalleryUIModule.cs
@@ -18,6 +18,7 @@ internal sealed class GalleryUIModule : IUIModule
         new("Login", "/login", Icons.Material.Filled.Login, typeof(SharedResource)),
         new("Register", "/register", Icons.Material.Filled.PersonAdd, typeof(SharedResource)),
         new("Components", "/components", Icons.Material.Filled.Widgets, typeof(SharedResource)),
+        new("Grid", "/grid", Icons.Material.Filled.TableRows, typeof(SharedResource)),
     ];
 
     public Assembly Assembly => typeof(GalleryUIModule).Assembly;

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationBellTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationBellTests.cs
@@ -3,8 +3,11 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using MMCA.Common.Shared.Abstractions;
 using MMCA.Common.UI.Common.Interfaces;
+using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Components.Notifications;
 using MMCA.Common.UI.Services.Notifications;
 using Moq;
@@ -49,18 +52,48 @@ internal sealed class NotificationBellHost : ComponentBase
 /// </summary>
 public sealed class NotificationBellTests : BunitTestBase
 {
+    /// <summary>
+    /// A poll interval far longer than any window the staleness tests advance through, so a
+    /// <see cref="FakeTimeProvider.Advance"/> that ages the count never also fires the periodic tick
+    /// and muddles the call count.
+    /// </summary>
+    private static readonly TimeSpan NoPollWithinTheTest = TimeSpan.FromHours(1);
+
     private readonly Mock<INotificationInboxUIService> _inbox = new();
-    private readonly NotificationState _state = new();
     private readonly Mock<IToastService> _toast = new();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+    private readonly NotificationState _state;
 
     public NotificationBellTests()
     {
+        _state = new NotificationState(_clock);
         Services.AddSingleton(_state);
         Services.AddSingleton(_inbox.Object);
+
+        // Registered after the base harness's TimeProvider.System, so the bell's periodic timer and
+        // the state's freshness stamp both run off the same driveable clock (last registration wins).
+        Services.AddSingleton<TimeProvider>(_clock);
+
         // Registered after the base class's default facade, so this wins: the bell has no error
         // surface of its own, and this is how a stray toast from it would be caught.
         Services.AddSingleton<IToastService>(_toast.Object);
     }
+
+    /// <summary>
+    /// Pins the bell's staleness policy for one test; call before rendering. Registered as the closed
+    /// <c>IOptions&lt;T&gt;</c> rather than through <c>Configure</c> because the settings properties are
+    /// init-only, matching the other settings classes in the framework.
+    /// </summary>
+    private void BellOptions(TimeSpan navigationRefreshMaxAge, TimeSpan? pollInterval = null) =>
+        Services.AddSingleton<IOptions<NotificationBellOptions>>(
+            Options.Create(new NotificationBellOptions
+            {
+                NavigationRefreshMaxAge = navigationRefreshMaxAge,
+                PollInterval = pollInterval ?? NoPollWithinTheTest,
+            }));
+
+    private void VerifyFetchCount(Times times) =>
+        _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), times);
 
     private void CountIs(int count) =>
         _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()))
@@ -183,6 +216,93 @@ public sealed class NotificationBellTests : BunitTestBase
             _inbox.Verify(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce()));
 
         _toast.VerifyNoOtherCalls();
+    }
+
+    // == Staleness policy (§19) ==
+    [Fact]
+    public void NavigatingWhileTheCountIsFresh_DoesNotRefetch()
+    {
+        // Navigation is an ambient trigger, not evidence the count moved. A user clicking through a
+        // menu used to issue one API read per click for a number that had not changed.
+        CountIs(2);
+        BellOptions(navigationRefreshMaxAge: TimeSpan.FromSeconds(30));
+        var nav = Services.GetRequiredService<NavigationManager>();
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Once()));
+
+        _clock.Advance(TimeSpan.FromSeconds(10));
+        nav.NavigateTo("/somewhere");
+        nav.NavigateTo("/somewhere-else");
+
+        VerifyFetchCount(Times.Once());
+    }
+
+    [Fact]
+    public void NavigatingOnceTheCountIsStale_Refetches()
+    {
+        CountIs(2);
+        BellOptions(navigationRefreshMaxAge: TimeSpan.FromSeconds(30));
+        var nav = Services.GetRequiredService<NavigationManager>();
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Once()));
+
+        _clock.Advance(TimeSpan.FromSeconds(31));
+        nav.NavigateTo("/somewhere");
+
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Exactly(2)));
+    }
+
+    [Fact]
+    public void NavigatingAfterAFailedRead_Refetches()
+    {
+        // A failed read never established a count, so nothing stamped it fresh: the next navigation
+        // must try again rather than sit on an unknown value for the whole window.
+        CountIsUnavailable();
+        BellOptions(navigationRefreshMaxAge: TimeSpan.FromHours(1));
+        var nav = Services.GetRequiredService<NavigationManager>();
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Once()));
+
+        nav.NavigateTo("/somewhere");
+
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Exactly(2)));
+    }
+
+    [Fact]
+    public void APushRefresh_MarksTheCountStaleAndRefetchesInsideTheWindow()
+    {
+        // The server has just said the data changed, so the age of the number carries no information:
+        // this path must never be throttled by the navigation window.
+        CountIs(2);
+        BellOptions(navigationRefreshMaxAge: TimeSpan.FromHours(1));
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Once()));
+        _state.LastFetchedUtc.Should().NotBeNull();
+
+        _state.RequestRefresh();
+
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Exactly(2)));
+    }
+
+    [Fact]
+    public void ThePeriodicTick_RefetchesUnconditionally()
+    {
+        // The tick runs off the injected TimeProvider (the PeriodicTimer overload), so the poll is
+        // asserted directly rather than inferred: advancing one interval produces one read even
+        // though the count is seconds old and a navigation would have skipped it.
+        CountIs(2);
+        BellOptions(navigationRefreshMaxAge: TimeSpan.FromHours(1), pollInterval: TimeSpan.FromSeconds(30));
+
+        var cut = RenderUnderTest<NotificationBell>(_ => { });
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Once()));
+
+        _clock.Advance(TimeSpan.FromSeconds(30));
+
+        cut.WaitForAssertion(() => VerifyFetchCount(Times.Exactly(2)));
     }
 
     [Fact]

--- a/Tests/Presentation/MMCA.Common.UI.Tests/MMCA.Common.UI.Tests.csproj
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/MMCA.Common.UI.Tests.csproj
@@ -11,6 +11,9 @@
     <!-- Direct pin so the transitive AngleSharp resolves to the patched 1.5.0 (CVE-2026-54570). -->
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Moq" />
+    <!-- FakeTimeProvider drives the read cache's TTL expiry and the notification badge's staleness
+         window without a real wait. -->
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
@@ -79,6 +79,36 @@ public sealed class DataGridListPageBaseTests : BunitTestBase
         public Task LoadMobileAsync() => LoadMobileDataAsync(Fetch);
 
         public void ToggleDensityNow() => ToggleDensity();
+
+        public bool VirtualizeGridNow => VirtualizeGrid;
+
+        public string VirtualizedGridHeightNow => VirtualizedGridHeight;
+
+        public int VirtualizedItemSizeNow => VirtualizedItemSize;
+
+        public Task<GridData<WidgetRow>> LoadVirtualizedAsync(
+            GridStateVirtualize<WidgetRow> state,
+            Action<Dictionary<string, (string Operator, string Value)>>? additionalFilters = null) =>
+            LoadVirtualizedServerDataAsync(state, Fetch, additionalFilters);
+    }
+
+    /// <summary>
+    /// A page that holds a REAL <see cref="MudDataGrid{T}"/> as its <c>GridRef</c> and can be flipped
+    /// between the paged and virtualized modes by parameter. The rows-per-page restore is only
+    /// observable through a live grid, so the pager-machinery tests bind one here rather than through
+    /// the grid-less <see cref="TestGridPage"/>.
+    /// </summary>
+    private sealed class GridBackedTestPage : DataGridListPageBase<WidgetRow>
+    {
+        [Parameter] public MudDataGrid<WidgetRow>? Grid { get; set; }
+
+        [Parameter] public bool Virtualize { get; set; }
+
+        protected override string Title => "Widgets";
+
+        protected override MudDataGrid<WidgetRow>? GridRef => Grid;
+
+        protected override bool VirtualizeGrid => Virtualize;
     }
 
     private static GridState<WidgetRow> State(int page, int pageSize, string? sortBy = null, bool descending = false)
@@ -433,5 +463,241 @@ public sealed class DataGridListPageBaseTests : BunitTestBase
         cut.Instance.LoadFailedNow.Should().BeTrue();
         cut.Instance.LoadingNow.Should().BeFalse();
         _toast.Verify(t => t.Show("The widget service is unavailable.", ToastSeverity.Error), Times.Once);
+    }
+
+    // == Virtualization: window arithmetic ==
+    [Theory]
+    // startIndex, count -> firstPage, pageSize, offset, needsSecondPage
+    [InlineData(0, 10, 1, 10, 0, false)] // the very first window
+    [InlineData(20, 10, 3, 10, 0, false)] // aligned: exactly one page
+    [InlineData(25, 10, 3, 10, 5, true)] // unaligned: spills into the next page
+    [InlineData(7, 5, 2, 5, 2, true)] // unaligned again, different page size
+    [InlineData(0, 0, 1, 1, 0, false)] // count 0: page size clamps to 1, nothing spills
+    [InlineData(0, -4, 1, 1, 0, false)] // a negative count is clamped the same way
+    public void ComputeVirtualWindow_MapsTheRowWindowOntoPagedFetches(
+        int startIndex, int count, int firstPage, int pageSize, int offset, bool needsSecondPage)
+    {
+        var window = DataGridListPageBase<WidgetRow>.ComputeVirtualWindow(startIndex, count);
+
+        window.FirstPage.Should().Be(firstPage, "pages are 1-based for the fetch delegate");
+        window.PageSize.Should().Be(pageSize);
+        window.Offset.Should().Be(offset);
+        window.NeedsSecondPage.Should().Be(needsSecondPage);
+    }
+
+    private static GridStateVirtualize<WidgetRow> VirtualState(
+        int startIndex, int count, string? sortBy = null, bool descending = false)
+    {
+        var state = new GridStateVirtualize<WidgetRow> { StartIndex = startIndex, Count = count };
+        if (sortBy is not null)
+        {
+            state.SortDefinitions = [new SortDefinition<WidgetRow>(sortBy, descending, 0, row => row.Name)];
+        }
+
+        return state;
+    }
+
+    private async Task<GridData<WidgetRow>> LoadVirtualizedOnDispatcherAsync(
+        IRenderedComponent<TestGridPage> cut,
+        GridStateVirtualize<WidgetRow> state,
+        Action<Dictionary<string, (string Operator, string Value)>>? additionalFilters = null)
+    {
+        GridData<WidgetRow>? data = null;
+        await cut.InvokeAsync(async () => data = await cut.Instance.LoadVirtualizedAsync(state, additionalFilters));
+        return data!;
+    }
+
+    // == Virtualization: the VirtualizeServerData funnel ==
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_AlignedWindow_FetchesOnePageAndReturnsIt()
+    {
+        var cut = Render<TestGridPage>();
+        var calls = new List<(int PageNumber, int PageSize)>();
+        cut.Instance.Fetch = (_, pageNumber, pageSize, _, _, _) =>
+        {
+            calls.Add((pageNumber, pageSize));
+            return Loaded(40, new WidgetRow(1, "First"), new WidgetRow(2, "Second"), new WidgetRow(3, "Third"));
+        };
+
+        var data = await LoadVirtualizedOnDispatcherAsync(cut, VirtualState(startIndex: 3, count: 3));
+
+        calls.Should().ContainSingle("an aligned window is exactly one page")
+            .Which.Should().Be((2, 3));
+        data.Items.Should().HaveCount(3);
+        data.TotalItems.Should().Be(40, "the fetch result carries the unpaginated total");
+        cut.Instance.LoadingNow.Should().BeFalse();
+        cut.Instance.LoadFailedNow.Should().BeFalse();
+        _toast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_UnalignedWindow_FetchesBothPagesAndSlicesToCount()
+    {
+        // startIndex 4 / count 3 -> page size 3, first page 2 (rows 3-5), offset 1, so the window
+        // (rows 4-6) needs page 3 as well and the concatenation is sliced from the second row.
+        var cut = Render<TestGridPage>();
+        var calls = new List<int>();
+        cut.Instance.Fetch = (_, pageNumber, _, _, _, _) =>
+        {
+            calls.Add(pageNumber);
+            return pageNumber == 2
+                ? Loaded(40, new WidgetRow(4, "D"), new WidgetRow(5, "E"), new WidgetRow(6, "F"))
+                : Loaded(40, new WidgetRow(7, "G"), new WidgetRow(8, "H"), new WidgetRow(9, "I"));
+        };
+
+        var data = await LoadVirtualizedOnDispatcherAsync(cut, VirtualState(startIndex: 4, count: 3));
+
+        calls.Should().Equal(2, 3);
+        // The concatenated pages are sliced to exactly the requested window.
+        data.Items.Select(r => r.Name).Should().Equal("E", "F", "G");
+        data.TotalItems.Should().Be(40);
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_AtTheEndOfTheData_ReturnsFewerRowsThanRequested()
+    {
+        var cut = Render<TestGridPage>();
+        cut.Instance.Fetch = (_, pageNumber, _, _, _, _) => pageNumber == 2
+            ? Loaded(7, new WidgetRow(4, "D"), new WidgetRow(5, "E"), new WidgetRow(6, "F"))
+            : Loaded(7, new WidgetRow(7, "G"));
+
+        var data = await LoadVirtualizedOnDispatcherAsync(cut, VirtualState(startIndex: 4, count: 3));
+
+        data.Items.Select(r => r.Name).Should().Equal("E", "F", "G");
+        data.TotalItems.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_WhenFetchFails_SetsLoadFailedAndReturnsAnEmptyGrid()
+    {
+        var cut = Render<TestGridPage>();
+        cut.Instance.Fetch = (_, _, _, _, _, _) => LoadFailure("The widget service is unavailable.");
+
+        var act = async () => await LoadVirtualizedOnDispatcherAsync(cut, VirtualState(startIndex: 0, count: 10));
+        await act.Should().NotThrowAsync();
+
+        var data = await LoadVirtualizedOnDispatcherAsync(cut, VirtualState(startIndex: 0, count: 10));
+        data.Items.Should().BeEmpty();
+        data.TotalItems.Should().Be(0);
+        cut.Instance.LoadFailedNow.Should().BeTrue();
+        cut.Instance.LoadingNow.Should().BeFalse("the loading flag must always be reset");
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_AppliesAdditionalFilters()
+    {
+        var cut = Render<TestGridPage>();
+        Dictionary<string, (string Operator, string Value)>? seenFilters = null;
+        cut.Instance.Fetch = (filters, _, _, _, _, _) =>
+        {
+            seenFilters = filters;
+            return Loaded(0);
+        };
+
+        await LoadVirtualizedOnDispatcherAsync(
+            cut,
+            VirtualState(startIndex: 0, count: 10),
+            additionalFilters: filters => filters["search"] = ("contains", "blue"));
+
+        seenFilters.Should().NotBeNull();
+        seenFilters!.Should().ContainKey("search").WhoseValue.Should().Be(("contains", "blue"));
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_MapsSortDefinitionsIntoTheFetchCall()
+    {
+        var cut = Render<TestGridPage>();
+        string? seenColumn = null;
+        string? seenDirection = null;
+        cut.Instance.Fetch = (_, _, _, sortColumn, sortDirection, _) =>
+        {
+            seenColumn = sortColumn;
+            seenDirection = sortDirection;
+            return Loaded(0);
+        };
+
+        await LoadVirtualizedOnDispatcherAsync(
+            cut,
+            VirtualState(startIndex: 0, count: 10, sortBy: "Name", descending: true));
+
+        seenColumn.Should().Be("Name", "GridStateVirtualize carries the same SortDefinitions as GridState");
+        seenDirection.Should().Be("desc");
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_WhenFetchCanceled_StaysSilent()
+    {
+        // Scroll bursts supersede in-flight window fetches constantly, so a cancel toast would fire
+        // continuously during ordinary scrolling. The paged funnel still toasts; this one never does.
+        var cut = Render<TestGridPage>();
+        cut.Instance.Fetch = (_, _, _, _, _, _) => throw new OperationCanceledException();
+
+        var data = await LoadVirtualizedOnDispatcherAsync(cut, VirtualState(startIndex: 0, count: 10));
+
+        data.Items.Should().BeEmpty();
+        cut.Instance.LoadFailedNow.Should().BeFalse("a superseded window is not a failure");
+        _toast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task LoadVirtualizedServerDataAsync_PersistsSortWithoutMirroringPagerStateToTheUrl()
+    {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        var cut = Render<TestGridPage>();
+        cut.Instance.Fetch = (_, _, _, _, _, _) => Loaded(100, new WidgetRow(1, "First"));
+
+        await LoadVirtualizedOnDispatcherAsync(
+            cut,
+            VirtualState(startIndex: 40, count: 20, sortBy: "Name", descending: true));
+
+        var saved = Services.GetRequiredService<ListPageStateService>().GetState("/");
+        saved.Should().NotBeNull();
+        saved!.SortColumn.Should().Be("Name");
+        saved.SortDescending.Should().BeTrue();
+        saved.Page.Should().Be(0, "a virtualized grid has no page number to remember");
+        saved.PageSize.Should().Be(0);
+        navigation.Uri.Should().Contain("s=Name").And.Contain("sd=desc");
+        navigation.Uri.Should().NotContain("p=").And.NotContain("ps=");
+    }
+
+    // == Virtualization: opt-in defaults and the skipped pager machinery ==
+    [Fact]
+    public void VirtualizeGrid_DefaultsToFalse_WithTheDocumentedHeightAndItemSize()
+    {
+        var cut = Render<TestGridPage>();
+
+        cut.Instance.VirtualizeGridNow.Should().BeFalse("virtualization is opt-in, never the default");
+        cut.Instance.VirtualizedGridHeightNow.Should().Be("70vh");
+        cut.Instance.VirtualizedItemSizeNow.Should().Be(52);
+    }
+
+    [Fact]
+    public void RestoreGridState_WhenPaged_RestoresRowsPerPageOntoTheGrid()
+    {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("/widgets?p=0&ps=50");
+        var grid = Render<MudDataGrid<WidgetRow>>().Instance;
+
+        Render<GridBackedTestPage>(ps => ps
+            .Add(p => p.Grid, grid)
+            .Add(p => p.Virtualize, false));
+
+        grid.RowsPerPage.Should().Be(50, "the paged page restores the saved rows-per-page after first render");
+    }
+
+    [Fact]
+    public void RestoreGridState_WhenVirtualized_SkipsTheRowsPerPageRestore()
+    {
+        // Same saved state, same grid: the only difference is the opt-in flag, and it must short-circuit
+        // the whole pager-restore block (a virtualized grid renders no pager to restore).
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("/widgets?p=0&ps=50");
+        var grid = Render<MudDataGrid<WidgetRow>>().Instance;
+
+        Render<GridBackedTestPage>(ps => ps
+            .Add(p => p.Grid, grid)
+            .Add(p => p.Virtualize, true));
+
+        grid.RowsPerPage.Should().Be(10, "MudDataGrid's own default is left untouched");
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Notifications/NotificationInboxTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Notifications/NotificationInboxTests.cs
@@ -9,6 +9,7 @@ using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Pages.Notifications;
 using MMCA.Common.UI.Services.Notifications;
 using Moq;
+using MudBlazor;
 
 namespace MMCA.Common.UI.Tests.Pages.Notifications;
 
@@ -23,6 +24,7 @@ public sealed class NotificationInboxTests : BunitTestBase
     private readonly Mock<INotificationInboxUIService> _inbox = new();
     private readonly NotificationState _state = new();
     private readonly Mock<IToastService> _toast = new();
+    private readonly Mock<IScrollManager> _scroll = new();
 
     public NotificationInboxTests()
     {
@@ -31,6 +33,9 @@ public sealed class NotificationInboxTests : BunitTestBase
         // Registered after the base class's default facade, so this wins and the page's toast
         // surface can be counted without rendering a snackbar provider.
         Services.AddSingleton<IToastService>(_toast.Object);
+        // Same reasoning for MudBlazor's scroll manager (registered by AddMudServices in the base):
+        // the deep-link scroll is a JS call, so the assertion has to be on the call, not on markup.
+        Services.AddSingleton(_scroll.Object);
     }
 
     private static Result<PagedCollectionResult<UserNotificationDTO>> Inbox(params UserNotificationDTO[] items)
@@ -54,6 +59,11 @@ public sealed class NotificationInboxTests : BunitTestBase
 
     private void VerifyOneToast(string message) =>
         _toast.Verify(t => t.Show(message, ToastSeverity.Error), Times.Once());
+
+    private void VerifyNeverScrolled() =>
+        _scroll.Verify(
+            s => s.ScrollIntoViewAsync(It.IsAny<string>(), It.IsAny<ScrollBehavior>()),
+            Times.Never());
 
     [Fact]
     public void WhenInboxEmpty_RendersEmptyState()
@@ -293,5 +303,103 @@ public sealed class NotificationInboxTests : BunitTestBase
         cut.WaitForAssertion(() => VerifyOneToast("Nothing could be marked read."));
         _state.UnreadCount.Should().Be(2, "the optimistic zeroing belongs to the success path only");
         cut.FindAll(".notification-card.unread").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void WhenDeepLinkedNotificationIsOnThePage_HighlightsItAndScrollsToIt()
+    {
+        _inbox
+            .Setup(x => x.GetInboxAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Inbox(Unread(1), Unread(2)));
+
+        var cut = RenderUnderTest<NotificationInbox>(p => p.Add(c => c.Id, 2));
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll(".notification-card.deep-linked").Should().ContainSingle(
+                "exactly the deep-linked card carries the highlight"));
+        cut.Find(".notification-card.deep-linked").Id.Should().Be("notification-2");
+        cut.WaitForAssertion(() => _scroll.Verify(
+            s => s.ScrollIntoViewAsync("#notification-2", ScrollBehavior.Smooth),
+            Times.Once()));
+        _toast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void WhenTheDeepLinkedNotificationIsNotOnThePage_RendersThePlainInboxSilently()
+    {
+        // A later page, a deleted notification, or another user's id: the route constraint already
+        // proved the value is an integer, so there is nothing the user can do about the miss and no
+        // toast is raised. The inbox simply renders as if the id had not been supplied.
+        _inbox
+            .Setup(x => x.GetInboxAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Inbox(Unread(1), Unread(2)));
+
+        var cut = RenderUnderTest<NotificationInbox>(p => p.Add(c => c.Id, 999));
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Notice 1"));
+        cut.FindAll(".notification-card").Should().HaveCount(2);
+        cut.FindAll(".notification-card.deep-linked").Should().BeEmpty();
+        VerifyNeverScrolled();
+        _toast.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void WhenNoDeepLinkIdIsSupplied_NothingIsHighlightedAndNothingScrolls()
+    {
+        _inbox
+            .Setup(x => x.GetInboxAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Inbox(Unread(1), Unread(2)));
+
+        var cut = RenderUnderTest<NotificationInbox>(_ => { });
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Notice 2"));
+        cut.FindAll(".notification-card.deep-linked").Should().BeEmpty(
+            "the parameterless route must render byte-identically to the pre-deep-link inbox");
+        VerifyNeverScrolled();
+    }
+
+    [Fact]
+    public void WhenTheDeepLinkIdChanges_HighlightsAndScrollsToTheNewTarget()
+    {
+        // Re-navigating between two deep links reuses this component instance, so the "already
+        // scrolled" latch has to clear on the parameter change or the second link would highlight
+        // without ever moving the viewport.
+        _inbox
+            .Setup(x => x.GetInboxAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Inbox(Unread(1), Unread(2)));
+
+        var cut = RenderUnderTest<NotificationInbox>(p => p.Add(c => c.Id, 1));
+        cut.WaitForAssertion(() => _scroll.Verify(
+            s => s.ScrollIntoViewAsync("#notification-1", ScrollBehavior.Smooth), Times.Once()));
+
+        cut.Render(p => p.Add(c => c.Id, 2));
+
+        cut.WaitForAssertion(() => _scroll.Verify(
+            s => s.ScrollIntoViewAsync("#notification-2", ScrollBehavior.Smooth), Times.Once()));
+        cut.Find(".notification-card.deep-linked").Id.Should().Be("notification-2");
+        cut.FindAll(".notification-card.deep-linked").Should().ContainSingle();
+    }
+
+    [Fact]
+    public void WhenAPushReloadsTheSamePage_TheDeepLinkScrollDoesNotRepeat()
+    {
+        // The highlight survives a reload, but scrolling the user's viewport again mid-read would be
+        // a real annoyance, so the scroll is once per deep link, not once per load.
+        _inbox
+            .Setup(x => x.GetInboxAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Inbox(Unread(1), Unread(2)));
+
+        var cut = RenderUnderTest<NotificationInbox>(p => p.Add(c => c.Id, 2));
+        cut.WaitForAssertion(() => _scroll.Verify(
+            s => s.ScrollIntoViewAsync("#notification-2", ScrollBehavior.Smooth), Times.Once()));
+
+        _state.RequestRefresh();
+
+        cut.WaitForAssertion(() => _inbox.Verify(
+            x => x.GetInboxAsync(1, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(2)));
+        cut.FindAll(".notification-card.deep-linked").Should().ContainSingle();
+        _scroll.Verify(
+            s => s.ScrollIntoViewAsync(It.IsAny<string>(), It.IsAny<ScrollBehavior>()),
+            Times.Once());
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Caching/UiReadCacheTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Caching/UiReadCacheTests.cs
@@ -1,0 +1,248 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.UI.Common.Settings;
+using MMCA.Common.UI.Services.Caching;
+
+namespace MMCA.Common.UI.Tests.Services.Caching;
+
+/// <summary>
+/// Pins the client-side staleness policy of <see cref="UiReadCache"/> (§19): a hit inside the TTL,
+/// a miss once the clock passes it, longest-prefix TTL resolution, prefix invalidation after a write,
+/// a full clear on sign-out, and the disabled passthrough a host uses to turn the whole tier off.
+/// Time is driven by <see cref="FakeTimeProvider"/>, so expiry is asserted rather than waited out.
+/// </summary>
+public sealed class UiReadCacheTests
+{
+    private static readonly DateTimeOffset Origin = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static (UiReadCache Sut, FakeTimeProvider Clock) CreateSut(
+        bool enabled = true,
+        TimeSpan? defaultTtl = null,
+        IReadOnlyList<(string Prefix, TimeSpan Ttl)>? prefixTtls = null)
+    {
+        var clock = new FakeTimeProvider(Origin);
+        var options = new UiReadCacheOptions
+        {
+            Enabled = enabled,
+            DefaultTtl = defaultTtl ?? TimeSpan.FromSeconds(60),
+        };
+
+        foreach (var (prefix, ttl) in prefixTtls ?? [])
+        {
+            options.RoutePrefixTtls[prefix] = ttl;
+        }
+
+        return (new UiReadCache(clock, Options.Create(options)), clock);
+    }
+
+    // == Freshness ==
+    [Fact]
+    public void TryGetFresh_WithinTheDefaultTtl_ReturnsTheStoredValue()
+    {
+        var (sut, clock) = CreateSut();
+        sut.Set("widgets?page=1", "the-page");
+
+        clock.Advance(TimeSpan.FromSeconds(59));
+
+        sut.TryGetFresh<string>("widgets?page=1", out var value).Should().BeTrue();
+        value.Should().Be("the-page");
+    }
+
+    [Fact]
+    public void TryGetFresh_PastTheTtl_MissesAndDropsTheEntry()
+    {
+        var (sut, clock) = CreateSut();
+        sut.Set("widgets?page=1", "the-page");
+
+        clock.Advance(TimeSpan.FromSeconds(61));
+
+        sut.TryGetFresh<string>("widgets?page=1", out var value).Should().BeFalse();
+        value.Should().BeNull();
+
+        // The expired entry is removed on the read that found it stale (lazy expiry): rewinding the
+        // clock cannot resurrect it, which is what proves the removal rather than a comparison.
+        sut.TryGetFresh<string>("widgets?page=1", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryGetFresh_ExactlyAtTheTtl_StillHits()
+    {
+        // The boundary is inclusive: freshness is "not older than", so an entry stored exactly one
+        // TTL ago is still the answer.
+        var (sut, clock) = CreateSut();
+        sut.Set("widgets", "value");
+
+        clock.Advance(TimeSpan.FromSeconds(60));
+
+        sut.TryGetFresh<string>("widgets", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryGetFresh_ForAnUnknownUrl_Misses()
+    {
+        var (sut, _) = CreateSut();
+
+        sut.TryGetFresh<string>("widgets?page=2", out var value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetFresh_ForTheSameUrlAtADifferentType_Misses()
+    {
+        // The key is the URL alone, so a caller asking for a different shape must not be handed the
+        // stored one cast blindly.
+        var (sut, _) = CreateSut();
+        sut.Set("widgets", "a string");
+
+        sut.TryGetFresh<int[]>("widgets", out var value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void Keys_DifferingOnlyInTheQueryString_AreSeparateEntries()
+    {
+        // The server's authenticated output cache varies on the full query string (QueryKeys = "*",
+        // ADR-040). The client key mirrors that shape, so a page/filter change misses on both tiers.
+        var (sut, _) = CreateSut();
+        sut.Set("widgets/paged?pageNumber=1", "page one");
+
+        sut.TryGetFresh<string>("widgets/paged?pageNumber=2", out _).Should().BeFalse();
+        sut.TryGetFresh<string>("widgets/paged?pageNumber=1", out var first).Should().BeTrue();
+        first.Should().Be("page one");
+    }
+
+    // == TTL resolution ==
+    [Fact]
+    public void ResolveTtl_UsesTheLongestMatchingRoutePrefix()
+    {
+        // Two prefixes match the same URL; the more specific one must win whatever order the
+        // configuration enumerated them in.
+        var (sut, clock) = CreateSut(
+            defaultTtl: TimeSpan.FromSeconds(10),
+            prefixTtls:
+            [
+                ("widgets", TimeSpan.FromSeconds(30)),
+                ("widgets/lookup", TimeSpan.FromMinutes(10)),
+            ]);
+
+        sut.Set("widgets/lookup?nameProperty=Name", "lookups");
+        sut.Set("widgets?includeFKs=False", "list");
+
+        clock.Advance(TimeSpan.FromMinutes(1));
+
+        sut.TryGetFresh<string>("widgets/lookup?nameProperty=Name", out _).Should()
+            .BeTrue("the ten-minute lookup budget is the longest matching prefix");
+        sut.TryGetFresh<string>("widgets?includeFKs=False", out _).Should()
+            .BeFalse("the list read only had the thirty-second budget of its own prefix");
+    }
+
+    [Fact]
+    public void ResolveTtl_WithNoMatchingPrefix_FallsBackToTheDefault()
+    {
+        var (sut, clock) = CreateSut(
+            defaultTtl: TimeSpan.FromSeconds(5),
+            prefixTtls: [("countries", TimeSpan.FromHours(1))]);
+
+        sut.Set("widgets", "list");
+
+        clock.Advance(TimeSpan.FromSeconds(6));
+
+        sut.TryGetFresh<string>("widgets", out _).Should().BeFalse();
+    }
+
+    // == Invalidation ==
+    [Fact]
+    public void InvalidatePrefix_RemovesOnlyTheMatchingKeys()
+    {
+        var (sut, _) = CreateSut();
+        sut.Set("widgets?includeFKs=False", "list");
+        sut.Set("widgets/7?includeChildren=False", "one widget");
+        sut.Set("gadgets?includeFKs=False", "other list");
+
+        sut.InvalidatePrefix("widgets");
+
+        sut.TryGetFresh<string>("widgets?includeFKs=False", out _).Should().BeFalse();
+        sut.TryGetFresh<string>("widgets/7?includeChildren=False", out _).Should().BeFalse();
+        sut.TryGetFresh<string>("gadgets?includeFKs=False", out var untouched).Should()
+            .BeTrue("another endpoint's reads are not made stale by this endpoint's write");
+        untouched.Should().Be("other list");
+    }
+
+    [Fact]
+    public void InvalidatePrefix_MatchesOrdinally()
+    {
+        // A prefix that differs only in case is a different route to the server, so it must not be
+        // swept by this endpoint's invalidation.
+        var (sut, _) = CreateSut();
+        sut.Set("Widgets?includeFKs=False", "differently cased");
+
+        sut.InvalidatePrefix("widgets");
+
+        sut.TryGetFresh<string>("Widgets?includeFKs=False", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Clear_EmptiesEveryEntry()
+    {
+        var (sut, _) = CreateSut();
+        sut.Set("widgets", "list");
+        sut.Set("gadgets", "other list");
+
+        sut.Clear();
+
+        sut.TryGetFresh<string>("widgets", out _).Should().BeFalse();
+        sut.TryGetFresh<string>("gadgets", out _).Should().BeFalse();
+    }
+
+    // == Disabled ==
+    [Fact]
+    public void WhenDisabled_SetIsANoOpAndEveryLookupMisses()
+    {
+        // The host's escape hatch: with Enabled=false the services behave exactly as they did before
+        // a cache was registered, so a deployment can opt out of client-side staleness entirely.
+        var (sut, _) = CreateSut(enabled: false);
+
+        sut.Set("widgets", "list");
+
+        sut.TryGetFresh<string>("widgets", out var value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenDisabled_InvalidateAndClearStillSucceed()
+    {
+        var (sut, _) = CreateSut(enabled: false);
+
+        var act = () =>
+        {
+            sut.InvalidatePrefix("widgets");
+            sut.Clear();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    // == Guards ==
+    [Fact]
+    public void Set_WithANullValue_StoresNothing()
+    {
+        // A null is not an answer worth replaying: the read that produced it failed or came back
+        // empty, and both should re-ask.
+        var (sut, _) = CreateSut();
+
+        sut.Set<string?>("widgets", null);
+
+        sut.TryGetFresh<string>("widgets", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryGetFresh_WithABlankUrl_Throws()
+    {
+        var (sut, _) = CreateSut();
+
+        var act = () => sut.TryGetFresh<string>(" ", out _);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/EntityServiceBaseCachingTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/EntityServiceBaseCachingTests.cs
@@ -1,0 +1,314 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.DTOs;
+using MMCA.Common.UI.Common.Settings;
+using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Auth;
+using MMCA.Common.UI.Services.Caching;
+using MMCA.Common.UI.Tests.Infrastructure;
+using Moq;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// The read-through half of <see cref="EntityServiceBase{TEntityDTO, TId}"/> (§19): with an
+/// <see cref="IUiReadCache"/> injected, repeated reads inside the TTL collapse onto one HTTP call,
+/// a failed read is never cached, an explicit bypass forces a round trip, and a successful write
+/// invalidates the endpoint so the next read is authoritative again. With no cache injected the
+/// service behaves exactly as <c>EntityServiceBaseTests</c> pins it.
+/// </summary>
+public sealed class EntityServiceBaseCachingTests
+{
+    private sealed record WidgetDto : IBaseDTO<int>
+    {
+        public required int Id { get; init; }
+
+        public string? Name { get; init; }
+    }
+
+    /// <summary>
+    /// Minimal concrete service. <see cref="GetAllBypassingCacheAsync"/> is the derived-service view of
+    /// the bypass switch: a page with a refresh button calls a method shaped like this rather than
+    /// getting a fresh-by-the-clock entry it did not ask for.
+    /// </summary>
+    private sealed class WidgetService(
+        IHttpClientFactory httpClientFactory,
+        ITokenStorageService tokenStorageService,
+        IUiReadCache? readCache)
+        : EntityServiceBase<WidgetDto, int>("widgets", httpClientFactory, tokenStorageService, readCache)
+    {
+        public async Task<Result<PagedCollectionResult<WidgetDto>>> GetAllBypassingCacheAsync(CancellationToken cancellationToken) =>
+            await GetCachedAsync<PagedCollectionResult<WidgetDto>>(
+                "widgets?includeFKs=False&includeChildren=False", cancellationToken, bypassCache: true);
+    }
+
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+    private static WidgetDto Widget(int id, string name = "Widget") => new() { Id = id, Name = name };
+
+    private static HttpResponseMessage PagedResponse(params WidgetDto[] items) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(
+                new PagedCollectionResult<WidgetDto>(items, new PaginationMetadata(items.Length, 25, 1))),
+        };
+
+    private (WidgetService Sut, StubHttpMessageHandler Handler) CreateSut(
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        IUiReadCache? readCache)
+    {
+        var handler = new StubHttpMessageHandler(responder);
+        var tokenStorage = new Mock<ITokenStorageService>();
+        tokenStorage.Setup(s => s.GetAccessTokenAsync()).ReturnsAsync("stored-access-token");
+        return (new WidgetService(new StubHttpClientFactory(handler), tokenStorage.Object, readCache), handler);
+    }
+
+    private UiReadCache CreateCache(TimeSpan? defaultTtl = null) =>
+        new(_clock, Options.Create(new UiReadCacheOptions { DefaultTtl = defaultTtl ?? TimeSpan.FromSeconds(60) }));
+
+    /// <summary>Runs one CRUD write by name, flattening the create's typed result to a bare outcome.</summary>
+    private static Task<Result> WriteAsync(WidgetService service, string verb, CancellationToken cancellationToken) =>
+        verb switch
+        {
+            "add" => Flatten(service.AddAsync(Widget(0), cancellationToken)),
+            "update" => service.UpdateAsync(Widget(1, "Renamed"), cancellationToken),
+            _ => service.DeleteAsync(1, cancellationToken),
+        };
+
+    private static async Task<Result> Flatten<T>(Task<Result<T>> pending) => await pending;
+
+    /// <summary>
+    /// The shared responder: each read shape answers with its own payload so a hit served under the
+    /// wrong key would deserialize into the wrong thing, and every write answers 2xx.
+    /// </summary>
+    private static HttpResponseMessage RespondByShape(HttpRequestMessage request)
+    {
+        if (request.Method != HttpMethod.Get)
+        {
+            return request.Method == HttpMethod.Post
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Widget(2)) }
+                : new HttpResponseMessage(HttpStatusCode.NoContent);
+        }
+
+        var path = request.RequestUri!.PathAndQuery;
+
+        if (path.Contains("/lookup", StringComparison.Ordinal))
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new CollectionResult<BaseLookup<int>>(
+                    [new BaseLookup<int> { Id = 1, Name = "First" }])),
+            };
+        }
+
+        return path.Contains("/widgets/7", StringComparison.Ordinal)
+            ? new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Widget(7)) }
+            : PagedResponse(Widget(1));
+    }
+
+    // == Read-through ==
+    [Fact]
+    public async Task TwoIdenticalReadsInsideTheTtl_HitTheApiOnce()
+    {
+        var (sut, handler) = CreateSut(_ => PagedResponse(Widget(1)), CreateCache());
+
+        var first = await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        _clock.Advance(TimeSpan.FromSeconds(30));
+        var second = await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        handler.CallCount.Should().Be(1, "the second read is inside the freshness budget");
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+        second.Value!.Select(w => w.Id).Should().Equal(1);
+    }
+
+    [Fact]
+    public async Task AReadPastTheTtl_GoesBackToTheApi()
+    {
+        var (sut, handler) = CreateSut(_ => PagedResponse(Widget(1)), CreateCache());
+
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        _clock.Advance(TimeSpan.FromSeconds(61));
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        handler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReadsThatDifferByOneQueryParameter_AreTwoCallsAndTwoEntries()
+    {
+        // The cache key is the path plus the FULL query string, mirroring the server's
+        // QueryKeys = "*" rule (ADR-040): a paging or filter change must not be answered from the
+        // entry belonging to a different page.
+        var (sut, handler) = CreateSut(_ => PagedResponse(Widget(1)), CreateCache());
+
+        await sut.GetPagedAsync([], pageNumber: 1, pageSize: 25, sortColumn: null, sortDirection: null,
+            includeChildren: false, TestContext.Current.CancellationToken);
+        await sut.GetPagedAsync([], pageNumber: 2, pageSize: 25, sortColumn: null, sortDirection: null,
+            includeChildren: false, TestContext.Current.CancellationToken);
+        await sut.GetPagedAsync([], pageNumber: 1, pageSize: 25, sortColumn: null, sortDirection: null,
+            includeChildren: false, TestContext.Current.CancellationToken);
+
+        handler.CallCount.Should().Be(2, "page 1 is served from its own entry the second time");
+    }
+
+    [Fact]
+    public async Task TheFourReadMethods_EachCacheUnderTheirOwnUrl()
+    {
+        var (sut, handler) = CreateSut(RespondByShape, CreateCache());
+
+        var token = TestContext.Current.CancellationToken;
+        for (var pass = 0; pass < 2; pass++)
+        {
+            await sut.GetAllAsync(cancellationToken: token);
+            await sut.GetPagedAsync([], 1, 25, null, null, false, token);
+            await sut.GetAllForLookupAsync("Name", token);
+            await sut.GetByIdAsync(7, cancellationToken: token);
+        }
+
+        handler.CallCount.Should().Be(4, "the second pass is served entirely from cache");
+    }
+
+    // == Bypass ==
+    [Fact]
+    public async Task BypassCache_ForcesASecondCallAndLeavesTheEntryAlone()
+    {
+        var (sut, handler) = CreateSut(_ => PagedResponse(Widget(1)), CreateCache());
+
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await sut.GetAllBypassingCacheAsync(TestContext.Current.CancellationToken);
+
+        handler.CallCount.Should().Be(2);
+
+        // The bypass neither read nor rewrote the entry, so the cached answer is still serving.
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        handler.CallCount.Should().Be(2);
+    }
+
+    // == Failures are never cached ==
+    [Fact]
+    public async Task AFailedRead_IsNotCached()
+    {
+        // Caching a failure would pin the error in front of the user for the whole TTL. A 4xx rather
+        // than a 5xx so the class-level Polly retry stays out of the way (2s/4s/8s of backoff).
+        var responses = new Queue<HttpResponseMessage>(
+        [
+            new HttpResponseMessage(HttpStatusCode.BadRequest),
+            PagedResponse(Widget(1)),
+        ]);
+        var (sut, handler) = CreateSut(_ => responses.Dequeue(), CreateCache());
+
+        var failed = await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var recovered = await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        failed.IsFailure.Should().BeTrue();
+        recovered.IsSuccess.Should().BeTrue();
+        handler.CallCount.Should().Be(2, "the failure left nothing behind to serve");
+    }
+
+    [Fact]
+    public async Task ANotFoundById_IsNotCached()
+    {
+        var responses = new Queue<HttpResponseMessage>(
+        [
+            new HttpResponseMessage(HttpStatusCode.NotFound),
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Widget(7)) },
+        ]);
+        var (sut, handler) = CreateSut(_ => responses.Dequeue(), CreateCache());
+
+        var missing = await sut.GetByIdAsync(7, cancellationToken: TestContext.Current.CancellationToken);
+        var found = await sut.GetByIdAsync(7, cancellationToken: TestContext.Current.CancellationToken);
+
+        missing.IsFailure.Should().BeTrue();
+        found.IsSuccess.Should().BeTrue();
+        handler.CallCount.Should().Be(2);
+    }
+
+    // == Write invalidation ==
+    [Theory]
+    [InlineData("add")]
+    [InlineData("update")]
+    [InlineData("delete")]
+    public async Task ASuccessfulWrite_InvalidatesTheEndpointSoTheNextReadRefetches(string verb)
+    {
+        var (sut, handler) = CreateSut(RespondByShape, CreateCache());
+        var token = TestContext.Current.CancellationToken;
+
+        await sut.GetAllAsync(cancellationToken: token);
+
+        var write = await WriteAsync(sut, verb, token);
+        await sut.GetAllAsync(cancellationToken: token);
+
+        write.IsSuccess.Should().BeTrue();
+        handler.CallCount.Should().Be(3, "the write cleared the list the read had cached");
+    }
+
+    [Fact]
+    public async Task AWriteThatFailed_LeavesTheCacheAlone()
+    {
+        // A rejected write changed nothing on the server, so the cached reads are still accurate;
+        // invalidating there would throw away entries for no reason.
+        var (sut, handler) = CreateSut(
+            request => request.Method == HttpMethod.Get
+                ? PagedResponse(Widget(1))
+                : new HttpResponseMessage(HttpStatusCode.Conflict),
+            CreateCache());
+        var token = TestContext.Current.CancellationToken;
+
+        await sut.GetAllAsync(cancellationToken: token);
+        var rejected = await sut.UpdateAsync(Widget(1, "Renamed"), token);
+        await sut.GetAllAsync(cancellationToken: token);
+
+        rejected.IsFailure.Should().BeTrue();
+        handler.CallCount.Should().Be(2, "only the read and the rejected write reached the wire");
+    }
+
+    [Fact]
+    public async Task AWrite_InvalidatesEveryShapeOfReadOnTheEndpoint()
+    {
+        var (sut, handler) = CreateSut(RespondByShape, CreateCache());
+        var token = TestContext.Current.CancellationToken;
+
+        await sut.GetAllAsync(cancellationToken: token);
+        await sut.GetPagedAsync([], 1, 25, null, null, false, token);
+        await sut.GetByIdAsync(7, cancellationToken: token);
+        handler.CallCount.Should().Be(3);
+
+        await sut.DeleteAsync(1, token);
+
+        await sut.GetAllAsync(cancellationToken: token);
+        await sut.GetPagedAsync([], 1, 25, null, null, false, token);
+        await sut.GetByIdAsync(7, cancellationToken: token);
+
+        handler.CallCount.Should().Be(7, "list, paged and by-id all share the endpoint prefix the write cleared");
+    }
+
+    // == No cache registered ==
+    [Fact]
+    public async Task WithNoCacheRegistered_EveryReadStillReachesTheApi()
+    {
+        var (sut, handler) = CreateSut(_ => PagedResponse(Widget(1)), readCache: null);
+
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        handler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task WithADisabledCache_EveryReadStillReachesTheApi()
+    {
+        // The configuration switch has the same effect as registering no cache at all.
+        var disabled = new UiReadCache(_clock, Options.Create(new UiReadCacheOptions { Enabled = false }));
+        var (sut, handler) = CreateSut(_ => PagedResponse(Widget(1)), disabled);
+
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await sut.GetAllAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        handler.CallCount.Should().Be(2);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationStateTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Notifications/NotificationStateTests.cs
@@ -1,16 +1,22 @@
 using AwesomeAssertions;
+using Microsoft.Extensions.Time.Testing;
 using MMCA.Common.UI.Services.Notifications;
 
 namespace MMCA.Common.UI.Tests.Services.Notifications;
 
 /// <summary>
 /// Verifies <see cref="NotificationState"/>: unread-count mutation and change notification,
-/// the refresh-request signal, and the poller registration protocol that keeps a single
+/// the refresh-request signal, the freshness stamp subscribers use to decide whether the count is
+/// worth re-reading (§19), and the poller registration protocol that keeps a single
 /// NotificationBell instance polling when the bell renders in multiple DOM locations.
 /// </summary>
 public sealed class NotificationStateTests
 {
-    private readonly NotificationState _sut = new();
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+    private readonly NotificationState _sut;
+
+    public NotificationStateTests() => _sut = new NotificationState(_clock);
 
     // == Unread count ==
     [Fact]
@@ -56,6 +62,80 @@ public sealed class NotificationStateTests
 
         _sut.UnreadCount.Should().Be(3);
         raised.Should().Be(1);
+    }
+
+    // == Freshness stamp (§19) ==
+    [Fact]
+    public void LastFetchedUtc_StartsNull() =>
+        _sut.LastFetchedUtc.Should().BeNull("no count has been established yet");
+
+    [Fact]
+    public void SetUnreadCount_WithANewValue_StampsLastFetched()
+    {
+        _sut.SetUnreadCount(5);
+
+        _sut.LastFetchedUtc.Should().Be(_clock.GetUtcNow());
+    }
+
+    [Fact]
+    public void SetUnreadCount_WithTheSameValue_StillStampsLastFetched()
+    {
+        // The stamp answers "how old is this number", not "when did it change". On a quiet inbox
+        // almost every read re-confirms the same count, and treating that as no read at all is what
+        // would leave a subscriber permanently stale and re-fetching on every trigger.
+        _sut.SetUnreadCount(5);
+        _clock.Advance(TimeSpan.FromMinutes(5));
+
+        _sut.SetUnreadCount(5);
+
+        _sut.LastFetchedUtc.Should().Be(_clock.GetUtcNow());
+    }
+
+    [Fact]
+    public void IsStale_BeforeAnyFetch_IsTrue() =>
+        _sut.IsStale(TimeSpan.FromSeconds(30)).Should().BeTrue();
+
+    [Fact]
+    public void IsStale_WithinTheWindow_IsFalse()
+    {
+        _sut.SetUnreadCount(3);
+
+        _clock.Advance(TimeSpan.FromSeconds(29));
+
+        _sut.IsStale(TimeSpan.FromSeconds(30)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsStale_PastTheWindow_IsTrue()
+    {
+        _sut.SetUnreadCount(3);
+
+        _clock.Advance(TimeSpan.FromSeconds(31));
+
+        _sut.IsStale(TimeSpan.FromSeconds(30)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MarkStale_DiscardsTheStampWhateverTheClockSays()
+    {
+        // A real-time push says the data moved, so the age of the number is no longer evidence of
+        // anything: the next read must happen even though the stamp is seconds old.
+        _sut.SetUnreadCount(3);
+
+        _sut.MarkStale();
+
+        _sut.LastFetchedUtc.Should().BeNull();
+        _sut.IsStale(TimeSpan.FromHours(1)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IncrementUnreadCount_DoesNotStampLastFetched()
+    {
+        // The optimistic increment from a push is a guess, not an authoritative read; stamping it
+        // would let the guess suppress the API read that confirms it.
+        _sut.IncrementUnreadCount();
+
+        _sut.LastFetchedUtc.Should().BeNull();
     }
 
     // == Refresh request ==

--- a/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/packages.lock.json
@@ -46,6 +46,12 @@
         "resolved": "3.0.190",
         "contentHash": "CFX3BWg27iLO78RORLAGWghpP+1afiAaijAIfhU7+JI+n6V0uVpNIr6H7LYVnRTFb2WAH/450FcvarFl7STOQA=="
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.9.0, )",
+        "resolved": "10.9.0",
+        "contentHash": "0If8xc915BgRpYmKB9tOOOprvHMt8Tue6kiD8ARgVf8Ok6PNUxkJScKT7QUp7+RllR4RN2DNACgaxioy9BJxeQ=="
+      },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
         "requested": "[18.7.23, )",

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/BlazorCspPolicyProviderTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/BlazorCspPolicyProviderTests.cs
@@ -14,9 +14,10 @@ namespace MMCA.Common.UI.Web.Tests.Security;
 /// Pins the exact Content-Security-Policy assembled by <c>BlazorCspPolicyProvider</c> (resolved as
 /// <see cref="ICspPolicyProvider"/> through <c>AddCommonBlazorCsp()</c>; the class itself is internal):
 /// the enforced production policy with connect-src pinned to the configured API/Gateway origin
-/// (https + matching ws scheme, port preserved, WasmApiEndpoint preferred), the permissive
-/// Report-Only degradation on missing/unparseable endpoints, the Development-only localhost and
-/// inline-script allowances, and the no-unsafe-eval / no-inline-script-in-production regressions.
+/// (https + matching ws scheme, port preserved, WasmApiEndpoint preferred), the fail-closed
+/// <c>connect-src 'self'</c> degradation on missing/unparseable endpoints (still enforced), the
+/// Development-only localhost and inline-script allowances, and the no-unsafe-eval /
+/// no-inline-script-in-production regressions.
 /// </summary>
 public sealed class BlazorCspPolicyProviderTests
 {
@@ -32,14 +33,15 @@ public sealed class BlazorCspPolicyProviderTests
         "form-action 'self'; " +
         "frame-ancestors 'none'";
 
-    /// <summary>The permissive Report-Only fallback policy, pinned verbatim.</summary>
+    /// <summary>The fail-closed fallback policy, pinned verbatim: identical to the production policy
+    /// except that connect-src narrows to 'self'.</summary>
     private const string ExpectedFallbackPolicy =
         "default-src 'self'; " +
         "script-src 'self' 'wasm-unsafe-eval'; " +
         "style-src 'self' 'unsafe-inline'; " +
         "img-src 'self' data: https:; " +
         "font-src 'self'; " +
-        "connect-src 'self' https: wss:; " +
+        "connect-src 'self'; " +
         "base-uri 'self'; " +
         "form-action 'self'; " +
         "frame-ancestors 'none'";
@@ -103,7 +105,7 @@ public sealed class BlazorCspPolicyProviderTests
             "connect-src 'self' https://gateway.example.com:8443 wss://gateway.example.com:8443");
     }
 
-    // == Report-Only degradation ==
+    // == Fail-closed degradation ==
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -112,13 +114,17 @@ public sealed class BlazorCspPolicyProviderTests
     [InlineData("/relative/path")]
     [InlineData("file:///etc/hosts")]
     [InlineData("ftp://gateway.example.com")]
-    public void GetPolicy_WithMissingOrUnparseableEndpoint_DegradesToPermissiveReportOnly(string? endpoint)
+    public void GetPolicy_WithMissingOrUnparseableEndpoint_FailsClosedOnSelfOnlyConnectSrc(string? endpoint)
     {
         var policy = GetPolicy(endpoint);
 
         policy.Should().NotBeNull();
-        policy!.Enforce.Should().BeFalse("a CSP we cannot construct correctly must never be enforced");
-        policy.Value.Should().Be(ExpectedFallbackPolicy);
+        policy!.Enforce.Should().BeTrue("a security response header that stops being enforced protects nothing");
+
+        var directives = policy.Value.Split("; ", StringSplitOptions.None);
+        directives.Single(d => d.StartsWith("connect-src", StringComparison.Ordinal))
+            .Should().Be("connect-src 'self'");
+        policy.Value.Should().Be(ExpectedFallbackPolicy, "only connect-src narrows; the rest of the policy is unchanged");
     }
 
     // == Development-only allowances ==

--- a/build/facts/FactsGenerator.cs
+++ b/build/facts/FactsGenerator.cs
@@ -205,7 +205,7 @@ _As of: {{AS_OF}} (framework {{VERSION}}) — **generated from source by `build/
   rollout).
 
 ## Published packages — **{{PKG_COUNT}}**
-Released in lockstep to GitHub Packages (the packable projects under `Source/` carrying a `<PackageId>`):
+Released in lockstep to nuget.org and GitHub Packages (dual-registry, ADR-053; the packable projects under `Source/` carrying a `<PackageId>`):
 
 {{PKG_LIST}}
 


### PR DESCRIPTION
Extends the h2c probe keep-alive fix with the approved six-front implementation-lift wave (one PR by design: minimum PRs/deploys).

**Original fix (unchanged):** keep-alive pings on the h2c probe handler so a poisoned pre-handshake connection cannot wedge WaitFor.

**Wave commits (one per scorecard category):**
- §34: FactsGenerator names both registries (dual-registry, ADR-053); CONTRIBUTING count-free.
- §8: consumer-source-build applies Helpdesk's real SQL Server migrations against an ephemeral container (pinned dotnet-ef, __EFMigrationsHistory + schema assertions); an in-repo fixture migration proves Migrate/None strategies in the unit tier. New CascadeSoftDelete fitness rule + base (IL-verified via a six-fixture self-test); Common subclasses both it and the hard-delete gate over its own map.
- §26: default static CSP carries script-src/style-src at Blazor/MudBlazor strength; {nonce} placeholder + CspNonce accessor ship the path off unsafe-inline; BlazorCspPolicyProvider fails closed (connect-src 'self', enforced) on a misconfigured endpoint.
- §19: IUiReadCache client staleness policy (TTL-per-route-prefix, ADR-040-aligned URL keys) behind EntityServiceBase reads, write-invalidation, logout clear; NotificationState/Bell go staleness-aware with options-bound cadence. Inert until a service passes the cache (sweep adopts).
- §23: opt-in desktop grid virtualization on DataGridListPageBase (VirtualizeServerData funnel, container-aware scroll restore, pager machinery gated off); gallery /grid page (1000 rows) under the axe + WebVitals gates, all WebVitals cases migrated onto MeasureWebVitalsAsync.
- §25: /notifications/inbox/{Id:int} typed deep link (constraint = validation; highlight + scroll; silent degradation) + a navigation-contract fact requiring constraints on all future route parameters.

Breaking (binary, source-compatible): EntityServiceBase/AuthUIService/NotificationState ctors gain optional params; default CSP and the CSP fail-closed fallback change behavior. All CHANGELOG-flagged with call-site guidance for the lockstep sweep.

Local verification: full slnx Release build 0 warnings; suites green via direct exes (Infrastructure 1309, API 683, Architecture 169, UI 831, UI.Web 31, Aspire 162, Testing 37, E2E 53 headless chromium incl. new /grid + deep-link cases); FACTS --check green (122 methods / 46 bases / Common executes 187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw