### PR TITLE
release: v1.175.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
-## [Unreleased]
+## [1.175.0] - 2026-08-31
 
 A six-front implementation-lift wave (scorecard categories 8, 19, 23, 25, 26, 34): migrations proven
 in CI, cascade soft-delete enforced, a complete default CSP with a nonce path, an explicit client-side


### PR DESCRIPTION
Release docs for v1.175.0: the CHANGELOG Unreleased block becomes [1.175.0] - 2026-08-31.

Ships the six-front implementation-lift wave (scorecard categories 8, 19, 23, 25, 26, 34) plus the h2c probe keep-alive fix (PR #325). Three binary-breaking ctor signature changes (optional params, source-compatible) and two CSP behavior changes are documented with call-site guidance for the lockstep sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw