### PR TITLE
feat: Service Bus emulator broker path + generic WithBroker; AbsoluteUrl attribute; per-module layer overrides

### DIFF
--- a/FACTS.md
+++ b/FACTS.md
@@ -46,7 +46,7 @@ it owns the range/count and the one-line summaries. Do not restate the `(001-NNN
 - **122 test methods across 46 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **187** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **193** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/DependencyInjection.cs
@@ -958,7 +958,19 @@ public static class DependencyInjection
                 {
                     if (!string.IsNullOrWhiteSpace(connectionString))
                     {
-                        cfg.Host(connectionString);
+                        // The emulator branch exists so a development stack can run the SAME
+                        // transport production runs. It is entered only when the connection string
+                        // carries UseDevelopmentEmulator=true, a token no real namespace emits, so
+                        // the production path below is reached byte-for-byte as before.
+                        if (Messaging.ServiceBusEmulatorSupport.IsEmulatorConnectionString(connectionString))
+                        {
+                            Messaging.ServiceBusEmulatorSupport.ConfigureEmulatorHost(
+                                cfg, connectionString, settings.EmulatorAdminEndpoint);
+                        }
+                        else
+                        {
+                            cfg.Host(connectionString);
+                        }
                     }
 
                     // Unconditional: Azure Service Bus schedules messages natively, so there is no

--- a/Source/Core/MMCA.Common.Infrastructure/Messaging/ServiceBusEmulatorSupport.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Messaging/ServiceBusEmulatorSupport.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using MassTransit;
+
+namespace MMCA.Common.Infrastructure.Messaging;
+
+/// <summary>
+/// Everything the Azure Service Bus transport needs to run against the OFFICIAL local emulator
+/// instead of a real namespace, kept in one place so the production path in
+/// <c>ConfigureBrokerTransport</c> stays a single unconditional <c>cfg.Host(connectionString)</c>.
+/// <para>
+/// The emulator is entered only when the resolved connection string carries
+/// <c>UseDevelopmentEmulator=true</c> (<see cref="IsEmulatorConnectionString"/>). A real Azure
+/// Service Bus connection string never carries that token, so no production deployment can reach any
+/// of this by accident: that is the whole reason detection keys off the connection string rather than
+/// an environment name or a separate flag anyone could set in the wrong place.
+/// </para>
+/// <para>
+/// Two things make the emulator different from the real service, and both are MassTransit v8
+/// constraints rather than choices. First, v8 has no vendor emulator mode (that shipped in v9, which
+/// the workspace excludes because it needs a commercial license), so the ONLY way onto the emulator
+/// is the custom-clients <c>Host</c> overload, handing MassTransit a data-plane
+/// <see cref="ServiceBusClient"/> and a management-plane <see cref="ServiceBusAdministrationClient"/>
+/// built by the caller. The emulator serves those two planes on two ports (AMQP and HTTP), which is
+/// why the admin client needs its own connection string and its own configured endpoint. Second, the
+/// emulator enforces a one-hour ceiling on entity time-to-live and auto-delete, and MassTransit v8's
+/// defaults sit far above it (366 days TTL, 427 days auto-delete), so every entity it tries to
+/// provision is rejected until the defaults are lowered.
+/// </para>
+/// </summary>
+internal static class ServiceBusEmulatorSupport
+{
+    /// <summary>
+    /// The token an emulator connection string carries and a real namespace never does.
+    /// </summary>
+    internal const string EmulatorMarker = "UseDevelopmentEmulator=true";
+
+    /// <summary>
+    /// The ceiling the emulator enforces on entity time-to-live and auto-delete-on-idle.
+    /// </summary>
+    internal static readonly TimeSpan EmulatorEntityQuota = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// The host address the custom-clients <c>Host</c> overload is anchored to. It names the bus, not
+    /// a network location: both clients are already bound to the emulator's actual ports.
+    /// </summary>
+    private static readonly Uri EmulatorHostAddress = new("sb://localhost/");
+
+    /// <summary>
+    /// Guards <see cref="ApplyEmulatorEntityQuotas"/>. The defaults it writes are process-global
+    /// MassTransit statics, so they are applied once per process and only on the emulator branch.
+    /// </summary>
+    private static int _entityQuotasApplied;
+
+    /// <summary>
+    /// Reports whether <paramref name="connectionString"/> targets the local emulator rather than a
+    /// real Azure Service Bus namespace.
+    /// </summary>
+    /// <param name="connectionString">The resolved broker connection string.</param>
+    /// <returns><see langword="true"/> when the emulator marker is present.</returns>
+    internal static bool IsEmulatorConnectionString(string? connectionString) =>
+        connectionString is not null
+        && connectionString.Contains(EmulatorMarker, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Configures the bus host against the emulator: lowers the process-global entity quotas, then
+    /// binds MassTransit to a data-plane and a management-plane client built from
+    /// <paramref name="connectionString"/> and <paramref name="adminEndpoint"/>.
+    /// </summary>
+    /// <param name="cfg">The Azure Service Bus bus factory configurator.</param>
+    /// <param name="connectionString">The emulator AMQP connection string.</param>
+    /// <param name="adminEndpoint">
+    /// The emulator management-plane base address (<c>MessageBus:EmulatorAdminEndpoint</c>), for
+    /// example <c>http://localhost:32771</c>.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="adminEndpoint"/> is missing or is not an absolute URL. Without it there is no
+    /// management client, and MassTransit cannot provision the topology it needs to run at all, so
+    /// this fails at registration rather than at the first publish.
+    /// </exception>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MassTransit takes ownership of the ServiceBusClient handed to the custom-clients Host overload and keeps it for the life of the bus, which is the life of the process. Disposing it here would close the connection before the first publish.")]
+    internal static void ConfigureEmulatorHost(
+        IServiceBusBusFactoryConfigurator cfg,
+        string connectionString,
+        string? adminEndpoint)
+    {
+        ArgumentNullException.ThrowIfNull(cfg);
+
+        ApplyEmulatorEntityQuotas();
+
+        string adminConnectionString = BuildAdminConnectionString(connectionString, adminEndpoint);
+
+        cfg.Host(
+            EmulatorHostAddress,
+            new ServiceBusClient(connectionString),
+            new ServiceBusAdministrationClient(adminConnectionString));
+    }
+
+    /// <summary>
+    /// Lowers MassTransit's process-global entity defaults beneath the emulator's one-hour ceiling,
+    /// once per process. These are static properties on the transport, so this is deliberately NOT
+    /// reached on the real-namespace path: a production bus keeps MassTransit's own defaults.
+    /// </summary>
+    internal static void ApplyEmulatorEntityQuotas()
+    {
+        if (Interlocked.Exchange(ref _entityQuotasApplied, 1) != 0)
+        {
+            return;
+        }
+
+        global::MassTransit.AzureServiceBusTransport.Defaults.DefaultMessageTimeToLive = EmulatorEntityQuota;
+        global::MassTransit.AzureServiceBusTransport.Defaults.BasicMessageTimeToLive = EmulatorEntityQuota;
+        global::MassTransit.AzureServiceBusTransport.Defaults.AutoDeleteOnIdle = EmulatorEntityQuota;
+    }
+
+    /// <summary>
+    /// Derives the management-plane connection string from the AMQP one by swapping in the admin
+    /// endpoint's host and port. Rebuilding it from the data-plane string (rather than composing a
+    /// fresh one) is what keeps the shared-access key name and value identical across both clients:
+    /// the two planes authenticate against the same emulator namespace, so a hand-written second
+    /// string is one silent typo away from an admin client that cannot provision anything.
+    /// </summary>
+    /// <param name="connectionString">The emulator AMQP connection string.</param>
+    /// <param name="adminEndpoint">The management-plane base address, an absolute http/https URL.</param>
+    /// <returns>The connection string for the management-plane client.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="adminEndpoint"/> is missing or malformed.</exception>
+    internal static string BuildAdminConnectionString(string connectionString, string? adminEndpoint)
+    {
+        // An absolute URI is not enough: "localhost:5300" parses as one, with "localhost" read as the
+        // scheme and no host at all, which would silently produce an admin string pointing nowhere.
+        // Requiring http or https is what makes a bare host:port fail here instead.
+        if (string.IsNullOrWhiteSpace(adminEndpoint)
+            || !Uri.TryCreate(adminEndpoint, UriKind.Absolute, out Uri? adminUri)
+            || !string.Equals(adminUri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+                && !string.Equals(adminUri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "MessageBus:EmulatorAdminEndpoint is required when MessageBus:ConnectionString targets the Azure Service Bus emulator (it carries UseDevelopmentEmulator=true). MassTransit v8 reaches the emulator only through the custom-clients Host overload, which needs a management-plane client in addition to the AMQP one, and the emulator serves that plane on a different port. Set it to the emulator's management-plane base address, for example 'http://localhost:5300'; an Aspire AppHost gets this for free from WithBroker(serviceBusEmulator).");
+        }
+
+        string endpointSegment = string.Create(
+            CultureInfo.InvariantCulture,
+            $"Endpoint=sb://{adminUri.Host}:{adminUri.Port}");
+
+        IEnumerable<string> segments = connectionString
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(segment => segment.StartsWith("Endpoint=", StringComparison.OrdinalIgnoreCase)
+                ? endpointSegment
+                : segment);
+
+        return string.Join(';', segments) + ';';
+    }
+}

--- a/Source/Core/MMCA.Common.Infrastructure/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Infrastructure/PublicAPI.Unshipped.txt
@@ -52,6 +52,8 @@ MMCA.Common.Infrastructure.Settings.CacheSettings.PopulateLockTimeout.get -> Sys
 MMCA.Common.Infrastructure.Settings.CacheSettings.PopulateLockTimeout.init -> void
 MMCA.Common.Infrastructure.Settings.DataSourceEntrySettings.SqliteMigrationsAssembly.get -> string!
 MMCA.Common.Infrastructure.Settings.DataSourceEntrySettings.SqliteMigrationsAssembly.init -> void
+MMCA.Common.Infrastructure.Settings.MessageBusSettings.EmulatorAdminEndpoint.get -> string?
+MMCA.Common.Infrastructure.Settings.MessageBusSettings.EmulatorAdminEndpoint.init -> void
 MMCA.Common.Infrastructure.Settings.MessageBusSettings.EnableInbox.get -> bool?
 MMCA.Common.Infrastructure.Settings.MessageBusSettings.EnableOutbox.get -> bool?
 MMCA.Common.Infrastructure.Settings.MessageBusSettings.EnableOutbox.init -> void

--- a/Source/Core/MMCA.Common.Infrastructure/Settings/MessageBusSettings.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Settings/MessageBusSettings.cs
@@ -26,6 +26,29 @@ public sealed class MessageBusSettings
     public string? ConnectionString { get; init; }
 
     /// <summary>
+    /// Gets the base address of the Azure Service Bus emulator's HTTP management plane, for example
+    /// <c>http://localhost:5300</c>. Set ONLY by a development stack pointing at the local emulator;
+    /// leave it unset for a real Azure Service Bus namespace, which serves both planes on one
+    /// endpoint and needs nothing here.
+    /// <para>
+    /// It exists because MassTransit is pinned to v8, which has no vendor emulator mode (that
+    /// arrived in v9, excluded by the commercial-license policy). The only v8 path onto the emulator
+    /// is the custom-clients <c>Host</c> overload, which takes a data-plane client AND a
+    /// management-plane client; the emulator serves those on two different ports, so the management
+    /// client cannot be derived from <see cref="ConnectionString"/> alone. An Aspire AppHost gets
+    /// this value for free from the emulator <c>WithBroker</c> overload.
+    /// </para>
+    /// <para>
+    /// The setting is read only when <see cref="ConnectionString"/> carries
+    /// <c>UseDevelopmentEmulator=true</c>; when it does, a missing or malformed value fails at
+    /// registration rather than at the first publish, because a bus with no management client cannot
+    /// provision the topology it needs to run at all.
+    /// </para>
+    /// </summary>
+    [StringLength(2048)]
+    public string? EmulatorAdminEndpoint { get; init; }
+
+    /// <summary>
     /// Gets the endpoint name prefix used to namespace queues per service (e.g. <c>store-catalog</c>).
     /// When set, the broker registration installs a kebab-case endpoint name formatter carrying this
     /// prefix, so a consumer named <c>OrderPlacedConsumer</c> in a service prefixed

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/Extensions.cs
@@ -35,6 +35,29 @@ public static class Extensions
     public const int E2eRegistrationsPerIpPerHour = 1000;
 
     /// <summary>
+    /// Default Aspire resource name used for the Azure Service Bus emulator container.
+    /// </summary>
+    public const string DefaultServiceBusEmulatorResourceName = "servicebus";
+
+    /// <summary>
+    /// Registry the Azure Service Bus emulator image is pulled from.
+    /// </summary>
+    public const string ServiceBusEmulatorImageRegistry = "mcr.microsoft.com";
+
+    /// <summary>
+    /// Repository of the official Azure Service Bus emulator image.
+    /// </summary>
+    public const string ServiceBusEmulatorImage = "azure-messaging/servicebus-emulator";
+
+    /// <summary>
+    /// Emulator image tag. Pinned to a 2.x build on purpose: the HTTP management plane (port 5300)
+    /// that lets a client create its own topics, subscriptions and queues shipped in 2.0.0, and
+    /// MassTransit provisions its whole topology at bus start. A silent downgrade to a 1.x image
+    /// would leave the broker unusable rather than merely older.
+    /// </summary>
+    public const string ServiceBusEmulatorImageTag = "2.0.1";
+
+    /// <summary>
     /// Default Aspire resource name used for the MailDev container.
     /// </summary>
     public const string DefaultMailDevResourceName = "maildev";
@@ -91,6 +114,79 @@ public static class Extensions
             ArgumentNullException.ThrowIfNull(builder);
             return builder.AddRabbitMQ(name).WithManagementPlugin();
         }
+
+        /// <summary>
+        /// Provisions the official Azure Service Bus emulator as a local container, so a development
+        /// stack runs the SAME transport production runs. <see cref="AddMessageBroker"/> gives a
+        /// developer RabbitMQ, which is fast and dependency-free but is a different broker with
+        /// different topology semantics: anything that only breaks on Azure Service Bus (entity
+        /// naming limits, topic/subscription provisioning, scheduled redelivery) is invisible locally
+        /// until it reaches production. This closes that divergence for hosts that want it, and it is
+        /// opt-in rather than the default because the emulator costs two containers and a warm-up.
+        /// <para>
+        /// The emulator keeps its state in SQL Server, so it is wired to an EXISTING SQL Server
+        /// resource (<paramref name="sqlServer"/>) rather than starting one of its own: a stack that
+        /// already runs SQL Server for its databases should not run a second engine for the broker.
+        /// The emulator reaches it over the container network, so only the SQL host name is passed
+        /// (the emulator connects on the default port 1433, which is the container's target port).
+        /// </para>
+        /// <para>
+        /// Both planes are published: AMQP (container port
+        /// <see cref="ServiceBusEmulatorResource.AmqpTargetPort"/>) carries every publish and
+        /// consume, and the HTTP management plane (container port
+        /// <see cref="ServiceBusEmulatorResource.AdminTargetPort"/>) is what MassTransit provisions
+        /// topology through. Host ports are left to Aspire: nothing outside the stack dials these,
+        /// so fixing them would only invite a collision with a stray container.
+        /// </para>
+        /// <para>
+        /// Wire a service to it with the <c>WithBroker</c> overload that takes this resource; that is
+        /// what sets <c>MessageBus:Provider=AzureServiceBus</c> plus the two connection settings.
+        /// </para>
+        /// </summary>
+        /// <param name="sqlServer">The SQL Server resource the emulator stores its state in.</param>
+        /// <param name="name">
+        /// The resource name (defaults to <see cref="DefaultServiceBusEmulatorResourceName"/>). It is
+        /// also the container's network alias.
+        /// </param>
+        /// <returns>The emulator resource builder, for <c>WithBroker</c> / <c>WaitFor</c> wiring.</returns>
+        public IResourceBuilder<ServiceBusEmulatorResource> AddServiceBusEmulatorBroker(
+            IResourceBuilder<SqlServerServerResource> sqlServer,
+            string name = DefaultServiceBusEmulatorResourceName)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(sqlServer);
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+            var resource = new ServiceBusEmulatorResource(name);
+
+            return builder.AddResource(resource)
+                // WithImage first: WithImageRegistry updates the image annotation that WithImage
+                // creates, and throws when there is none yet.
+                .WithImage(ServiceBusEmulatorImage, ServiceBusEmulatorImageTag)
+                .WithImageRegistry(ServiceBusEmulatorImageRegistry)
+                .WithEndpoint(
+                    targetPort: ServiceBusEmulatorResource.AmqpTargetPort,
+                    name: ServiceBusEmulatorResource.AmqpEndpointName,
+                    scheme: "tcp")
+                .WithHttpEndpoint(
+                    targetPort: ServiceBusEmulatorResource.AdminTargetPort,
+                    name: ServiceBusEmulatorResource.AdminEndpointName)
+
+                // The emulator refuses to start without an explicit EULA acknowledgement. Accepting
+                // it here is the same posture the Testcontainers module takes: the image is only ever
+                // used for local development and test.
+                .WithEnvironment("ACCEPT_EULA", "Y")
+                .WithEnvironment(
+                    "SQL_SERVER",
+                    ReferenceExpression.Create($"{sqlServer.Resource.PrimaryEndpoint.Property(EndpointProperty.Host)}"))
+                .WithEnvironment(
+                    "MSSQL_SA_PASSWORD",
+                    ReferenceExpression.Create($"{sqlServer.Resource.PasswordParameter}"))
+
+                // The emulator's first act is to create its schema, so it cannot start before SQL
+                // Server is accepting connections.
+                .WaitFor(sqlServer);
+        }
     }
 
     extension<TResource>(IResourceBuilder<TResource> service)
@@ -114,6 +210,36 @@ public static class Extensions
                 .WithReference(broker)
                 .WaitFor(broker)
                 .WithEnvironment("MessageBus__Provider", "RabbitMq");
+        }
+
+        /// <summary>
+        /// Wires a service to the local Azure Service Bus emulator instead of RabbitMQ, so the
+        /// development stack runs the production transport. Sets
+        /// <c>MessageBus:Provider=AzureServiceBus</c>, the AMQP connection string, and the
+        /// management-plane address the infrastructure layer needs to build MassTransit v8's
+        /// administration client. Adds a wait-for so the service does not start before the emulator
+        /// container is up.
+        /// <para>
+        /// The connection string carries <c>UseDevelopmentEmulator=true</c>, which is the marker
+        /// <c>AddBrokerMessaging</c> keys its emulator branch off. Everything a real Azure Service Bus
+        /// deployment does is left untouched: a production connection string never carries that
+        /// suffix, so the emulator path cannot be entered by accident.
+        /// </para>
+        /// </summary>
+        /// <param name="broker">The emulator resource builder.</param>
+        /// <returns>The service resource builder for chaining.</returns>
+        public IResourceBuilder<TResource> WithBroker(
+            IResourceBuilder<ServiceBusEmulatorResource> broker)
+        {
+            ArgumentNullException.ThrowIfNull(service);
+            ArgumentNullException.ThrowIfNull(broker);
+
+            return service
+                .WithReference(broker)
+                .WaitFor(broker)
+                .WithEnvironment("MessageBus__Provider", "AzureServiceBus")
+                .WithEnvironment("MessageBus__ConnectionString", broker.Resource.ConnectionStringExpression)
+                .WithEnvironment("MessageBus__EmulatorAdminEndpoint", broker.Resource.AdminEndpointExpression);
         }
 
         /// <summary>

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,12 +1,30 @@
 #nullable enable
 MMCA.Common.Aspire.Hosting.Extensions.extension(Aspire.Hosting.IDistributedApplicationBuilder!).AddMailDev(string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+MMCA.Common.Aspire.Hosting.Extensions.extension(Aspire.Hosting.IDistributedApplicationBuilder!).AddServiceBusEmulatorBroker(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqlServerServerResource!>! sqlServer, string! name = "servicebus") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource!>!
+MMCA.Common.Aspire.Hosting.Extensions.extension<TResource>(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>!).WithBroker(Aspire.Hosting.ApplicationModel.IResourceBuilder<MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource!>! broker) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>!
 MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions
 MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!)
 MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.extension(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!).WithH2cHealthCheck(string! path = "/alive", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource
+MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AdminEndpoint.get -> Aspire.Hosting.ApplicationModel.EndpointReference!
+MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AdminEndpointExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AmqpEndpoint.get -> Aspire.Hosting.ApplicationModel.EndpointReference!
+MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.ServiceBusEmulatorResource(string! name) -> void
 const MMCA.Common.Aspire.Hosting.Extensions.DefaultMailDevResourceName = "maildev" -> string!
+const MMCA.Common.Aspire.Hosting.Extensions.DefaultServiceBusEmulatorResourceName = "servicebus" -> string!
 const MMCA.Common.Aspire.Hosting.Extensions.MailDevHttpPort = 1080 -> int
 const MMCA.Common.Aspire.Hosting.Extensions.MailDevSmtpPort = 1025 -> int
+const MMCA.Common.Aspire.Hosting.Extensions.ServiceBusEmulatorImage = "azure-messaging/servicebus-emulator" -> string!
+const MMCA.Common.Aspire.Hosting.Extensions.ServiceBusEmulatorImageRegistry = "mcr.microsoft.com" -> string!
+const MMCA.Common.Aspire.Hosting.Extensions.ServiceBusEmulatorImageTag = "2.0.1" -> string!
 const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultEndpointName = "http" -> string!
 const MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.DefaultProbePath = "/alive" -> string!
+const MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AdminEndpointName = "admin" -> string!
+const MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AdminTargetPort = 5300 -> int
+const MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AmqpEndpointName = "amqp" -> string!
+const MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource.AmqpTargetPort = 5672 -> int
 static MMCA.Common.Aspire.Hosting.Extensions.AddMailDev(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name = "maildev") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+static MMCA.Common.Aspire.Hosting.Extensions.AddServiceBusEmulatorBroker(this Aspire.Hosting.IDistributedApplicationBuilder! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqlServerServerResource!>! sqlServer, string! name = "servicebus") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource!>!
+static MMCA.Common.Aspire.Hosting.Extensions.WithBroker<TResource>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>! service, Aspire.Hosting.ApplicationModel.IResourceBuilder<MMCA.Common.Aspire.Hosting.ServiceBusEmulatorResource!>! broker) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>!
 static MMCA.Common.Aspire.Hosting.H2cHealthCheckExtensions.WithH2cHealthCheck(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, string! path = "/alive", string! endpointName = "http") -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!

--- a/Source/Hosting/MMCA.Common.Aspire.Hosting/ServiceBusEmulatorResource.cs
+++ b/Source/Hosting/MMCA.Common.Aspire.Hosting/ServiceBusEmulatorResource.cs
@@ -1,0 +1,83 @@
+using Aspire.Hosting.ApplicationModel;
+
+namespace MMCA.Common.Aspire.Hosting;
+
+/// <summary>
+/// The official Azure Service Bus emulator running as a local container, so a development stack can
+/// exercise the SAME transport production uses (<c>MessageBus:Provider=AzureServiceBus</c>) instead
+/// of RabbitMQ. Provisioned by
+/// <c>IDistributedApplicationBuilder.AddServiceBusEmulatorBroker(sqlServer, name)</c>.
+/// <para>
+/// The resource publishes two endpoints because the emulator serves two planes on two protocols:
+/// AMQP on 5672 (the data plane every publish and consume flows through) and HTTP on 5300 (the
+/// management plane that creates topics, subscriptions and queues). MassTransit provisions its own
+/// topology at bus start, so a broker with no admin plane is not usable at all: the admin plane
+/// shipped in emulator 2.0.0, which is why the image tag floor is 2.x.
+/// </para>
+/// <para>
+/// <see cref="ConnectionStringExpression"/> is the emulator connection-string form, ending in
+/// <c>UseDevelopmentEmulator=true</c>. That suffix is not decoration: it is what keeps the Azure SDK
+/// clients on plain TCP/HTTP against a local host, and it is the marker
+/// <c>MMCA.Common.Infrastructure</c> detects to take its emulator configuration branch. A real Azure
+/// Service Bus connection string never carries it, so production behavior cannot be reached by
+/// accident.
+/// </para>
+/// <para>
+/// No health check is declared. A <c>WaitFor</c> on this resource therefore gates on the container
+/// running, not on the emulator having finished its warm-up; the consuming service absorbs the
+/// remainder, because MassTransit starts its bus in the background and reconnects rather than
+/// failing host startup.
+/// </para>
+/// </summary>
+public sealed class ServiceBusEmulatorResource : ContainerResource, IResourceWithConnectionString
+{
+    /// <summary>Endpoint name of the AMQP data plane (container port 5672).</summary>
+    public const string AmqpEndpointName = "amqp";
+
+    /// <summary>Endpoint name of the HTTP management plane (container port 5300).</summary>
+    public const string AdminEndpointName = "admin";
+
+    /// <summary>Container port the emulator serves AMQP on.</summary>
+    public const int AmqpTargetPort = 5672;
+
+    /// <summary>Container port the emulator serves its management plane on.</summary>
+    public const int AdminTargetPort = 5300;
+
+    /// <summary>Creates the emulator container resource.</summary>
+    /// <param name="name">The Aspire resource name, which is also the container's network alias.</param>
+    public ServiceBusEmulatorResource(string name)
+        : base(name)
+    {
+        AmqpEndpoint = new EndpointReference(this, AmqpEndpointName);
+        AdminEndpoint = new EndpointReference(this, AdminEndpointName);
+    }
+
+    /// <summary>Gets the AMQP data-plane endpoint.</summary>
+    public EndpointReference AmqpEndpoint { get; }
+
+    /// <summary>Gets the HTTP management-plane endpoint.</summary>
+    public EndpointReference AdminEndpoint { get; }
+
+    /// <summary>
+    /// Gets the AMQP connection string in the emulator form. The shared-access key name and value are
+    /// the emulator's own fixed placeholders (it authenticates nothing), and
+    /// <c>UseDevelopmentEmulator=true</c> is the marker every consumer keys its emulator branch off.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create(
+            $"Endpoint=sb://{AmqpEndpoint.Property(EndpointProperty.Host)}:{AmqpEndpoint.Property(EndpointProperty.Port)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
+
+    /// <summary>
+    /// Gets the management-plane base address as a URL. A consumer hands this to
+    /// <c>MessageBus:EmulatorAdminEndpoint</c>, which is what lets the infrastructure layer build the
+    /// second (administration) client MassTransit v8 needs to provision topology on the emulator.
+    /// <para>
+    /// The scheme is read off the allocated endpoint rather than written literally, so the value
+    /// tracks whatever the endpoint was declared as (<c>http</c> today: the emulator's management
+    /// plane is cleartext by design and reachable only from the local development stack).
+    /// </para>
+    /// </summary>
+    public ReferenceExpression AdminEndpointExpression =>
+        ReferenceExpression.Create(
+            $"{AdminEndpoint.Property(EndpointProperty.Scheme)}://{AdminEndpoint.Property(EndpointProperty.Host)}:{AdminEndpoint.Property(EndpointProperty.Port)}");
+}

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Layers.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Layers.cs
@@ -86,17 +86,55 @@ public static partial class ArchitectureRules
     /// </summary>
     /// <param name="map">The repo's architecture map.</param>
     /// <param name="required">The layers every declared module must register.</param>
-    public static void ModulesDeclareLayers(IArchitectureMap map, IEnumerable<Layer> required)
+    public static void ModulesDeclareLayers(IArchitectureMap map, IEnumerable<Layer> required) =>
+        ModulesDeclareLayers(map, required, overrides: null);
+
+    /// <summary>
+    /// Every module the map declares registers an assembly for each layer in
+    /// <paramref name="required"/>, EXCEPT a module named in <paramref name="overrides"/>, which is
+    /// checked against its own list instead.
+    /// <para>
+    /// The override exists for a deliberately thin module: one that legitimately has no Domain or
+    /// Infrastructure assembly because it owns no aggregate and no persistence (a SignalR hub module,
+    /// say, that is Shared plus Application plus Api and nothing else). Without a per-module escape
+    /// the only way to express that is to trim the DEFAULT list, which silently stops enforcing those
+    /// layers for every OTHER module in the repo: one thin module would buy blanket permission to
+    /// forget an assembly anywhere. Naming the exception keeps the default strict and puts the
+    /// weakening exactly where it is true.
+    /// </para>
+    /// </summary>
+    /// <param name="map">The repo's architecture map.</param>
+    /// <param name="required">The layers every module not named in <paramref name="overrides"/> must register.</param>
+    /// <param name="overrides">
+    /// Per-module replacements for <paramref name="required"/>, keyed by module name. A module listed
+    /// here is checked against its own list only; <see langword="null"/> or empty means every module
+    /// uses <paramref name="required"/>.
+    /// </param>
+    public static void ModulesDeclareLayers(
+        IArchitectureMap map,
+        IEnumerable<Layer> required,
+        IReadOnlyDictionary<string, IReadOnlyList<Layer>>? overrides)
     {
+        ArgumentNullException.ThrowIfNull(map);
+        ArgumentNullException.ThrowIfNull(required);
+
         var requiredList = required.ToList();
         var missing = map.ModuleNames
-            .SelectMany(module => requiredList
+            .SelectMany(module => LayersRequiredFor(module, requiredList, overrides)
                 .Where(layer => map.For(module, layer) is null)
                 .Select(layer => $"  - module '{module}' declares no Layer.{layer} assembly"));
 
         ArchitectureAssert.NoViolations(missing,
             "every declared module must register its expected layer assemblies so the per-module layer rules run non-vacuously");
     }
+
+    private static IReadOnlyList<Layer> LayersRequiredFor(
+        string module,
+        IReadOnlyList<Layer> required,
+        IReadOnlyDictionary<string, IReadOnlyList<Layer>>? overrides)
+        => overrides is not null && overrides.TryGetValue(module, out var moduleLayers)
+            ? moduleLayers
+            : required;
 
     private static void LayerNotDependOnLayer(IArchitectureMap map, Layer from, Layer to, string reason)
     {

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/LayerDependencyTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/LayerDependencyTestsBase.cs
@@ -17,17 +17,44 @@ public abstract class LayerDependencyTestsBase
         [Layer.Shared, Layer.Domain, Layer.Application, Layer.Infrastructure, Layer.Api];
 
     /// <summary>
-    /// The layers every declared business module must register. Defaults to
-    /// <see cref="RequiredLayers"/>; override for repos with deliberately thin modules
-    /// (e.g. an API-plus-Application-only module) by trimming the list.
+    /// The layers every declared business module must register, unless the module names itself in
+    /// <see cref="ModuleRequiredLayerOverrides"/>. Defaults to <see cref="RequiredLayers"/>.
+    /// <para>
+    /// Prefer the per-module override to trimming this list: trimming applies to EVERY module, so one
+    /// thin module would stop the rule from catching a forgotten assembly anywhere in the repo.
+    /// </para>
     /// </summary>
     protected virtual IReadOnlyList<Layer> RequiredModuleLayers => RequiredLayers;
+
+    /// <summary>
+    /// Per-module replacements for <see cref="RequiredModuleLayers"/>, keyed by module name. Empty by
+    /// default: every module is held to the same list.
+    /// <para>
+    /// Override this for a deliberately thin module, one that owns no aggregate and no persistence
+    /// and therefore legitimately ships no Domain or Infrastructure assembly (a SignalR hub module,
+    /// say, that is Shared plus Application plus Api and nothing else). Listing it here keeps full
+    /// enforcement on every other module, so the exception is recorded where it is true rather than
+    /// paid for by the whole repo.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// protected override IReadOnlyDictionary&lt;string, IReadOnlyList&lt;Layer&gt;&gt; ModuleRequiredLayerOverrides
+    ///     =&gt; new Dictionary&lt;string, IReadOnlyList&lt;Layer&gt;&gt;(StringComparer.Ordinal)
+    ///     {
+    ///         ["Notification"] = [Layer.Shared, Layer.Application, Layer.Api],
+    ///     };
+    /// </code>
+    /// </example>
+    protected virtual IReadOnlyDictionary<string, IReadOnlyList<Layer>> ModuleRequiredLayerOverrides
+        => new Dictionary<string, IReadOnlyList<Layer>>(StringComparer.Ordinal);
 
     [Fact]
     public void LayerMap_DeclaresEveryExpectedLayer() => ArchitectureRules.LayerMapDeclaresLayers(Map, RequiredLayers);
 
     [Fact]
-    public void LayerMap_ModulesDeclareEveryExpectedLayer() => ArchitectureRules.ModulesDeclareLayers(Map, RequiredModuleLayers);
+    public void LayerMap_ModulesDeclareEveryExpectedLayer() =>
+        ArchitectureRules.ModulesDeclareLayers(Map, RequiredModuleLayers, ModuleRequiredLayerOverrides);
 
     [Fact]
     public void Domain_ShouldNotDependOn_Application() => ArchitectureRules.DomainDoesNotDependOnApplication(Map);

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
@@ -32,6 +32,7 @@ MMCA.Common.Testing.Architecture.ErrorCatalogTestsBase.ErrorCodes_ShouldBe_Uniqu
 MMCA.Common.Testing.Architecture.ErrorCatalogTestsBase.ErrorCodes_ShouldCarry_TheOwningModulePrefix() -> void
 MMCA.Common.Testing.Architecture.EventConventionTestsBase.EventUpcasters_ShouldHave_UniqueSourceTypes() -> void
 MMCA.Common.Testing.Architecture.EventConventionTestsBase.EventUpcasters_ShouldIncrease_SchemaVersion() -> void
+virtual MMCA.Common.Testing.Architecture.LayerDependencyTestsBase.ModuleRequiredLayerOverrides.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<MMCA.Common.Testing.Architecture.Layer>!>!
 MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase
 MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase.ServiceContractPurityTestsBase() -> void
 MMCA.Common.Testing.Architecture.ServiceContractPurityTestsBase.ServiceContracts_ShouldNotDependOn_ServiceInternals() -> void
@@ -69,6 +70,7 @@ static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersHaveUniq
 static MMCA.Common.Testing.Architecture.ArchitectureRules.EventUpcastersIncreaseSchemaVersion(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.HandledCommandCount(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> int
 static MMCA.Common.Testing.Architecture.ArchitectureRules.HardDeletesOnlyInAllowedTypes(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedTypesAndNamespaces) -> void
+static MMCA.Common.Testing.Architecture.ArchitectureRules.ModulesDeclareLayers(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IEnumerable<MMCA.Common.Testing.Architecture.Layer>! required, System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<MMCA.Common.Testing.Architecture.Layer>!>? overrides) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractImplementationsAreNotPublic(MMCA.Common.Testing.Architecture.IArchitectureMap! map, System.Collections.Generic.IReadOnlyCollection<string!>! allowedPublicImplementations) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.ServiceContractsDoNotDependOnServiceInternals(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
 static MMCA.Common.Testing.Architecture.ArchitectureRules.SortableGridColumnsUsePropertyColumn(System.Collections.Generic.IReadOnlyCollection<string!>! markupRoots) -> void

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -1,62 +1,4 @@
 ﻿#nullable enable
-*REMOVED*MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
-*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
-*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.NotificationInboxService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Notifications.INotificationScopeProvider! scopeProvider) -> void
-*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.TryRegisterPoller() -> bool
-*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.UnregisterPoller() -> void
-MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.get -> string!
-MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.init -> void
-MMCA.Common.UI.Components.MmcaThemeProviders.Theme.get -> MudBlazor.MudTheme!
-MMCA.Common.UI.Components.MmcaThemeProviders.Theme.set -> void
-MMCA.Common.UI.Services.AuthenticatedServiceBase.CreateClientWithToken(string! accessToken) -> System.Net.Http.HttpClient!
-MMCA.Common.UI.Services.Notifications.NotificationInboxService.NotificationInboxService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Notifications.INotificationScopeProvider! scopeProvider, MMCA.Common.UI.Services.Auth.ITokenRefresher? tokenRefresher = null) -> void
-MMCA.Common.UI.Services.Notifications.NotificationState.OnPollerSlotFreed -> System.EventHandler?
-MMCA.Common.UI.Services.Notifications.NotificationState.TryRegisterPoller(object! owner) -> bool
-MMCA.Common.UI.Services.Notifications.NotificationState.UnregisterPoller(object! owner) -> void
-MMCA.Common.UI.Pages.Auth.ForgotPassword
-MMCA.Common.UI.Pages.Auth.ForgotPassword.ForgotPassword() -> void
-MMCA.Common.UI.Pages.Auth.ForgotPasswordModel
-MMCA.Common.UI.Pages.Auth.ForgotPasswordModel.Email.get -> string!
-MMCA.Common.UI.Pages.Auth.ForgotPasswordModel.Email.set -> void
-MMCA.Common.UI.Pages.Auth.ForgotPasswordModel.ForgotPasswordModel() -> void
-MMCA.Common.UI.Pages.Auth.ResetPassword
-MMCA.Common.UI.Pages.Auth.ResetPassword.Email.get -> string?
-MMCA.Common.UI.Pages.Auth.ResetPassword.Email.set -> void
-MMCA.Common.UI.Pages.Auth.ResetPassword.ResetPassword() -> void
-MMCA.Common.UI.Pages.Auth.ResetPassword.Token.get -> string?
-MMCA.Common.UI.Pages.Auth.ResetPassword.Token.set -> void
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.ConfirmPassword.get -> string!
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.ConfirmPassword.set -> void
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Email.get -> string!
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Email.set -> void
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.NewPassword.get -> string!
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.NewPassword.set -> void
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.ResetPasswordModel() -> void
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Token.get -> string!
-MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Token.set -> void
-MMCA.Common.UI.Services.Auth.ConfigurationOAuthUISettings.AppleEnabled.get -> bool
-MMCA.Common.UI.Services.Auth.IOAuthUISettings.AppleEnabled.get -> bool
-MMCA.Common.UI.Pages.Notifications.NotificationSendModel
-MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Body.get -> string!
-MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Body.set -> void
-MMCA.Common.UI.Pages.Notifications.NotificationSendModel.NotificationSendModel() -> void
-MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Title.get -> string!
-MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Title.set -> void
-MMCA.Common.UI.Validation.DataAnnotationsModelValidator
-MMCA.Common.UI.Validation.DataAnnotationsModelValidator.DataAnnotationsModelValidator(Microsoft.Extensions.Localization.IStringLocalizer! localizer) -> void
-MMCA.Common.UI.Validation.DataAnnotationsModelValidator.Validate(object! model, string! propertyPath) -> System.Collections.Generic.IEnumerable<string!>!
-MMCA.Common.UI.Validation.DataAnnotationsModelValidator.ValidateValue(object! model, string! propertyPath, object? value) -> System.Collections.Generic.IEnumerable<string!>!
-MMCA.Common.UI.Validation.IModelValidator
-MMCA.Common.UI.Validation.IModelValidator.Validate(object! model, string! propertyPath) -> System.Collections.Generic.IEnumerable<string!>!
-MMCA.Common.UI.Validation.ModelValidation
-override MMCA.Common.UI.Pages.Auth.ResetPassword.OnParametersSet() -> void
-static MMCA.Common.UI.Validation.ModelValidation.For(object! model, MMCA.Common.UI.Validation.IModelValidator! validator) -> System.Func<object!, string!, System.Collections.Generic.IEnumerable<string!>!>!
-static MMCA.Common.UI.Validation.ModelValidation.ForProperty<TModel, TValue>(TModel! model, System.Linq.Expressions.Expression<System.Func<TModel!, TValue>!>! property, MMCA.Common.UI.Validation.DataAnnotationsModelValidator! validator) -> System.Func<TValue, System.Collections.Generic.IEnumerable<string!>!>!
-static MMCA.Common.UI.Validation.ModelValidation.GetPropertyPath<TModel, TValue>(System.Linq.Expressions.Expression<System.Func<TModel, TValue>!>! property) -> string!
-static MMCA.Common.UI.Validation.ModelValidation.IsRequired(object! model, string! propertyPath) -> bool
-~override MMCA.Common.UI.Pages.Auth.ForgotPassword.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-~override MMCA.Common.UI.Pages.Auth.ResetPassword.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
 *REMOVED*MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.AddAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TEntityDTO>!
 *REMOVED*MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.DeleteAsync(TIdentifierType id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 *REMOVED*MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.GetAllAsync(bool includeFKs = false, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<TEntityDTO>?>!
@@ -66,11 +8,15 @@ static MMCA.Common.UI.Validation.ModelValidation.IsRequired(object! model, strin
 *REMOVED*MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.UpdateAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 *REMOVED*MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadMobileDataAsync(System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null) -> System.Threading.Tasks.Task!
 *REMOVED*MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadServerDataAsync(MudBlazor.GridState<TDto>! state, System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null, bool showCancelSnackbar = true) -> System.Threading.Tasks.Task<MudBlazor.GridData<TDto>!>!
+*REMOVED*MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Snackbar.get -> MudBlazor.ISnackbar!
+*REMOVED*MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Snackbar.set -> void
+*REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.AuthUIService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Auth.ITokenRefresher! tokenRefresher, Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider! authStateProvider, MMCA.Common.UI.Services.Capabilities.IPushRegistrationService! pushRegistration) -> void
 *REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.ChangePasswordAsync(string! currentPassword, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 *REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.ExchangeOAuthCodeAsync(string! code, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Auth.AuthenticationResponse?>!
 *REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.LastError.get -> string?
 *REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.LoginAsync(MMCA.Common.Shared.Auth.LoginRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Auth.AuthenticationResponse?>!
 *REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.RegisterAsync(MMCA.Common.Shared.Auth.RegisterRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Auth.AuthenticationResponse?>!
+*REMOVED*MMCA.Common.UI.Services.Auth.DirectApiTokenRefresher.DirectApiTokenRefresher(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService) -> void
 *REMOVED*MMCA.Common.UI.Services.Auth.IAuthUIService.ChangePasswordAsync(string! currentPassword, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 *REMOVED*MMCA.Common.UI.Services.Auth.IAuthUIService.ExchangeOAuthCodeAsync(string! code, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Auth.AuthenticationResponse?>!
 *REMOVED*MMCA.Common.UI.Services.Auth.IAuthUIService.LastError.get -> string?
@@ -78,15 +24,22 @@ static MMCA.Common.UI.Validation.ModelValidation.IsRequired(object! model, strin
 *REMOVED*MMCA.Common.UI.Services.Auth.IAuthUIService.RegisterAsync(MMCA.Common.Shared.Auth.RegisterRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Auth.AuthenticationResponse?>!
 *REMOVED*MMCA.Common.UI.Services.ChildEntityServiceBase.DeleteByIdAsync(string! id, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
 *REMOVED*MMCA.Common.UI.Services.ChildEntityServiceBase.PostAsync<TRequest>(TRequest request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!
+*REMOVED*MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.EntityServiceBase(string! endpoint, System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService) -> void
 *REMOVED*MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.SendRequestAsync<T>(System.Func<System.Net.Http.HttpClient!, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!>! httpAction, System.Threading.CancellationToken cancellationToken, bool treatNotFoundAsDefault = false, bool throwIfNull = false, bool expectContent = true, string? idempotencyKey = null) -> System.Threading.Tasks.Task<T?>!
 *REMOVED*MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetInboxAsync(int pageNumber = 1, int pageSize = 20, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.UserNotifications.UserNotificationDTO!>?>!
+*REMOVED*MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 *REMOVED*MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.MarkAllReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.MarkReadAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*MMCA.Common.UI.Services.Notifications.IPushNotificationUIService.GetHistoryAsync(int pageNumber = 1, int pageSize = 10, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>?>!
 *REMOVED*MMCA.Common.UI.Services.Notifications.IPushNotificationUIService.SendAsync(MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO?>!
 *REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetInboxAsync(int pageNumber = 1, int pageSize = 20, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.UserNotifications.UserNotificationDTO!>?>!
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 *REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.MarkAllReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.MarkReadAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationInboxService.NotificationInboxService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Notifications.INotificationScopeProvider! scopeProvider) -> void
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.NotificationState() -> void
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.TryRegisterPoller() -> bool
+*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.UnregisterPoller() -> void
 *REMOVED*MMCA.Common.UI.Services.Notifications.PushNotificationService.GetHistoryAsync(int pageNumber = 1, int pageSize = 10, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>?>!
 *REMOVED*MMCA.Common.UI.Services.Notifications.PushNotificationService.SendAsync(MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO?>!
 *REMOVED*MMCA.Common.UI.Services.ServiceExceptionHelper
@@ -98,6 +51,8 @@ static MMCA.Common.UI.Validation.ModelValidation.IsRequired(object! model, strin
 *REMOVED*virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetByIdAsync(TIdentifierType id, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TEntityDTO?>!
 *REMOVED*virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetPagedAsync(System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>! filters, int pageNumber, int pageSize, string? sortColumn, string? sortDirection, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TEntityDTO>! Items, int TotalItems)>!
 *REMOVED*virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.UpdateAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+MMCA.Common.UI.Common.Interfaces.IAppDialogService
+MMCA.Common.UI.Common.Interfaces.IAppDialogService.ConfirmAsync(string! title, string! message, string! confirmText, string! cancelText) -> System.Threading.Tasks.Task<bool>!
 MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.AddAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TEntityDTO>!>!
 MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.DeleteAsync(TIdentifierType id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
 MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.GetAllAsync(bool includeFKs = false, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<TEntityDTO>!>!>!
@@ -105,101 +60,39 @@ MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.Get
 MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.GetByIdAsync(TIdentifierType id, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TEntityDTO>!>!
 MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.GetPagedAsync(System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>! filters, int pageNumber, int pageSize, string? sortColumn, string? sortDirection, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TEntityDTO>! Items, int TotalItems)>!>!
 MMCA.Common.UI.Common.Interfaces.IEntityService<TEntityDTO, TIdentifierType>.UpdateAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Common.Interfaces.IToastService
+MMCA.Common.UI.Common.Interfaces.IToastService.Error(string! message) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.Info(string! message) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.Show(string! message, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.ShowAction(string! message, string! actionText, System.Func<System.Threading.Tasks.Task!>! onAction, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info, bool requireInteraction = false) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.ShowPersistent(string! title, string! body, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.Success(string! message) -> void
+MMCA.Common.UI.Common.Interfaces.IToastService.Warning(string! message) -> void
+MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.Interfaces.ToastSeverity.Error = 4 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info = 1 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.Interfaces.ToastSeverity.Normal = 0 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.Interfaces.ToastSeverity.Success = 2 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.Interfaces.ToastSeverity.Warning = 3 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.NavItem.Deconstruct(out string! Title, out string! Href, out string! Icon, out System.Type! TitleResource, out string? RequiredRole, out string? RequiredClaim, out MMCA.Common.UI.Common.NavSection Section, out string? Group) -> void
+MMCA.Common.UI.Common.NavItem.NavItem(string! Title, string! Href, string! Icon, System.Type! TitleResource, string? RequiredRole = null, string? RequiredClaim = null, MMCA.Common.UI.Common.NavSection Section = MMCA.Common.UI.Common.NavSection.General, string? Group = null) -> void
+MMCA.Common.UI.Common.NavItem.TitleResource.get -> System.Type!
 MMCA.Common.UI.Common.ResultUiExtensions
-MMCA.Common.UI.Components.ErrorSummary
-MMCA.Common.UI.Components.ErrorSummary.Class.get -> string!
-MMCA.Common.UI.Components.ErrorSummary.Class.set -> void
-MMCA.Common.UI.Components.ErrorSummary.Dense.get -> bool
-MMCA.Common.UI.Components.ErrorSummary.Dense.set -> void
-MMCA.Common.UI.Components.ErrorSummary.ErrorSummary() -> void
-MMCA.Common.UI.Components.ErrorSummary.Localizer.get -> Microsoft.Extensions.Localization.IStringLocalizer?
-MMCA.Common.UI.Components.ErrorSummary.Localizer.set -> void
-MMCA.Common.UI.Components.ErrorSummary.Messages.get -> System.Collections.Generic.IEnumerable<string!>?
-MMCA.Common.UI.Components.ErrorSummary.Messages.set -> void
-MMCA.Common.UI.Components.ErrorSummary.Result.get -> MMCA.Common.Shared.Abstractions.Result?
-MMCA.Common.UI.Components.ErrorSummary.Result.set -> void
-MMCA.Common.UI.Components.ErrorSummary.Severity.get -> MudBlazor.Severity
-MMCA.Common.UI.Components.ErrorSummary.Severity.set -> void
-MMCA.Common.UI.Components.ErrorSummary.Title.get -> string?
-MMCA.Common.UI.Components.ErrorSummary.Title.set -> void
-MMCA.Common.UI.Components.ErrorSummary.Variant.get -> MudBlazor.Variant
-MMCA.Common.UI.Components.ErrorSummary.Variant.set -> void
-MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadMobileDataAsync(System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null) -> System.Threading.Tasks.Task!
-MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadServerDataAsync(MudBlazor.GridState<TDto>! state, System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null, bool showCancelSnackbar = true) -> System.Threading.Tasks.Task<MudBlazor.GridData<TDto>!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.ChangePasswordAsync(string! currentPassword, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.ExchangeOAuthCodeAsync(string! code, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.GetSessionsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Auth.RefreshSessionSummaryResponse!>!>!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.LoginAsync(MMCA.Common.Shared.Auth.LoginRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.RegisterAsync(MMCA.Common.Shared.Auth.RegisterRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.RequestPasswordResetAsync(string! email, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.ResetPasswordAsync(string! email, string! token, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.AuthUIService.RevokeSessionAsync(System.Guid sessionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.ChangePasswordAsync(string! currentPassword, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.ExchangeOAuthCodeAsync(string! code, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.GetSessionsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Auth.RefreshSessionSummaryResponse!>!>!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.LoginAsync(MMCA.Common.Shared.Auth.LoginRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.RegisterAsync(MMCA.Common.Shared.Auth.RegisterRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.RequestPasswordResetAsync(string! email, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.ResetPasswordAsync(string! email, string! token, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Auth.IAuthUIService.RevokeSessionAsync(System.Guid sessionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.ChildEntityServiceBase.DeleteByIdAsync(string! id, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.ChildEntityServiceBase.PostAsync(object! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.ChildEntityServiceBase.PostAsync<TResponse>(object! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TResponse>!>!
-MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.SendRequestAsync(System.Func<System.Net.Http.HttpClient!, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!>! httpAction, System.Threading.CancellationToken cancellationToken, string? idempotencyKey = null, string? ifMatch = null) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.SendRequestAsync<T>(System.Func<System.Net.Http.HttpClient!, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!>! httpAction, System.Threading.CancellationToken cancellationToken, string? idempotencyKey = null, string? ifMatch = null) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!
-MMCA.Common.UI.Services.HttpResultExecutor
-MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetInboxAsync(int pageNumber = 1, int pageSize = 20, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.UserNotifications.UserNotificationDTO!>!>!>!
-MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<int>!>!
-MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.MarkAllReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.MarkReadAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Notifications.IPushNotificationUIService.GetHistoryAsync(int pageNumber = 1, int pageSize = 10, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!>!
-MMCA.Common.UI.Services.Notifications.IPushNotificationUIService.SendAsync(MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!
-MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetInboxAsync(int pageNumber = 1, int pageSize = 20, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.UserNotifications.UserNotificationDTO!>!>!>!
-MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<int>!>!
-MMCA.Common.UI.Services.Notifications.NotificationInboxService.MarkAllReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Notifications.NotificationInboxService.MarkReadAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-MMCA.Common.UI.Services.Notifications.PushNotificationService.GetHistoryAsync(int pageNumber = 1, int pageSize = 10, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!>!
-MMCA.Common.UI.Services.Notifications.PushNotificationService.SendAsync(MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!
-const MMCA.Common.UI.Services.Auth.AuthUIService.MissingAccessTokenCode = "Auth.MissingAccessToken" -> string!
-const MMCA.Common.UI.Services.Auth.AuthUIService.TokenStorageUnavailableCode = "Auth.TokenStorageUnavailable" -> string!
-const MMCA.Common.UI.Services.HttpResultExecutor.TimeoutErrorCode = "Http.Timeout" -> string!
-const MMCA.Common.UI.Services.HttpResultExecutor.TransportErrorCode = "Http.TransportFailure" -> string!
-override MMCA.Common.UI.Components.ErrorSummary.OnParametersSet() -> void
-static MMCA.Common.UI.Common.ResultUiExtensions.HasErrorType(this MMCA.Common.Shared.Abstractions.Result! result, MMCA.Common.Shared.Abstractions.ErrorType errorType) -> bool
-static MMCA.Common.UI.Common.ResultUiExtensions.IsNotFound(this MMCA.Common.Shared.Abstractions.Result! result) -> bool
-static MMCA.Common.UI.Common.ResultUiExtensions.IsUnauthorized(this MMCA.Common.Shared.Abstractions.Result! result) -> bool
-static MMCA.Common.UI.Common.ResultUiExtensions.LocalizeDistinct(System.Collections.Generic.IEnumerable<string!>? messages, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> System.Collections.Generic.IReadOnlyList<string!>!
-static MMCA.Common.UI.Common.ResultUiExtensions.LocalizedErrorMessage(this MMCA.Common.Shared.Abstractions.Result! result, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> string?
-static MMCA.Common.UI.Common.ResultUiExtensions.LocalizedErrorMessages(this MMCA.Common.Shared.Abstractions.Result! result, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> System.Collections.Generic.IReadOnlyList<string!>!
-static MMCA.Common.UI.Common.ResultUiExtensions.NotifyOnFailure(this MMCA.Common.Shared.Abstractions.Result! result, MMCA.Common.UI.Common.Interfaces.IToastService! toast, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Error) -> MMCA.Common.Shared.Abstractions.Result!
-static MMCA.Common.UI.Common.ResultUiExtensions.NotifyOnFailure<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, MMCA.Common.UI.Common.Interfaces.IToastService! toast, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Error) -> MMCA.Common.Shared.Abstractions.Result<T>!
-static MMCA.Common.UI.Common.ResultUiExtensions.OnFailureSetError(this MMCA.Common.Shared.Abstractions.Result! result, System.Action<string?>! setError, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> MMCA.Common.Shared.Abstractions.Result!
-static MMCA.Common.UI.Common.ResultUiExtensions.OnFailureSetError<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, System.Action<string?>! setError, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> MMCA.Common.Shared.Abstractions.Result<T>!
-static MMCA.Common.UI.Common.ResultUiExtensions.TryGetValue<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, out T? value) -> bool
-static MMCA.Common.UI.Common.ResultUiExtensions.TryGetValue<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, out T? value, out System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Abstractions.Error!>! errors) -> bool
-static MMCA.Common.UI.Services.HttpResultExecutor.ExecuteAsync(System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!>! operation, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-static MMCA.Common.UI.Services.HttpResultExecutor.ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!>! operation, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.AddAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TEntityDTO>!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.DeleteAsync(TIdentifierType id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetAllAsync(bool includeFKs = false, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<TEntityDTO>!>!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetAllForLookupAsync(string! nameProperty, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.DTOs.BaseLookup<TIdentifierType>!>!>!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetByIdAsync(TIdentifierType id, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TEntityDTO>!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetPagedAsync(System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>! filters, int pageNumber, int pageSize, string? sortColumn, string? sortDirection, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TEntityDTO>! Items, int TotalItems)>!>!
-virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.UpdateAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
-~override MMCA.Common.UI.Components.ErrorSummary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-MMCA.Common.UI.Pages.Auth.Sessions
-MMCA.Common.UI.Pages.Auth.Sessions.Dispose() -> void
-MMCA.Common.UI.Pages.Auth.Sessions.IsBusy.get -> bool
-MMCA.Common.UI.Pages.Auth.Sessions.IsLoading.get -> bool
-MMCA.Common.UI.Pages.Auth.Sessions.Sessions() -> void
-override MMCA.Common.UI.Pages.Auth.Sessions.OnInitializedAsync() -> System.Threading.Tasks.Task!
-static readonly MMCA.Common.UI.Common.RoutePaths.Sessions -> string!
-virtual MMCA.Common.UI.Pages.Auth.Sessions.Dispose(bool disposing) -> void
-~override MMCA.Common.UI.Pages.Auth.Sessions.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>!>?
-MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.set -> void
-MMCA.Common.UI.Services.Capabilities.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddDeviceCapabilityDefaults() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static MMCA.Common.UI.Services.Capabilities.DependencyInjection.AddDeviceCapabilityDefaults(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.get -> string!
+MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.init -> void
+MMCA.Common.UI.Common.Settings.NotificationBellOptions
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.get -> System.TimeSpan
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.init -> void
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.NotificationBellOptions() -> void
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.PollInterval.get -> System.TimeSpan
+MMCA.Common.UI.Common.Settings.NotificationBellOptions.PollInterval.init -> void
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.DefaultTtl.get -> System.TimeSpan
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.DefaultTtl.init -> void
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.Enabled.get -> bool
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.Enabled.init -> void
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.RoutePrefixTtls.get -> System.Collections.Generic.Dictionary<string!, System.TimeSpan>!
+MMCA.Common.UI.Common.Settings.UiReadCacheOptions.UiReadCacheOptions() -> void
 MMCA.Common.UI.Components.ApiFileDownloadButton
 MMCA.Common.UI.Components.ApiFileDownloadButton.ApiFileDownloadButton() -> void
 MMCA.Common.UI.Components.ApiFileDownloadButton.AriaLabel.get -> string?
@@ -222,6 +115,24 @@ MMCA.Common.UI.Components.ApiFileDownloadButton.Size.get -> MudBlazor.Size
 MMCA.Common.UI.Components.ApiFileDownloadButton.Size.set -> void
 MMCA.Common.UI.Components.ApiFileDownloadButton.UnavailableMessage.get -> string?
 MMCA.Common.UI.Components.ApiFileDownloadButton.UnavailableMessage.set -> void
+MMCA.Common.UI.Components.ErrorSummary
+MMCA.Common.UI.Components.ErrorSummary.Class.get -> string!
+MMCA.Common.UI.Components.ErrorSummary.Class.set -> void
+MMCA.Common.UI.Components.ErrorSummary.Dense.get -> bool
+MMCA.Common.UI.Components.ErrorSummary.Dense.set -> void
+MMCA.Common.UI.Components.ErrorSummary.ErrorSummary() -> void
+MMCA.Common.UI.Components.ErrorSummary.Localizer.get -> Microsoft.Extensions.Localization.IStringLocalizer?
+MMCA.Common.UI.Components.ErrorSummary.Localizer.set -> void
+MMCA.Common.UI.Components.ErrorSummary.Messages.get -> System.Collections.Generic.IEnumerable<string!>?
+MMCA.Common.UI.Components.ErrorSummary.Messages.set -> void
+MMCA.Common.UI.Components.ErrorSummary.Result.get -> MMCA.Common.Shared.Abstractions.Result?
+MMCA.Common.UI.Components.ErrorSummary.Result.set -> void
+MMCA.Common.UI.Components.ErrorSummary.Severity.get -> MudBlazor.Severity
+MMCA.Common.UI.Components.ErrorSummary.Severity.set -> void
+MMCA.Common.UI.Components.ErrorSummary.Title.get -> string?
+MMCA.Common.UI.Components.ErrorSummary.Title.set -> void
+MMCA.Common.UI.Components.ErrorSummary.Variant.get -> MudBlazor.Variant
+MMCA.Common.UI.Components.ErrorSummary.Variant.set -> void
 MMCA.Common.UI.Components.InfiniteScrollSentinel
 MMCA.Common.UI.Components.InfiniteScrollSentinel.DisposeAsync() -> System.Threading.Tasks.ValueTask
 MMCA.Common.UI.Components.InfiniteScrollSentinel.InfiniteScrollSentinel() -> void
@@ -242,6 +153,10 @@ MMCA.Common.UI.Components.ListNoRecordsContent.LoadFailed.get -> bool
 MMCA.Common.UI.Components.ListNoRecordsContent.LoadFailed.set -> void
 MMCA.Common.UI.Components.ListNoRecordsContent.OnRetry.get -> Microsoft.AspNetCore.Components.EventCallback
 MMCA.Common.UI.Components.ListNoRecordsContent.OnRetry.set -> void
+MMCA.Common.UI.Components.MmcaThemeProviders.Theme.get -> MudBlazor.MudTheme!
+MMCA.Common.UI.Components.MmcaThemeProviders.Theme.set -> void
+MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.get -> System.Func<int, int, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)>!>!>?
+MMCA.Common.UI.Components.MobileInfiniteScrollList<TItem>.FetchPageResult.set -> void
 MMCA.Common.UI.Components.QrCodeButton
 MMCA.Common.UI.Components.QrCodeButton.ErrorCorrection.get -> MMCA.Common.UI.Components.QrErrorCorrectionLevel
 MMCA.Common.UI.Components.QrCodeButton.ErrorCorrection.set -> void
@@ -258,97 +173,184 @@ MMCA.Common.UI.Components.SharePageButton.RelativePath.set -> void
 MMCA.Common.UI.Components.SharePageButton.SharePageButton() -> void
 MMCA.Common.UI.Components.SharePageButton.ShareTitle.get -> string!
 MMCA.Common.UI.Components.SharePageButton.ShareTitle.set -> void
+MMCA.Common.UI.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddCommonUiFacades() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.UI.Pages.Auth.ForgotPassword
+MMCA.Common.UI.Pages.Auth.ForgotPassword.ForgotPassword() -> void
+MMCA.Common.UI.Pages.Auth.ForgotPasswordModel
+MMCA.Common.UI.Pages.Auth.ForgotPasswordModel.Email.get -> string!
+MMCA.Common.UI.Pages.Auth.ForgotPasswordModel.Email.set -> void
+MMCA.Common.UI.Pages.Auth.ForgotPasswordModel.ForgotPasswordModel() -> void
+MMCA.Common.UI.Pages.Auth.ResetPassword
+MMCA.Common.UI.Pages.Auth.ResetPassword.Email.get -> string?
+MMCA.Common.UI.Pages.Auth.ResetPassword.Email.set -> void
+MMCA.Common.UI.Pages.Auth.ResetPassword.ResetPassword() -> void
+MMCA.Common.UI.Pages.Auth.ResetPassword.Token.get -> string?
+MMCA.Common.UI.Pages.Auth.ResetPassword.Token.set -> void
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.ConfirmPassword.get -> string!
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.ConfirmPassword.set -> void
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Email.get -> string!
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Email.set -> void
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.NewPassword.get -> string!
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.NewPassword.set -> void
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.ResetPasswordModel() -> void
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Token.get -> string!
+MMCA.Common.UI.Pages.Auth.ResetPasswordModel.Token.set -> void
+MMCA.Common.UI.Pages.Auth.Sessions
+MMCA.Common.UI.Pages.Auth.Sessions.Dispose() -> void
+MMCA.Common.UI.Pages.Auth.Sessions.IsBusy.get -> bool
+MMCA.Common.UI.Pages.Auth.Sessions.IsLoading.get -> bool
+MMCA.Common.UI.Pages.Auth.Sessions.Sessions() -> void
+MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadMobileDataAsync(System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null) -> System.Threading.Tasks.Task!
+MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadServerDataAsync(MudBlazor.GridState<TDto>! state, System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null, bool showCancelSnackbar = true) -> System.Threading.Tasks.Task<MudBlazor.GridData<TDto>!>!
+MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadVirtualizedServerDataAsync(MudBlazor.GridStateVirtualize<TDto>! state, System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MudBlazor.GridData<TDto>!>!
+MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Toast.get -> MMCA.Common.UI.Common.Interfaces.IToastService!
+MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Toast.set -> void
 MMCA.Common.UI.Pages.Common.ListPageActions
 MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>
 MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.CanServe(int page) -> bool
 MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.OfflineFirstPageSnapshot(MMCA.Common.UI.Services.Capabilities.ILocalCacheStore! store, MMCA.Common.UI.Services.Capabilities.IConnectivityStatusService! connectivity, string! cacheKey) -> void
 MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.RememberAsync((System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems) fetched, int page, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 MMCA.Common.UI.Pages.Common.OfflineFirstPageSnapshot<TItem>.TryReadAsync(int page, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<(System.Collections.Generic.IReadOnlyList<TItem>! Items, int TotalItems)?>!
-MMCA.Common.UI.Services.IPublicLinkBuilder
-MMCA.Common.UI.Services.IPublicLinkBuilder.BuildAbsolute(string! relativePath) -> System.Uri!
-MMCA.Common.UI.Services.NavigationPublicLinkBuilder
-MMCA.Common.UI.Services.NavigationPublicLinkBuilder.BuildAbsolute(string! relativePath) -> System.Uri!
-MMCA.Common.UI.Services.NavigationPublicLinkBuilder.NavigationPublicLinkBuilder(Microsoft.AspNetCore.Components.NavigationManager! navigationManager) -> void
-override MMCA.Common.UI.Components.InfiniteScrollSentinel.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
-static MMCA.Common.UI.Pages.Common.ListPageActions.DeleteWithConfirmationAsync(MMCA.Common.UI.Components.DeleteConfirmation! deleteConfirm, string? entityName, System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!>! deleteAsync, MMCA.Common.UI.Common.Interfaces.IToastService! toast, string! successMessage, System.Func<MMCA.Common.Shared.Abstractions.Result!, string!>! errorMessage, System.Func<System.Threading.Tasks.Task!>! reloadAsync) -> System.Threading.Tasks.Task!
-static MMCA.Common.UI.Pages.Common.ListPageActions.ReloadActiveLayoutAsync<TDto>(bool isMobile, MMCA.Common.UI.Components.MobileInfiniteScrollList<TDto>? mobileList, MudBlazor.MudDataGrid<TDto>? dataGrid) -> System.Threading.Tasks.Task!
-~override MMCA.Common.UI.Components.ApiFileDownloadButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-~override MMCA.Common.UI.Components.InfiniteScrollSentinel.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-~override MMCA.Common.UI.Components.ListNoRecordsContent.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-~override MMCA.Common.UI.Components.QrCodeButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-~override MMCA.Common.UI.Components.SharePageButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
-*REMOVED*MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Snackbar.get -> MudBlazor.ISnackbar!
-*REMOVED*MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Snackbar.set -> void
-MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Toast.get -> MMCA.Common.UI.Common.Interfaces.IToastService!
-MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.Toast.set -> void
-MMCA.Common.UI.Common.Interfaces.IAppDialogService
-MMCA.Common.UI.Common.Interfaces.IAppDialogService.ConfirmAsync(string! title, string! message, string! confirmText, string! cancelText) -> System.Threading.Tasks.Task<bool>!
-MMCA.Common.UI.Common.Interfaces.IToastService
-MMCA.Common.UI.Common.Interfaces.IToastService.Error(string! message) -> void
-MMCA.Common.UI.Common.Interfaces.IToastService.Info(string! message) -> void
-MMCA.Common.UI.Common.Interfaces.IToastService.Show(string! message, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity) -> void
-MMCA.Common.UI.Common.Interfaces.IToastService.ShowAction(string! message, string! actionText, System.Func<System.Threading.Tasks.Task!>! onAction, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info, bool requireInteraction = false) -> void
-MMCA.Common.UI.Common.Interfaces.IToastService.ShowPersistent(string! title, string! body, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info) -> void
-MMCA.Common.UI.Common.Interfaces.IToastService.Success(string! message) -> void
-MMCA.Common.UI.Common.Interfaces.IToastService.Warning(string! message) -> void
-MMCA.Common.UI.Common.Interfaces.ToastSeverity
-MMCA.Common.UI.Common.Interfaces.ToastSeverity.Error = 4 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
-MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info = 1 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
-MMCA.Common.UI.Common.Interfaces.ToastSeverity.Normal = 0 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
-MMCA.Common.UI.Common.Interfaces.ToastSeverity.Success = 2 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
-MMCA.Common.UI.Common.Interfaces.ToastSeverity.Warning = 3 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
-MMCA.Common.UI.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddCommonUiFacades() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static MMCA.Common.UI.DependencyInjection.AddCommonUiFacades(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.ConcurrencyTagOf(TEntityDTO entity) -> string?
-MMCA.Common.UI.Common.NavItem.Deconstruct(out string! Title, out string! Href, out string! Icon, out System.Type! TitleResource, out string? RequiredRole, out string? RequiredClaim, out MMCA.Common.UI.Common.NavSection Section, out string? Group) -> void
-MMCA.Common.UI.Common.NavItem.NavItem(string! Title, string! Href, string! Icon, System.Type! TitleResource, string? RequiredRole = null, string? RequiredClaim = null, MMCA.Common.UI.Common.NavSection Section = MMCA.Common.UI.Common.NavSection.General, string? Group = null) -> void
-MMCA.Common.UI.Common.NavItem.TitleResource.get -> System.Type!
-*REMOVED*MMCA.Common.UI.Services.Auth.DirectApiTokenRefresher.DirectApiTokenRefresher(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService) -> void
+MMCA.Common.UI.Pages.Notifications.NotificationInbox.Id.get -> int?
+MMCA.Common.UI.Pages.Notifications.NotificationInbox.Id.set -> void
+MMCA.Common.UI.Pages.Notifications.NotificationSendModel
+MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Body.get -> string!
+MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Body.set -> void
+MMCA.Common.UI.Pages.Notifications.NotificationSendModel.NotificationSendModel() -> void
+MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Title.get -> string!
+MMCA.Common.UI.Pages.Notifications.NotificationSendModel.Title.set -> void
+MMCA.Common.UI.Services.Auth.AuthUIService.AuthUIService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Auth.ITokenRefresher! tokenRefresher, Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider! authStateProvider, MMCA.Common.UI.Services.Capabilities.IPushRegistrationService! pushRegistration, MMCA.Common.UI.Services.Caching.IUiReadCache? readCache = null) -> void
+MMCA.Common.UI.Services.Auth.AuthUIService.ChangePasswordAsync(string! currentPassword, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.ExchangeOAuthCodeAsync(string! code, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.GetSessionsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Auth.RefreshSessionSummaryResponse!>!>!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.LoginAsync(MMCA.Common.Shared.Auth.LoginRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.RegisterAsync(MMCA.Common.Shared.Auth.RegisterRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.RequestPasswordResetAsync(string! email, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.ResetPasswordAsync(string! email, string! token, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.AuthUIService.RevokeSessionAsync(System.Guid sessionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.ConfigurationOAuthUISettings.AppleEnabled.get -> bool
 MMCA.Common.UI.Services.Auth.DirectApiTokenRefresher.DirectApiTokenRefresher(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ISecureTokenStore! tokenStore) -> void
+MMCA.Common.UI.Services.Auth.IAuthUIService.ChangePasswordAsync(string! currentPassword, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.ExchangeOAuthCodeAsync(string! code, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.GetSessionsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Auth.RefreshSessionSummaryResponse!>!>!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.LoginAsync(MMCA.Common.Shared.Auth.LoginRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.RegisterAsync(MMCA.Common.Shared.Auth.RegisterRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Auth.AuthenticationResponse>!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.RequestPasswordResetAsync(string! email, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.ResetPasswordAsync(string! email, string! token, string! newPassword, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.IAuthUIService.RevokeSessionAsync(System.Guid sessionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Auth.IOAuthUISettings.AppleEnabled.get -> bool
 MMCA.Common.UI.Services.Auth.ISecureTokenStore
 MMCA.Common.UI.Services.Auth.ISecureTokenStore.ClearTokensAsync() -> System.Threading.Tasks.Task!
 MMCA.Common.UI.Services.Auth.ISecureTokenStore.GetAccessTokenAsync() -> System.Threading.Tasks.Task<string?>!
 MMCA.Common.UI.Services.Auth.ISecureTokenStore.GetRefreshTokenAsync() -> System.Threading.Tasks.Task<string?>!
 MMCA.Common.UI.Services.Auth.ISecureTokenStore.SetTokensAsync(string! accessToken, string! refreshToken) -> System.Threading.Tasks.Task!
-MMCA.Common.UI.Services.Notifications.INotificationScopeProvider.GetCurrentScopeDisplayNameAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
-override MMCA.Common.UI.Pages.Notifications.NotificationSend.OnInitializedAsync() -> System.Threading.Tasks.Task!
-*REMOVED*MMCA.Common.UI.Services.Auth.AuthUIService.AuthUIService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Auth.ITokenRefresher! tokenRefresher, Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider! authStateProvider, MMCA.Common.UI.Services.Capabilities.IPushRegistrationService! pushRegistration) -> void
-*REMOVED*MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.EntityServiceBase(string! endpoint, System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService) -> void
-*REMOVED*MMCA.Common.UI.Services.Notifications.NotificationState.NotificationState() -> void
-MMCA.Common.UI.Common.Settings.NotificationBellOptions
-MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.get -> System.TimeSpan
-MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.init -> void
-MMCA.Common.UI.Common.Settings.NotificationBellOptions.NotificationBellOptions() -> void
-MMCA.Common.UI.Common.Settings.NotificationBellOptions.PollInterval.get -> System.TimeSpan
-MMCA.Common.UI.Common.Settings.NotificationBellOptions.PollInterval.init -> void
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions.DefaultTtl.get -> System.TimeSpan
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions.DefaultTtl.init -> void
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions.Enabled.get -> bool
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions.Enabled.init -> void
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions.RoutePrefixTtls.get -> System.Collections.Generic.Dictionary<string!, System.TimeSpan>!
-MMCA.Common.UI.Common.Settings.UiReadCacheOptions.UiReadCacheOptions() -> void
-MMCA.Common.UI.Services.Auth.AuthUIService.AuthUIService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Auth.ITokenRefresher! tokenRefresher, Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider! authStateProvider, MMCA.Common.UI.Services.Capabilities.IPushRegistrationService! pushRegistration, MMCA.Common.UI.Services.Caching.IUiReadCache? readCache = null) -> void
+MMCA.Common.UI.Services.AuthenticatedServiceBase.CreateClientWithToken(string! accessToken) -> System.Net.Http.HttpClient!
 MMCA.Common.UI.Services.Caching.IUiReadCache
 MMCA.Common.UI.Services.Caching.IUiReadCache.Clear() -> void
 MMCA.Common.UI.Services.Caching.IUiReadCache.InvalidatePrefix(string! routePrefix) -> void
 MMCA.Common.UI.Services.Caching.IUiReadCache.Set<T>(string! url, T value) -> void
 MMCA.Common.UI.Services.Caching.IUiReadCache.TryGetFresh<T>(string! url, out T? value) -> bool
+MMCA.Common.UI.Services.Capabilities.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddDeviceCapabilityDefaults() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.UI.Services.ChildEntityServiceBase.DeleteByIdAsync(string! id, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.ChildEntityServiceBase.PostAsync(object! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.ChildEntityServiceBase.PostAsync<TResponse>(object! request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TResponse>!>!
 MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.EntityServiceBase(string! endpoint, System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Caching.IUiReadCache? readCache = null) -> void
 MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetCachedAsync<T>(string! url, System.Threading.CancellationToken cancellationToken, bool bypassCache = false) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!
 MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.ReadCache.get -> MMCA.Common.UI.Services.Caching.IUiReadCache?
+MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.SendRequestAsync(System.Func<System.Net.Http.HttpClient!, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!>! httpAction, System.Threading.CancellationToken cancellationToken, string? idempotencyKey = null, string? ifMatch = null) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.SendRequestAsync<T>(System.Func<System.Net.Http.HttpClient!, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!>! httpAction, System.Threading.CancellationToken cancellationToken, string? idempotencyKey = null, string? ifMatch = null) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!
+MMCA.Common.UI.Services.HttpResultExecutor
+MMCA.Common.UI.Services.IPublicLinkBuilder
+MMCA.Common.UI.Services.IPublicLinkBuilder.BuildAbsolute(string! relativePath) -> System.Uri!
+MMCA.Common.UI.Services.NavigationPublicLinkBuilder
+MMCA.Common.UI.Services.NavigationPublicLinkBuilder.BuildAbsolute(string! relativePath) -> System.Uri!
+MMCA.Common.UI.Services.NavigationPublicLinkBuilder.NavigationPublicLinkBuilder(Microsoft.AspNetCore.Components.NavigationManager! navigationManager) -> void
+MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetInboxAsync(int pageNumber = 1, int pageSize = 20, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.UserNotifications.UserNotificationDTO!>!>!>!
+MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<int>!>!
+MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.MarkAllReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Notifications.INotificationInboxUIService.MarkReadAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Notifications.INotificationScopeProvider.GetCurrentScopeDisplayNameAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+MMCA.Common.UI.Services.Notifications.IPushNotificationUIService.GetHistoryAsync(int pageNumber = 1, int pageSize = 10, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!>!
+MMCA.Common.UI.Services.Notifications.IPushNotificationUIService.SendAsync(MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetInboxAsync(int pageNumber = 1, int pageSize = 20, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.UserNotifications.UserNotificationDTO!>!>!>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.GetUnreadCountAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<int>!>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.MarkAllReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.MarkReadAsync(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Notifications.NotificationInboxService.NotificationInboxService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.ITokenStorageService! tokenStorageService, MMCA.Common.UI.Services.Notifications.INotificationScopeProvider! scopeProvider, MMCA.Common.UI.Services.Auth.ITokenRefresher? tokenRefresher = null) -> void
 MMCA.Common.UI.Services.Notifications.NotificationState.IsStale(System.TimeSpan maxAge) -> bool
 MMCA.Common.UI.Services.Notifications.NotificationState.LastFetchedUtc.get -> System.DateTimeOffset?
 MMCA.Common.UI.Services.Notifications.NotificationState.MarkStale() -> void
 MMCA.Common.UI.Services.Notifications.NotificationState.NotificationState(System.TimeProvider? timeProvider = null) -> void
+MMCA.Common.UI.Services.Notifications.NotificationState.OnPollerSlotFreed -> System.EventHandler?
+MMCA.Common.UI.Services.Notifications.NotificationState.TryRegisterPoller(object! owner) -> bool
+MMCA.Common.UI.Services.Notifications.NotificationState.UnregisterPoller(object! owner) -> void
+MMCA.Common.UI.Services.Notifications.PushNotificationService.GetHistoryAsync(int pageNumber = 1, int pageSize = 10, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Abstractions.PagedCollectionResult<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!>!
+MMCA.Common.UI.Services.Notifications.PushNotificationService.SendAsync(MMCA.Common.Shared.Notifications.PushNotifications.SendPushNotificationRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<MMCA.Common.Shared.Notifications.PushNotifications.PushNotificationDTO!>!>!
+MMCA.Common.UI.Validation.AbsoluteUrlAttribute
+MMCA.Common.UI.Validation.AbsoluteUrlAttribute.AbsoluteUrlAttribute() -> void
+MMCA.Common.UI.Validation.DataAnnotationsModelValidator
+MMCA.Common.UI.Validation.DataAnnotationsModelValidator.DataAnnotationsModelValidator(Microsoft.Extensions.Localization.IStringLocalizer! localizer) -> void
+MMCA.Common.UI.Validation.DataAnnotationsModelValidator.Validate(object! model, string! propertyPath) -> System.Collections.Generic.IEnumerable<string!>!
+MMCA.Common.UI.Validation.DataAnnotationsModelValidator.ValidateValue(object! model, string! propertyPath, object? value) -> System.Collections.Generic.IEnumerable<string!>!
+MMCA.Common.UI.Validation.IModelValidator
+MMCA.Common.UI.Validation.IModelValidator.Validate(object! model, string! propertyPath) -> System.Collections.Generic.IEnumerable<string!>!
+MMCA.Common.UI.Validation.ModelValidation
+const MMCA.Common.UI.Services.Auth.AuthUIService.MissingAccessTokenCode = "Auth.MissingAccessToken" -> string!
+const MMCA.Common.UI.Services.Auth.AuthUIService.TokenStorageUnavailableCode = "Auth.TokenStorageUnavailable" -> string!
+const MMCA.Common.UI.Services.HttpResultExecutor.TimeoutErrorCode = "Http.Timeout" -> string!
+const MMCA.Common.UI.Services.HttpResultExecutor.TransportErrorCode = "Http.TransportFailure" -> string!
+override MMCA.Common.UI.Components.ErrorSummary.OnParametersSet() -> void
+override MMCA.Common.UI.Components.InfiniteScrollSentinel.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override MMCA.Common.UI.Pages.Auth.ResetPassword.OnParametersSet() -> void
+override MMCA.Common.UI.Pages.Auth.Sessions.OnInitializedAsync() -> System.Threading.Tasks.Task!
+override MMCA.Common.UI.Pages.Notifications.NotificationInbox.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override MMCA.Common.UI.Pages.Notifications.NotificationInbox.OnParametersSet() -> void
+override MMCA.Common.UI.Pages.Notifications.NotificationSend.OnInitializedAsync() -> System.Threading.Tasks.Task!
+static MMCA.Common.UI.Common.NotificationRoutePaths.NotificationInboxItem(int id) -> string!
+static MMCA.Common.UI.Common.ResultUiExtensions.HasErrorType(this MMCA.Common.Shared.Abstractions.Result! result, MMCA.Common.Shared.Abstractions.ErrorType errorType) -> bool
+static MMCA.Common.UI.Common.ResultUiExtensions.IsNotFound(this MMCA.Common.Shared.Abstractions.Result! result) -> bool
+static MMCA.Common.UI.Common.ResultUiExtensions.IsUnauthorized(this MMCA.Common.Shared.Abstractions.Result! result) -> bool
+static MMCA.Common.UI.Common.ResultUiExtensions.LocalizeDistinct(System.Collections.Generic.IEnumerable<string!>? messages, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> System.Collections.Generic.IReadOnlyList<string!>!
+static MMCA.Common.UI.Common.ResultUiExtensions.LocalizedErrorMessage(this MMCA.Common.Shared.Abstractions.Result! result, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> string?
+static MMCA.Common.UI.Common.ResultUiExtensions.LocalizedErrorMessages(this MMCA.Common.Shared.Abstractions.Result! result, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> System.Collections.Generic.IReadOnlyList<string!>!
+static MMCA.Common.UI.Common.ResultUiExtensions.NotifyOnFailure(this MMCA.Common.Shared.Abstractions.Result! result, MMCA.Common.UI.Common.Interfaces.IToastService! toast, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Error) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.UI.Common.ResultUiExtensions.NotifyOnFailure<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, MMCA.Common.UI.Common.Interfaces.IToastService! toast, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null, MMCA.Common.UI.Common.Interfaces.ToastSeverity severity = MMCA.Common.UI.Common.Interfaces.ToastSeverity.Error) -> MMCA.Common.Shared.Abstractions.Result<T>!
+static MMCA.Common.UI.Common.ResultUiExtensions.OnFailureSetError(this MMCA.Common.Shared.Abstractions.Result! result, System.Action<string?>! setError, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> MMCA.Common.Shared.Abstractions.Result!
+static MMCA.Common.UI.Common.ResultUiExtensions.OnFailureSetError<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, System.Action<string?>! setError, Microsoft.Extensions.Localization.IStringLocalizer? localizer = null) -> MMCA.Common.Shared.Abstractions.Result<T>!
+static MMCA.Common.UI.Common.ResultUiExtensions.TryGetValue<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, out T? value) -> bool
+static MMCA.Common.UI.Common.ResultUiExtensions.TryGetValue<T>(this MMCA.Common.Shared.Abstractions.Result<T>! result, out T? value, out System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.Abstractions.Error!>! errors) -> bool
+static MMCA.Common.UI.DependencyInjection.AddCommonUiFacades(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static MMCA.Common.UI.Pages.Common.ListPageActions.DeleteWithConfirmationAsync(MMCA.Common.UI.Components.DeleteConfirmation! deleteConfirm, string? entityName, System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!>! deleteAsync, MMCA.Common.UI.Common.Interfaces.IToastService! toast, string! successMessage, System.Func<MMCA.Common.Shared.Abstractions.Result!, string!>! errorMessage, System.Func<System.Threading.Tasks.Task!>! reloadAsync) -> System.Threading.Tasks.Task!
+static MMCA.Common.UI.Pages.Common.ListPageActions.ReloadActiveLayoutAsync<TDto>(bool isMobile, MMCA.Common.UI.Components.MobileInfiniteScrollList<TDto>? mobileList, MudBlazor.MudDataGrid<TDto>? dataGrid) -> System.Threading.Tasks.Task!
+static MMCA.Common.UI.Services.Capabilities.DependencyInjection.AddDeviceCapabilityDefaults(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.ConcurrencyTagOf(TEntityDTO entity) -> string?
+static MMCA.Common.UI.Services.HttpResultExecutor.ExecuteAsync(System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!>! operation, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+static MMCA.Common.UI.Services.HttpResultExecutor.ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!>! operation, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<T>!>!
+static MMCA.Common.UI.Validation.ModelValidation.For(object! model, MMCA.Common.UI.Validation.IModelValidator! validator) -> System.Func<object!, string!, System.Collections.Generic.IEnumerable<string!>!>!
+static MMCA.Common.UI.Validation.ModelValidation.ForProperty<TModel, TValue>(TModel! model, System.Linq.Expressions.Expression<System.Func<TModel!, TValue>!>! property, MMCA.Common.UI.Validation.DataAnnotationsModelValidator! validator) -> System.Func<TValue, System.Collections.Generic.IEnumerable<string!>!>!
+static MMCA.Common.UI.Validation.ModelValidation.GetPropertyPath<TModel, TValue>(System.Linq.Expressions.Expression<System.Func<TModel, TValue>!>! property) -> string!
+static MMCA.Common.UI.Validation.ModelValidation.IsRequired(object! model, string! propertyPath) -> bool
+static readonly MMCA.Common.UI.Common.RoutePaths.Sessions -> string!
 static readonly MMCA.Common.UI.Common.Settings.NotificationBellOptions.SectionName -> string!
 static readonly MMCA.Common.UI.Common.Settings.UiReadCacheOptions.SectionName -> string!
-MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.LoadVirtualizedServerDataAsync(MudBlazor.GridStateVirtualize<TDto>! state, System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TDto>! Items, int TotalItems)>!>!>! fetchAsync, System.Action<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!>? additionalFilters = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MudBlazor.GridData<TDto>!>!
+virtual MMCA.Common.UI.Pages.Auth.Sessions.Dispose(bool disposing) -> void
 virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizeGrid.get -> bool
 virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizedGridHeight.get -> string!
 virtual MMCA.Common.UI.Pages.Common.DataGridListPageBase<TDto>.VirtualizedItemSize.get -> int
-MMCA.Common.UI.Pages.Notifications.NotificationInbox.Id.get -> int?
-MMCA.Common.UI.Pages.Notifications.NotificationInbox.Id.set -> void
-override MMCA.Common.UI.Pages.Notifications.NotificationInbox.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
-override MMCA.Common.UI.Pages.Notifications.NotificationInbox.OnParametersSet() -> void
-static MMCA.Common.UI.Common.NotificationRoutePaths.NotificationInboxItem(int id) -> string!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.AddAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TEntityDTO>!>!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.DeleteAsync(TIdentifierType id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetAllAsync(bool includeFKs = false, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<TEntityDTO>!>!>!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetAllForLookupAsync(string! nameProperty, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<System.Collections.Generic.IReadOnlyList<MMCA.Common.Shared.DTOs.BaseLookup<TIdentifierType>!>!>!>!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetByIdAsync(TIdentifierType id, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TEntityDTO>!>!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.GetPagedAsync(System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>! filters, int pageNumber, int pageSize, string? sortColumn, string? sortDirection, bool includeChildren = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TEntityDTO>! Items, int TotalItems)>!>!
+virtual MMCA.Common.UI.Services.EntityServiceBase<TEntityDTO, TIdentifierType>.UpdateAsync(TEntityDTO entity, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+~override MMCA.Common.UI.Components.ApiFileDownloadButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.ErrorSummary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.InfiniteScrollSentinel.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.ListNoRecordsContent.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.QrCodeButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Components.SharePageButton.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Pages.Auth.ForgotPassword.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Pages.Auth.ResetPassword.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Pages.Auth.Sessions.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void

--- a/Source/Presentation/MMCA.Common.UI/Validation/AbsoluteUrlAttribute.cs
+++ b/Source/Presentation/MMCA.Common.UI/Validation/AbsoluteUrlAttribute.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MMCA.Common.UI.Validation;
+
+/// <summary>
+/// Client-side rule requiring an absolute <c>http</c> or <c>https</c> URL. It mirrors the server's
+/// <c>AbsoluteUrlRules</c> (MMCA.Common.Application) so a form gives the same verdict the API would
+/// (rubric §24 validation parity), which matters more here than for most rules: these values are
+/// rendered straight into an image source or a link target, so accepting <c>javascript:</c> or
+/// <c>data:</c> on the client and rejecting it on the server means the only thing standing between a
+/// pasted script URL and the page is a round trip.
+/// <para>
+/// Null, empty and whitespace pass. Optionality is the caller's decision, expressed by pairing this
+/// with <see cref="RequiredAttribute"/> when the field is mandatory, so a blank required field shows
+/// one clear message instead of two.
+/// </para>
+/// <para>
+/// <see cref="ValidationAttribute.ErrorMessage"/> is emitted unchanged rather than formatted, which
+/// is what lets a model declare a localization resource key
+/// (<c>ErrorMessage = "Validation.AbsoluteUrl"</c>): <c>DataAnnotationsModelValidator</c> resolves
+/// every message it receives against the page's <c>IStringLocalizer</c> and passes an unknown key
+/// through untouched, so a plain-English message renders exactly as written.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class AbsoluteUrlAttribute : ValidationAttribute
+{
+    /// <summary>Creates the rule with its default English message.</summary>
+    public AbsoluteUrlAttribute()
+        : base("The value must be an absolute http or https URL.")
+    {
+    }
+
+    /// <inheritdoc />
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        ArgumentNullException.ThrowIfNull(validationContext);
+
+        if (value is not string url || string.IsNullOrWhiteSpace(url))
+        {
+            return ValidationResult.Success;
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri)
+            && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+                || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)))
+        {
+            return ValidationResult.Success;
+        }
+
+        string[]? members = validationContext.MemberName is { } member ? [member] : null;
+        return new ValidationResult(ErrorMessage, members);
+    }
+}

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/LayerDependencyOverrideTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/LayerDependencyOverrideTests.cs
@@ -1,0 +1,133 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Tests for the per-module escape on <c>ModulesDeclareLayers</c>. The rule's value is that it fails
+/// when a repo forgets to register a module's assembly in its map, which is what stops every
+/// per-module layer rule from passing vacuously. A repo with one deliberately thin module (no
+/// aggregate, no persistence, so no Domain and no Infrastructure assembly exists to register) used to
+/// have only one way to express that: trim the DEFAULT list, which stops enforcing those layers for
+/// every OTHER module too. These tests pin that the override records the exception where it is true
+/// and leaves the rest of the repo strict.
+/// <para>
+/// The map is a fixture rather than a real repo's, because the point under test is the rule's
+/// arithmetic over module names and layers, not any particular assembly.
+/// </para>
+/// </summary>
+public sealed class LayerDependencyOverrideTests
+{
+    private static readonly IReadOnlyList<Layer> FiveLayers =
+        [Layer.Shared, Layer.Domain, Layer.Application, Layer.Infrastructure, Layer.Api];
+
+    [Fact]
+    public void ModulesDeclareLayers_FailsForAThinModule_WhenEveryModuleIsHeldToTheFullList()
+    {
+        var map = new FakeArchitectureMap(
+            Full("Conference"),
+            Thin("Notification"));
+
+        Action act = () => ArchitectureRules.ModulesDeclareLayers(map, FiveLayers);
+
+        act.Should().Throw<Exception>()
+            .WithMessage("*module 'Notification' declares no Layer.Domain*");
+    }
+
+    [Fact]
+    public void ModulesDeclareLayers_PassesForAThinModule_WhenTheOverrideNamesItsOwnLayers()
+    {
+        var map = new FakeArchitectureMap(
+            Full("Conference"),
+            Thin("Notification"));
+
+        Action act = () => ArchitectureRules.ModulesDeclareLayers(
+            map,
+            FiveLayers,
+            new Dictionary<string, IReadOnlyList<Layer>>(StringComparer.Ordinal)
+            {
+                ["Notification"] = [Layer.Shared, Layer.Application, Layer.Api],
+            });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ModulesDeclareLayers_KeepsEveryOtherModuleStrict_WhileOneIsOverridden()
+    {
+        // This is the whole reason the override exists rather than a trimmed default list: one thin
+        // module must not buy blanket permission to forget an assembly anywhere else.
+        var map = new FakeArchitectureMap(
+            Thin("Notification"),
+            Thin("Conference"));
+
+        Action act = () => ArchitectureRules.ModulesDeclareLayers(
+            map,
+            FiveLayers,
+            new Dictionary<string, IReadOnlyList<Layer>>(StringComparer.Ordinal)
+            {
+                ["Notification"] = [Layer.Shared, Layer.Application, Layer.Api],
+            });
+
+        act.Should().Throw<Exception>()
+            .WithMessage("*module 'Conference' declares no Layer.Domain*");
+    }
+
+    [Fact]
+    public void ModulesDeclareLayers_OverrideCanAlsoDemandMore_NotJustLess()
+    {
+        // The override REPLACES the list for that module rather than subtracting from it, so a repo
+        // can also hold one module to a stricter bar than the rest.
+        var map = new FakeArchitectureMap(Full("Conference"));
+
+        Action act = () => ArchitectureRules.ModulesDeclareLayers(
+            map,
+            FiveLayers,
+            new Dictionary<string, IReadOnlyList<Layer>>(StringComparer.Ordinal)
+            {
+                ["Conference"] = [.. FiveLayers, Layer.Ui],
+            });
+
+        act.Should().Throw<Exception>()
+            .WithMessage("*module 'Conference' declares no Layer.Ui*");
+    }
+
+    [Fact]
+    public void ModulesDeclareLayers_TwoArgumentOverloadIsUnchanged()
+    {
+        // The existing public overload is what every current consumer calls; it must keep behaving as
+        // the strict default.
+        var map = new FakeArchitectureMap(Full("Conference"), Full("Engagement"));
+
+        Action act = () => ArchitectureRules.ModulesDeclareLayers(map, FiveLayers);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ModulesDeclareLayers_NullOverrides_HoldEveryModuleToTheDefaultList()
+    {
+        var map = new FakeArchitectureMap(Thin("Notification"));
+
+        Action act = () => ArchitectureRules.ModulesDeclareLayers(map, FiveLayers, overrides: null);
+
+        act.Should().Throw<Exception>()
+            .WithMessage("*module 'Notification' declares no Layer.Domain*");
+    }
+
+    private static IEnumerable<LayerRef> Full(string module) =>
+        FiveLayers.Select(layer => Ref(module, layer));
+
+    private static IEnumerable<LayerRef> Thin(string module) =>
+        new[] { Layer.Shared, Layer.Application, Layer.Api }.Select(layer => Ref(module, layer));
+
+    private static LayerRef Ref(string module, Layer layer) =>
+        new(module, layer, typeof(LayerDependencyOverrideTests).Assembly, $"MMCA.Fake.{module}.{layer}");
+
+    /// <summary>A map declaring exactly the module/layer pairs a test hands it.</summary>
+    private sealed class FakeArchitectureMap(params IEnumerable<LayerRef>[] modules) : ArchitectureMapBase
+    {
+        public override string RepoToken => "MMCA.Fake";
+
+        protected override IEnumerable<LayerRef> DefineLayers() => modules.SelectMany(m => m);
+    }
+}

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Messaging/ServiceBusEmulatorSupportTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Messaging/ServiceBusEmulatorSupportTests.cs
@@ -1,0 +1,106 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using MMCA.Common.Infrastructure.Messaging;
+using MMCA.Common.Infrastructure.Settings;
+
+namespace MMCA.Common.Infrastructure.Tests.Messaging;
+
+/// <summary>
+/// Unit tests for the Azure Service Bus emulator branch: the detection that decides whether it runs
+/// at all, and the management-plane connection string it derives. The live round-trip against a real
+/// emulator container is a consumer-side integration tier (ADC's ServiceBusEmulator suite); what has
+/// to be pinned here is that production cannot be diverted into this branch by accident and that the
+/// admin client is built against the right endpoint with the right key.
+/// </summary>
+public sealed class ServiceBusEmulatorSupportTests
+{
+    private const string EmulatorConnectionString =
+        "Endpoint=sb://localhost:32771;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    [Fact]
+    public void IsEmulatorConnectionString_RecognizesTheEmulatorMarker() =>
+        ServiceBusEmulatorSupport.IsEmulatorConnectionString(EmulatorConnectionString).Should().BeTrue();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Endpoint=sb://adc-prod.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=redacted")]
+    // The whole safety argument for the emulator branch is that a production connection string never
+    // carries the marker, so the branch cannot be entered by a misconfigured environment name or a
+    // stray flag.
+    public void IsEmulatorConnectionString_LeavesARealNamespaceOnTheProductionPath(string? connectionString) =>
+        ServiceBusEmulatorSupport.IsEmulatorConnectionString(connectionString).Should().BeFalse();
+
+    [Fact]
+    public void IsEmulatorConnectionString_IgnoresCasing() =>
+        ServiceBusEmulatorSupport
+            .IsEmulatorConnectionString("Endpoint=sb://localhost:5672;usedevelopmentemulator=TRUE;")
+            .Should().BeTrue();
+
+    [Fact]
+    public void BuildAdminConnectionString_SwapsTheEndpointAndKeepsEverythingElse()
+    {
+        // The two planes authenticate against the same emulator namespace, so the key name and value
+        // are carried across verbatim: a hand-written second string is one typo away from an admin
+        // client that cannot provision anything.
+        string admin = ServiceBusEmulatorSupport.BuildAdminConnectionString(
+            EmulatorConnectionString, "http://localhost:33012");
+
+        admin.Should().Be(
+            "Endpoint=sb://localhost:33012;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
+    }
+
+    [Fact]
+    public void BuildAdminConnectionString_KeepsTheEmulatorMarker_SoTheAdminClientStaysOnCleartext()
+    {
+        string admin = ServiceBusEmulatorSupport.BuildAdminConnectionString(
+            EmulatorConnectionString, "http://127.0.0.1:5300");
+
+        admin.Should().Contain(ServiceBusEmulatorSupport.EmulatorMarker);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("localhost:5300")]
+    [InlineData("sb://localhost:5300")]
+    public void BuildAdminConnectionString_FailsLoudly_WhenTheAdminEndpointIsMissingOrNotAnHttpUrl(string? adminEndpoint)
+    {
+        // A bus with no management client cannot provision the topology it needs to run at all, so
+        // this has to be a registration failure rather than a mystery at the first publish.
+        Action act = () => ServiceBusEmulatorSupport.BuildAdminConnectionString(EmulatorConnectionString, adminEndpoint);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*MessageBus:EmulatorAdminEndpoint*");
+    }
+
+    [Fact]
+    public void MessageBusSettings_BindsTheAdminEndpointFromConfiguration()
+    {
+        MessageBusSettings settings = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MessageBus:Provider"] = "AzureServiceBus",
+                ["MessageBus:ConnectionString"] = EmulatorConnectionString,
+                ["MessageBus:EmulatorAdminEndpoint"] = "http://localhost:33012",
+            })
+            .Build()
+            .GetSection(MessageBusSettings.SectionName)
+            .Get<MessageBusSettings>()!;
+
+        settings.Provider.Should().Be(MessageBusProvider.AzureServiceBus);
+        settings.EmulatorAdminEndpoint.Should().Be("http://localhost:33012");
+    }
+
+    [Fact]
+    public void MessageBusSettings_AdminEndpointIsUnsetByDefault() =>
+        new MessageBusSettings().EmulatorAdminEndpoint.Should().BeNull(
+            because: "a real Azure Service Bus namespace serves both planes on one endpoint and needs nothing here");
+
+    [Fact]
+    public void EmulatorEntityQuota_SitsAtTheEmulatorsOneHourCeiling() =>
+        ServiceBusEmulatorSupport.EmulatorEntityQuota.Should().Be(TimeSpan.FromHours(1),
+            because: "the emulator rejects any entity whose TTL or auto-delete-on-idle exceeds one hour, "
+                + "and MassTransit v8 defaults to 366 days TTL and 427 days auto-delete");
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/ServiceBusEmulatorBrokerTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/ServiceBusEmulatorBrokerTests.cs
@@ -1,0 +1,195 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MMCA.Common.Aspire.Hosting.Tests;
+
+/// <summary>
+/// Unit tests for the Azure Service Bus emulator broker: the container resource
+/// <c>AddServiceBusEmulatorBroker</c> provisions, and what the matching <c>WithBroker</c> overload
+/// injects into a consuming service. They assert the application MODEL rather than a running stack:
+/// the emulator needs Docker and a warm-up measured in tens of seconds, which belongs in a consumer's
+/// integration tier, while everything that can silently break the wiring (image pin, endpoint names
+/// and ports, the connection-string form, the environment keys) is decided here.
+/// </summary>
+public sealed class ServiceBusEmulatorBrokerTests
+{
+    [Fact]
+    public void AddServiceBusEmulatorBroker_PinsTheImageToATwoPointXEmulator()
+    {
+        // The HTTP management plane shipped in emulator 2.0.0, and MassTransit provisions its whole
+        // topology through it at bus start. A silent downgrade to a 1.x image would leave the broker
+        // unusable rather than merely older.
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+
+        var image = emulator.Resource.Annotations.OfType<ContainerImageAnnotation>().Should().ContainSingle().Subject;
+        image.Registry.Should().Be("mcr.microsoft.com");
+        image.Image.Should().Be("azure-messaging/servicebus-emulator");
+        image.Tag.Should().Be("2.0.1");
+        Extensions.ServiceBusEmulatorImageTag.Should().StartWith("2.");
+    }
+
+    [Fact]
+    public void AddServiceBusEmulatorBroker_PublishesBothPlanes()
+    {
+        // AMQP carries every publish and consume; the management plane is what MassTransit creates
+        // its topics, subscriptions and queues through. A broker with only the first is not usable.
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+
+        List<EndpointAnnotation> endpoints = [.. emulator.Resource.Annotations.OfType<EndpointAnnotation>()];
+
+        var amqp = endpoints.Should().ContainSingle(e => e.Name == ServiceBusEmulatorResource.AmqpEndpointName).Subject;
+        amqp.TargetPort.Should().Be(ServiceBusEmulatorResource.AmqpTargetPort);
+
+        var admin = endpoints.Should().ContainSingle(e => e.Name == ServiceBusEmulatorResource.AdminEndpointName).Subject;
+        admin.TargetPort.Should().Be(ServiceBusEmulatorResource.AdminTargetPort);
+        admin.UriScheme.Should().Be("http");
+    }
+
+    [Fact]
+    public void AddServiceBusEmulatorBroker_LeavesHostPortsToAspire()
+    {
+        // Nothing outside the stack dials these, so fixing a host port would only invite a collision
+        // with a stray container from another run.
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+
+        emulator.Resource.Annotations.OfType<EndpointAnnotation>()
+            .Should().OnlyContain(e => e.Port == null);
+    }
+
+    [Fact]
+    public async Task AddServiceBusEmulatorBroker_WiresTheEmulatorToTheGivenSqlServer()
+    {
+        // The emulator keeps its state in SQL Server. It is pointed at an EXISTING resource so a
+        // stack that already runs SQL Server for its databases does not run a second engine for the
+        // broker, and it is handed the host name alone: the emulator dials the default port 1433,
+        // which is the container's target port.
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+
+        Dictionary<string, string> environment = await EnvironmentOf(builder, emulator.Resource);
+
+        environment.Should().ContainKey("ACCEPT_EULA").WhoseValue.Should().Be("Y");
+        environment.Should().ContainKey("SQL_SERVER").WhoseValue.Should().Be("{sql.bindings.tcp.host}");
+        environment.Should().ContainKey("MSSQL_SA_PASSWORD").WhoseValue.Should().Be("{sql-password.value}");
+    }
+
+    [Fact]
+    public void AddServiceBusEmulatorBroker_WaitsForSqlServer()
+    {
+        // The emulator's first act is to create its schema, so it cannot start before SQL Server is
+        // accepting connections.
+        var builder = DistributedApplication.CreateBuilder([]);
+        var sql = builder.AddSqlServer("sql");
+
+        var emulator = builder.AddServiceBusEmulatorBroker(sql);
+
+        emulator.Resource.Annotations.OfType<WaitAnnotation>()
+            .Should().ContainSingle(w => w.Resource == sql.Resource);
+    }
+
+    [Fact]
+    public void ConnectionString_IsTheEmulatorForm_BuiltFromTheAllocatedAmqpEndpoint()
+    {
+        // UseDevelopmentEmulator=true is not decoration: it keeps the Azure SDK clients on plain
+        // TCP/HTTP against a local host, and it is the marker the infrastructure layer keys its
+        // emulator branch off. A real namespace never emits it.
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+
+        emulator.Resource.ConnectionStringExpression.ValueExpression.Should().Be(
+            "Endpoint=sb://{servicebus.bindings.amqp.host}:{servicebus.bindings.amqp.port};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;");
+    }
+
+    [Fact]
+    public void AdminEndpoint_IsBuiltFromTheAllocatedManagementEndpoint()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+
+        emulator.Resource.AdminEndpointExpression.ValueExpression.Should().Be(
+            "{servicebus.bindings.admin.scheme}://{servicebus.bindings.admin.host}:{servicebus.bindings.admin.port}");
+    }
+
+    [Fact]
+    public async Task WithBroker_SelectsTheAzureServiceBusTransportAndPassesBothPlanes()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+        var service = builder.AddContainer("conference", "conference-image");
+
+        service.WithBroker(emulator);
+
+        Dictionary<string, string> environment = await EnvironmentOf(builder, service.Resource);
+
+        environment.Should().ContainKey("MessageBus__Provider").WhoseValue.Should().Be("AzureServiceBus");
+        environment.Should().ContainKey("MessageBus__ConnectionString")
+            .WhoseValue.Should().EndWith("UseDevelopmentEmulator=true;");
+        environment.Should().ContainKey("MessageBus__EmulatorAdminEndpoint")
+            .WhoseValue.Should().Be("{servicebus.bindings.admin.scheme}://{servicebus.bindings.admin.host}:{servicebus.bindings.admin.port}");
+    }
+
+    [Fact]
+    public void WithBroker_WaitsForTheBroker()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+        var emulator = builder.AddServiceBusEmulatorBroker(builder.AddSqlServer("sql"));
+        var service = builder.AddContainer("conference", "conference-image");
+
+        service.WithBroker(emulator);
+
+        service.Resource.Annotations.OfType<WaitAnnotation>()
+            .Should().ContainSingle(w => w.Resource == emulator.Resource);
+    }
+
+    [Fact]
+    public async Task WithBroker_RabbitMqOverloadIsUnchanged()
+    {
+        // The emulator is opt-in. Adding it must not move a single byte of what the RabbitMQ path
+        // injects, or every existing AppHost changes behavior on upgrade.
+        var builder = DistributedApplication.CreateBuilder([]);
+        var rabbit = builder.AddMessageBroker();
+        var service = builder.AddContainer("conference", "conference-image");
+
+        service.WithBroker(rabbit);
+
+        Dictionary<string, string> environment = await EnvironmentOf(builder, service.Resource);
+
+        environment.Should().ContainKey("MessageBus__Provider").WhoseValue.Should().Be("RabbitMq");
+        environment.Should().NotContainKey("MessageBus__EmulatorAdminEndpoint");
+    }
+
+    /// <summary>
+    /// Resolves a resource's environment variables in publish mode, where every reference stays a
+    /// manifest expression (<c>{servicebus.bindings.amqp.host}</c>). That is what makes the assertion
+    /// about WHICH endpoint a value is bound to, rather than about a port DCP happened to allocate.
+    /// </summary>
+    private static async Task<Dictionary<string, string>> EnvironmentOf(
+        IDistributedApplicationBuilder builder,
+        IResource resource)
+    {
+        await using ServiceProvider services = builder.Services.BuildServiceProvider();
+        var executionContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish)
+            {
+                Services = services,
+            });
+
+        IExecutionConfigurationResult result = await ExecutionConfigurationBuilder.Create(resource)
+            .WithEnvironmentVariablesConfig()
+            .BuildAsync(executionContext);
+
+        result.Exception.Should().BeNull();
+        return result.EnvironmentVariables.ToDictionary(StringComparer.Ordinal);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Validation/AbsoluteUrlAttributeTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Validation/AbsoluteUrlAttributeTests.cs
@@ -1,0 +1,119 @@
+using System.ComponentModel.DataAnnotations;
+using AwesomeAssertions;
+using Microsoft.Extensions.Localization;
+using MMCA.Common.UI.Validation;
+
+namespace MMCA.Common.UI.Tests.Validation;
+
+/// <summary>
+/// Unit tests for <see cref="AbsoluteUrlAttribute"/>: the client-side mirror of the server's
+/// <c>AbsoluteUrlRules</c>. What matters is that the two agree, including on the schemes they refuse
+/// (these values are rendered into image sources and link targets), and that the message still
+/// resolves as a localization resource key through the model validator.
+/// </summary>
+public sealed class AbsoluteUrlAttributeTests
+{
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com/logo.png?v=2")]
+    [InlineData("HTTPS://EXAMPLE.COM")]
+    public void Accepts_AbsoluteHttpAndHttpsUrls(string url) =>
+        Validate(url).Should().BeEmpty();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    // Pairing with [Required] is how a mandatory field is expressed. If this rule also rejected
+    // blanks, a blank required field would show two messages saying the same thing.
+    public void Accepts_AbsentValues_BecauseOptionalityIsRequiredAttributesJob(string? url) =>
+        Validate(url).Should().BeEmpty();
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4=")]
+    [InlineData("ftp://example.com/logo.png")]
+    [InlineData("/images/logo.png")]
+    [InlineData("example.com")]
+    [InlineData("not a url")]
+    public void Rejects_EverythingThatIsNotAnAbsoluteHttpUrl(string url) =>
+        Validate(url).Should().ContainSingle();
+
+    [Fact]
+    public void ErrorMessage_IsEmittedUnchanged_SoItCanBeALocalizationResourceKey()
+    {
+        // DataAnnotationsModelValidator resolves whatever message it receives against the page's
+        // localizer. That only works if the attribute hands the key over untouched.
+        var model = new UrlModel { Website = "javascript:alert(1)" };
+        var validator = new DataAnnotationsModelValidator(
+            new StubLocalizer(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Validation.AbsoluteUrl"] = "Enter a full web address.",
+            }));
+
+        validator.Validate(model, nameof(UrlModel.Website)).Should().ContainSingle()
+            .Which.Should().Be("Enter a full web address.");
+    }
+
+    [Fact]
+    public void ErrorMessage_FallsThroughUnchanged_WhenItIsNotAKnownResourceKey()
+    {
+        var model = new UrlModel { Website = "javascript:alert(1)" };
+        var validator = new DataAnnotationsModelValidator(
+            new StubLocalizer(new Dictionary<string, string>(StringComparer.Ordinal)));
+
+        validator.Validate(model, nameof(UrlModel.Website)).Should().ContainSingle()
+            .Which.Should().Be("Validation.AbsoluteUrl");
+    }
+
+    [Fact]
+    public void ReportsTheOffendingMember_SoTheMessageLandsOnTheRightField()
+    {
+        var model = new UrlModel { Website = "ftp://example.com" };
+        var context = new ValidationContext(model) { MemberName = nameof(UrlModel.Website) };
+        var results = new List<ValidationResult>();
+
+        Validator.TryValidateProperty(model.Website, context, results);
+
+        results.Should().ContainSingle()
+            .Which.MemberNames.Should().ContainSingle().Which.Should().Be(nameof(UrlModel.Website));
+    }
+
+    private static List<ValidationResult> Validate(string? url)
+    {
+        var model = new BareUrlModel { Url = url };
+        var context = new ValidationContext(model) { MemberName = nameof(BareUrlModel.Url) };
+        var results = new List<ValidationResult>();
+
+        Validator.TryValidateProperty(url, context, results);
+        return results;
+    }
+
+    /// <summary>A model carrying the rule alone, with the attribute's own default message.</summary>
+    private sealed class BareUrlModel
+    {
+        [AbsoluteUrl]
+        public string? Url { get; init; }
+    }
+
+    /// <summary>A model whose message is a localization resource key, the shipped idiom.</summary>
+    private sealed class UrlModel
+    {
+        [AbsoluteUrl(ErrorMessage = "Validation.AbsoluteUrl")]
+        public string? Website { get; init; }
+    }
+
+    /// <summary>A localizer that knows only the keys it is handed.</summary>
+    private sealed class StubLocalizer(Dictionary<string, string> entries) : IStringLocalizer
+    {
+        public LocalizedString this[string name] =>
+            entries.TryGetValue(name, out string? value)
+                ? new LocalizedString(name, value, resourceNotFound: false)
+                : new LocalizedString(name, name, resourceNotFound: true);
+
+        public LocalizedString this[string name, params object[] arguments] => this[name];
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+}


### PR DESCRIPTION
Four independent framework additions that ADC needs for its #33 / section 24 / TD-19 remediation wave. Targeted at v1.176.0.

## 1. Aspire hosting: Service Bus emulator broker + generic `WithBroker`

ADC (and Store) run RabbitMQ locally through Aspire but Azure Service Bus in production. RabbitMQ is fast and dependency-free, but it is a different broker with different topology semantics, so anything that only breaks on Azure Service Bus (entity naming limits, topic/subscription provisioning, scheduled redelivery) stays invisible until it reaches production. This closes that divergence for hosts that opt in.

- New `ServiceBusEmulatorResource` (`ContainerResource` + `IResourceWithConnectionString`) for the official `mcr.microsoft.com/azure-messaging/servicebus-emulator` image, pinned to `2.0.1`. The 2.x floor is load bearing: the HTTP management plane that lets a client create its own topics, subscriptions and queues shipped in 2.0.0, and MassTransit provisions its whole topology at bus start.
- `AddServiceBusEmulatorBroker(sqlServer, name = "servicebus")` wires the emulator to an EXISTING SQL Server resource (`SQL_SERVER` host name, `MSSQL_SA_PASSWORD` from its password parameter, `ACCEPT_EULA=Y`) and publishes both planes: AMQP (target 5672) and the HTTP management plane (target 5300). Host ports are left to Aspire. It `WaitFor`s SQL Server, since the emulator's first act is to create its schema.
- New `WithBroker` overload taking the emulator resource: sets `MessageBus__Provider=AzureServiceBus`, `MessageBus__ConnectionString` (emulator form, ending `;UseDevelopmentEmulator=true`) and `MessageBus__EmulatorAdminEndpoint`. The existing RabbitMQ overload is byte-for-byte unchanged, and a test pins that.
- No new package reference. Plain `AddContainer` / `WithEndpoint` / `ReferenceExpression`; no `Aspire.Hosting.Azure.*` dependency was added.

## 2. Infrastructure: emulator branch inside the AzureServiceBus transport

MassTransit is pinned to v8 by policy (v9 needs a commercial license and `DependencyVersionTests` fails the build at major 9). v8 has no vendor emulator mode, so the only path onto the emulator is the custom-clients `Host(Uri, ServiceBusClient, ServiceBusAdministrationClient)` overload. New `ServiceBusEmulatorSupport` (internal) does exactly that when the resolved connection string carries `UseDevelopmentEmulator=true`:

- builds the management-plane connection string by swapping the admin endpoint's host and port into the AMQP one, so both clients carry the same shared-access key by construction;
- lowers `AzureServiceBusTransport.Defaults.{DefaultMessageTimeToLive, BasicMessageTimeToLive, AutoDeleteOnIdle}` to one hour once per process (`Interlocked` guard). The emulator rejects v8's defaults (366 day TTL, 427 day auto-delete). These are process-global statics, so they are applied ONLY on this branch;
- fails at registration with a named message when `MessageBus:EmulatorAdminEndpoint` is missing or is not an absolute http/https URL, rather than at the first publish.

A real Azure Service Bus connection string never carries the marker, so detection cannot be tripped by a misconfigured environment name or a stray flag, and the production path stays a single unconditional `cfg.Host(connectionString)`. New setting `MessageBusSettings.EmulatorAdminEndpoint` with full XML docs.

## 3. MMCA.Common.UI: `AbsoluteUrlAttribute`

The client-side mirror of the server's `AbsoluteUrlRules` (rubric section 24, validation parity). These values are rendered straight into image sources and link targets, so accepting `javascript:` or `data:` on the client and rejecting it on the server means the only thing between a pasted script URL and the page is a round trip. Null/empty/whitespace pass (pair with `[Required]` when mandatory, so a blank required field shows one message, not two), and `ErrorMessage` is emitted unchanged so it resolves as a localization resource key through `DataAnnotationsModelValidator`.

## 4. Testing.Architecture: per-module required-layer overrides

`RequiredModuleLayers` applies to every module, so a repo with one deliberately thin module (ADC's Notification: only Shared/Application/Api assemblies exist) could only express that by trimming the DEFAULT list, which silently stops enforcing those layers for every other module. Added `protected virtual IReadOnlyDictionary<string, IReadOnlyList<Layer>> ModuleRequiredLayerOverrides` (empty by default) and a new three-argument `ArchitectureRules.ModulesDeclareLayers(map, required, overrides)` that the `[Fact]` calls. The existing two-argument public overload is untouched and keeps delegating with no overrides.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: clean, zero warnings.
- Tests (run as built executables; `dotnet test` hits a machine-wide zero-discovery bug on this box):
  - `MMCA.Common.Aspire.Hosting.Tests`: 30 passed (13 new)
  - `MMCA.Common.Infrastructure.Tests`: 1324 passed (10 new)
  - `MMCA.Common.UI.Tests`: 847 passed (10 new)
  - `MMCA.Common.Architecture.Tests`: 175 passed (6 new)
- `FACTS.md` regenerated: "Common executes" 187 to 193.
- No new `PackageReference`, so no `packages.lock.json` diffs. `Azure.Messaging.ServiceBus` and `MassTransit.Azure.ServiceBus.Core` were already referenced.
- Two real defects were caught by the new tests during the run and fixed: `WithImageRegistry` must follow `WithImage` (it throws when there is no image annotation yet), and a bare `host:port` admin endpoint parsed as an absolute URI with `localhost` as the scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9m4FQpur2bH9eHmybo485
