### PR TITLE
feat: register the update validator bridge in AddEntityCrud and add id rule bases

### DIFF
--- a/Source/Core/MMCA.Common.Application/DependencyInjection.cs
+++ b/Source/Core/MMCA.Common.Application/DependencyInjection.cs
@@ -272,8 +272,9 @@ public static class DependencyInjection
 
         /// <summary>
         /// Registers the framework's generic write side for one aggregate: the create, update and
-        /// delete handlers, each closed over that aggregate's own types. One call replaces the three
-        /// hand-written handler classes a straightforward CRUD aggregate would otherwise need.
+        /// delete handlers, each closed over that aggregate's own types, plus the validator bridge
+        /// for the update command. One call replaces the three hand-written handler classes a
+        /// straightforward CRUD aggregate would otherwise need.
         /// </summary>
         /// <typeparam name="TEntity">The aggregate root.</typeparam>
         /// <typeparam name="TEntityDTO">The DTO the create and update handlers return.</typeparam>
@@ -305,6 +306,16 @@ public static class DependencyInjection
         /// generic pair for the other two.
         /// </para>
         /// <para>
+        /// <b>The update command's validator bridge is registered too</b>, exactly as
+        /// <see cref="AddEntityUpdateVerb{TEntity, TEntityDTO, TIdentifierType, TUpdateRequest, TApplier}"/>
+        /// does for a verb: a <see cref="CommandRequestValidator{TCommand, TRequest}"/> closed over
+        /// <c>UpdateEntityCommand</c> and <typeparamref name="TUpdateRequest"/>, so the rules a module
+        /// writes for the request run against the command the generic controller constructs. The
+        /// command is a closed generic built at registration time, so the module scan's reflection
+        /// bridge cannot see it. <c>TryAdd</c> semantics, like the scan: an explicitly registered
+        /// <c>IValidator</c> for that command wins.
+        /// </para>
+        /// <para>
         /// Call it where a module registers its handlers, which means before
         /// <c>AddApplicationDecorators()</c>: inside the module's own <c>Register</c>, or inside the
         /// <c>AddMmcaApplicationPipeline(...)</c> callback.
@@ -334,6 +345,10 @@ public static class DependencyInjection
             services.TryAddScoped<
                 ICommandHandler<DeleteEntityCommand<TEntity, TIdentifierType>, Result>,
                 DeleteEntityHandler<TEntity, TIdentifierType>>();
+
+            services.AddCommandRequestValidator<
+                UpdateEntityCommand<TEntity, TUpdateRequest, TIdentifierType>,
+                TUpdateRequest>();
 
             return services;
         }

--- a/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
@@ -242,10 +242,14 @@ MMCA.Common.Application.Validation.AbsoluteUrlRules<T>
 MMCA.Common.Application.Validation.AbsoluteUrlRules<T>.AbsoluteUrlRules(System.Linq.Expressions.Expression<System.Func<T, string?>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.EmailRules<T>.EmailRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.NonNegativeIntRules<T>.NonNegativeIntRules(System.Linq.Expressions.Expression<System.Func<T, int>!>! selector, string! fieldName, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.OptionalPositiveIdRules<T, TId>
+MMCA.Common.Application.Validation.OptionalPositiveIdRules<T, TId>.OptionalPositiveIdRules(System.Linq.Expressions.Expression<System.Func<T, TId?>!>! selector, string! fieldName, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.OptionalStringRules<T>.OptionalStringRules(System.Linq.Expressions.Expression<System.Func<T, string?>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.PasswordRules<T>.PasswordRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.PositiveDecimalRules<T>.PositiveDecimalRules(System.Linq.Expressions.Expression<System.Func<T, decimal>!>! selector, string! fieldName, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.PositiveIntRules<T>.PositiveIntRules(System.Linq.Expressions.Expression<System.Func<T, int>!>! selector, string! fieldName, string? errorCode = null) -> void
+MMCA.Common.Application.Validation.RequiredIdRules<T, TId>
+MMCA.Common.Application.Validation.RequiredIdRules<T, TId>.RequiredIdRules(System.Linq.Expressions.Expression<System.Func<T, TId>!>! selector, string! fieldName, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.RequiredStringRules<T>.RequiredStringRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string! fieldName, int maxLength, string? errorCode = null) -> void
 MMCA.Common.Application.Validation.StrongPasswordRules<T>.StrongPasswordRules(System.Linq.Expressions.Expression<System.Func<T, string!>!>! selector, string? errorCode = null) -> void
 abstract MMCA.Common.Application.DomainEvents.ScopedIntegrationEventHandlerBase<TIntegrationEvent>.HandleScopedAsync(TIntegrationEvent integrationEvent, System.IServiceProvider! services, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/Source/Core/MMCA.Common.Application/Validation/CommonValidationRules.cs
+++ b/Source/Core/MMCA.Common.Application/Validation/CommonValidationRules.cs
@@ -127,6 +127,46 @@ public class NonNegativeIntRules<T> : AbstractValidator<T>
 }
 
 /// <summary>
+/// Reusable validation rules for a required identifier field: the field must carry a value that is
+/// not the identifier type's default.
+/// </summary>
+/// <remarks>
+/// <c>NotEmpty</c> is the deliberate check: it rejects zero for an integer key and
+/// <see cref="Guid.Empty"/> for a <see cref="Guid"/> key, which is exactly what "an id was never
+/// supplied" looks like on the wire for both shapes. The field phrase is interpolated verbatim
+/// into "You must specify {fieldName}", so the caller supplies the article and any qualifier:
+/// "a Category", "an Event for the Session".
+/// </remarks>
+/// <typeparam name="T">The parent type containing the field.</typeparam>
+/// <typeparam name="TId">The identifier type of the field.</typeparam>
+public class RequiredIdRules<T, TId> : AbstractValidator<T>
+    where TId : notnull
+{
+    public RequiredIdRules(Expression<Func<T, TId>> selector, string fieldName, string? errorCode = null)
+        => RuleFor(selector)
+            .NotEmpty().WithMessage($"You must specify {fieldName}").WithOptionalErrorCode(errorCode);
+}
+
+/// <summary>
+/// Reusable validation rules for an optional identifier field: when a value is supplied it must be
+/// positive. A <see langword="null"/> value passes.
+/// </summary>
+/// <remarks>
+/// FluentValidation skips a comparison rule when the nullable property holds
+/// <see langword="null"/>, so the "when provided" part needs no <c>When</c> clause and no compiled
+/// selector re-evaluated per validation pass.
+/// </remarks>
+/// <typeparam name="T">The parent type containing the field.</typeparam>
+/// <typeparam name="TId">The underlying identifier type of the nullable field.</typeparam>
+public class OptionalPositiveIdRules<T, TId> : AbstractValidator<T>
+    where TId : struct, IComparable<TId>, IComparable
+{
+    public OptionalPositiveIdRules(Expression<Func<T, TId?>> selector, string fieldName, string? errorCode = null)
+        => RuleFor(selector)
+            .GreaterThan(default(TId)).WithMessage($"{fieldName} must be a valid positive value when provided.").WithOptionalErrorCode(errorCode);
+}
+
+/// <summary>
 /// Reusable validation rules for a password field: required, min 8, max 128 characters.
 /// For stricter complexity requirements, use <see cref="StrongPasswordRules{T}"/> instead.
 /// </summary>

--- a/Tests/Core/MMCA.Common.Application.Tests/UseCases/UpdateEntityHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/UseCases/UpdateEntityHandlerTests.cs
@@ -1,8 +1,10 @@
 ﻿using AwesomeAssertions;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Application.Interfaces;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.UseCases;
+using MMCA.Common.Application.Validation;
 using MMCA.Common.Shared.Abstractions;
 using Moq;
 
@@ -225,9 +227,43 @@ public sealed class AddEntityCrudTests
 
         services.AddEntityCrud<OrderAggregate, OrderDTO, int, OrderCreateRequest, OrderUpdateRequest>();
 
-        services.Should().HaveCount(3);
-        services.Should().OnlyContain(d =>
-            d.Lifetime == ServiceLifetime.Scoped && !d.ServiceType.ContainsGenericParameters);
+        // Three handlers plus the update command's validator bridge.
+        services.Should().HaveCount(4);
+        services.Should().OnlyContain(d => !d.ServiceType.ContainsGenericParameters);
+        services.Where(d => d.ServiceType.IsGenericType
+                && d.ServiceType.GetGenericTypeDefinition() == typeof(ICommandHandler<,>))
+            .Should().HaveCount(3)
+            .And.OnlyContain(d => d.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    // The generic controller constructs UpdateEntityCommand itself, so the closed generic never
+    // appears in a scanned module assembly: without this bridge the request's rules never run.
+    [Fact]
+    public void AddEntityCrud_BridgesTheUpdateCommandToItsRequestValidators()
+    {
+        using ServiceProvider provider = BuildProvider();
+
+        provider.GetRequiredService<IValidator<
+                UpdateEntityCommand<OrderAggregate, OrderUpdateRequest, int>>>()
+            .Should().BeOfType<CommandRequestValidator<
+                UpdateEntityCommand<OrderAggregate, OrderUpdateRequest, int>, OrderUpdateRequest>>();
+    }
+
+    // TryAdd semantics for the bridge too: an aggregate whose update needs cross-field rules over
+    // the whole command registers its own IValidator first and keeps it.
+    [Fact]
+    public void AddEntityCrud_LeavesAnExplicitCommandValidatorAlone()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<
+            IValidator<UpdateEntityCommand<OrderAggregate, OrderUpdateRequest, int>>,
+            ExplicitOrderUpdateCommandValidator>();
+
+        services.AddEntityCrud<OrderAggregate, OrderDTO, int, OrderCreateRequest, OrderUpdateRequest>();
+
+        ServiceDescriptor descriptor = services.Single(
+            d => d.ServiceType == typeof(IValidator<UpdateEntityCommand<OrderAggregate, OrderUpdateRequest, int>>));
+        descriptor.ImplementationType.Should().Be<ExplicitOrderUpdateCommandValidator>();
     }
 
     // TryAdd semantics: an aggregate that outgrows one of the three registers its own handler first
@@ -261,6 +297,9 @@ public sealed class AddEntityCrudTests
 
 // ── Test doubles (public so Moq's DynamicProxy can see them) ─────────────────
 public sealed record OrderUpdateRequest(string Name);
+
+public sealed class ExplicitOrderUpdateCommandValidator
+    : AbstractValidator<UpdateEntityCommand<OrderAggregate, OrderUpdateRequest, int>>;
 
 public sealed class CustomDeleteOrderHandler : ICommandHandler<DeleteEntityCommand<OrderAggregate, int>, Result>
 {

--- a/Tests/Core/MMCA.Common.Application.Tests/Validation/CommonValidationRulesTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Validation/CommonValidationRulesTests.cs
@@ -207,6 +207,124 @@ public sealed class CommonValidationRulesTests
         result.ShouldNotHaveValidationErrorFor(x => x.Quantity);
     }
 
+    // ── RequiredIdRules ──
+    [Fact]
+    public void RequiredIdRules_WhenIntIsZero_HasValidationError()
+    {
+        var validator = new RequiredIdRules<TestIntModel, int>(x => x.Quantity, "a Category");
+        var model = new TestIntModel { Quantity = 0 };
+
+        TestValidationResult<TestIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Quantity)
+            .WithErrorMessage("You must specify a Category");
+    }
+
+    [Fact]
+    public void RequiredIdRules_WhenIntIsPositive_NoErrors()
+    {
+        var validator = new RequiredIdRules<TestIntModel, int>(x => x.Quantity, "Category");
+        var model = new TestIntModel { Quantity = 7 };
+
+        TestValidationResult<TestIntModel> result = validator.TestValidate(model);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Quantity);
+    }
+
+    [Fact]
+    public void RequiredIdRules_WhenGuidIsEmpty_HasValidationError()
+    {
+        var validator = new RequiredIdRules<TestGuidModel, Guid>(x => x.OwnerId, "an Owner");
+        var model = new TestGuidModel { OwnerId = Guid.Empty };
+
+        TestValidationResult<TestGuidModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.OwnerId)
+            .WithErrorMessage("You must specify an Owner");
+    }
+
+    [Fact]
+    public void RequiredIdRules_WhenGuidIsPopulated_NoErrors()
+    {
+        var validator = new RequiredIdRules<TestGuidModel, Guid>(x => x.OwnerId, "Owner");
+        var model = new TestGuidModel { OwnerId = Guid.NewGuid() };
+
+        TestValidationResult<TestGuidModel> result = validator.TestValidate(model);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.OwnerId);
+    }
+
+    [Fact]
+    public void RequiredIdRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new RequiredIdRules<TestIntModel, int>(x => x.Quantity, "Event", "Session.EventId.Required");
+        var model = new TestIntModel { Quantity = 0 };
+
+        TestValidationResult<TestIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Quantity)
+            .WithErrorCode("Session.EventId.Required");
+    }
+
+    // ── OptionalPositiveIdRules ──
+    [Fact]
+    public void OptionalPositiveIdRules_WhenNull_NoErrors()
+    {
+        var validator = new OptionalPositiveIdRules<TestOptionalIntModel, int>(x => x.CategoryId, "Category ID");
+        var model = new TestOptionalIntModel { CategoryId = null };
+
+        TestValidationResult<TestOptionalIntModel> result = validator.TestValidate(model);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.CategoryId);
+    }
+
+    [Fact]
+    public void OptionalPositiveIdRules_WhenZero_HasValidationError()
+    {
+        var validator = new OptionalPositiveIdRules<TestOptionalIntModel, int>(x => x.CategoryId, "Category ID");
+        var model = new TestOptionalIntModel { CategoryId = 0 };
+
+        TestValidationResult<TestOptionalIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.CategoryId)
+            .WithErrorMessage("Category ID must be a valid positive value when provided.");
+    }
+
+    [Fact]
+    public void OptionalPositiveIdRules_WhenNegative_HasValidationError()
+    {
+        var validator = new OptionalPositiveIdRules<TestOptionalIntModel, int>(x => x.CategoryId, "Category ID");
+        var model = new TestOptionalIntModel { CategoryId = -1 };
+
+        TestValidationResult<TestOptionalIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.CategoryId);
+    }
+
+    [Fact]
+    public void OptionalPositiveIdRules_WhenPositive_NoErrors()
+    {
+        var validator = new OptionalPositiveIdRules<TestOptionalIntModel, int>(x => x.CategoryId, "Category ID");
+        var model = new TestOptionalIntModel { CategoryId = 42 };
+
+        TestValidationResult<TestOptionalIntModel> result = validator.TestValidate(model);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.CategoryId);
+    }
+
+    [Fact]
+    public void OptionalPositiveIdRules_WhenErrorCodeSupplied_AppliesIt()
+    {
+        var validator = new OptionalPositiveIdRules<TestOptionalIntModel, int>(
+            x => x.CategoryId, "Category ID", "Product.CategoryId.Invalid");
+        var model = new TestOptionalIntModel { CategoryId = 0 };
+
+        TestValidationResult<TestOptionalIntModel> result = validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.CategoryId)
+            .WithErrorCode("Product.CategoryId.Invalid");
+    }
+
     // ── PasswordRules ──
     [Fact]
     public void PasswordRules_WhenEmpty_HasValidationError()
@@ -514,4 +632,14 @@ public sealed record TestIntModel
 public sealed record TestDecimalModel
 {
     public decimal Price { get; init; }
+}
+
+public sealed record TestOptionalIntModel
+{
+    public int? CategoryId { get; init; }
+}
+
+public sealed record TestGuidModel
+{
+    public Guid OwnerId { get; init; }
 }


### PR DESCRIPTION
## Summary

- `AddEntityCrud` now registers the `CommandRequestValidator` bridge for its closed `UpdateEntityCommand<TEntity, TUpdateRequest, TIdentifierType>`, exactly as `AddEntityUpdateVerb` and `AddEntityUpdate` already do for theirs. TryAdd semantics are unchanged: an explicitly registered `IValidator` for the command still wins, so the hand-registered bridges in ADC, Store, and Helpdesk become harmless no-ops until their sweep PRs delete them.
- `CommonValidationRules` gains two id rule bases:
  - `RequiredIdRules<T, TId>` (`NotEmpty`: rejects 0 for int keys and `Guid.Empty` for Guid keys). The field phrase interpolates verbatim into "You must specify {fieldName}" so callers supply the article ("a Category", "an Event for the Session"), which lets consumers preserve their existing messages byte-exact.
  - `OptionalPositiveIdRules<T, TId>` (`GreaterThan(default)`; null passes with no `When` clause and no per-evaluation compiled selector).
- New public API entries in `PublicAPI.Unshipped.txt`.

## Tests

- `AddEntityCrudTests`: bridge resolution + explicit-validator-wins cases (8 total, was 6); the closed-service-types case updated for the fourth (transient) descriptor.
- `CommonValidationRulesTests`: 10 new cases covering int/Guid required ids, null/zero/negative/positive optional ids, and error-code application (56 total).
- Full local runs: MMCA.Common.Application.Tests 1026 passed, Architecture.Tests 175 passed, build warning-free.

Consumer sweeps (ADC, Store, Helpdesk) follow in the next release cycle per the approved refactor plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m7U3JGh8u2eb9FsQhSuvw