### PR TITLE
fix: bug-hunt remediation H35, M85, M86, M89, M91-M96, L34, L35, L37, L38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ consumer at bump time beyond the pin.
   short-circuited on the dedup lookup and reported success forever. The whole sequence is now one
   unit, so a failed attempt rolls back and a retry re-runs the send. The sender calls now run inside
   the transaction.
+- **`OwnerOrAdminFilter` parses owner ids invariantly** (`MMCA.Common.API`). The route-value and
+  bound-argument parses used the host's ambient culture, unlike every other machine-data parse in the
+  framework. They now pass `NumberStyles.Integer` and `CultureInfo.InvariantCulture`. The filter
+  already failed closed on a non-parse, so this is a convention fix rather than a security fix.
 - **`CommandRequestValidator` runs every registered `IValidator<TRequest>`**
   (`MMCA.Common.Application`). It took `FirstOrDefault()`, so a module that authored a validator
   beside a framework-supplied one for the same request type had one of them silently turned into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [Unreleased]
+
+Bug-hunt remediation (2026-09-01 run): a refresh-token rotation race, a non-atomic push-notification
+send, request validators that were silently dropped, and a set of UI, API and test-package defects.
+Everything is additive: no signature breaks and no schema changes, so nothing is required of a
+consumer at bump time beyond the pin.
+
+### Fixed
+
+- **Concurrent refresh-token rotation is now claimed atomically** (`MMCA.Common.Application`,
+  `MMCA.Common.Infrastructure`). Two requests presenting the SAME still-live refresh token each read
+  their own un-revoked copy of the session row, so both used to mint a successor and the presented
+  row could never fire reuse detection again, leaving one permanently undetected extra session.
+  Rotation now runs through the new `IRefreshSessionStore.TryRotateAsync`, which the EF store
+  implements as a conditional `UPDATE ... WHERE Id = @id AND RevokedAt IS NULL` plus the successor
+  insert in one transaction. The request that loses the claim gets the answer a replay gets: the
+  user's whole live family is revoked (BR-206) and the refresh fails with `Auth.InvalidRefreshToken`.
+  No schema change and no migration: the row still carries no concurrency token.
+- **`SendPushNotificationCommand` is `ITransactional`** (`MMCA.Common.Application`). The handler
+  committed the audit row (carrying `DedupKey`) before the per-recipient rows and the sends, so a
+  fault in between left a committed row nothing ever delivered, and every retry with that key
+  short-circuited on the dedup lookup and reported success forever. The whole sequence is now one
+  unit, so a failed attempt rolls back and a retry re-runs the send. The sender calls now run inside
+  the transaction.
+- **`CommandRequestValidator` runs every registered `IValidator<TRequest>`**
+  (`MMCA.Common.Application`). It took `FirstOrDefault()`, so a module that authored a validator
+  beside a framework-supplied one for the same request type had one of them silently turned into
+  dead code, in DI registration order. All of them now run and their failures are unioned, matching
+  the policy the command and query decorators already apply to `IValidator<TCommand>` (ADR-014);
+  duplicate registrations of one validator class are de-duplicated by runtime type. A module with two
+  validators for one request will now surface failures that were previously not reported.
+
+### Added
+
+- **`IRefreshSessionStore.TryRotateAsync`** (`MMCA.Common.Application`). Additive interface member
+  with a default implementation (revoke, add, save), so an existing custom or test store keeps
+  compiling and behaving as it did; the shipped EF store overrides it with the database-arbitrated
+  claim described above.
+
 ## [1.178.0] - 2026-09-01
 
 Two move-to-Common extractions from the 2026-08-31 drift run: the E2E gateway rate-limit lift both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ consumer at bump time beyond the pin.
   `LoadMobileDataAsync` saved `MobilePageSize` into the state the desktop grid shares, so narrowing
   the viewport replaced a user's 50-rows-per-page choice with 10 on the next visit. It now saves 0,
   which the restore guards skip, exactly as the virtualized path already did.
+- **`ApnsTokenBridge` re-arms its rendezvous per registration attempt** (`MMCA.Common.UI.Maui`). A
+  single one-shot `TaskCompletionSource` handed every later caller the first attempt's outcome
+  instantly, so after a failed APNs registration the next `GetTokenAsync` re-registered and then
+  reported failure without waiting for the callback it had just triggered. `WaitForTokenAsync` now
+  completes on the NEXT callback, and `Publish` swaps in the new source before completing the old
+  one. Call `WaitForTokenAsync` before asking UIKit to register, as the shipped provider does.
 - **`NotificationBell` cannot start a poll loop after disposal** (`MMCA.Common.UI`). Disposal during
   the first unread-count read left it creating a `PeriodicTimer` nothing would dispose and starting a
   loop whose first act was to read an already-disposed `CancellationTokenSource`, faulting a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,34 @@ consumer at bump time beyond the pin.
   `LoadMobileDataAsync` saved `MobilePageSize` into the state the desktop grid shares, so narrowing
   the viewport replaced a user's 50-rows-per-page choice with 10 on the next visit. It now saves 0,
   which the restore guards skip, exactly as the virtualized path already did.
+- **`E2ETestBase` no longer reports success on a silent auth failure**
+  (`MMCA.Common.Testing.E2E`). `LoginAsync` and `RegisterNewUserAsync` raced three signals and
+  returned normally when ALL of them timed out, which is what a submit that fails with neither a
+  navigation nor a rendered error alert looks like (a 500 that renders nothing, a dropped request, a
+  JS exception mid-submit). The caller's follow-up interactivity wait was already satisfied by the
+  still-rendered auth page, so the helper reported a sign-in that never happened. The four-way
+  classification is now explicit (`AuthOutcomeRules.Classify`) and the silent case throws an
+  `InvalidOperationException` naming the operation, the budget and the URL. The losing waits are also
+  observed, so their timeouts cannot surface as unobserved task exceptions elsewhere in a run.
+  **Consumer-visible at bump time:** an E2E suite whose login is genuinely broken but was passing
+  silently will turn RED. That is the point, but expect it.
+- **`ConfigureTestFeatureFlags` layers onto the host configuration** (`MMCA.Common.Testing`). It
+  built a flags-only `IConfiguration` and registered it, and .NET DI hands a non-collection
+  dependency the LAST registration, so anything constructed afterwards that injects `IConfiguration`
+  directly saw no connection strings, no authentication settings and no data sources, contradicting
+  the helper's own docstring. It now chains the host's configuration and adds the flags on top (the
+  flags still win). Behind a factory registration of `IConfiguration` there is nothing to read, and
+  the flags stand alone exactly as before.
+- **Module isolation covers the full internal-layer cross product**
+  (`MMCA.Common.Testing.Architecture`). Six rules checked each internal layer against its own layer
+  in other modules, plus Domain and Application against another module's Infrastructure. A module's
+  Domain reaching another module's Application or Api (and the other unchecked pairs) passed every
+  gate: the per-module layer rules forbid only the SAME module's higher layers, and the compile-time
+  guard only knows `MMCA.Common.*` references. New `ArchitectureRules.ModuleInternalLayersAreIsolated`
+  plus a `ModuleIsolationTestsBase` fact close it. UI is deliberately excluded (a module's UI
+  composing another module's UI is intended). **Consumer-visible at bump time:** the new fact runs in
+  every repo that subclasses the base; ADC and Store cross-module project references are Shared-only
+  today, so it should be green.
 - **`ApnsTokenBridge` re-arms its rendezvous per registration attempt** (`MMCA.Common.UI.Maui`). A
   single one-shot `TaskCompletionSource` handed every later caller the first attempt's outcome
   instantly, so after a failed APNs registration the next `GetTokenAsync` re-registered and then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,32 @@ consumer at bump time beyond the pin.
   short-circuited on the dedup lookup and reported success forever. The whole sequence is now one
   unit, so a failed attempt rolls back and a retry re-runs the send. The sender calls now run inside
   the transaction.
+- **The retry policy disposes every retried HTTP response** (`MMCA.Common.UI`). Polly hands the
+  caller only the final outcome, so each intermediate 5xx/408/429 attempt leaked its content buffer
+  and kept its connection out of the handler pool until finalization, under exactly the sustained
+  backend failure the retries exist to survive. The final response is still the caller's to dispose.
+- **`DeepLinkDispatcher.Publish` decides under its lock** (`MMCA.Common.UI`). The handler was read
+  outside the lock, so a native callback publishing while a listener was subscribing and draining
+  could buffer the route after that drain, stranding it with no future consumer (the warm-boot deep
+  link on a MAUI head). The raise-or-buffer decision is now one locked step; the event is still
+  invoked outside the lock.
+- **The Admin nav section is hidden from anonymous visitors** (`MMCA.Common.UI`). It was gated on
+  item count alone, unlike the User section beside it, so a module registering a `Section.Admin`
+  `NavItem` without a `RequiredRole` (which defaults to null) disclosed the feature's existence and
+  URL. Consumers that already set a role on every admin item see no change.
+- **`ApiFileDownloadButton` sanitizes `FileName` before staging** (`MMCA.Common.UI`). The parameter
+  went into `Path.Combine(Path.GetTempPath(), FileName)` verbatim, so a rooted value discarded the
+  temp root and `..` segments walked out of it: reachable for a consumer that builds the name from
+  entity data. Directory segments are now stripped to the bare file name, and an unusable name warns
+  without even performing the download.
+- **The mobile card fetch no longer overwrites the persisted `RowsPerPage`** (`MMCA.Common.UI`).
+  `LoadMobileDataAsync` saved `MobilePageSize` into the state the desktop grid shares, so narrowing
+  the viewport replaced a user's 50-rows-per-page choice with 10 on the next visit. It now saves 0,
+  which the restore guards skip, exactly as the virtualized path already did.
+- **`NotificationBell` cannot start a poll loop after disposal** (`MMCA.Common.UI`). Disposal during
+  the first unread-count read left it creating a `PeriodicTimer` nothing would dispose and starting a
+  loop whose first act was to read an already-disposed `CancellationTokenSource`, faulting a
+  discarded task. It re-checks after the await, and the loop also catches `ObjectDisposedException`.
 - **`OwnerOrAdminFilter` parses owner ids invariantly** (`MMCA.Common.API`). The route-value and
   bound-argument parses used the host's ambient culture, unlike every other machine-data parse in the
   framework. They now pass `NumberStyles.Integer` and `CultureInfo.InvariantCulture`. The filter
@@ -42,6 +68,12 @@ consumer at bump time beyond the pin.
 
 ### Added
 
+- **`LatestLoadGuard`** (`MMCA.Common.UI`, `MMCA.Common.UI.Common`). Small disposable helper for
+  routed detail pages: `Begin()` cancels the previous load and hands back a token plus a generation,
+  and `IsCurrent(generation)` says whether that load's result may still be assigned. Blazor reuses a
+  routed component instance across route-parameter changes, so a slow load for one id otherwise
+  overwrites the page after a faster load for the next id has rendered. Not thread-safe by contract
+  (renderer synchronization context only).
 - **`IRefreshSessionStore.TryRotateAsync`** (`MMCA.Common.Application`). Additive interface member
   with a default implementation (revoke, add, save), so an existing custom or test store keeps
   compiling and behaving as it did; the shipped EF store overrides it with the database-arbitrated

--- a/FACTS.md
+++ b/FACTS.md
@@ -43,10 +43,10 @@ The ADRs live in the Website repo (`docs-src/adr/`), published at
 it owns the range/count and the one-line summaries. Do not restate the `(001-NNN)` range elsewhere.
 
 ## Architecture fitness functions
-- **122 test methods across 46 abstract `*TestsBase` classes**, shipped once in the
+- **123 test methods across 46 abstract `*TestsBase` classes**, shipped once in the
   `MMCA.Common.Testing.Architecture` package (ADR-015) and re-run as thin subclasses across all consuming
   repos (Common, ADC, Store).
-- MMCA.Common's own build executes **193** of them (the methods of the bases its arch-tests
+- MMCA.Common's own build executes **196** of them (the methods of the bases its arch-tests
   subclass, plus its Common-only direct tests, e.g. `FrameworkSanityTests`/`SpecificationFitnessTests`).
 
 ## Governance rubric

--- a/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
+++ b/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
@@ -38,7 +38,10 @@ namespace MMCA.Common.Application.Auth;
 /// and the store holds only
 /// <see cref="RefreshSession.HashToken"/> digests. Rotation revokes the presented session and links it
 /// to its successor; presenting an already-rotated token lands on that revoked row, which is the reuse
-/// signal that revokes the user's whole live family (BR-206). An expired session is not a reuse signal
+/// signal that revokes the user's whole live family (BR-206). Two requests presenting the same live
+/// token at the same instant are covered by the same rule: the rotation is claimed atomically through
+/// <see cref="IRefreshSessionStore.TryRotateAsync"/>, and the request that loses the claim is answered
+/// as a replay rather than being handed a second successor. An expired session is not a reuse signal
 /// and fails alone. A per-user cap (<see cref="MaxActiveSessionsPerUser"/>) evicts the oldest live
 /// session on a new sign-in so one account cannot grow the table without bound.
 /// </para>
@@ -643,8 +646,14 @@ public abstract class AuthenticationServiceBase<TUser>(
     }
 
     /// <summary>
-    /// Revokes the presented session, links it to a freshly minted successor, and stages both
+    /// Revokes the presented session, links it to a freshly minted successor, and persists both
     /// (BR-205 rotation). Rotation replaces one session with one, so the cap is not re-evaluated here.
+    /// <para>
+    /// The revocation is a <see cref="IRefreshSessionStore.TryRotateAsync"/> claim rather than an
+    /// in-memory mutation: two requests presenting the same still-live token both read an un-revoked
+    /// row, and the store is what decides which of them owns the rotation. The loser is answered
+    /// exactly like a replay (family revoked, BR-206), since a caller cannot tell the two apart.
+    /// </para>
     /// </summary>
     /// <returns>The plaintext successor token to hand to the client, and the successor's session id.</returns>
     private async Task<Result<IssuedSession>> RotateAsync(
@@ -670,9 +679,21 @@ public abstract class AuthenticationServiceBase<TUser>(
         }
 
         var successor = successorResult.Value!;
-        session.Revoke(now, RefreshSession.ReasonRotated, successor.TokenHash);
-        await refreshSessions.AddAsync(successor, cancellationToken).ConfigureAwait(false);
-        await refreshSessions.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        var rotated = await refreshSessions
+            .TryRotateAsync(session, successor, now, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!rotated)
+        {
+            // Another request rotated this exact token in the same instant, so this one is holding a
+            // token that has already been spent. That is indistinguishable from a replay, and it
+            // gets the replay answer: the whole live family goes (BR-206).
+            await RevokeLiveSessionsAsync(userId, RefreshSession.ReasonReuseDetected, now, cancellationToken)
+                .ConfigureAwait(false);
+            await refreshSessions.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            return Result.Failure<IssuedSession>(InvalidRefreshTokenError());
+        }
 
         return Result.Success(new IssuedSession(refreshToken, successor.Id));
     }

--- a/Source/Core/MMCA.Common.Application/Auth/IRefreshSessionStore.cs
+++ b/Source/Core/MMCA.Common.Application/Auth/IRefreshSessionStore.cs
@@ -10,6 +10,8 @@ namespace MMCA.Common.Application.Auth;
 /// user for the cap and for family revocation, and mutated only through
 /// <see cref="RefreshSession.Revoke"/> on instances this store returned, so an implementation that
 /// tracks its entities (the shipped EF one) persists a revocation with no update method at all.
+/// <see cref="TryRotateAsync"/> is the one exception: rotation is a claim, not a mutation, so it
+/// needs a write the store itself decides the outcome of.
 /// </para>
 /// <para>
 /// Implementations must return <b>tracked</b> instances: a no-tracking read would take revocations and
@@ -63,4 +65,50 @@ public interface IRefreshSessionStore
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The number of rows written.</returns>
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically claims <paramref name="presented"/> for rotation (revoking it as
+    /// <see cref="RefreshSession.ReasonRotated"/> and linking it to
+    /// <paramref name="successor"/>), then stages and persists the successor.
+    /// <para>
+    /// The return value is the whole point: two requests presenting the SAME still-live token both
+    /// read an un-revoked row, so a check-then-act rotation mints two successors from one token and
+    /// the presented row can never fire reuse detection again (BR-206). Returning
+    /// <see langword="false"/> tells the caller it lost that claim, which is indistinguishable from
+    /// a replay and gets the same answer.
+    /// </para>
+    /// <para>
+    /// The default implementation is the shape the interface always had (revoke in memory, add,
+    /// save). It is atomic only per instance, which is all an in-memory or test store can offer;
+    /// the shipped EF store overrides it with a conditional UPDATE the database arbitrates.
+    /// </para>
+    /// </summary>
+    /// <param name="presented">The tracked session behind the presented refresh token.</param>
+    /// <param name="successor">The freshly minted session to persist in its place.</param>
+    /// <param name="revokedAt">The UTC instant to record on the presented session.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see langword="true"/> when this caller claimed the rotation and the successor is persisted;
+    /// <see langword="false"/> when the presented session was already revoked, in which case
+    /// nothing was written.
+    /// </returns>
+    async Task<bool> TryRotateAsync(
+        RefreshSession presented,
+        RefreshSession successor,
+        DateTime revokedAt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(presented);
+        ArgumentNullException.ThrowIfNull(successor);
+
+        if (presented.Revoke(revokedAt, RefreshSession.ReasonRotated, successor.TokenHash).IsFailure)
+        {
+            return false;
+        }
+
+        await AddAsync(successor, cancellationToken).ConfigureAwait(false);
+        await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return true;
+    }
 }

--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationCommand.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationCommand.cs
@@ -7,10 +7,19 @@ namespace MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
 /// Command to send a push notification to all recipients.
 /// Embeds the <see cref="SendPushNotificationRequest"/> for automatic FluentValidation via
 /// <see cref="ICommandWithRequest{TRequest}"/>.
+/// <para>
+/// <b>Transactional on purpose.</b> The handler writes the audit row first and the per-recipient rows
+/// second, so without a transaction a fault between the two leaves a committed notification row
+/// carrying <see cref="DedupKey"/> that nothing ever delivered: every retry with that key then
+/// short-circuits on the dedup lookup and reports success forever. Under
+/// <see cref="ITransactional"/> the failed attempt rolls back whole, so the retry re-runs the send.
+/// The cost is that the sender calls run inside the transaction; both are bounded by their own
+/// timeouts and hold locks only on rows this request just inserted.
+/// </para>
 /// </summary>
 public sealed record SendPushNotificationCommand(
     SendPushNotificationRequest Request,
-    UserIdentifierType SentByUserId) : ICommandWithRequest<SendPushNotificationRequest>
+    UserIdentifierType SentByUserId) : ICommandWithRequest<SendPushNotificationRequest>, ITransactional
 {
     /// <summary>
     /// Gets an optional deduplication key for the send (typically the caller's

--- a/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationHandler.cs
+++ b/Source/Core/MMCA.Common.Application/Notifications/PushNotifications/UseCases/Send/SendPushNotificationHandler.cs
@@ -13,6 +13,15 @@ namespace MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
 /// Handles sending a push notification to all recipients. Creates a <see cref="PushNotification"/>
 /// entity for audit, queries recipient user IDs via <see cref="INotificationRecipientProvider"/>, and
 /// dispatches via <see cref="IPushNotificationSender"/>.
+/// <para>
+/// <b>Atomicity.</b> The three saves below (audit row, recipient rows, terminal status) are one unit:
+/// <see cref="SendPushNotificationCommand"/> is <c>ITransactional</c>, so a fault anywhere in the
+/// sequence rolls the audit row back with everything else. That is what keeps the dedup
+/// short-circuit honest, since a committed row is otherwise indistinguishable from a delivered one
+/// and would answer every retry of that key with success. A business failure (no recipients) returns
+/// before the first write, and a delivery that fails is still recorded, because
+/// <c>MarkAsFailed</c> ends in a success result.
+/// </para>
 /// </summary>
 public sealed partial class SendPushNotificationHandler(
     IUnitOfWork unitOfWork,

--- a/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Application/PublicAPI.Unshipped.txt
@@ -47,6 +47,7 @@ MMCA.Common.Application.Auth.IRefreshSessionStore.FindByIdAsync(System.Guid id, 
 MMCA.Common.Application.Auth.IRefreshSessionStore.FindByTokenHashAsync(string! tokenHash, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Domain.Auth.RefreshSession?>!
 MMCA.Common.Application.Auth.IRefreshSessionStore.GetUnrevokedByUserAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<MMCA.Common.Domain.Auth.RefreshSession!>!>!
 MMCA.Common.Application.Auth.IRefreshSessionStore.SaveChangesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+MMCA.Common.Application.Auth.IRefreshSessionStore.TryRotateAsync(MMCA.Common.Domain.Auth.RefreshSession! presented, MMCA.Common.Domain.Auth.RefreshSession! successor, System.DateTime revokedAt, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 MMCA.Common.Application.Auth.PasswordResetSettings
 MMCA.Common.Application.Auth.PasswordResetSettings.MaxRequestsPerEmail.get -> int
 MMCA.Common.Application.Auth.PasswordResetSettings.MaxRequestsPerEmail.init -> void

--- a/Source/Core/MMCA.Common.Application/Validation/CommandRequestValidator.cs
+++ b/Source/Core/MMCA.Common.Application/Validation/CommandRequestValidator.cs
@@ -5,13 +5,24 @@ namespace MMCA.Common.Application.Validation;
 
 /// <summary>
 /// Auto-registered validator for commands implementing <see cref="ICommandWithRequest{TRequest}"/>.
-/// Delegates validation to the registered <c>IValidator&lt;TRequest&gt;</c> by calling
+/// Delegates validation to the registered <c>IValidator&lt;TRequest&gt;</c> instances by calling
 /// <see cref="FluentValidation.AbstractValidator{T}.RuleFor"/> on the <c>Request</c> property
 /// with <c>SetValidator</c>.
 /// <para>
+/// <b>Every</b> registered validator for the request type runs, not just the first one, which is the
+/// same policy the command and query decorators apply to <c>IValidator&lt;TCommand&gt;</c>: a module
+/// that authors a validator beside a framework-supplied one expects both sets of rules enforced, and
+/// honoring only the first registration would turn the others into dead code whose rules are silently
+/// unenforced. FluentValidation unions the failures of the rules placed on one property.
+/// </para>
+/// <para>
+/// Registrations are de-duplicated by runtime type, so a validator class registered twice (a module
+/// assembly scanned twice, say) reports each of its failures once rather than in duplicate.
+/// </para>
+/// <para>
 /// This validator is registered automatically by
 /// <see cref="DependencyInjection.ScanModuleApplicationServices{TAssemblyMarker}"/> using
-/// <c>TryAdd</c> semantics — explicit command validators take precedence.
+/// <c>TryAdd</c> semantics: explicit command validators take precedence.
 /// </para>
 /// </summary>
 /// <typeparam name="TCommand">The command type that embeds the request.</typeparam>
@@ -21,8 +32,11 @@ public sealed class CommandRequestValidator<TCommand, TRequest> : AbstractValida
 {
     public CommandRequestValidator(IEnumerable<IValidator<TRequest>> requestValidators)
     {
-        var validator = requestValidators.FirstOrDefault();
-        if (validator is not null)
+        ArgumentNullException.ThrowIfNull(requestValidators);
+
+        foreach (var validator in requestValidators.DistinctBy(v => v.GetType()))
+        {
             RuleFor(c => c.Request).SetValidator(validator);
+        }
     }
 }

--- a/Source/Core/MMCA.Common.Infrastructure/Persistence/Auth/EFRefreshSessionStore.cs
+++ b/Source/Core/MMCA.Common.Infrastructure/Persistence/Auth/EFRefreshSessionStore.cs
@@ -87,6 +87,69 @@ internal sealed class EFRefreshSessionStore(
     public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
         dbContextFactory.SaveChangesAsync(cancellationToken);
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// The claim is a conditional UPDATE (<c>WHERE Id = @id AND RevokedAt IS NULL</c>) rather than a
+    /// tracked mutation, because the tracked read that produced <paramref name="presented"/> is a
+    /// check-then-act: two concurrent refreshes of the SAME token each get their own copy with
+    /// <c>RevokedAt</c> null and both would save. The row itself carries no concurrency token by
+    /// design (<see cref="RefreshSession"/>), so the database arbitrates through the predicate: the
+    /// winner affects one row, the loser affects none and writes nothing.
+    /// </para>
+    /// <para>
+    /// The UPDATE and the successor INSERT share one transaction so a loser cannot observe a
+    /// half-finished rotation: its UPDATE blocks on the winner's row lock, re-evaluates the
+    /// predicate after the winner commits, and the family revocation it then performs sees the
+    /// committed successor. A nested call joins the ambient transaction, so an
+    /// <c>ITransactional</c> caller is unaffected.
+    /// </para>
+    /// </remarks>
+    public Task<bool> TryRotateAsync(
+        RefreshSession presented,
+        RefreshSession successor,
+        DateTime revokedAt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(presented);
+        ArgumentNullException.ThrowIfNull(successor);
+
+        // Resolved BEFORE the transaction opens so this session's context is one of the contexts
+        // BeginTransaction enlists, rather than a late arrival.
+        var entry = Context.Entry(presented);
+
+        return dbContextFactory.ExecuteInTransactionAsync(
+            async ct =>
+            {
+                var claimed = await Sessions
+                    .Where(s => s.Id == presented.Id && s.RevokedAt == null)
+                    .ExecuteUpdateAsync(
+                        set => set
+                            .SetProperty(s => s.RevokedAt, revokedAt)
+                            .SetProperty(s => s.ReasonRevoked, RefreshSession.ReasonRotated)
+                            .SetProperty(s => s.ReplacedByTokenHash, successor.TokenHash),
+                        ct)
+                    .ConfigureAwait(false) == 1;
+
+                if (!claimed)
+                {
+                    return false;
+                }
+
+                // Mirror the claim onto the tracked instance so callers see a revoked session, then
+                // accept those values as original: without it the next SaveChanges would re-issue
+                // the same UPDATE as a tracked modification.
+                presented.Revoke(revokedAt, RefreshSession.ReasonRotated, successor.TokenHash);
+                entry.OriginalValues.SetValues(entry.CurrentValues);
+
+                await Sessions.AddAsync(successor, ct).ConfigureAwait(false);
+                await dbContextFactory.SaveChangesAsync(ct).ConfigureAwait(false);
+
+                return true;
+            },
+            cancellationToken);
+    }
+
     // The configured NAME is used verbatim, as it always was; only the engine goes through the
     // resolver, so a host that configures no SQL Server connection string gets the engine it does
     // configure rather than a context over an empty connection string.

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Modules.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/ArchitectureRules.Modules.cs
@@ -28,6 +28,35 @@ public static partial class ArchitectureRules
         ModuleLayerIsolated(map, Layer.Application, Layer.Infrastructure,
             "use Shared contracts, not another module's Infrastructure");
 
+    /// <summary>
+    /// The complete internal-layer cross product: every module's Domain, Application, Infrastructure
+    /// and Api against every OTHER module's Domain, Application, Infrastructure and Api.
+    /// <para>
+    /// The six named rules above cover the pairs worth their own failure message; this covers the
+    /// rest, which nothing checked before. A per-module layer rule
+    /// (<c>DomainDoesNotDependOnApplication</c> and friends) only forbids the SAME module's higher
+    /// layers, and the compile-time layer guard only knows about <c>MMCA.Common.*</c> references, so
+    /// a <c>Sales.Domain -> Catalog.Application</c> project reference passed every gate while
+    /// compile-coupling two modules that ADR-007/008 promise can be extracted separately.
+    /// </para>
+    /// <para>
+    /// <see cref="Layer.Ui"/> is deliberately NOT in the product: a module's UI composing another
+    /// module's UI is a real, intended arrangement in the shipped apps.
+    /// </para>
+    /// </summary>
+    public static void ModuleInternalLayersAreIsolated(IArchitectureMap map)
+    {
+        Layer[] internalLayers = [Layer.Domain, Layer.Application, Layer.Infrastructure, Layer.Api];
+        foreach (var from in internalLayers)
+        {
+            foreach (var to in internalLayers)
+            {
+                ModuleLayerIsolated(map, from, to,
+                    "a module reaches another module only through its Shared contracts");
+            }
+        }
+    }
+
     // ── Shared (contract) layer isolation: a module's Shared is contracts-only. ──
     public static void ModuleSharedDoesNotDependOnOwnInternalLayers(IArchitectureMap map)
     {

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ModuleIsolationTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/Bases/ModuleIsolationTestsBase.cs
@@ -26,4 +26,12 @@ public abstract class ModuleIsolationTestsBase
 
     [Fact]
     public void ModuleApplications_ShouldNotReach_OtherModuleInfrastructures() => ArchitectureRules.ModuleApplicationsDoNotReachOtherInfrastructures(Map);
+
+    /// <summary>
+    /// Closes the coverage the six rules above leave open: every remaining internal-layer pair across
+    /// modules (Domain to another Application or Api, Application to another Domain or Api,
+    /// Infrastructure and Api to anything but their own module). UI is excluded on purpose.
+    /// </summary>
+    [Fact]
+    public void ModuleInternalLayers_ShouldNotReach_OtherModuleInternalLayers() => ArchitectureRules.ModuleInternalLayersAreIsolated(Map);
 }

--- a/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.Architecture/PublicAPI.Unshipped.txt
@@ -88,3 +88,6 @@ virtual MMCA.Common.Testing.Architecture.ErrorCatalogTestsBase.AllowedSharedCode
 virtual MMCA.Common.Testing.Architecture.ErrorCatalogTestsBase.IsCodePrefixAllowed(string! code) -> bool
 virtual MMCA.Common.Testing.Architecture.ErrorCatalogTestsBase.MinimumErrorCodes.get -> int
 virtual MMCA.Common.Testing.Architecture.SoftDeleteEnforcementTestsBase.AllowedHardDeleteTypes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+
+static MMCA.Common.Testing.Architecture.ArchitectureRules.ModuleInternalLayersAreIsolated(MMCA.Common.Testing.Architecture.IArchitectureMap! map) -> void
+MMCA.Common.Testing.Architecture.ModuleIsolationTestsBase.ModuleInternalLayers_ShouldNotReach_OtherModuleInternalLayers() -> void

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/AuthOutcomeRules.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/AuthOutcomeRules.cs
@@ -1,0 +1,47 @@
+namespace MMCA.Common.Testing.E2E.Infrastructure;
+
+/// <summary>What the three post-submit signals add up to.</summary>
+internal enum AuthOutcome
+{
+    /// <summary>The submit was accepted: the page navigated away, or a signed-in state is showing.</summary>
+    Succeeded,
+
+    /// <summary>The auth page is still showing, with an error alert on it.</summary>
+    ErrorShown,
+
+    /// <summary>None of the three signals fired. Neither success nor a reported failure.</summary>
+    Silent,
+}
+
+/// <summary>
+/// The decision behind <c>E2ETestBase.WaitForAuthResultAsync</c>, pulled out as a pure function so
+/// the four-way classification is directly testable without a browser.
+/// <para>
+/// The case that matters is <see cref="AuthOutcome.Silent"/>. A submit that fails with NEITHER a
+/// navigation NOR a rendered error alert (a 500 that renders nothing, a dropped request, a JS
+/// exception mid-submit) used to leave the wait returning normally, and the caller's follow-up
+/// interactivity wait was already satisfied by the still-rendered auth page. Login and registration
+/// then reported success on a sign-in that never happened, and the real failure surfaced much later
+/// as an unrelated assertion.
+/// </para>
+/// </summary>
+internal static class AuthOutcomeRules
+{
+    /// <summary>
+    /// Classifies the three signals. Navigation away from the auth page wins outright: a forceLoad
+    /// that already happened is unambiguous, and an error alert flashed on the way out is not a
+    /// failure. A visible logout button is the same verdict reached through interactivity instead.
+    /// </summary>
+    /// <param name="navigatedAway">The URL no longer points at the auth page.</param>
+    /// <param name="errorAlertVisible">An error alert is showing.</param>
+    /// <param name="logoutVisible">The signed-in state's logout control is showing.</param>
+    public static AuthOutcome Classify(bool navigatedAway, bool errorAlertVisible, bool logoutVisible)
+    {
+        if (navigatedAway || logoutVisible)
+        {
+            return AuthOutcome.Succeeded;
+        }
+
+        return errorAlertVisible ? AuthOutcome.ErrorShown : AuthOutcome.Silent;
+    }
+}

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/E2ETestBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Infrastructure/E2ETestBase.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Playwright;
 using Xunit;
 using static Microsoft.Playwright.Assertions;
@@ -219,21 +220,61 @@ public abstract class E2ETestBase : IAsyncLifetime
             url => !url.Contains(authPagePath, StringComparison.OrdinalIgnoreCase),
             new() { Timeout = E2ETestConfiguration.AuthTimeout });
 
-        await Task.WhenAny(
-            leftAuthPage,
-            logoutButton.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = E2ETestConfiguration.AuthTimeout }),
-            errorAlert.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = E2ETestConfiguration.AuthTimeout })).ConfigureAwait(false);
+        var logoutVisible = logoutButton.WaitForAsync(
+            new() { State = WaitForSelectorState.Visible, Timeout = E2ETestConfiguration.AuthTimeout });
+        var errorVisible = errorAlert.WaitForAsync(
+            new() { State = WaitForSelectorState.Visible, Timeout = E2ETestConfiguration.AuthTimeout });
 
-        // Success is unambiguous once the forceLoad has navigated away from the auth page. Only treat an
-        // error alert STILL on the auth page (after the grace window, with no navigation) as a failure.
-        if (await errorAlert.IsVisibleAsync().ConfigureAwait(false)
-            && Page.Url.Contains(authPagePath, StringComparison.OrdinalIgnoreCase)
-            && !await AuthSucceededWithinGraceAsync(authPagePath, logoutButton).ConfigureAwait(false))
+        await Task.WhenAny(leftAuthPage, logoutVisible, errorVisible).ConfigureAwait(false);
+
+        // The losers time out and fault; nothing awaits them, so observe their exceptions here rather
+        // than letting them surface as unobserved-task failures in an unrelated test.
+        Observe(leftAuthPage);
+        Observe(logoutVisible);
+        Observe(errorVisible);
+
+        var outcome = AuthOutcomeRules.Classify(
+            navigatedAway: !Page.Url.Contains(authPagePath, StringComparison.OrdinalIgnoreCase),
+            errorAlertVisible: await errorAlert.IsVisibleAsync().ConfigureAwait(false),
+            logoutVisible: await logoutButton.IsVisibleAsync().ConfigureAwait(false));
+
+        if (outcome == AuthOutcome.Succeeded)
+        {
+            return;
+        }
+
+        // Both remaining outcomes get the grace window once: a slow Server-mode success can flash an
+        // error alert on its way out, and can also still be finishing when all three waits time out.
+        if (await AuthSucceededWithinGraceAsync(authPagePath, logoutButton).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        if (outcome == AuthOutcome.ErrorShown)
         {
             var errorText = await errorAlert.TextContentAsync().ConfigureAwait(false);
             throw new InvalidOperationException($"{operation} failed: {errorText}");
         }
+
+        // Silent: all three waits timed out and the grace window added nothing. The auth page is
+        // still showing with nothing rendered to say why, so the submit was never accepted. Returning
+        // here is what used to let a broken login report success (the caller's interactivity wait is
+        // already satisfied by the still-rendered auth page), so fail with the diagnostics instead.
+        var budget = (E2ETestConfiguration.AuthTimeout + E2ETestConfiguration.AuthGraceTimeout)
+            .ToString(CultureInfo.InvariantCulture);
+        throw new InvalidOperationException(
+            $"{operation} produced neither a navigation away from {authPagePath}, a signed-in state, "
+            + $"nor an error alert within {budget} ms (url: {Page.Url}).");
     }
+
+    // The two losing waits of the three-way race always fault on timeout. Observing them keeps a
+    // finalized faulted Task from raising TaskScheduler.UnobservedTaskException later.
+    private static void Observe(Task task) =>
+        _ = task.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     // Within the grace window, treats EITHER the forceLoad navigating away from the auth page OR the
     // interactive logout button appearing as success — so a transient error-alert flash during a slow

--- a/Source/Hosting/MMCA.Common.Testing.E2E/MMCA.Common.Testing.E2E.csproj
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/MMCA.Common.Testing.E2E.csproj
@@ -7,6 +7,12 @@
     <NoWarn>$(NoWarn);SA1600;SA1601;SA1602;SA1611;SA1615;SA1618;SA1623;SA1629;SA1642;SA1649;CA1054;CA1056;MA0009;MA0110;SYSLIB1045</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Lets the ui-e2e tier cover AuthOutcomeRules directly: the four-way auth classification is a
+         pure function, and asserting it needs no browser. -->
+    <InternalsVisibleTo Include="MMCA.Common.UI.E2E.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
     <!-- Explicit pin of the transitive Deque.AxeCore.Commons (deterministic restore — see Directory.Packages.props). -->
     <PackageReference Include="Deque.AxeCore.Commons" />

--- a/Source/Hosting/MMCA.Common.Testing/FeatureManagementTestExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Testing/FeatureManagementTestExtensions.cs
@@ -15,13 +15,40 @@ public static class FeatureManagementTestExtensions
         /// Adds feature management with the specified feature flags configured via in-memory settings.
         /// Call this in <c>ConfigureServices</c> of a test <c>WebApplicationFactory</c> to override
         /// feature flag values from <c>appsettings.json</c>.
+        /// <para>
+        /// The flags are LAYERED on top of the <see cref="IConfiguration"/> the host already
+        /// registered, and the resulting root is registered in its place, so everything else the host
+        /// configured (connection strings, authentication settings, the data-source section) still
+        /// resolves. .NET DI hands a non-collection dependency the LAST registration, so building a
+        /// flags-only root here would silently give every component constructed afterwards a
+        /// configuration with nothing but <c>FeatureManagement</c> in it.
+        /// </para>
+        /// <para>
+        /// The host's configuration is picked up only when it was registered as an instance, which is
+        /// how <c>WebApplicationFactory</c> and the framework's own hosts register it. Behind a
+        /// factory registration there is nothing to read without building the provider, so the flags
+        /// stand alone, exactly as they did before.
+        /// </para>
         /// </summary>
         /// <param name="features">A dictionary of feature flag names to their enabled/disabled state.</param>
         /// <returns>The service collection for chaining.</returns>
         public IServiceCollection ConfigureTestFeatureFlags(
             Dictionary<string, bool> features)
         {
-            var config = new ConfigurationBuilder()
+            ArgumentNullException.ThrowIfNull(features);
+
+            var existing = services
+                .LastOrDefault(d => d.ServiceType == typeof(IConfiguration))?
+                .ImplementationInstance as IConfiguration;
+
+            var builder = new ConfigurationBuilder();
+            if (existing is not null)
+            {
+                builder.AddConfiguration(existing);
+            }
+
+            // Added last, so these keys win over any FeatureManagement section the host configured.
+            var config = builder
                 .AddInMemoryCollection(
                     features.Select(kvp =>
                         new KeyValuePair<string, string?>(

--- a/Source/Presentation/MMCA.Common.API/Authorization/OwnerOrAdminFilter.cs
+++ b/Source/Presentation/MMCA.Common.API/Authorization/OwnerOrAdminFilter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Options;
@@ -85,18 +86,22 @@ public sealed class OwnerOrAdminFilter(
 
     // The owner identifier can arrive as a route value (/customers/{id}) or as a model-bound
     // query/body argument (/bookmarks?userId=42); check the route first, then the bound arguments.
+    //
+    // Both parses are invariant, which is the convention every machine-data parse in the framework
+    // follows: an owner id off the wire is not a number the request's ambient culture formatted, so
+    // the host's CurrentCulture must not decide which strings are ids.
     private static bool TryGetOwnerParameter(ActionExecutingContext context, string parameterName, out int value)
     {
         if (context.RouteData.Values.TryGetValue(parameterName, out var routeValue)
             && routeValue is not null
-            && int.TryParse(routeValue.ToString(), out value))
+            && int.TryParse(routeValue.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
         {
             return true;
         }
 
         if (context.ActionArguments.TryGetValue(parameterName, out var argumentValue)
             && argumentValue is not null
-            && int.TryParse(argumentValue.ToString(), out value))
+            && int.TryParse(argumentValue.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
         {
             return true;
         }

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsPushDeviceTokenProvider.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsPushDeviceTokenProvider.cs
@@ -53,6 +53,9 @@ public sealed partial class ApnsPushDeviceTokenProvider(
                     UNAuthorizationOptions.Alert | UNAuthorizationOptions.Badge | UNAuthorizationOptions.Sound)
                 .ConfigureAwait(false);
 
+            // Taken BEFORE RegisterForRemoteNotifications: the bridge re-arms its rendezvous on each
+            // published callback, so this is the handle for the attempt started on the next line
+            // rather than a previous attempt's already-decided outcome.
             var wait = ApnsTokenBridge.WaitForTokenAsync();
             await MainThread.InvokeOnMainThreadAsync(static () =>
                 UIApplication.SharedApplication.RegisterForRemoteNotifications()).ConfigureAwait(false);

--- a/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsTokenBridge.cs
+++ b/Source/Presentation/MMCA.Common.UI.Maui/Capabilities/ApnsTokenBridge.cs
@@ -22,14 +22,21 @@ namespace MMCA.Common.UI.Maui.Capabilities;
 /// </summary>
 public static class ApnsTokenBridge
 {
-    private static readonly TaskCompletionSource<string?> Pending =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static TaskCompletionSource<string?> _pending = NewPending();
 
     /// <summary>The most recent APNs token (lowercase hex), or null when none was issued.</summary>
     public static string? CurrentToken { get; private set; }
 
-    /// <summary>Completes when the first registration attempt reports success or failure.</summary>
-    public static Task<string?> WaitForTokenAsync() => Pending.Task;
+    /// <summary>
+    /// Completes when the NEXT registration callback reports success or failure.
+    /// <para>
+    /// The rendezvous is re-armed per attempt on purpose. A single one-shot source completed by a
+    /// failed first registration would hand every later caller that same decided outcome instantly,
+    /// so a retry would report failure without ever waiting for the registration it just started.
+    /// Call this BEFORE asking UIKit to register, so the attempt's own callback is the one awaited.
+    /// </para>
+    /// </summary>
+    public static Task<string?> WaitForTokenAsync() => Volatile.Read(ref _pending).Task;
 
     /// <summary>Publishes a callback outcome; null means registration failed.</summary>
     /// <param name="hexToken">The lowercase-hex device token, or null on failure.</param>
@@ -40,7 +47,13 @@ public static class ApnsTokenBridge
             CurrentToken = hexToken;
         }
 
-        Pending.TrySetResult(hexToken);
+        // Re-arm BEFORE completing: a waiter arriving between the two lines gets the next attempt's
+        // rendezvous rather than this one's already-decided outcome.
+        var completed = Interlocked.Exchange(ref _pending, NewPending());
+        completed.TrySetResult(hexToken);
     }
+
+    private static TaskCompletionSource<string?> NewPending() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 }
 #endif

--- a/Source/Presentation/MMCA.Common.UI/Common/LatestLoadGuard.cs
+++ b/Source/Presentation/MMCA.Common.UI/Common/LatestLoadGuard.cs
@@ -1,0 +1,92 @@
+namespace MMCA.Common.UI.Common;
+
+/// <summary>
+/// Keeps a routed page showing the load it asked for last.
+/// <para>
+/// Blazor reuses a routed component instance across route-parameter changes, so a page that opens
+/// entity 100 (slow response), then navigates to entity 101 (fast response), gets 100's late answer
+/// after 101 has already rendered. Assigning it unconditionally leaves the URL on 101 while the page
+/// holds 100, and any action bound to the loaded entity then fires against the wrong one.
+/// </para>
+/// <para>
+/// This guard gives each load a generation and a cancellation token, cancelling the previous load as
+/// the new one starts. Use it as a field on the page, disposed with the component:
+/// </para>
+/// <code>
+/// private readonly LatestLoadGuard _load = new();
+///
+/// protected override async Task OnParametersSetAsync()
+/// {
+///     var (token, generation) = _load.Begin();
+///     var result = await Service.GetByIdAsync(Id, token);
+///     if (!_load.IsCurrent(generation))
+///     {
+///         return;
+///     }
+///
+///     Order = result;
+/// }
+///
+/// public void Dispose() => _load.Dispose();
+/// </code>
+/// <para>
+/// <b>Not thread-safe by contract.</b> It is built for the renderer's synchronization context, where
+/// component lifecycle methods and event callbacks are already serialized; do not share one instance
+/// across threads.
+/// </para>
+/// </summary>
+public sealed class LatestLoadGuard : IDisposable
+{
+    private CancellationTokenSource? _cts;
+    private int _generation;
+    private bool _disposed;
+
+    /// <summary>
+    /// Starts a new load: cancels and disposes the previous one, then hands back the token to pass
+    /// to the fetch and the generation to check against once it returns.
+    /// </summary>
+    /// <returns>The new load's cancellation token and its generation.</returns>
+    /// <exception cref="ObjectDisposedException">The guard has been disposed.</exception>
+    public (CancellationToken Token, int Generation) Begin()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        CancelAndDisposeCurrent();
+        _cts = new CancellationTokenSource();
+        _generation++;
+
+        return (_cts.Token, _generation);
+    }
+
+    /// <summary>
+    /// Reports whether <paramref name="generation"/> is still the latest load, i.e. whether its
+    /// result may be assigned to the page.
+    /// </summary>
+    /// <param name="generation">The generation returned by the matching <see cref="Begin"/> call.</param>
+    /// <returns><see langword="false"/> once a newer <see cref="Begin"/> has run, or after disposal.</returns>
+    public bool IsCurrent(int generation) => !_disposed && generation == _generation;
+
+    /// <summary>Cancels the in-flight load and releases the guard.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        CancelAndDisposeCurrent();
+    }
+
+    private void CancelAndDisposeCurrent()
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+
+        _cts.Cancel();
+        _cts.Dispose();
+        _cts = null;
+    }
+}

--- a/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/ApiFileDownloadButton.razor.cs
@@ -18,7 +18,13 @@ public partial class ApiFileDownloadButton
     [EditorRequired]
     public string RelativeApiPath { get; set; } = string.Empty;
 
-    /// <summary>File name for the staged temp file on native heads, e.g. <c>session-42.ics</c>.</summary>
+    /// <summary>
+    /// File name for the staged temp file on native heads, e.g. <c>session-42.ics</c>.
+    /// <para>
+    /// Directory segments and rooted paths are stripped to the file name before staging, so a value
+    /// built from entity data cannot steer the write out of the temp directory.
+    /// </para>
+    /// </summary>
     [Parameter]
     [EditorRequired]
     public string FileName { get; set; } = string.Empty;
@@ -101,21 +107,18 @@ public partial class ApiFileDownloadButton
         _isExporting = true;
         try
         {
+            // Sanitized BEFORE the fetch: a name that cannot be staged must not cost a download.
+            var safeName = ResolveStagedFileName(FileName);
+            if (safeName is null)
+            {
+                Toast.Warning(FailureMessage ?? L["Snackbar.DownloadFailed"].Value);
+                return;
+            }
+
             using var client = HttpClientFactory.CreateClient(HttpClientName);
             var bytes = await client.GetByteArrayAsync(new Uri(RelativeApiPath, UriKind.Relative));
 
-            var filePath = Path.Combine(Path.GetTempPath(), FileName);
-
-            // The staged file is not deleted after the share: on Android the share intent returns
-            // as soon as it launches, so deleting here would race the receiving app reading it.
-            // The path is per-entity, so a stale copy from a previous tap is simply replaced.
-            // Clearing it first keeps a truncated or half-written leftover from being shared.
-            if (File.Exists(filePath))
-            {
-                File.Delete(filePath);
-            }
-
-            await File.WriteAllBytesAsync(filePath, bytes);
+            var filePath = await StageFileAsync(safeName, bytes);
 
             if (!await Share.ShareFileAsync(ShareTitle, filePath, ContentType))
             {
@@ -143,5 +146,48 @@ public partial class ApiFileDownloadButton
         {
             _isExporting = false;
         }
+    }
+
+    /// <summary>
+    /// Reduces <paramref name="fileName"/> to a bare file name, or returns null when nothing usable
+    /// is left.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Path.Combine(string, string)"/> discards the temp root outright when its second
+    /// argument is rooted, and <c>..</c> segments walk out of it, so a name built from entity data
+    /// would otherwise decide where the staging delete and write land on the native head's
+    /// filesystem. <see cref="Path.GetFileName(string)"/> strips separators and directory segments;
+    /// the two relative-directory names it leaves intact are rejected here.
+    /// </remarks>
+    private static string? ResolveStagedFileName(string? fileName)
+    {
+        var safeName = Path.GetFileName(fileName?.Trim() ?? string.Empty);
+
+        return string.IsNullOrEmpty(safeName)
+            || string.Equals(safeName, ".", StringComparison.Ordinal)
+            || string.Equals(safeName, "..", StringComparison.Ordinal)
+                ? null
+                : safeName;
+    }
+
+    /// <summary>Writes the payload into the temp directory under an already-sanitized name.</summary>
+    /// <remarks>
+    /// The staged file is not deleted after the share: on Android the share intent returns as soon
+    /// as it launches, so deleting here would race the receiving app reading it. The path is
+    /// per-entity, so a stale copy from a previous tap is simply replaced; clearing it first keeps a
+    /// truncated or half-written leftover from being shared.
+    /// </remarks>
+    private static async Task<string> StageFileAsync(string safeName, byte[] bytes)
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), safeName);
+
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+
+        await File.WriteAllBytesAsync(filePath, bytes);
+
+        return filePath;
     }
 }

--- a/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationBell.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Components/Notifications/NotificationBell.razor.cs
@@ -78,6 +78,15 @@ public partial class NotificationBell : IDisposable
         // The first read is unconditional: nothing has established the count yet.
         await RefreshUnreadCountAsync();
 
+        // Re-check after the await: Dispose may have run while that read was in flight, and it has
+        // already disposed the (then null) timer and the token source. Starting the loop now would
+        // leak a PeriodicTimer nothing disposes and fault the discarded task on a disposed _cts. The
+        // slot was released by Dispose through UnregisterPoller, so there is nothing else to undo.
+        if (_disposed)
+        {
+            return;
+        }
+
         // The TimeProvider overload rather than the ambient system clock, so a test drives the loop
         // deterministically instead of waiting out a real interval.
         _pollTimer = new PeriodicTimer(Options.Value.PollInterval, Clock);
@@ -123,6 +132,11 @@ public partial class NotificationBell : IDisposable
         catch (OperationCanceledException)
         {
             // Expected on disposal
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed between the timer creation and the first wait: reading _cts.Token throws
+            // rather than cancelling. Nothing to observe, and this task is discarded.
         }
     }
 

--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
@@ -101,7 +101,10 @@
             }
         }
 
-        @if (_adminItems.Count > 0)
+        @* Authentication is checked here as well as per item: NavItem.RequiredRole defaults to null,
+           so a module that registers a Section.Admin item without one would otherwise disclose the
+           admin feature's existence and URL to anonymous visitors. *@
+        @if (_adminItems.Count > 0 && _user?.Identity?.IsAuthenticated == true)
         {
             <div class="nav-section-label" role="heading" aria-level="2">@L["Nav.Administration"]</div>
             @foreach (var group in _adminItems.GroupBy(i => i.Group))

--- a/Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs
@@ -751,7 +751,12 @@ public abstract class DataGridListPageBase<TDto> : ComponentBase, IBrowserViewpo
 
             MobileItems = page.Items;
             MobileTotalItems = page.TotalItems;
-            SaveCurrentState(0, MobilePageSize, _savedSortColumn, _savedSortDescending);
+
+            // Page size 0, like the virtualized path above: the restore guards skip a saved size of
+            // 0, and MobilePageSize is never restored from state anyway. Persisting it would only
+            // overwrite the desktop grid's RowsPerPage, so a user who set 50 rows and then narrowed
+            // the viewport would come back to 10.
+            SaveCurrentState(0, 0, _savedSortColumn, _savedSortDescending);
         }
         catch (OperationCanceledException)
         {

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -74,6 +74,11 @@ MMCA.Common.UI.Common.Interfaces.ToastSeverity.Info = 1 -> MMCA.Common.UI.Common
 MMCA.Common.UI.Common.Interfaces.ToastSeverity.Normal = 0 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
 MMCA.Common.UI.Common.Interfaces.ToastSeverity.Success = 2 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
 MMCA.Common.UI.Common.Interfaces.ToastSeverity.Warning = 3 -> MMCA.Common.UI.Common.Interfaces.ToastSeverity
+MMCA.Common.UI.Common.LatestLoadGuard
+MMCA.Common.UI.Common.LatestLoadGuard.Begin() -> (System.Threading.CancellationToken Token, int Generation)
+MMCA.Common.UI.Common.LatestLoadGuard.Dispose() -> void
+MMCA.Common.UI.Common.LatestLoadGuard.IsCurrent(int generation) -> bool
+MMCA.Common.UI.Common.LatestLoadGuard.LatestLoadGuard() -> void
 MMCA.Common.UI.Common.NavItem.Deconstruct(out string! Title, out string! Href, out string! Icon, out System.Type! TitleResource, out string? RequiredRole, out string? RequiredClaim, out MMCA.Common.UI.Common.NavSection Section, out string? Group) -> void
 MMCA.Common.UI.Common.NavItem.NavItem(string! Title, string! Href, string! Icon, System.Type! TitleResource, string? RequiredRole = null, string? RequiredClaim = null, MMCA.Common.UI.Common.NavSection Section = MMCA.Common.UI.Common.NavSection.General, string? Group = null) -> void
 MMCA.Common.UI.Common.NavItem.TitleResource.get -> System.Type!

--- a/Source/Presentation/MMCA.Common.UI/Services/AuthenticatedServiceBase.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/AuthenticatedServiceBase.cs
@@ -16,21 +16,13 @@ public abstract class AuthenticatedServiceBase(
     IHttpClientFactory httpClientFactory,
     ITokenStorageService tokenStorageService)
 {
-#pragma warning disable S2245, CA5394 // Random only spaces retry attempts apart (jitter); it feeds no security, token, key or cryptographic decision, so a pseudorandom generator is the correct tool here.
-
     /// <summary>
     /// Polly retry policy: 3 retries on <see cref="HttpRequestException"/> or a retryable response
     /// status (see <c>IsRetryableResponse</c>), with exponential backoff (2s, 4s, 8s) plus up to
     /// one second of random jitter so a fleet of clients does not re-converge on the same instant.
+    /// Every retried response is disposed; the caller owns the final one.
     /// </summary>
-    protected static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy = Policy
-        .Handle<HttpRequestException>()
-        .OrResult<HttpResponseMessage>(IsRetryableResponse)
-        .WaitAndRetryAsync(
-            3,
-            attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt))
-                + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000)));
-#pragma warning restore S2245
+    protected static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy = BuildRetryPolicy(DefaultBackoff);
 
     private const string ApiClientName = "APIClient";
 
@@ -115,4 +107,29 @@ public abstract class AuthenticatedServiceBase(
         return (int)response.StatusCode >= 500
             || response.StatusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests;
     }
+
+#pragma warning disable S2245, CA5394 // Random only spaces retry attempts apart (jitter); it feeds no security, token, key or cryptographic decision, so a pseudorandom generator is the correct tool here.
+
+    /// <summary>The shipped backoff: 2s, 4s, 8s plus up to one second of jitter.</summary>
+    private static TimeSpan DefaultBackoff(int attempt) =>
+        TimeSpan.FromSeconds(Math.Pow(2, attempt))
+            + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000));
+#pragma warning restore S2245, CA5394
+
+    /// <summary>
+    /// Builds the retry policy. Internal and backoff-injectable so a test can exercise the disposal
+    /// contract below without waiting out the real delays.
+    /// </summary>
+    /// <remarks>
+    /// <c>onRetry</c> disposes the retried attempt's response. Polly hands the caller only the FINAL
+    /// outcome, so without this every intermediate 5xx/408/429 response leaks its content buffer and
+    /// keeps its connection out of the handler pool until finalization: exactly under the sustained
+    /// backend failure the retries exist to survive. A retried <see cref="HttpRequestException"/>
+    /// carries no result, hence the null-conditional. The final response is NOT disposed here, since
+    /// the caller owns it.
+    /// </remarks>
+    internal static AsyncRetryPolicy<HttpResponseMessage> BuildRetryPolicy(Func<int, TimeSpan> backoff) => Policy
+        .Handle<HttpRequestException>()
+        .OrResult<HttpResponseMessage>(IsRetryableResponse)
+        .WaitAndRetryAsync(3, backoff, onRetry: (outcome, _) => outcome.Result?.Dispose());
 }

--- a/Source/Presentation/MMCA.Common.UI/Services/Capabilities/DeepLinkDispatcher.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Capabilities/DeepLinkDispatcher.cs
@@ -3,7 +3,7 @@ namespace MMCA.Common.UI.Services.Capabilities;
 /// <summary>
 /// Default <see cref="IDeepLinkDispatcher"/>: raises <see cref="RouteRequested"/> when a
 /// listener is attached, otherwise buffers the most recent route (capacity one) so a
-/// cold-start tap survives until the Blazor router renders. Registered as a singleton —
+/// cold-start tap survives until the Blazor router renders. Registered as a singleton:
 /// native callers resolve it from the MAUI root service provider.
 /// </summary>
 public sealed class DeepLinkDispatcher : IDeepLinkDispatcher
@@ -19,17 +19,28 @@ public sealed class DeepLinkDispatcher : IDeepLinkDispatcher
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(route);
 
-        var handler = RouteRequested;
-        if (handler is null)
+        // Read the handler INSIDE the lock: the decision (raise now, or buffer for the listener that
+        // has not attached yet) and the buffer write have to be one step. Reading it outside allowed
+        // this interleaving, which drops the route: Publish sees no handler, the listener subscribes,
+        // the listener drains an empty buffer, then Publish writes into a buffer nobody will read
+        // again. That is the warm-boot deep link on a native head, where the callback thread and the
+        // first render are genuinely concurrent.
+        //
+        // Under the lock the two orders are the only ones left. If the subscription was visible, the
+        // event fires. If it was not, the buffer write completes before the lock is released, and the
+        // listener's TryConsumePending, which must take the same lock afterwards, finds the route.
+        EventHandler<DeepLinkRouteEventArgs>? handler;
+        lock (_gate)
         {
-            lock (_gate)
+            handler = RouteRequested;
+            if (handler is null)
             {
                 _pendingRoute = route;
+                return;
             }
-
-            return;
         }
 
+        // Invoked outside the lock: a listener that navigates on this callback must not run under it.
         handler.Invoke(this, new DeepLinkRouteEventArgs(route));
     }
 

--- a/Tests/Architecture/MMCA.Common.Architecture.Tests/ModuleIsolationTestsBaseTests.cs
+++ b/Tests/Architecture/MMCA.Common.Architecture.Tests/ModuleIsolationTestsBaseTests.cs
@@ -1,0 +1,112 @@
+using MMCA.Common.Testing.Architecture;
+
+namespace MMCA.Common.Architecture.Tests;
+
+/// <summary>
+/// Coverage of the module-isolation rule set itself. MMCA.Common is module-less, so every rule here
+/// is vacuous against the real map; a stub map is what makes the CROSS-LAYER pairs assertable.
+/// <para>
+/// The gap this pins: the six named rules cover only Domain/Application/Infrastructure/Api against
+/// their OWN layer in another module, plus Domain and Application against another module's
+/// Infrastructure. A module's Domain reaching another module's Application (or Api, or the reverse)
+/// passed every gate, including the per-module layer rules, which forbid only the SAME module's
+/// higher layers, and the compile-time guard, which only knows <c>MMCA.Common.*</c> references.
+/// </para>
+/// </summary>
+public sealed class ModuleIsolationTestsBaseTests
+{
+    // Module "Beta" owns one Domain assembly. That assembly really does depend on
+    // MMCA.Common.Application, and the map declares that namespace as another module's APPLICATION
+    // layer, which is the Domain-to-other-Application pair nothing checked before.
+    private static readonly StubMap CrossLayerViolation = new(
+        fromLayer: Layer.Domain,
+        forbiddenLayer: Layer.Application,
+        forbiddenNamespace: "MMCA.Common.Application",
+        assembly: typeof(Common.Infrastructure.Persistence.DbContexts.ApplicationDbContext).Assembly);
+
+    [Fact]
+    public void ModuleInternalLayersAreIsolated_CatchesADomainReachingAnotherModulesApplication()
+    {
+        var act = () => ArchitectureRules.ModuleInternalLayersAreIsolated(CrossLayerViolation);
+
+        act.Should().Throw<Exception>("the full internal-layer cross product covers Domain to another module's Application");
+    }
+
+    [Fact]
+    public void TheSixNamedRules_DoNotCoverThatPair()
+    {
+        // Documents exactly why the rule above exists: same violation, none of the shipped rules see
+        // it. If one of them ever does, this test says so and the new rule can be re-scoped.
+        var named = new Action[]
+        {
+            () => ArchitectureRules.ModuleDomainsAreIsolated(CrossLayerViolation),
+            () => ArchitectureRules.ModuleApplicationsAreIsolated(CrossLayerViolation),
+            () => ArchitectureRules.ModuleInfrastructuresAreIsolated(CrossLayerViolation),
+            () => ArchitectureRules.ModuleApisAreIsolated(CrossLayerViolation),
+            () => ArchitectureRules.ModuleDomainsDoNotReachOtherInfrastructures(CrossLayerViolation),
+            () => ArchitectureRules.ModuleApplicationsDoNotReachOtherInfrastructures(CrossLayerViolation),
+        };
+
+        foreach (var rule in named)
+        {
+            rule.Should().NotThrow();
+        }
+    }
+
+    [Fact]
+    public void ModuleInternalLayersAreIsolated_IsSatisfiedWhenNothingCrossesAModuleBoundary()
+    {
+        var clean = new StubMap(
+            fromLayer: Layer.Domain,
+            forbiddenLayer: Layer.Application,
+            forbiddenNamespace: "Some.Namespace.Nothing.References",
+            assembly: typeof(Common.Domain.Entities.BaseEntity<>).Assembly);
+
+        var act = () => ArchitectureRules.ModuleInternalLayersAreIsolated(clean);
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// A hand-built map rather than an <see cref="ArchitectureMapBase"/> subclass: the base derives
+    /// every other module's namespaces from the repo token, so it cannot express "one forbidden
+    /// namespace, for one layer only", which is what isolates the pair under test.
+    /// </summary>
+    private sealed class StubMap(
+        Layer fromLayer,
+        Layer forbiddenLayer,
+        string forbiddenNamespace,
+        Assembly assembly) : IArchitectureMap
+    {
+        public string RepoToken => "MMCA.Fixture";
+
+        public IReadOnlyList<string> ModuleNames => ["Beta", "Gamma"];
+
+        public IReadOnlyList<LayerRef> Layers =>
+            [new LayerRef("Beta", fromLayer, assembly, $"{RepoToken}.Beta.{fromLayer}")];
+
+        public IEnumerable<Assembly> OfLayer(Layer layer) =>
+            Layers.Where(l => l.Layer == layer).Select(l => l.Assembly);
+
+        public IEnumerable<Assembly> ModuleDomain() => OfLayer(Layer.Domain);
+
+        public IEnumerable<Assembly> ModuleApplication() => OfLayer(Layer.Application);
+
+        public IEnumerable<Assembly> ModuleShared() => OfLayer(Layer.Shared);
+
+        public IEnumerable<Assembly> Infrastructure() => OfLayer(Layer.Infrastructure);
+
+        public IEnumerable<Assembly> Api() => OfLayer(Layer.Api);
+
+        public Assembly? For(string module, Layer layer) =>
+            Layers.FirstOrDefault(l => l.Layer == layer && string.Equals(l.Module, module, StringComparison.Ordinal))?.Assembly;
+
+        public string ModuleOf(Assembly assembly) =>
+            Layers.FirstOrDefault(l => l.Assembly == assembly)?.Module ?? string.Empty;
+
+        public string RootNamespace(string module, Layer layer) => $"{RepoToken}.{module}.{layer}";
+
+        public string[] OtherModuleNamespaces(string module, Layer layer) =>
+            layer == forbiddenLayer ? [forbiddenNamespace] : [];
+    }
+}

--- a/Tests/Core/MMCA.Common.Application.Tests/Auth/AuthenticationServiceBaseTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Auth/AuthenticationServiceBaseTests.cs
@@ -569,6 +569,52 @@ public sealed class AuthenticationServiceBaseTests
         mocks.Sessions.Saved.Should().OnlyContain(s => s.IsRevoked, "the successor minted by the first call goes too");
     }
 
+    // H35: two requests presenting the same still-live token both read an un-revoked row. The store
+    // arbitrates; the request that loses the claim must not walk away with a second live successor.
+    [Fact]
+    public async Task RefreshTokenAsync_WhenTheRotationLosesTheRace_FailsAndRevokesTheFamily()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = CreateTestUser(id: 1);
+        var presented = SeedSession(mocks, userId: 1, token: "stored-refresh");
+        var otherDevice = SeedSession(mocks, userId: 1, token: "phone-token");
+        var otherUsersSession = SeedSession(mocks, userId: 2, token: "someone-elses");
+        ArrangeRefreshFetch(mocks, user);
+        mocks.Sessions.RotationOutcome = () => false;
+
+        Result<AuthenticationResponse> result = await sut.RefreshTokenAsync(
+            new RefreshTokenRequest("expired", "stored-refresh"));
+
+        result.IsFailure.Should().BeTrue();
+        result.Errors.Should().ContainSingle(e => e.Code == "Auth.InvalidRefreshToken");
+        mocks.Sessions.Saved.Should().NotContain(
+            s => string.Equals(s.TokenHash, RefreshSession.HashToken("refresh-1"), StringComparison.Ordinal),
+            "the loser of the claim mints nothing");
+        presented.IsRevoked.Should().BeTrue();
+        otherDevice.IsRevoked.Should().BeTrue("losing the claim is indistinguishable from a replay (BR-206)");
+        otherDevice.ReasonRevoked.Should().Be(RefreshSession.ReasonReuseDetected);
+        otherUsersSession.IsRevoked.Should().BeFalse("family revocation is scoped to the token's own user");
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_WhenTheRotationWinsTheClaim_StillRotates()
+    {
+        var (sut, mocks) = CreateSut();
+        var user = CreateTestUser(id: 1);
+        var presented = SeedSession(mocks, userId: 1, token: "stored-refresh");
+        ArrangeRefreshFetch(mocks, user);
+        mocks.Sessions.RotationOutcome = () => true;
+
+        Result<AuthenticationResponse> result = await sut.RefreshTokenAsync(
+            new RefreshTokenRequest("expired", "stored-refresh"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RefreshToken.Should().Be("refresh-1");
+        presented.IsRevoked.Should().BeTrue();
+        presented.ReplacedByTokenHash.Should().Be(RefreshSession.HashToken("refresh-1"));
+        mocks.Sessions.Saved.Should().ContainSingle(s => !s.IsRevoked);
+    }
+
     [Fact]
     public async Task RefreshTokenAsync_WhenSessionExpired_FailsWithoutRevokingTheFamily()
     {
@@ -847,6 +893,13 @@ public sealed class FakeRefreshSessionStore : IRefreshSessionStore
     /// <summary>How many times the workflow flushed.</summary>
     public int SaveCount { get; private set; }
 
+    /// <summary>
+    /// When set, decides whether <see cref="TryRotateAsync"/> claims the rotation. A false outcome
+    /// stands in for the database arbitrating a concurrent rotation of the same token: the loser
+    /// writes nothing at all.
+    /// </summary>
+    public Func<bool>? RotationOutcome { get; set; }
+
     /// <summary>Places an already-persisted session in the store.</summary>
     public void Seed(RefreshSession session) => _saved.Add(session);
 
@@ -886,6 +939,29 @@ public sealed class FakeRefreshSessionStore : IRefreshSessionStore
         _saved.AddRange(_staged);
         _staged.Clear();
         return Task.FromResult(written);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryRotateAsync(
+        RefreshSession presented,
+        RefreshSession successor,
+        DateTime revokedAt,
+        CancellationToken cancellationToken = default)
+    {
+        if (RotationOutcome is not null && !RotationOutcome())
+        {
+            return false;
+        }
+
+        if (presented.Revoke(revokedAt, RefreshSession.ReasonRotated, successor.TokenHash).IsFailure)
+        {
+            return false;
+        }
+
+        await AddAsync(successor, cancellationToken);
+        await SaveChangesAsync(cancellationToken);
+
+        return true;
     }
 }
 

--- a/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationHandlerTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Notifications/SendPushNotificationHandlerTests.cs
@@ -1,9 +1,10 @@
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using MMCA.Common.Application.Interfaces.Infrastructure;
 using MMCA.Common.Application.Notifications.PushNotifications.DTOs;
 using MMCA.Common.Application.Notifications.PushNotifications.UseCases.Send;
+using MMCA.Common.Application.UseCases;
 using MMCA.Common.Domain.Notifications.PushNotifications;
 using MMCA.Common.Domain.Notifications.UserNotifications;
 using MMCA.Common.Shared.Abstractions;
@@ -279,6 +280,35 @@ public class SendPushNotificationHandlerTests
 
         result.IsFailure.Should().BeTrue();
         result.Errors.Should().Contain(e => e.Code == "PushNotification.ScopeKey.TooLong");
+    }
+
+    // -- Atomicity (M86) --
+
+    // The handler commits the audit row (carrying DedupKey) before the recipient rows and the sends.
+    // Without one transaction around the whole sequence, a fault in between leaves that row
+    // committed and every retry of the same key short-circuits on it, reporting success for a
+    // notification nobody ever received.
+    [Fact]
+    public void SendPushNotificationCommand_IsTransactional_SoAPartialSendRollsBack() =>
+        typeof(SendPushNotificationCommand).Should().Implement<ITransactional>(
+            "the audit row must roll back with the recipient rows, or a retry with the same DedupKey "
+            + "short-circuits on an undelivered notification forever");
+
+    [Fact]
+    public async Task HandleAsync_WhenTheRecipientSaveThrows_PropagatesInsteadOfReportingSuccess()
+    {
+        var (sut, mocks) = CreateSut();
+
+        // First save (the audit row) commits; the second (the per-recipient rows) faults.
+        mocks.UnitOfWork.SetupSequence(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1)
+            .ThrowsAsync(new InvalidOperationException("recipient rows failed"));
+
+        Func<Task> act = () => sut.HandleAsync(CreateCommand());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("recipient rows failed");
+        VerifyNoSend(mocks);
     }
 
     // -- Helpers --

--- a/Tests/Core/MMCA.Common.Application.Tests/Validation/CommandRequestValidatorTests.cs
+++ b/Tests/Core/MMCA.Common.Application.Tests/Validation/CommandRequestValidatorTests.cs
@@ -48,21 +48,61 @@ public sealed class CommandRequestValidatorTests
             .WithErrorMessage("Name is required");
     }
 
-    // ── Uses only the first registered validator ──
+    // ── Every registered validator runs, not just the first ──
     [Fact]
-    public void Validate_MultipleRequestValidatorsRegistered_UsesFirstValidator()
+    public void Validate_MultipleRequestValidatorsRegistered_RunsEveryValidator()
     {
         IEnumerable<IValidator<TestRequest>> requestValidators =
         [
             new TestRequestValidator(),
-            new PermissiveTestRequestValidator()
+            new SecondTestRequestValidator()
+        ];
+        var sut = new CommandRequestValidator<TestCommandWithRequest, TestRequest>(requestValidators);
+
+        FluentValidation.Results.ValidationResult result = sut.Validate(
+            new TestCommandWithRequest(new TestRequest(string.Empty)));
+
+        result.Errors.Select(e => e.ErrorMessage).Should()
+            .Contain("Name is required").And
+            .Contain(
+                "Name must be on the approved list",
+                "honoring only the first registration turns every other validator's rules into dead code");
+    }
+
+    // ── The same validator class registered twice must not double-report ──
+    [Fact]
+    public void Validate_TheSameValidatorTypeRegisteredTwice_ReportsEachFailureOnce()
+    {
+        IEnumerable<IValidator<TestRequest>> requestValidators =
+        [
+            new TestRequestValidator(),
+            new TestRequestValidator()
+        ];
+        var sut = new CommandRequestValidator<TestCommandWithRequest, TestRequest>(requestValidators);
+
+        FluentValidation.Results.ValidationResult result = sut.Validate(
+            new TestCommandWithRequest(new TestRequest(string.Empty)));
+
+        result.Errors.Should().ContainSingle(
+            "duplicate registrations of one validator class are de-duplicated by runtime type");
+    }
+
+    // ── A permissive validator alongside a strict one still reports the strict failure ──
+    [Fact]
+    public void Validate_APermissiveValidatorRegisteredFirst_StillReportsTheStrictFailure()
+    {
+        IEnumerable<IValidator<TestRequest>> requestValidators =
+        [
+            new PermissiveTestRequestValidator(),
+            new TestRequestValidator()
         ];
         var sut = new CommandRequestValidator<TestCommandWithRequest, TestRequest>(requestValidators);
 
         TestValidationResult<TestCommandWithRequest> result = sut.TestValidate(
             new TestCommandWithRequest(new TestRequest(string.Empty)));
 
-        result.ShouldHaveValidationErrorFor(c => c.Request.Name);
+        result.ShouldHaveValidationErrorFor(c => c.Request.Name)
+            .WithErrorMessage("Name is required");
     }
 }
 
@@ -79,7 +119,15 @@ public sealed class TestRequestValidator : AbstractValidator<TestRequest>
             .WithMessage("Name is required");
 }
 
+public sealed class SecondTestRequestValidator : AbstractValidator<TestRequest>
+{
+    public SecondTestRequestValidator() =>
+        RuleFor(x => x.Name)
+            .Must(name => string.Equals(name, "Approved", StringComparison.Ordinal))
+            .WithMessage("Name must be on the approved list");
+}
+
 public sealed class PermissiveTestRequestValidator : AbstractValidator<TestRequest>
 {
-    // No rules — always passes
+    // No rules: always passes.
 }

--- a/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Auth/EFRefreshSessionStoreRotationTests.cs
+++ b/Tests/Core/MMCA.Common.Infrastructure.Tests/Persistence/Auth/EFRefreshSessionStoreRotationTests.cs
@@ -1,0 +1,173 @@
+using AwesomeAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using MMCA.Common.Application.Auth;
+using MMCA.Common.Application.Interfaces.Infrastructure;
+using MMCA.Common.Domain.Auth;
+using MMCA.Common.Infrastructure.Persistence.DataSources;
+using MMCA.Common.Infrastructure.Persistence.DbContexts;
+using MMCA.Common.Infrastructure.Tests.TestDoubles;
+using Moq;
+using IDbContextFactory = MMCA.Common.Infrastructure.Persistence.DbContexts.Factory.IDbContextFactory;
+using StoreUnderTest = MMCA.Common.Infrastructure.Persistence.Auth.EFRefreshSessionStore;
+
+namespace MMCA.Common.Infrastructure.Tests.Persistence.Auth;
+
+/// <summary>
+/// The rotation claim (H35), asserted against a real SQLite database because the guarantee is the
+/// database's, not the change tracker's: two requests presenting the SAME still-live refresh token
+/// each load their own tracked copy with <c>RevokedAt</c> null, so an in-memory check-then-act lets
+/// both mint a successor and leaves the presented row unable to ever fire reuse detection again.
+/// <para>
+/// Two stores over two contexts sharing ONE open connection are exactly that pair of requests: each
+/// has its own change tracker, and the row they contend for is the same row.
+/// </para>
+/// </summary>
+public sealed class EFRefreshSessionStoreRotationTests
+{
+    private const UserIdentifierType OwnerId = 42;
+
+    private static readonly DateTime Now = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task TryRotateAsync_WhenTheRowIsStillLive_ClaimsItAndPersistsTheSuccessor()
+    {
+        await using var harness = await RotationHarness.CreateAsync();
+        RefreshSession seeded = await harness.SeedAsync("presented");
+        Participant writer = harness.NewParticipant();
+
+        RefreshSession presented = (await writer.Store.FindByTokenHashAsync(seeded.TokenHash, CancellationToken.None))!;
+        RefreshSession successor = NewSession("successor");
+
+        var claimed = await writer.Store.TryRotateAsync(presented, successor, Now, CancellationToken.None);
+
+        claimed.Should().BeTrue();
+        presented.IsRevoked.Should().BeTrue("the tracked instance mirrors the row the claim just wrote");
+        presented.ReasonRevoked.Should().Be(RefreshSession.ReasonRotated);
+        presented.ReplacedByTokenHash.Should().Be(successor.TokenHash);
+        writer.Context.ChangeTracker.HasChanges().Should().BeFalse(
+            "the claim was written by the conditional UPDATE, so the tracked row must not be re-issued as a modification");
+
+        RefreshSession[] rows = await harness.ReadAllAsync();
+        rows.Should().HaveCount(2);
+        rows.Should().ContainSingle(r => r.Id == successor.Id && !r.IsRevoked);
+        rows.Should().ContainSingle(r =>
+            r.Id == presented.Id && r.IsRevoked && r.ReplacedByTokenHash == successor.TokenHash);
+    }
+
+    [Fact]
+    public async Task TryRotateAsync_WhenAnotherWriterAlreadyClaimedTheRow_ReturnsFalseAndWritesNothing()
+    {
+        await using var harness = await RotationHarness.CreateAsync();
+        RefreshSession seeded = await harness.SeedAsync("presented");
+
+        // Both requests read the row while it is still live, exactly as two concurrent refreshes do.
+        Participant winner = harness.NewParticipant();
+        Participant loser = harness.NewParticipant();
+        RefreshSession winnersCopy = (await winner.Store.FindByTokenHashAsync(seeded.TokenHash, CancellationToken.None))!;
+        RefreshSession losersCopy = (await loser.Store.FindByTokenHashAsync(seeded.TokenHash, CancellationToken.None))!;
+
+        RefreshSession winnersSuccessor = NewSession("winner-successor");
+        RefreshSession losersSuccessor = NewSession("loser-successor");
+
+        var winnerClaimed = await winner.Store.TryRotateAsync(
+            winnersCopy, winnersSuccessor, Now, CancellationToken.None);
+        var loserClaimed = await loser.Store.TryRotateAsync(
+            losersCopy, losersSuccessor, Now.AddSeconds(1), CancellationToken.None);
+
+        winnerClaimed.Should().BeTrue();
+        loserClaimed.Should().BeFalse(
+            "the row is claimed by a conditional UPDATE, so only one of two concurrent rotations may win");
+
+        RefreshSession[] rows = await harness.ReadAllAsync();
+        rows.Should().HaveCount(2, "the loser must not mint a second successor from one presented token");
+        rows.Should().NotContain(r => r.Id == losersSuccessor.Id);
+        RefreshSession rotated = rows.Single(r => r.Id == seeded.Id);
+        rotated.ReplacedByTokenHash.Should().Be(
+            winnersSuccessor.TokenHash,
+            "the rotation chain records the winner, and the loser overwrites nothing");
+        rotated.RevokedAt.Should().Be(Now);
+    }
+
+    private static RefreshSession NewSession(string token) =>
+        RefreshSession.Create(OwnerId, token, Now, Now.AddDays(7)).Value!;
+
+    private sealed record Participant(ApplicationDbContext Context, IRefreshSessionStore Store);
+
+    /// <summary>
+    /// One SQLite in-memory database, several independent contexts over it. Each participant is a
+    /// separate request: its own change tracker, its own store, the same rows.
+    /// </summary>
+    private sealed class RotationHarness : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly List<ApplicationDbContext> _contexts = [];
+
+        private RotationHarness(SqliteConnection connection) => _connection = connection;
+
+        public static async Task<RotationHarness> CreateAsync()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync(CancellationToken.None);
+            return new RotationHarness(connection);
+        }
+
+        public Participant NewParticipant()
+        {
+            ApplicationDbContext context =
+                RefreshSessionCleanupServiceTests.SessionCleanupTestContext.Create(_connection);
+            _contexts.Add(context);
+
+            var dbContextFactory = new Mock<IDbContextFactory>();
+            dbContextFactory.Setup(f => f.GetDbContext(It.IsAny<DataSourceKey>())).Returns(context);
+            dbContextFactory
+                .Setup(f => f.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .Returns((CancellationToken ct) => context.SaveChangesAsync(ct));
+
+            // The transaction belongs to the factory in production; here the delegate runs directly,
+            // so the assertions are about the claim itself rather than about SQLite locking.
+            dbContextFactory
+                .Setup(f => f.ExecuteInTransactionAsync(
+                    It.IsAny<Func<CancellationToken, Task<bool>>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns((Func<CancellationToken, Task<bool>> operation, CancellationToken ct) => operation(ct));
+
+            var store = new StoreUnderTest(
+                dbContextFactory.Object,
+                new EmptyEntityDataSourceRegistry(),
+                Mock.Of<IDataSourceResolver>(),
+                Options.Create(new RefreshSessionSettings { Enabled = true }));
+
+            return new Participant(context, store);
+        }
+
+        public async Task<RefreshSession> SeedAsync(string token)
+        {
+            Participant seeder = NewParticipant();
+            RefreshSession session = NewSession(token);
+            seeder.Context.Add(session);
+            await seeder.Context.SaveChangesAsync(CancellationToken.None);
+            seeder.Context.ChangeTracker.Clear();
+            return session;
+        }
+
+        public async Task<RefreshSession[]> ReadAllAsync()
+        {
+            Participant reader = NewParticipant();
+            return await reader.Context.Set<RefreshSession>()
+                .AsNoTracking()
+                .ToArrayAsync(CancellationToken.None);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (ApplicationDbContext context in _contexts)
+            {
+                await context.DisposeAsync();
+            }
+
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Testing.Tests/FeatureManagementTestExtensionsTests.cs
+++ b/Tests/Hosting/MMCA.Common.Testing.Tests/FeatureManagementTestExtensionsTests.cs
@@ -1,0 +1,85 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+using Xunit;
+
+namespace MMCA.Common.Testing.Tests;
+
+/// <summary>
+/// The helper's docstring promises it overrides feature-flag values from <c>appsettings.json</c>,
+/// i.e. that everything else survives. It used to register a flags-only <see cref="IConfiguration"/>,
+/// and .NET DI hands a non-collection dependency the LAST registration, so every component built
+/// afterwards that injects <see cref="IConfiguration"/> directly (a connection-string reader, a JWT
+/// authority check) got a root with nothing in it but the flags.
+/// </summary>
+public sealed class FeatureManagementTestExtensionsTests
+{
+    [Fact]
+    public void ConfigureTestFeatureFlags_LayersTheFlagsOnTopOfTheHostConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(HostConfiguration());
+
+        services.ConfigureTestFeatureFlags(new Dictionary<string, bool>(StringComparer.Ordinal)
+        {
+            ["New"] = true,
+            ["Old"] = false,
+        });
+
+        var configuration = services.BuildServiceProvider().GetRequiredService<IConfiguration>();
+
+        configuration["ConnectionStrings:Default"].Should().Be(
+            "Server=host;Database=app",
+            "the host's own configuration must survive the flag override");
+        configuration["Authentication:JwtBearer:Authority"].Should().Be("https://issuer.test");
+        configuration["FeatureManagement:New"].Should().Be("True");
+        configuration["FeatureManagement:Old"].Should().Be(
+            "False",
+            "the in-memory source is added last, so it wins over the host's value");
+    }
+
+    [Fact]
+    public async Task ConfigureTestFeatureFlags_DrivesTheFeatureManager()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(HostConfiguration());
+        services.AddLogging();
+
+        services.ConfigureTestFeatureFlags(new Dictionary<string, bool>(StringComparer.Ordinal)
+        {
+            ["New"] = true,
+            ["Old"] = false,
+        });
+
+        var featureManager = services.BuildServiceProvider().GetRequiredService<IFeatureManager>();
+
+        (await featureManager.IsEnabledAsync("New")).Should().BeTrue();
+        (await featureManager.IsEnabledAsync("Old")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConfigureTestFeatureFlags_WithNoHostConfiguration_StillRegistersTheFlags()
+    {
+        var services = new ServiceCollection();
+
+        services.ConfigureTestFeatureFlags(new Dictionary<string, bool>(StringComparer.Ordinal)
+        {
+            ["New"] = true,
+        });
+
+        var configuration = services.BuildServiceProvider().GetRequiredService<IConfiguration>();
+
+        configuration["FeatureManagement:New"].Should().Be("True");
+    }
+
+    private static IConfiguration HostConfiguration() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["ConnectionStrings:Default"] = "Server=host;Database=app",
+                ["Authentication:JwtBearer:Authority"] = "https://issuer.test",
+                ["FeatureManagement:Old"] = "true",
+            })
+            .Build();
+}

--- a/Tests/Presentation/MMCA.Common.API.Tests/Authorization/OwnerOrAdminFilterTests.cs
+++ b/Tests/Presentation/MMCA.Common.API.Tests/Authorization/OwnerOrAdminFilterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -223,6 +224,68 @@ public sealed class OwnerOrAdminFilterTests
                 new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!)));
 
         context.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    // ── Owner ids are machine data: parsed invariantly, never with the host's culture ──
+    [Theory]
+    [InlineData("sv-SE")]
+    [InlineData("ar-SA")]
+    [InlineData("fa-IR")]
+    public async Task OnActionExecutionAsync_UnderAnyAmbientCulture_StillAuthorizesTheOwner(string cultureName)
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+            _currentUserService.Setup(s => s.Role).Returns("Customer");
+            _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(42);
+            var (context, _) = CreateContext(new RouteValueDictionary { ["id"] = "42" });
+            var nextCalled = false;
+            var sut = CreateFilter();
+
+            await sut.OnActionExecutionAsync(context, () =>
+            {
+                nextCalled = true;
+                return Task.FromResult(new ActionExecutedContext(
+                    new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!));
+            });
+
+            nextCalled.Should().BeTrue();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_ACultureFormattedOwnerId_IsNotAccepted()
+    {
+        // Pins the convention rather than a real-world input: an owner id arrives off the wire, so
+        // whichever strings the host's CurrentCulture would accept as numbers is not the question.
+        // The custom negative sign is what makes the assertion deterministic across ICU versions.
+        var culture = (CultureInfo)CultureInfo.GetCultureInfo("sv-SE").Clone();
+        culture.NumberFormat.NegativeSign = "\u2212";
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = culture;
+            _currentUserService.Setup(s => s.Role).Returns("Customer");
+            _currentUserService.Setup(s => s.GetClaimValue<int>("customer_id")).Returns(-5);
+            var (context, _) = CreateContext(new RouteValueDictionary { ["id"] = "\u22125" });
+            var sut = CreateFilter();
+
+            await sut.OnActionExecutionAsync(context, () =>
+                Task.FromResult(new ActionExecutedContext(
+                    new ActionContext(context.HttpContext, context.RouteData, context.ActionDescriptor), [], null!)));
+
+            context.Result.Should().BeOfType<ForbidResult>(
+                "an ambient-culture parse would have accepted this id, and the filter must not depend on the host's culture");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     // ── Explicit opt-out ──

--- a/Tests/Presentation/MMCA.Common.UI.E2E.Tests/AuthOutcomeRulesTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.E2E.Tests/AuthOutcomeRulesTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using MMCA.Common.Testing.E2E.Infrastructure;
+using Xunit;
+
+namespace MMCA.Common.UI.E2E.Tests;
+
+/// <summary>
+/// The four-way classification behind <c>E2ETestBase.WaitForAuthResultAsync</c>. Browser-free: the
+/// decision is a pure function precisely so the silent case can be pinned without staging a server
+/// that fails without rendering anything.
+/// </summary>
+public sealed class AuthOutcomeRulesTests
+{
+    [Fact]
+    public void AllSignalsQuiet_IsSilent() =>
+        AuthOutcomeRules.Classify(navigatedAway: false, errorAlertVisible: false, logoutVisible: false)
+            .Should().Be(
+                AuthOutcome.Silent,
+                "a submit that produced no navigation, no signed-in state and no error alert was never accepted");
+
+    [Fact]
+    public void NavigatedAway_WinsOverAnErrorAlert() =>
+        AuthOutcomeRules.Classify(navigatedAway: true, errorAlertVisible: true, logoutVisible: false)
+            .Should().Be(
+                AuthOutcome.Succeeded,
+                "an alert flashed on the way out of a completed forceLoad is not a failure");
+
+    [Fact]
+    public void LogoutVisibleAlone_IsSucceeded() =>
+        AuthOutcomeRules.Classify(navigatedAway: false, errorAlertVisible: false, logoutVisible: true)
+            .Should().Be(AuthOutcome.Succeeded);
+
+    [Fact]
+    public void LogoutVisible_WinsOverAnErrorAlert() =>
+        AuthOutcomeRules.Classify(navigatedAway: false, errorAlertVisible: true, logoutVisible: true)
+            .Should().Be(AuthOutcome.Succeeded);
+
+    [Fact]
+    public void ErrorAlertAlone_IsErrorShown() =>
+        AuthOutcomeRules.Classify(navigatedAway: false, errorAlertVisible: true, logoutVisible: false)
+            .Should().Be(AuthOutcome.ErrorShown);
+
+    [Fact]
+    public void NavigatedAwayAlone_IsSucceeded() =>
+        AuthOutcomeRules.Classify(navigatedAway: true, errorAlertVisible: false, logoutVisible: false)
+            .Should().Be(AuthOutcome.Succeeded);
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Common/LatestLoadGuardTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Common/LatestLoadGuardTests.cs
@@ -1,0 +1,83 @@
+using AwesomeAssertions;
+using MMCA.Common.UI.Common;
+
+namespace MMCA.Common.UI.Tests.Common;
+
+/// <summary>
+/// The stale-response guard for routed pages: Blazor reuses the component instance across route
+/// parameter changes, so a slow load for one id must not overwrite the page after a faster load for
+/// the next id has already rendered.
+/// </summary>
+public sealed class LatestLoadGuardTests
+{
+    [Fact]
+    public void Begin_CancelsThePreviousLoad()
+    {
+        using var sut = new LatestLoadGuard();
+
+        var (first, _) = sut.Begin();
+        first.IsCancellationRequested.Should().BeFalse();
+
+        var (second, _) = sut.Begin();
+
+        first.IsCancellationRequested.Should().BeTrue("the superseded fetch has no reader left");
+        second.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCurrent_IsFalseForASupersededGenerationAndTrueForTheLatest()
+    {
+        using var sut = new LatestLoadGuard();
+
+        var (_, first) = sut.Begin();
+        var (_, second) = sut.Begin();
+
+        sut.IsCurrent(first).Should().BeFalse("its result would overwrite the page with the wrong entity");
+        sut.IsCurrent(second).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCurrent_IsTrueForASingleLoad()
+    {
+        using var sut = new LatestLoadGuard();
+
+        var (_, generation) = sut.Begin();
+
+        sut.IsCurrent(generation).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dispose_CancelsTheInFlightLoadAndInvalidatesItsGeneration()
+    {
+        var sut = new LatestLoadGuard();
+        var (token, generation) = sut.Begin();
+
+        sut.Dispose();
+
+        token.IsCancellationRequested.Should().BeTrue();
+        sut.IsCurrent(generation).Should().BeFalse("a disposed component assigns nothing");
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var sut = new LatestLoadGuard();
+        sut.Begin();
+
+        sut.Dispose();
+        var act = sut.Dispose;
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Begin_AfterDispose_Throws()
+    {
+        var sut = new LatestLoadGuard();
+        sut.Dispose();
+
+        var act = () => sut.Begin();
+
+        act.Should().Throw<ObjectDisposedException>();
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/ApiFileDownloadButtonTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/ApiFileDownloadButtonTests.cs
@@ -25,6 +25,8 @@ public sealed class ApiFileDownloadButtonTests : BunitTestBase
 {
     private static readonly byte[] PayloadBytes = "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"u8.ToArray();
 
+    private int _requestsSeen;
+
     public ApiFileDownloadButtonTests()
     {
         // The button injects both capabilities unconditionally (it branches on InterceptsLinks at
@@ -148,22 +150,116 @@ public sealed class ApiFileDownloadButtonTests : BunitTestBase
     }
 
     [Fact]
-    public async Task OnNativeHead_WhenStagingTheFileFails_WarnsInsteadOfKillingTheHost()
+    public async Task OnNativeHead_WhenStagingOrSharingFails_WarnsInsteadOfKillingTheHost()
     {
-        // An IOException from the temp-file write escaped the HttpRequestException-only catch.
-        // A file name that is a directory separator makes the write fail deterministically.
+        // An IOException from the staging write or the share sheet escaped the
+        // HttpRequestException-only catch. The file name can no longer be the failure injection
+        // (directory segments are stripped now), so the share surface throws instead.
         var toast = ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new ByteArrayContent(PayloadBytes),
         });
 
+        var share = new Mock<IShareService>();
+        share
+            .Setup(x => x.ShareFileAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("the share surface failed"));
+        Services.AddSingleton(share.Object);
+
         var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
             .Add(c => c.RelativeApiPath, "Sessions/42/ics")
-            .Add(c => c.FileName, "no-such-directory/session-42.ics")
+            .Add(c => c.FileName, "staging-failure.ics")
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+        try
+        {
+            await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+            VerifyToast(toast, "Could not download the file");
+        }
+        finally
+        {
+            File.Delete(Path.Combine(Path.GetTempPath(), "staging-failure.ics"));
+        }
+    }
+
+    // The FileName parameter is caller-supplied and a consumer may build it from entity data, so it
+    // must never steer the staging write: Path.Combine drops the temp root for a rooted second
+    // argument, and ".." segments walk out of it.
+    [Fact]
+    public async Task OnNativeHead_StripsDirectoryTraversalFromTheFileName()
+    {
+        var sharedPath = await ShareWithFileNameAsync("../../evil.ics");
+
+        sharedPath.Should().Be(Path.Combine(Path.GetTempPath(), "evil.ics"));
+        File.Delete(sharedPath!);
+    }
+
+    [Fact]
+    public async Task OnNativeHead_IgnoresARootedFileName()
+    {
+        var rooted = Path.Combine(Path.GetTempPath(), "sub", "escaped.ics");
+
+        var sharedPath = await ShareWithFileNameAsync(rooted);
+
+        sharedPath.Should().Be(Path.Combine(Path.GetTempPath(), "escaped.ics"));
+        File.Delete(sharedPath!);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("some/directory/")]
+    public async Task OnNativeHead_WithAnUnusableFileName_WarnsWithoutFetching(string fileName)
+    {
+        var toast = ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+
+        var share = new Mock<IShareService>();
+        Services.AddSingleton(share.Object);
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/42/ics")
+            .Add(c => c.FileName, fileName)
             .Add(c => c.ShareTitle, "Intro to Blazor"));
         await cut.Find("button").ClickAsync(new MouseEventArgs());
 
         VerifyToast(toast, "Could not download the file");
+        _requestsSeen.Should().Be(0, "a name that cannot be staged must not cost a download");
+        share.Verify(
+            x => x.ShareFileAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private async Task<string?> ShareWithFileNameAsync(string fileName)
+    {
+        ArrangeNativeHead(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(PayloadBytes),
+        });
+
+        string? sharedPath = null;
+        var share = new Mock<IShareService>();
+        share
+            .Setup(x => x.ShareFileAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string path, string _, CancellationToken _) => sharedPath = path)
+            .ReturnsAsync(true);
+        Services.AddSingleton(share.Object);
+
+        var cut = RenderUnderTest<ApiFileDownloadButton>(p => p
+            .Add(c => c.RelativeApiPath, "Sessions/42/ics")
+            .Add(c => c.FileName, fileName)
+            .Add(c => c.ShareTitle, "Intro to Blazor"));
+        await cut.Find("button").ClickAsync(new MouseEventArgs());
+
+        sharedPath.Should().NotBeNull();
+        return sharedPath;
     }
 
     [Fact]
@@ -263,7 +359,11 @@ public sealed class ApiFileDownloadButtonTests : BunitTestBase
         ArrangeWebHead();
         ArrangeLinkInterceptingHead();
 
-        var handler = new CapturingHttpMessageHandler(respond);
+        var handler = new CapturingHttpMessageHandler(request =>
+        {
+            _requestsSeen++;
+            return respond(request);
+        });
         Services.AddSingleton(HttpTestDoubles.ClientFactory(handler));
 
         // Last registration wins, so this recording double replaces the base's real toast service.

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationBellTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Components/NotificationBellTests.cs
@@ -170,6 +170,29 @@ public sealed class NotificationBellTests : BunitTestBase
     }
 
     [Fact]
+    public async Task DisposingWhileTheFirstReadIsInFlight_DoesNotStartThePollTimer()
+    {
+        // BecomeActivePollerAsync checked _disposed only on entry, then awaited the first read. A
+        // teardown during that await left it creating a PeriodicTimer nothing would ever dispose and
+        // starting a loop whose first act is to read an already-disposed CancellationTokenSource.
+        var counting = new TimerCountingTimeProvider(_clock);
+        Services.AddSingleton<TimeProvider>(counting);
+
+        var gate = new TaskCompletionSource<Result<int>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _inbox.Setup(x => x.GetUnreadCountAsync(It.IsAny<CancellationToken>())).Returns(gate.Task);
+
+        RenderUnderTest<NotificationBell>(_ => { });
+        counting.TimersCreated.Should().Be(0, "the first read has not returned yet");
+
+        await DisposeComponentsAsync();
+        gate.SetResult(Result.Success(3));
+        await Task.Yield();
+
+        counting.TimersCreated.Should().Be(0, "a disposed bell must not start a poll loop");
+        VerifyFetchCount(Times.Once());
+    }
+
+    [Fact]
     public void WhenTheActiveBellIsTornDown_TheSurvivingBellTakesOverPolling()
     {
         CountIs(0);
@@ -323,5 +346,32 @@ public sealed class NotificationBellTests : BunitTestBase
 
         cut.WaitForAssertion(() => cut.Markup.Should().Contain("7"));
         _state.UnreadCount.Should().Be(7);
+    }
+
+    /// <summary>
+    /// Delegates the clock to the driveable <see cref="FakeTimeProvider"/> and counts timer
+    /// creations: <c>new PeriodicTimer(TimeSpan, TimeProvider)</c> goes through
+    /// <see cref="TimeProvider.CreateTimer"/>, so the count is how a test observes whether the poll
+    /// loop was ever started.
+    /// </summary>
+    private sealed class TimerCountingTimeProvider(FakeTimeProvider inner) : TimeProvider
+    {
+        private int _timersCreated;
+
+        public int TimersCreated => Volatile.Read(ref _timersCreated);
+
+        public override DateTimeOffset GetUtcNow() => inner.GetUtcNow();
+
+        public override long GetTimestamp() => inner.GetTimestamp();
+
+        public override TimeZoneInfo LocalTimeZone => inner.LocalTimeZone;
+
+        public override long TimestampFrequency => inner.TimestampFrequency;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            Interlocked.Increment(ref _timersCreated);
+            return inner.CreateTimer(callback, state, dueTime, period);
+        }
     }
 }

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
@@ -134,6 +134,36 @@ public sealed class NavMenuTests : BunitTestBase
         cut.Markup.Should().Contain("Manage Events");
     }
 
+    // NavItem.RequiredRole defaults to null and is independent of Section, so an Admin item
+    // registered without one used to render for anonymous visitors: the section itself was gated on
+    // item count alone, unlike the User section beside it.
+    [Fact]
+    public void WhenAnonymous_HidesAdminItemsEvenWithoutARequiredRole()
+    {
+        RegisterModule(
+            new NavItem("Browse Catalog", "/catalog", "icon", typeof(SharedResource)),
+            new NavItem("Manage Events", "/events", "icon", typeof(SharedResource), Section: NavSection.Admin));
+
+        RenderMudProviders();
+        var cut = RenderUnderTest<NavMenu>(_ => { });
+
+        cut.Markup.Should().Contain("Browse Catalog");
+        cut.Markup.Should().NotContain("Manage Events", "an admin URL is not for anonymous visitors");
+        cut.Markup.Should().NotContain("Administration");
+    }
+
+    [Fact]
+    public void WhenAuthenticated_ShowsAdminItemsWithoutARequiredRole()
+    {
+        RegisterModule(
+            new NavItem("Manage Events", "/events", "icon", typeof(SharedResource), Section: NavSection.Admin));
+
+        RenderMudProviders();
+        var cut = RenderAs<NavMenu>(TestPrincipal.AuthenticatedUser(), _ => { });
+
+        cut.Markup.Should().Contain("Manage Events", "the guard is authentication, not a role the item never declared");
+    }
+
     [Fact]
     public void WithoutBrandLogoUrl_RendersTheTextOnlyBrand()
     {

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Common/DataGridListPageBaseTests.cs
@@ -465,6 +465,30 @@ public sealed class DataGridListPageBaseTests : BunitTestBase
         _toast.Verify(t => t.Show("The widget service is unavailable.", ToastSeverity.Error), Times.Once);
     }
 
+    [Fact]
+    public async Task LoadMobileDataAsync_DoesNotOverwriteThePersistedRowsPerPage()
+    {
+        // The mobile card fetch shares the persisted state with the desktop grid, and MobilePageSize
+        // is never restored from it. Writing it there only clobbered the user's real RowsPerPage:
+        // set 50 rows, narrow the viewport past the mobile breakpoint, come back to 10.
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("/widgets?p=0&ps=50");
+        var cut = Render<TestGridPage>();
+        cut.Instance.RowsPerPageNow.Should().Be(50);
+        cut.Instance.Fetch = (_, _, _, _, _, _) => Loaded(8, new WidgetRow(1, "First"));
+
+        await cut.InvokeAsync(() => cut.Instance.LoadMobileAsync());
+
+        var saved = Services.GetRequiredService<ListPageStateService>().GetState("/widgets");
+        saved.Should().NotBeNull();
+        saved!.PageSize.Should().Be(
+            0,
+            "0 is skipped by the restore guards, exactly as the virtualized path already saves it");
+        navigation.Uri.Should().NotContain(
+            "ps=10",
+            "MobilePageSize is a layout constant, not a row-count preference the user expressed");
+    }
+
     // == Virtualization: window arithmetic ==
     [Theory]
     // startIndex, count -> firstPage, pageSize, offset, needsSecondPage

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/AuthenticatedServiceBaseRetryTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/AuthenticatedServiceBaseRetryTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using AwesomeAssertions;
+using MMCA.Common.UI.Services;
+
+namespace MMCA.Common.UI.Tests.Services;
+
+/// <summary>
+/// The retry policy's disposal contract. Polly hands the caller only the FINAL outcome, so every
+/// retried response has to be disposed by the policy itself: under sustained backend 5xx/429, which
+/// is exactly when the retries fire, an undisposed attempt keeps its content buffer alive and its
+/// connection out of the handler pool until finalization.
+/// </summary>
+public sealed class AuthenticatedServiceBaseRetryTests
+{
+    [Fact]
+    public async Task RetryPolicy_DisposesEveryRetriedResponseAndLeavesTheFinalOneToTheCaller()
+    {
+        var attempts = new List<TrackingHttpResponseMessage>
+        {
+            new(HttpStatusCode.ServiceUnavailable),
+            new(HttpStatusCode.ServiceUnavailable),
+            new(HttpStatusCode.OK),
+        };
+
+        var index = 0;
+        var policy = AuthenticatedServiceBase.BuildRetryPolicy(_ => TimeSpan.Zero);
+
+        HttpResponseMessage final = await policy.ExecuteAsync(() =>
+            Task.FromResult<HttpResponseMessage>(attempts[index++]));
+
+        index.Should().Be(3, "two retryable responses are retried and the third ends the run");
+        attempts[0].IsDisposed.Should().BeTrue("a retried response is never handed to the caller");
+        attempts[1].IsDisposed.Should().BeTrue();
+        attempts[2].IsDisposed.Should().BeFalse("the caller owns the final response and its `using`");
+        final.Should().BeSameAs(attempts[2]);
+
+        final.Dispose();
+    }
+
+    [Fact]
+    public async Task RetryPolicy_WhenAnAttemptThrows_HasNoResponseToDispose()
+    {
+        var responses = new List<TrackingHttpResponseMessage> { new(HttpStatusCode.OK) };
+        var attempt = 0;
+        var policy = AuthenticatedServiceBase.BuildRetryPolicy(_ => TimeSpan.Zero);
+
+        HttpResponseMessage final = await policy.ExecuteAsync(() =>
+            attempt++ == 0
+                ? throw new HttpRequestException("connection reset")
+                : Task.FromResult<HttpResponseMessage>(responses[0]));
+
+        // A thrown attempt carries no result, so the onRetry callback must tolerate a null outcome.
+        final.Should().BeSameAs(responses[0]);
+        responses[0].IsDisposed.Should().BeFalse();
+
+        final.Dispose();
+    }
+
+    private sealed class TrackingHttpResponseMessage(HttpStatusCode statusCode)
+        : HttpResponseMessage(statusCode)
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/Capabilities/DeepLinkDispatcherTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/Capabilities/DeepLinkDispatcherTests.cs
@@ -66,6 +66,51 @@ public sealed class DeepLinkDispatcherTests
         route.Should().Be("/notifications");
     }
 
+    /// <summary>
+    /// The warm-boot deep link: a native callback publishes while the listener component is
+    /// subscribing and draining. Reading the handler outside the lock allowed
+    /// publish-sees-nothing, subscribe, drain-finds-nothing, buffer, which strands the route with
+    /// no future consumer.
+    /// <para>
+    /// The lock placement is the guarantee; this is a regression net, not a proof. The window is a
+    /// few instructions wide, so a reverted fix fails this probabilistically rather than always.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Publish_ConcurrentWithSubscribeAndDrain_NeverLosesTheRoute()
+    {
+        for (var i = 0; i < 2000; i++)
+        {
+            var sut = new DeepLinkDispatcher();
+            var deliveries = 0;
+            using var barrier = new Barrier(2);
+
+            var publisher = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                sut.Publish("/conference/sessions/42");
+            });
+
+            var listener = Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                sut.RouteRequested += (_, _) => Interlocked.Increment(ref deliveries);
+                if (sut.TryConsumePending(out _))
+                {
+                    Interlocked.Increment(ref deliveries);
+                }
+            });
+
+            await Task.WhenAll(publisher, listener);
+
+            deliveries.Should().Be(
+                1,
+                "the listener must receive the route exactly once, through the event or through its own drain");
+            sut.TryConsumePending(out _).Should().BeFalse(
+                "a route left in the buffer after the listener has subscribed and drained has no future consumer");
+        }
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]


### PR DESCRIPTION
Bug-hunt remediation (2026-09-01 run) for MMCA.Common: 14 findings across five waves, one commit
each. Everything is additive: no signature breaks, no schema changes, no migrations, and nothing is
required of a consumer at bump time beyond the pin.

M90 (MiniProfiler results endpoint) was REFUTED at planning and is deliberately untouched: no host
calls `UseMiniProfiler()`, `AddMiniProfilerIfEnabled` has zero callers anywhere, and every consumer
sets `UseMiniProfiler: false`, so there is no reachable endpoint to gate.

## Per finding

### Wave A: Application / persistence / validation

**H35 (High) Concurrent refresh-token rotation was unguarded.** Two requests presenting the SAME
still-live refresh token each loaded their own tracked copy with `RevokedAt` null, so both minted a
successor and the presented row could never fire reuse detection again: one permanently undetected
extra session per race. Rotation now goes through the new `IRefreshSessionStore.TryRotateAsync`
(additive, default interface member); `EFRefreshSessionStore` overrides it with a conditional
`UPDATE ... WHERE Id = @id AND RevokedAt IS NULL` (rows-affected checked) plus the successor insert
in one transaction, and `AuthenticationServiceBase.RotateAsync` answers a lost claim exactly like a
replay (family revoked, `Auth.InvalidRefreshToken`). Schema-free by design: the RowVersion option was
rejected because it would need a consumer migration at bump time.

- Tests: `EFRefreshSessionStoreRotationTests` (new; two stores over two contexts sharing one open
  SQLite connection, which is what makes the two tracked copies real) and
  `AuthenticationServiceBaseTests.RefreshTokenAsync_WhenTheRotationLosesTheRace_FailsAndRevokesTheFamily`
  / `RefreshTokenAsync_WhenTheRotationWinsTheClaim_StillRotates`.
- Revert-proof: DONE, both halves. With the EF override disabled the loser test fails (it returns
  true and inserts a second successor); with `RotateAsync` reverted the Application test fails.

**M86 (Medium) SendPushNotificationHandler non-atomic saves.** The audit row (carrying `DedupKey`)
committed before the recipient rows and the sends, so a fault in between left a committed row nothing
delivered, and every retry of that key short-circuited on the dedup lookup, reporting success
forever. `SendPushNotificationCommand` is now `ITransactional`.

- Tests: `SendPushNotificationCommand_IsTransactional_SoAPartialSendRollsBack` plus
  `HandleAsync_WhenTheRecipientSaveThrows_PropagatesInsteadOfReportingSuccess`.
- Revert-proof: DONE (removing `ITransactional` fails the type assertion).

**M89 (Medium) CommandRequestValidator ran only the first `IValidator<TRequest>`.** It took
`FirstOrDefault()`, so a module authoring a validator beside a framework one had one of them silently
turned into dead code. Every registered validator now runs, de-duplicated by runtime type.

- Tests: `Validate_MultipleRequestValidatorsRegistered_RunsEveryValidator` (replaces the
  `UsesFirstValidator` test that pinned the old behavior),
  `Validate_TheSameValidatorTypeRegisteredTwice_ReportsEachFailureOnce`,
  `Validate_APermissiveValidatorRegisteredFirst_StillReportsTheStrictFailure`.
- Revert-proof: DONE.

### Wave B: API

**L38 (Low) OwnerOrAdminFilter parsed owner ids with the ambient culture.** Both sites now use
`NumberStyles.Integer` + `CultureInfo.InvariantCulture`. RE-SCOPED as planned: the functional defect
was refuted (the filter fails closed on a non-parse), so this pins the machine-data parsing
convention rather than closing a hole.

- Tests: `OnActionExecutionAsync_UnderAnyAmbientCulture_StillAuthorizesTheOwner` (sv-SE, ar-SA,
  fa-IR) and `OnActionExecutionAsync_ACultureFormattedOwnerId_IsNotAccepted`.
- Revert-proof: DONE.

### Wave C: UI

**M91** the Polly retry policy dropped every intermediate `HttpResponseMessage` undisposed; an
`onRetry` callback disposes it (the final one stays the caller's). Test:
`AuthenticatedServiceBaseRetryTests` (tracking response subclass; also covers the thrown-attempt
null-result path). Revert-proof: DONE.

**M92** `DeepLinkDispatcher.Publish` read `RouteRequested` outside the lock, so a publish racing a
listener's subscribe-then-drain could strand the route in the one-slot buffer. The raise-or-buffer
decision is now one locked step; the event is still invoked outside the lock. Test:
`Publish_ConcurrentWithSubscribeAndDrain_NeverLosesTheRoute` (2000 iterations, `Barrier(2)`).
Revert-proof: DONE in this run, but the lock placement is the guarantee and the test is a
probabilistic regression net, not a proof, exactly as the plan said.

**M93** the Admin nav section rendered on item count alone, disclosing an admin item registered
without a `RequiredRole` (which defaults to null) to anonymous visitors. Tests:
`WhenAnonymous_HidesAdminItemsEvenWithoutARequiredRole`,
`WhenAuthenticated_ShowsAdminItemsWithoutARequiredRole`. Revert-proof: DONE.

**M94** `ApiFileDownloadButton` staged the temp file at the caller-supplied `FileName` verbatim, so a
rooted value discarded the temp root and `..` walked out of it. The name is reduced to
`Path.GetFileName` BEFORE the fetch, and an unusable name warns without downloading. Tests:
`OnNativeHead_StripsDirectoryTraversalFromTheFileName`, `OnNativeHead_IgnoresARootedFileName`,
`OnNativeHead_WithAnUnusableFileName_WarnsWithoutFetching` (theory), and the existing staging-failure
test re-pointed at the share surface (its old injection, a directory segment in the name, now
sanitizes and succeeds). Revert-proof: DONE.

**M95** the mobile card fetch persisted `MobilePageSize` into the state the desktop grid shares,
replacing the user's `RowsPerPage`. It now saves 0, which the restore guards skip, exactly as the
virtualized path already did. Test: `LoadMobileDataAsync_DoesNotOverwriteThePersistedRowsPerPage`.
Revert-proof: DONE.

**L37** `NotificationBell` could create a `PeriodicTimer` and start a poll loop after disposal (the
loop's first act being to read a disposed `CancellationTokenSource`). It re-checks `_disposed` after
the first read, and the loop also catches `ObjectDisposedException`. Test:
`DisposingWhileTheFirstReadIsInFlight_DoesNotStartThePollTimer` (a `TimeProvider` that counts
`CreateTimer`). Revert-proof: DONE.

**M88** RE-SCOPED for Common exactly as planned. `Routes.razor` deliberately gets no `@key` (keying
the `AuthorizeRouteView` per URL would remount the page on every parameter change: double fetch, lost
scroll, the UnsavedChangesGuard trap), and Common has no affected page. This ships the additive
`LatestLoadGuard` helper so the Store and ADC detail pages can stop hand-rolling variants at the next
bump. Tests: `LatestLoadGuardTests` (6). No revert-proof applies: the type is new, so removing it
fails compilation.

### Wave D: UI.Maui

**M96** `ApnsTokenBridge` used one static `TaskCompletionSource`, so a failed first APNs registration
left it completed with null forever and the provider's retry awaited that decided task instead of the
callback it had just triggered. `Publish` now swaps in a fresh source before completing the old one.

- No test is possible: UI.Maui has no test project and the file is compiled only under
  `IOS || MACCATALYST`. Revert-proof: NOT POSSIBLE, stated here per the plan. The gate is the CI
  `build-maui` job. Verified locally against `net10.0-windows10.0.19041.0` (which compiles the file
  OUT) and `net10.0-ios` (which compiles it IN, proven by a deliberate syntax error surfacing errors
  in this exact file, then reverted).

### Wave E: Testing packages

**M85** `E2ETestBase.LoginAsync` / `RegisterNewUserAsync` reported success on a silent auth failure:
all three waits timing out returned normally, and the caller's interactivity wait was already
satisfied by the still-rendered auth page. The classification is now the pure internal
`AuthOutcomeRules.Classify`, the silent case throws an `InvalidOperationException` naming the
operation, the budget and the URL, and the losing waits are observed so their timeouts cannot fault
an unrelated test. Test: `AuthOutcomeRulesTests` (browser-free, runs in the `ui-e2e` job on all three
engines). Revert-proof: DONE (a reverted `Classify` fails `AllSignalsQuiet_IsSilent`).

**L34** `ConfigureTestFeatureFlags` replaced `IConfiguration` with a flags-only root. It now chains
the host's root and adds the flags on top. Tests: `FeatureManagementTestExtensionsTests` (3).
Revert-proof: DONE.

**L35** module isolation checked six of the sixteen internal-layer pairs. Adds
`ArchitectureRules.ModuleInternalLayersAreIsolated` plus the matching `ModuleIsolationTestsBase`
fact; UI is excluded on purpose (a module's UI composing another module's UI is intended and shipped
in both apps). Tests: `ModuleIsolationTestsBaseTests` (a hand-built stub map isolating the
Domain-to-other-Application pair, plus a companion test asserting the six named rules do NOT catch
it). Revert-proof: DONE, and stronger than the plan's "FACTS count plus consumer runs" fallback.

## Deviations from the plan

- **M95 test assertion.** The plan asked the test to also show a second render reporting
  `RowsPerPageNow == 50`. That is wrong against the code: `SaveCurrentState` builds a fresh
  `ListPageState` and writes `PageSize` unconditionally
  (`Source/Presentation/MMCA.Common.UI/Pages/Common/DataGridListPageBase.cs:868`), so passing 0
  replaces the stored 50 with 0 rather than preserving it. Zero is the "no preference expressed"
  value the restore guards skip, which is the same contract the virtualized path uses. The test
  asserts `PageSize == 0` and that the URL no longer carries `ps=10`.
- **M94 refactor beyond the plan's diff.** The inline sanitize pushed `ShareDownloadedFileAsync` to
  cyclomatic complexity 13 (S1541 limit 10) and `safeName is "." or ".."` tripped MA0127. The check
  and the staging write were extracted into `ResolveStagedFileName` / `StageFileAsync`, which lands
  the method back at its original complexity.
- **M85 control flow.** Implemented as an if-chain rather than the plan's `switch` (IDE0010 demanded
  a populated switch, then S3458 rejected the resulting empty `case`), and the timeout budget is
  formatted with `CultureInfo.InvariantCulture` (MA0076). The behavior is the plan's.
- **L35 FACTS numbers.** The plan predicted 123 methods / 46 bases / **194** executed. The generator
  reports 123 / 46 / **196**: `build/facts` counts Common's own direct arch tests too, and this PR
  adds three of them (the stub-map fixture tests). `facts --check` is clean.
- **L35 test scope.** The plan offered "document instead of testing" as the fallback. A stub
  `IArchitectureMap` turned out to be cheap, so the rule got a real revert-proof.

## Consumer-visible behavior changes

- **M85 turns a silently green broken E2E login RED at bump.** A consumer suite whose login never
  actually worked now throws with the URL in the message instead of failing obscurely later.
- **H35** a refresh that loses a same-instant rotation race now fails with `Auth.InvalidRefreshToken`
  and revokes the user's live family, where it previously succeeded with a second live session. No
  migration, no config, no consumer code change: the ADC and Store `InMemoryRefreshSessionStore`
  fakes inherit the default interface member.
- **M89** a module with two validators for one request type will now surface failures that were
  previously never reported.
- **M86** the SignalR and native sends now run inside the command's transaction.
- **M93** an Admin nav item registered without a `RequiredRole` is now hidden from anonymous
  visitors. Every shipped consumer admin item already sets a role.
- **L35** the new module-isolation fact runs in every repo subclassing the base. ADC and Store
  cross-module project references are Shared-only today, so it should be green at bump.

## New public API surface

- `MMCA.Common.Application`: `IRefreshSessionStore.TryRotateAsync` (default interface member).
- `MMCA.Common.UI`: `LatestLoadGuard` (type, constructor, `Begin`, `IsCurrent`, `Dispose`).
- `MMCA.Common.Testing.Architecture`: `ArchitectureRules.ModuleInternalLayersAreIsolated` and
  `ModuleIsolationTestsBase.ModuleInternalLayers_ShouldNotReach_OtherModuleInternalLayers`.

All carry their `PublicAPI.Unshipped.txt` lines. Nothing existing changed shape.

## Build and test counts

- `dotnet build MMCA.Common.slnx -c Release`: 0 errors, 0 warnings.
- `dotnet test --solution MMCA.Common.slnx -c Release`: **5250 passed, 0 failed, 0 skipped**.
- Out-of-slnx: `MMCA.Common.UI.Gallery` and `MMCA.Common.UI.E2E.Tests` build clean;
  `AuthOutcomeRulesTests` 6/6. `MMCA.Common.UI.Maui` builds clean on the windows and iOS TFMs.
- `dotnet run --project build/facts -- . --check`: up to date.

## Follow-up NOT done here

The ADR-097 amendment recording the **concurrent same-token** rotation case and the conditional-claim
mechanism (`Website/docs-src/adr/097-multi-device-refresh-sessions.md`, whose "benign race" section
covers only the serialized case today) is a Website-repo change and is **not** part of this PR. It
needs its own Website PR plus `cd Website/tools && npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFaTUw34BQJneR4auAyBH8
