### PR TITLE
feat(gateway): secret-gated synthetic-traffic bypass for the edge rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,17 @@ consumer at bump time beyond the pin.
   routed component instance across route-parameter changes, so a slow load for one id otherwise
   overwrites the page after a faster load for the next id has rendered. Not thread-safe by contract
   (renderer synchronization context only).
+- **Secret-gated synthetic-traffic bypass for the edge rate limiter** (`MMCA.Common.Aspire`).
+  `GatewayRateLimitingSettings` gains `SyntheticTrafficHeaderName` (default
+  `X-Synthetic-Traffic-Key`) and `SyntheticTrafficSecret`; a request presenting that header with
+  that secret takes the no-limiter partition on BOTH chained limiters, exactly as a bypassed path
+  does. A scheduled capacity proof drives its whole run from ONE runner IP, which the per-IP fixed
+  window cannot tell from an unauthenticated flood, so the run measured the limiter instead of the
+  system. Off by default: the bypass cannot be claimed while the secret is unset, the comparison is
+  constant time over UTF-8 bytes, exactly one header value is accepted, and a configured secret
+  shorter than 32 characters fails at registration. Supply it from a secret store or the
+  environment (`GatewayRateLimiting__SyntheticTrafficSecret`), never from a checked-in
+  `appsettings` file.
 - **`IRefreshSessionStore.TryRotateAsync`** (`MMCA.Common.Application`). Additive interface member
   with a default implementation (revoke, add, save), so an existing custom or test store keeps
   compiling and behaving as it did; the shipped EF store overrides it with the database-arbitrated

--- a/Source/Hosting/MMCA.Common.Aspire/Gateway/GatewayRateLimitingExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Gateway/GatewayRateLimitingExtensions.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -22,6 +24,12 @@ namespace MMCA.Common.Aspire.Gateway;
 /// The two limiters are chained rather than merged because they answer different questions: the
 /// fixed window bounds how fast ONE caller may arrive, the concurrency limiter bounds how much work
 /// the replica will hold at once regardless of who sent it. A request must satisfy both.
+/// </para>
+/// <para>
+/// Three kinds of request take the no-limiter partition on BOTH limiters: an always-bypassed
+/// infrastructure prefix, a host-configured bypass prefix, and a synthetic-traffic request proving
+/// the configured secret in the configured header (off unless
+/// <see cref="GatewayRateLimitingSettings.SyntheticTrafficSecret"/> is set).
 /// </para>
 /// </summary>
 [SuppressMessage(
@@ -68,8 +76,46 @@ public static class GatewayRateLimitingExtensions
     }
 
     /// <summary>
-    /// Per-client-IP partition: no limiter for bypassed paths, no limiter for an unresolvable IP
-    /// (fail open), otherwise one fixed window per IP.
+    /// Whether this request proves the configured synthetic-traffic secret and is therefore exempt
+    /// from BOTH edge limiters. Always <see langword="false"/> when no secret is configured, so the
+    /// bypass cannot be claimed by presenting the header alone.
+    /// </summary>
+    /// <param name="httpContext">The request.</param>
+    /// <param name="settings">The bound gateway settings.</param>
+    /// <returns><see langword="true"/> when the request carries the configured secret.</returns>
+    /// <remarks>
+    /// The comparison runs over UTF-8 bytes through
+    /// <see cref="CryptographicOperations.FixedTimeEquals(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>,
+    /// which is constant time for equal-length inputs and returns false for unequal lengths without
+    /// leaking anything past the length an attacker already chose. Exactly one header value is
+    /// required, so a caller cannot spray candidates in a multi-valued header. Internal (not
+    /// private) so the check is unit-testable via <c>InternalsVisibleTo</c>.
+    /// </remarks>
+    internal static bool IsSyntheticTraffic(HttpContext httpContext, GatewayRateLimitingSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (string.IsNullOrWhiteSpace(settings.SyntheticTrafficSecret))
+        {
+            return false;
+        }
+
+        var presented = httpContext.Request.Headers[settings.SyntheticTrafficHeaderName];
+        if (presented.Count != 1)
+        {
+            return false;
+        }
+
+        var presentedBytes = Encoding.UTF8.GetBytes(presented[0] ?? string.Empty);
+        var expectedBytes = Encoding.UTF8.GetBytes(settings.SyntheticTrafficSecret);
+
+        return CryptographicOperations.FixedTimeEquals(presentedBytes, expectedBytes);
+    }
+
+    /// <summary>
+    /// Per-client-IP partition: no limiter for bypassed paths or proven synthetic traffic, no
+    /// limiter for an unresolvable IP (fail open), otherwise one fixed window per IP.
     /// </summary>
     /// <param name="httpContext">The request.</param>
     /// <param name="settings">The bound gateway settings.</param>
@@ -82,7 +128,7 @@ public static class GatewayRateLimitingExtensions
         ArgumentNullException.ThrowIfNull(httpContext);
         ArgumentNullException.ThrowIfNull(settings);
 
-        if (IsBypassed(httpContext.Request.Path, settings))
+        if (IsBypassed(httpContext.Request.Path, settings) || IsSyntheticTraffic(httpContext, settings))
         {
             return RateLimitPartition.GetNoLimiter(BypassPartitionKey);
         }
@@ -106,8 +152,8 @@ public static class GatewayRateLimitingExtensions
     }
 
     /// <summary>
-    /// Process-wide concurrency partition: one bucket for the whole replica, bypassed on the same
-    /// paths the per-IP window is.
+    /// Process-wide concurrency partition: one bucket for the whole replica, bypassed for the same
+    /// paths and the same proven synthetic traffic the per-IP window is.
     /// </summary>
     /// <param name="httpContext">The request.</param>
     /// <param name="settings">The bound gateway settings.</param>
@@ -120,7 +166,7 @@ public static class GatewayRateLimitingExtensions
         ArgumentNullException.ThrowIfNull(httpContext);
         ArgumentNullException.ThrowIfNull(settings);
 
-        return IsBypassed(httpContext.Request.Path, settings)
+        return IsBypassed(httpContext.Request.Path, settings) || IsSyntheticTraffic(httpContext, settings)
             ? RateLimitPartition.GetNoLimiter(BypassPartitionKey)
             : RateLimitPartition.GetConcurrencyLimiter(ConcurrencyPartitionKey, _ => new ConcurrencyLimiterOptions
             {

--- a/Source/Hosting/MMCA.Common.Aspire/Gateway/GatewayRateLimitingSettings.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Gateway/GatewayRateLimitingSettings.cs
@@ -25,6 +25,13 @@ namespace MMCA.Common.Aspire.Gateway;
 /// attributed to the ingress. An unresolvable IP fails open rather than collapsing into one shared
 /// bucket that would throttle an in-process TestServer to a standstill.
 /// </para>
+/// <para>
+/// <b>Synthetic traffic.</b> A scheduled capacity proof runs its whole load from ONE runner IP, so
+/// the per-IP window reads it as a flood and answers almost entirely with <c>429</c>. Setting
+/// <see cref="SyntheticTrafficSecret"/> lets such a run present
+/// <see cref="SyntheticTrafficHeaderName"/> and take the same no-limiter partition a bypassed path
+/// takes. It is off unless the secret is configured.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>
@@ -32,7 +39,8 @@ namespace MMCA.Common.Aspire.Gateway;
 ///   "PermitLimit": 240,
 ///   "WindowSeconds": 60,
 ///   "GlobalConcurrencyLimit": 300,
-///   "BypassPathPrefixes": [ "/metrics" ]
+///   "BypassPathPrefixes": [ "/metrics" ],
+///   "SyntheticTrafficHeaderName": "X-Synthetic-Traffic-Key"
 /// }
 /// </code>
 /// </example>
@@ -72,4 +80,37 @@ public sealed class GatewayRateLimitingSettings
     /// liveness probe and a container restart.
     /// </summary>
     public IReadOnlyList<string> BypassPathPrefixes { get; init; } = [];
+
+    /// <summary>
+    /// Name of the request header a synthetic-traffic run presents to claim the bypass. Only the
+    /// NAME lives here: the header is worthless without <see cref="SyntheticTrafficSecret"/>, which
+    /// is why this one is safe in <c>appsettings.json</c> and the secret is not. Renaming it is a
+    /// coordination change, not a security control.
+    /// </summary>
+    [Required]
+    public string SyntheticTrafficHeaderName { get; init; } = "X-Synthetic-Traffic-Key";
+
+    /// <summary>
+    /// Shared secret that <see cref="SyntheticTrafficHeaderName"/> must carry, compared in constant
+    /// time. Null or empty (the default) disables the bypass entirely, so no header value can claim
+    /// it. When set it must be at least 32 characters.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why it exists.</b> A load or capacity proof drives its whole run from ONE runner IP, which
+    /// the per-IP fixed window cannot tell from an unauthenticated flood: the run measures the
+    /// limiter instead of the system. A run holding this secret takes the no-limiter partition on
+    /// BOTH chained limiters and measures the thing it was pointed at.
+    /// </para>
+    /// <para>
+    /// <b>Where it belongs.</b> Production must supply it from a secret store or the environment
+    /// (<c>GatewayRateLimiting__SyntheticTrafficSecret</c>), NEVER from a checked-in
+    /// <c>appsettings</c> file: a value in source control is a published key to the edge limiter.
+    /// The 32-character minimum is validated at registration, so a short value fails startup rather
+    /// than shipping a guessable bypass. <c>StringLength</c> treats null as valid, which is exactly
+    /// the intended "off" state.
+    /// </para>
+    /// </remarks>
+    [StringLength(int.MaxValue, MinimumLength = 32)]
+    public string? SyntheticTrafficSecret { get; init; }
 }

--- a/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
@@ -8,6 +8,10 @@ MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.GatewayDownstream
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeVersion.get -> MMCA.Common.Aspire.Gateway.DownstreamProbeVersion
 MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions.ProbeVersion.set -> void
 MMCA.Common.Aspire.Gateway.GatewayHealthCheckExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddGatewayDownstreamHealthChecks(System.Action<MMCA.Common.Aspire.Gateway.GatewayDownstreamHealthCheckOptions!>? configure, params string![]! serviceNames) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.Aspire.Gateway.GatewayRateLimitingSettings.SyntheticTrafficHeaderName.get -> string!
+MMCA.Common.Aspire.Gateway.GatewayRateLimitingSettings.SyntheticTrafficHeaderName.init -> void
+MMCA.Common.Aspire.Gateway.GatewayRateLimitingSettings.SyntheticTrafficSecret.get -> string?
+MMCA.Common.Aspire.Gateway.GatewayRateLimitingSettings.SyntheticTrafficSecret.init -> void
 MMCA.Common.Aspire.Logging.SerilogHostExtensions
 MMCA.Common.Aspire.Logging.SerilogHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!)
 MMCA.Common.Aspire.Logging.SerilogHostExtensions.extension(Microsoft.AspNetCore.Builder.WebApplicationBuilder!).AddCommonSerilog(string! logFilePath, System.Action<Serilog.LoggerConfiguration!>? configure = null) -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Gateway/GatewayRateLimitingTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Gateway/GatewayRateLimitingTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading.RateLimiting;
 using AwesomeAssertions;
@@ -6,6 +7,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using MMCA.Common.Aspire.Gateway;
 
 namespace MMCA.Common.Aspire.Tests.Gateway;
@@ -18,6 +20,9 @@ namespace MMCA.Common.Aspire.Tests.Gateway;
 /// </summary>
 public sealed class GatewayRateLimitingTests
 {
+    /// <summary>A well-formed synthetic-traffic secret: long enough to clear the 32-character floor.</summary>
+    private const string ConfiguredSecret = "synthetic-traffic-secret-for-tests-0000000";
+
     [Fact]
     public void Settings_Defaults_MatchTheDocumentedEdgeBudget()
     {
@@ -27,6 +32,9 @@ public sealed class GatewayRateLimitingTests
         settings.WindowSeconds.Should().Be(60);
         settings.GlobalConcurrencyLimit.Should().Be(200);
         settings.BypassPathPrefixes.Should().BeEmpty();
+        settings.SyntheticTrafficHeaderName.Should().Be("X-Synthetic-Traffic-Key");
+        settings.SyntheticTrafficSecret.Should().BeNull(
+            because: "the synthetic-traffic bypass is off until a host configures a secret");
         GatewayRateLimitingSettings.SectionName.Should().Be("GatewayRateLimiting");
     }
 
@@ -41,6 +49,8 @@ public sealed class GatewayRateLimitingTests
                 ["GatewayRateLimiting:GlobalConcurrencyLimit"] = "7",
                 ["GatewayRateLimiting:BypassPathPrefixes:0"] = "/metrics",
                 ["GatewayRateLimiting:BypassPathPrefixes:1"] = "/status",
+                ["GatewayRateLimiting:SyntheticTrafficHeaderName"] = "X-Load-Proof",
+                ["GatewayRateLimiting:SyntheticTrafficSecret"] = ConfiguredSecret,
             })
             .Build();
 
@@ -54,6 +64,8 @@ public sealed class GatewayRateLimitingTests
         settings.WindowSeconds.Should().Be(10);
         settings.GlobalConcurrencyLimit.Should().Be(7);
         settings.BypassPathPrefixes.Should().Equal("/metrics", "/status");
+        settings.SyntheticTrafficHeaderName.Should().Be("X-Load-Proof");
+        settings.SyntheticTrafficSecret.Should().Be(ConfiguredSecret);
     }
 
     [Fact]
@@ -235,11 +247,174 @@ public sealed class GatewayRateLimitingTests
         }
     }
 
+    // A single-runner capacity proof arrives entirely from one IP, which the per-IP window cannot
+    // tell from an unauthenticated flood. The bypass is what lets such a run measure the system
+    // instead of the limiter, so both halves matter: it must work with the secret, and it must be
+    // unclaimable without one.
+    [Fact]
+    public void IsSyntheticTraffic_WithNoSecretConfigured_IsFalseEvenWhenTheHeaderIsPresent()
+    {
+        var settings = new GatewayRateLimitingSettings();
+        var context = ContextFor("/api/orders", IPAddress.Loopback, settings.SyntheticTrafficHeaderName, "anything");
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(context, settings)
+            .Should().BeFalse(because: "the bypass is off until a host configures a secret");
+    }
+
+    [Fact]
+    public void IsSyntheticTraffic_WithTheConfiguredSecret_IsTrue()
+    {
+        var settings = new GatewayRateLimitingSettings { SyntheticTrafficSecret = ConfiguredSecret };
+        var context = ContextFor(
+            "/api/orders", IPAddress.Loopback, settings.SyntheticTrafficHeaderName, ConfiguredSecret);
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(context, settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSyntheticTraffic_HonorsAConfiguredHeaderName()
+    {
+        var settings = new GatewayRateLimitingSettings
+        {
+            SyntheticTrafficHeaderName = "X-Load-Proof",
+            SyntheticTrafficSecret = ConfiguredSecret,
+        };
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(
+            ContextFor("/api/orders", IPAddress.Loopback, "X-Load-Proof", ConfiguredSecret), settings)
+            .Should().BeTrue();
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(
+            ContextFor("/api/orders", IPAddress.Loopback, "X-Synthetic-Traffic-Key", ConfiguredSecret), settings)
+            .Should().BeFalse(because: "only the configured header name is read");
+    }
+
+    [Theory]
+    [InlineData("wrong-value")]
+    [InlineData("")]
+    [InlineData("synthetic-traffic-secret-for-tests-000000")] // one character short
+    [InlineData("synthetic-traffic-secret-for-tests-00000000")] // one character long
+    public void IsSyntheticTraffic_WithAWrongValue_IsFalse(string presented)
+    {
+        var settings = new GatewayRateLimitingSettings { SyntheticTrafficSecret = ConfiguredSecret };
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(
+            ContextFor("/api/orders", IPAddress.Loopback, settings.SyntheticTrafficHeaderName, presented), settings)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSyntheticTraffic_WithNoHeader_IsFalse()
+    {
+        var settings = new GatewayRateLimitingSettings { SyntheticTrafficSecret = ConfiguredSecret };
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(ContextFor("/api/orders", IPAddress.Loopback), settings)
+            .Should().BeFalse();
+    }
+
+    // A multi-valued header would let a caller spray candidate secrets in one request, so exactly
+    // one value is required rather than "any value matches".
+    [Fact]
+    public void IsSyntheticTraffic_WithMultipleHeaderValues_IsFalse()
+    {
+        var settings = new GatewayRateLimitingSettings { SyntheticTrafficSecret = ConfiguredSecret };
+        var context = ContextFor(
+            "/api/orders", IPAddress.Loopback, settings.SyntheticTrafficHeaderName, "decoy", ConfiguredSecret);
+
+        GatewayRateLimitingExtensions.IsSyntheticTraffic(context, settings)
+            .Should().BeFalse(because: "one request may present exactly one candidate");
+    }
+
+    [Fact]
+    public void ClientIpPartition_ForProvenSyntheticTraffic_UsesTheBypassPartition()
+    {
+        var settings = new GatewayRateLimitingSettings { SyntheticTrafficSecret = ConfiguredSecret };
+        var proven = ContextFor(
+            "/api/orders", IPAddress.Parse("203.0.113.7"), settings.SyntheticTrafficHeaderName, ConfiguredSecret);
+        var ordinary = ContextFor("/api/orders", IPAddress.Parse("203.0.113.7"));
+
+        GatewayRateLimitingExtensions.ClientIpPartition(proven, settings).PartitionKey.Should().Be("__bypass");
+        GatewayRateLimitingExtensions.ClientIpPartition(ordinary, settings).PartitionKey.Should().Be("203.0.113.7");
+    }
+
+    [Fact]
+    public void ConcurrencyPartition_ForProvenSyntheticTraffic_UsesTheBypassPartition()
+    {
+        var settings = new GatewayRateLimitingSettings { SyntheticTrafficSecret = ConfiguredSecret };
+        var proven = ContextFor(
+            "/api/orders", IPAddress.Parse("203.0.113.7"), settings.SyntheticTrafficHeaderName, ConfiguredSecret);
+        var ordinary = ContextFor("/api/orders", IPAddress.Parse("203.0.113.7"));
+
+        GatewayRateLimitingExtensions.ConcurrencyPartition(proven, settings).PartitionKey.Should().Be("__bypass");
+        GatewayRateLimitingExtensions.ConcurrencyPartition(ordinary, settings).PartitionKey.Should().Be("__gateway");
+    }
+
+    // A guessable bypass key is worse than no bypass at all, so a short secret must fail at
+    // registration (ADR-070) rather than at the first synthetic run.
+    [Fact]
+    public void AddGatewayRateLimiting_WithATooShortSecret_ThrowsAtRegistration()
+    {
+        var act = () => new ServiceCollection().AddGatewayRateLimiting(
+            new GatewayRateLimitingSettings { SyntheticTrafficSecret = new string('s', 31) });
+
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void AddGatewayRateLimiting_WithAThirtyTwoCharacterSecret_IsAccepted()
+    {
+        var act = () => new ServiceCollection().AddGatewayRateLimiting(
+            new GatewayRateLimitingSettings { SyntheticTrafficSecret = new string('s', 32) });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task GlobalLimiter_AdmitsProvenSyntheticTrafficPastAnExhaustedPerIpWindow()
+    {
+        var settings = new GatewayRateLimitingSettings
+        {
+            PermitLimit = 1,
+            WindowSeconds = 60,
+            SyntheticTrafficSecret = ConfiguredSecret,
+        };
+
+        var services = new ServiceCollection();
+        services.AddGatewayRateLimiting(settings);
+
+        await using var provider = services.BuildServiceProvider();
+        var limiter = provider.GetRequiredService<IOptions<RateLimiterOptions>>().Value.GlobalLimiter!;
+
+        var runnerIp = IPAddress.Parse("198.51.100.9");
+
+        using var first = await limiter.AcquireAsync(ContextFor("/api/orders", runnerIp), 1, CancellationToken.None);
+        using var second = await limiter.AcquireAsync(ContextFor("/api/orders", runnerIp), 1, CancellationToken.None);
+        using var synthetic = await limiter.AcquireAsync(
+            ContextFor("/api/orders", runnerIp, settings.SyntheticTrafficHeaderName, ConfiguredSecret),
+            1,
+            CancellationToken.None);
+
+        first.IsAcquired.Should().BeTrue();
+        second.IsAcquired.Should().BeFalse(because: "the whole run arrives from one runner IP");
+        synthetic.IsAcquired.Should().BeTrue(because: "the proof measures the system, not the limiter");
+    }
+
     private static DefaultHttpContext ContextFor(string path, IPAddress? remoteIp)
     {
         var context = new DefaultHttpContext();
         context.Request.Path = path;
         context.Connection.RemoteIpAddress = remoteIp;
+        return context;
+    }
+
+    private static DefaultHttpContext ContextFor(
+        string path,
+        IPAddress? remoteIp,
+        string headerName,
+        params string[] headerValues)
+    {
+        var context = ContextFor(path, remoteIp);
+        context.Request.Headers[headerName] = new StringValues(headerValues);
         return context;
     }
 }


### PR DESCRIPTION
## Why

The gateway edge rate limiter (ADR-088) partitions anonymous traffic per client IP (default 120 requests / 60 s). Both consumer apps run a monthly single-runner k6 capacity proof against production through that gateway. Since the limiter shipped (2026-08-18) those runs arrive entirely from ONE runner IP, so the limiter reads them as an unauthenticated flood and answers ~96% of the run with `429` (ADC run 33500095682, Store run 33499906085 on 2026-09-01). The proof measures the limiter instead of the system, and ADC's deploy `load-freshness` gate starts blocking deploys on 2026-09-05.

## What changed

`GatewayRateLimitingSettings` gains two properties:

- `SyntheticTrafficHeaderName` (default `X-Synthetic-Traffic-Key`, `[Required]`). Only the name, so it is safe in `appsettings.json`.
- `SyntheticTrafficSecret` (nullable, `[StringLength(int.MaxValue, MinimumLength = 32)]`). Null or empty is the default and means the bypass is off.

`GatewayRateLimitingExtensions` gains `internal static bool IsSyntheticTraffic(HttpContext, GatewayRateLimitingSettings)`, and both `ClientIpPartition` and `ConcurrencyPartition` now return the existing `__bypass` no-limiter partition for `IsBypassed(path) || IsSyntheticTraffic(ctx)`. Nothing else in the limiter composition moved. This joins the two bypass tiers already present (always-exempt infrastructure prefixes, host-configured prefixes) as a third.

Safety posture:

- Off by default: a null or empty secret disables the bypass outright, so the header alone can never claim it.
- Constant-time comparison over UTF-8 bytes via `CryptographicOperations.FixedTimeEquals`.
- Exactly one header value is accepted, so one request cannot spray candidate secrets in a multi-valued header.
- A configured secret shorter than 32 characters throws at registration (`Validator.ValidateObject(..., validateAllProperties: true)`, ADR-070 fail-fast); the `IConfiguration` overload covers the options path with `ValidateDataAnnotations().ValidateOnStart()`.
- Documented that production supplies the secret from a secret store or the environment (`GatewayRateLimiting__SyntheticTrafficSecret`), never from a checked-in `appsettings` file.

Also updated: `PublicAPI.Unshipped.txt` (four new lines) and the `CHANGELOG.md` Unreleased `Added` section. No ADR edited (ADRs live in the Website repo and are amended separately), no version bumped, `FACTS.md` untouched.

## Test evidence

`dotnet build MMCA.Common.slnx -c Release`

```
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

`Tests/Hosting/MMCA.Common.Aspire.Tests/bin/Release/net10.0/MMCA.Common.Aspire.Tests.exe` (whole project)

```
MMCA.Common.Aspire.Tests  Total: 176, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 14.532s
```

Same executable filtered to the touched class (`-class MMCA.Common.Aspire.Tests.Gateway.GatewayRateLimitingTests`)

```
MMCA.Common.Aspire.Tests  Total: 37, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 0.136s
```

That is 23 pre-existing cases plus 14 new ones covering: the two defaults, binding both values from the configuration section, `IsSyntheticTraffic` false with no secret configured even when the header is present, true on a match, honoring a non-default header name, false on a wrong / empty / off-by-one value, false with no header, false with multiple header values, both partitions returning `__bypass` for a proven request and their normal keys otherwise, a `ValidationException` for a 31-character secret and acceptance of a 32-character one, and an end-to-end run where `PermitLimit = 1` rejects the second request from the runner IP and admits it once the header is presented.

`dotnet format MMCA.Common.slnx --verify-no-changes` reports nothing in any file this PR touches (its remaining repo-wide IDE0200 / IDE0042 / IDE0290 findings are pre-existing in untouched test files).

## Consumer follow-ups (not in this PR)

1. Bump `MMCA.Common.*` in ADC and Store once this ships in a release.
2. Add the secret to each app's gateway bicep / environment as `GatewayRateLimiting__SyntheticTrafficSecret`, sourced from Key Vault, and generate a fresh value per app (32+ characters).
3. Have each k6 capacity-proof workflow send `X-Synthetic-Traffic-Key` from the same secret, then re-run to confirm the 429 rate drops.
4. Amend ADR-088 in the Website repo to document the third bypass tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDwq8GEDNc5seF2WAeN5wL
