### PR TITLE
fix: readiness-safe Redis registration + authoritative metric drop views

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -247,6 +247,11 @@
          ServiceDiscovery) above. -->
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <!-- Test tier only (Tests/Hosting/MMCA.Common.Aspire.Tests): an in-memory metric reader is the
+         only way to prove that the Telemetry:Disable*Metrics knobs actually drop a stream, rather
+         than merely skipping one AddXInstrumentation call that another component re-adds. Version
+         tracks the OpenTelemetry family pinned below. -->
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.18.0" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="4.0.0" />
     <!-- Shared integration-test scaffolding (MMCA.Common.Testing.SqlServerIntegrationTestFixtureBase):
@@ -258,8 +263,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
-    <!-- Health Checks -->
-    <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
+    <!-- Health Checks. AspNetCore.HealthChecks.Redis is deliberately absent: its check issues
+         CLUSTER INFO against any server StackExchange.Redis 3.x reports as clustered, which Azure
+         Managed Redis (Enterprise tier) refuses outside admin mode, so every probe threw against a
+         healthy cache. MMCA.Common.Aspire ships a PING-only replacement instead
+         (Health/RedisPingHealthCheck). The package still arrives transitively through
+         Aspire.StackExchange.Redis, which is harmless because the Aspire checks are switched off at
+         registration (Caching/RedisCachingExtensions) and this repo does not enable central
+         transitive pinning, so no PackageVersion entry is required to keep the restore graph valid. -->
     <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Sqlite" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
@@ -289,6 +300,14 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <!-- Redis client integrations (MMCA.Common.Aspire.Caching.RedisCachingExtensions). Held at the
+         same 13.5.3 the hosting stack sits on, and matching the pins both consumer apps already
+         carry, so a host that swaps its direct Aspire references for the framework wrapper resolves
+         exactly the same assemblies. Microsoft.AspNetCore.OutputCaching.StackExchangeRedis is the
+         shared Redis output-cache store the wrapper registers; it ships no health check of its own. -->
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.5.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.5.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="10.0.11" />
     <!-- Aspire AppHost -->
     <PackageVersion Include="Aspire.Hosting" Version="13.5.3" />
     <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="13.5.3" />

--- a/Source/Hosting/MMCA.Common.Aspire/Caching/RedisCachingExtensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Caching/RedisCachingExtensions.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MMCA.Common.Aspire.Caching;
+
+/// <summary>
+/// The framework-owned way to wire a host to Redis. Service hosts call these instead of Aspire's
+/// <c>AddRedisDistributedCache</c> / <c>AddRedisClient</c> / <c>AddStackExchangeRedisOutputCache</c>
+/// directly, because the raw Aspire integrations register a health check that is fatal to readiness.
+/// <para>
+/// Why this wrapper exists (production incident, 2026-09-02). Aspire's Redis integrations register
+/// the <c>AspNetCore.HealthChecks.Redis</c> check under the name <c>StackExchange.Redis</c> with NO
+/// tags. The readiness endpoint from <c>MapDefaultEndpoints()</c> includes every check that is not
+/// tagged <c>live</c> or <c>optional</c>, so an untagged check silently gates readiness. That check
+/// issues <c>CLUSTER INFO</c> whenever the client detects a clustered server, and Azure Managed Redis
+/// (Enterprise tier, port 10000) is detected as a cluster by StackExchange.Redis 3.x, which refuses
+/// the command without admin mode. Every probe therefore threw, every replica reported not ready,
+/// and the platform stopped routing traffic the applications were perfectly able to serve.
+/// </para>
+/// <para>
+/// The fix is structural rather than a tag patch on someone else's registration: the Aspire checks
+/// are switched off at the source (<c>DisableHealthChecks</c>) and Common contributes its own
+/// PING-only check, named <c>redis</c> and tagged <see cref="HealthCheckTags.Optional"/>, from
+/// <c>AddInfrastructureHealthChecks()</c>. A cache the application degrades gracefully without must
+/// be visible on <c>/health</c> and invisible to <c>/health/ready</c>.
+/// </para>
+/// </summary>
+public static class RedisCachingExtensions
+{
+    /// <summary>
+    /// The connection-string name every MMCA host uses for its Redis resource.
+    /// </summary>
+    public const string DefaultConnectionName = "redis";
+
+    extension<TBuilder>(TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        /// <summary>
+        /// Registers the Redis distributed cache and the <c>IConnectionMultiplexer</c> client when the
+        /// named connection string is configured, with the Aspire health checks disabled so nothing
+        /// untagged reaches readiness.
+        /// <para>
+        /// A no-op when the connection string is absent or blank: Redis is optional per host, and the
+        /// in-memory cache fallback is the documented behavior for local runs and tests. The client is
+        /// registered alongside the cache on purpose: <c>DistributedCacheService</c> needs an
+        /// <c>IConnectionMultiplexer</c> for SCAN-based prefix eviction, and without it every
+        /// <c>ICacheInvalidating</c> command's prefix invalidation degrades to a silent no-op bounded
+        /// only by TTL.
+        /// </para>
+        /// </summary>
+        /// <param name="connectionName">
+        /// The connection-string name of the Redis resource. Defaults to
+        /// <see cref="DefaultConnectionName"/>.
+        /// </param>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddRedisCaching(string connectionName = DefaultConnectionName)
+        {
+            if (string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString(connectionName)))
+            {
+                return builder;
+            }
+
+            builder.AddRedisDistributedCache(connectionName, settings => settings.DisableHealthChecks = true);
+            builder.AddRedisClient(connectionName, settings => settings.DisableHealthChecks = true);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Backs the ASP.NET Core output cache with the same Redis instance when the named connection
+        /// string is configured, so tag eviction crosses replicas instead of reaching only the replica
+        /// that served the mutation.
+        /// <para>
+        /// A no-op when the connection string is absent: the built-in per-replica memory store still
+        /// applies, which is correct at a single replica. Call this BEFORE <c>AddOutputCache(...)</c>;
+        /// that call registers its store with <c>TryAdd</c>, so the explicit Redis store registered
+        /// here wins either way, but keeping the order explicit documents the intent.
+        /// </para>
+        /// <para>
+        /// This integration registers no health check of its own, so there is nothing to disable here.
+        /// The PING check contributed by <c>AddInfrastructureHealthChecks()</c> already covers
+        /// reachability for the whole Redis resource.
+        /// </para>
+        /// </summary>
+        /// <param name="connectionName">
+        /// The connection-string name of the Redis resource. Defaults to
+        /// <see cref="DefaultConnectionName"/>.
+        /// </param>
+        /// <returns>The same builder instance for chaining.</returns>
+        public TBuilder AddRedisOutputCaching(string connectionName = DefaultConnectionName)
+        {
+            var connectionString = builder.Configuration.GetConnectionString(connectionName);
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                return builder;
+            }
+
+            builder.Services.AddStackExchangeRedisOutputCache(options => options.Configuration = connectionString);
+
+            return builder;
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -138,7 +139,25 @@ public static class Extensions
                     // A deployed host sets Telemetry:DisableHttpClientMetrics=true to drop them; outbound
                     // dependency latency is still captured as AppDependencies traces. Unset (default) keeps
                     // them, so no behavior change for a host that does not opt in.
-                    if (!IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableHttpClientMetrics"))
+                    if (IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableHttpClientMetrics"))
+                    {
+                        // Skipping AddHttpClientInstrumentation is NOT enough on its own. A deployed
+                        // host also calls UseAzureMonitor() (see AddOpenTelemetryExporters below), and
+                        // the Azure Monitor distro adds the System.Net.Http meter itself, so
+                        // http.client.open_connections kept flowing and stayed the single largest
+                        // AppMetrics stream in both production workspaces despite the toggle being on.
+                        // A View applies to the whole MeterProvider regardless of which component added
+                        // the meter, so dropping every instrument on those two meters makes the toggle
+                        // authoritative instead of advisory. System.Net.NameResolution rides along
+                        // because DNS-lookup metrics are part of the same HttpClient family and carry
+                        // no signal without it.
+                        metrics.AddView(instrument =>
+                            string.Equals(instrument.Meter.Name, "System.Net.Http", StringComparison.Ordinal)
+                            || string.Equals(instrument.Meter.Name, "System.Net.NameResolution", StringComparison.Ordinal)
+                                ? MetricStreamConfiguration.Drop
+                                : null);
+                    }
+                    else
                     {
                         metrics.AddHttpClientInstrumentation();
                     }
@@ -147,7 +166,17 @@ public static class Extensions
                     // ~17 instruments emitted every collection interval regardless of traffic) are the second
                     // highest-volume contributor and are rarely consulted operationally for these apps. A
                     // deployed host sets Telemetry:DisableRuntimeMetrics=true to drop them. Unset keeps them.
-                    if (!IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableRuntimeMetrics"))
+                    if (IsInstrumentationDisabled(builder.Configuration, "Telemetry:DisableRuntimeMetrics"))
+                    {
+                        // Same reasoning as the HttpClient branch above: the Azure Monitor distro adds
+                        // the System.Runtime meter on its own, so the toggle only becomes authoritative
+                        // once a View drops the whole meter.
+                        metrics.AddView(instrument =>
+                            string.Equals(instrument.Meter.Name, "System.Runtime", StringComparison.Ordinal)
+                                ? MetricStreamConfiguration.Drop
+                                : null);
+                    }
+                    else
                     {
                         metrics.AddRuntimeInstrumentation();
                     }
@@ -244,7 +273,20 @@ public static class Extensions
             var redisConnectionString = builder.Configuration.GetConnectionString("redis");
             if (!string.IsNullOrWhiteSpace(redisConnectionString))
             {
-                healthChecks.AddRedis(redisConnectionString, name: "redis", tags: [HealthCheckTags.Optional]);
+                // PING only, never an administrative command. The AspNetCore.HealthChecks.Redis check
+                // this replaced issued CLUSTER INFO against any server it detected as clustered, which
+                // is how StackExchange.Redis 3.x sees Azure Managed Redis (Enterprise tier), and the
+                // server refuses that command outside admin mode: every probe threw against a healthy
+                // cache. The check is registered as a singleton so the fallback multiplexer is built
+                // once, not per probe, and disposed with the container.
+                builder.Services.TryAddSingleton(
+                    sp => new Health.RedisPingHealthCheck(redisConnectionString, sp));
+
+                healthChecks.Add(new HealthCheckRegistration(
+                    "redis",
+                    sp => sp.GetRequiredService<Health.RedisPingHealthCheck>(),
+                    failureStatus: null,
+                    tags: [HealthCheckTags.Optional]));
             }
 
             var rabbitConnectionString = builder.Configuration.GetConnectionString("rabbitmq")

--- a/Source/Hosting/MMCA.Common.Aspire/Health/RedisPingHealthCheck.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Health/RedisPingHealthCheck.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+
+namespace MMCA.Common.Aspire.Health;
+
+/// <summary>
+/// Reachability check for the Redis resource that issues nothing but <c>PING</c>.
+/// <para>
+/// It replaces the <c>AspNetCore.HealthChecks.Redis</c> check, which branches on the detected server
+/// type and issues <c>CLUSTER INFO</c> against anything it considers clustered. Azure Managed Redis
+/// (Enterprise tier, port 10000) is detected as a cluster by StackExchange.Redis 3.x and refuses
+/// administrative commands unless the client opted into admin mode, so that check threw
+/// <c>RedisCommandException</c> on every probe against a perfectly healthy cache. <c>PING</c> answers
+/// the only question a health check has ("can this process talk to Redis right now?") and is never
+/// gated on admin mode, on the server topology, or on the deployment tier.
+/// </para>
+/// <para>
+/// The multiplexer is resolved from DI when the host wired Redis through
+/// <c>AddRedisCaching()</c>. A host that configured a connection string without registering a client
+/// gets a lazily created, connection-check-owned multiplexer instead, created once and disposed with
+/// this singleton, so a health probe never opens a fresh connection per call.
+/// </para>
+/// </summary>
+internal sealed class RedisPingHealthCheck : IHealthCheck, IAsyncDisposable
+{
+    private readonly string _connectionString;
+    private readonly IServiceProvider _services;
+    private readonly SemaphoreSlim _connectGate = new(1, 1);
+    private ConnectionMultiplexer? _ownedMultiplexer;
+
+    public RedisPingHealthCheck(string connectionString, IServiceProvider services)
+    {
+        _connectionString = connectionString;
+        _services = services;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        try
+        {
+            IConnectionMultiplexer multiplexer = _services.GetService<IConnectionMultiplexer>()
+                ?? await GetOrCreateOwnedMultiplexerAsync().ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var latency = await multiplexer.GetDatabase().PingAsync().ConfigureAwait(false);
+
+            return HealthCheckResult.Healthy(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Redis responded to PING in {0:F1} ms.",
+                    latency.TotalMilliseconds));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Any failure to reach Redis is reported, never thrown: this check is tagged optional and
+            // must degrade the /health payload rather than fault the probe pipeline.
+            return new HealthCheckResult(
+                context.Registration.FailureStatus,
+                description: "Redis did not respond to PING.",
+                exception: ex);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_ownedMultiplexer is not null)
+        {
+            await _ownedMultiplexer.DisposeAsync().ConfigureAwait(false);
+            _ownedMultiplexer = null;
+        }
+
+        _connectGate.Dispose();
+    }
+
+    // No lock-free fast path on purpose: health probes run on a timer, not on the request path, so an
+    // uncontended semaphore wait costs nothing measurable and the single write keeps the "connect at
+    // most once" invariant obvious. A failed connect leaves the field null, so the next probe retries
+    // rather than latching a faulted result forever.
+    private async Task<ConnectionMultiplexer> GetOrCreateOwnedMultiplexerAsync()
+    {
+        await _connectGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return _ownedMultiplexer ??= await ConnectionMultiplexer.ConnectAsync(_connectionString).ConfigureAwait(false);
+        }
+        finally
+        {
+            _connectGate.Release();
+        }
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
+++ b/Source/Hosting/MMCA.Common.Aspire/MMCA.Common.Aspire.csproj
@@ -14,9 +14,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
-    <PackageReference Include="AspNetCore.HealthChecks.Redis" />
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
+    <!-- Redis wiring is owned by the framework (Caching/RedisCachingExtensions): the raw Aspire
+         integrations register an untagged health check that gates readiness and issues CLUSTER INFO,
+         which Azure Managed Redis refuses. The wrapper turns those checks off and Common contributes
+         a PING-only check instead (Health/RedisPingHealthCheck), which is why StackExchange.Redis is
+         a direct reference here and AspNetCore.HealthChecks.Redis is deliberately NOT referenced. -->
+    <PackageReference Include="Aspire.StackExchange.Redis" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" />
+    <PackageReference Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" />
+    <PackageReference Include="StackExchange.Redis" />
     <!-- Shared DataProtection key ring: blob persistence (required for multi-replica cookie and
          antiforgery decryption) plus the optional Key Vault at-rest encryption, both config-gated
          in DataProtection/DataProtectionExtensions.cs. Azure.Identity supplies the

--- a/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
@@ -25,3 +25,10 @@ static MMCA.Common.Aspire.Extensions.AddInfrastructureHealthChecks<TBuilder>(thi
 MMCA.Common.Aspire.Security.CspNonce
 const MMCA.Common.Aspire.Security.CspNonce.ItemKey = "MMCA.CspNonce" -> string!
 static MMCA.Common.Aspire.Security.CspNonce.Get(Microsoft.AspNetCore.Http.HttpContext! context) -> string?
+MMCA.Common.Aspire.Caching.RedisCachingExtensions
+MMCA.Common.Aspire.Caching.RedisCachingExtensions.extension<TBuilder>(TBuilder)
+MMCA.Common.Aspire.Caching.RedisCachingExtensions.extension<TBuilder>(TBuilder).AddRedisCaching(string! connectionName = "redis") -> TBuilder
+MMCA.Common.Aspire.Caching.RedisCachingExtensions.extension<TBuilder>(TBuilder).AddRedisOutputCaching(string! connectionName = "redis") -> TBuilder
+const MMCA.Common.Aspire.Caching.RedisCachingExtensions.DefaultConnectionName = "redis" -> string!
+static MMCA.Common.Aspire.Caching.RedisCachingExtensions.AddRedisCaching<TBuilder>(this TBuilder builder, string! connectionName = "redis") -> TBuilder
+static MMCA.Common.Aspire.Caching.RedisCachingExtensions.AddRedisOutputCaching<TBuilder>(this TBuilder builder, string! connectionName = "redis") -> TBuilder

--- a/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
+++ b/Source/Hosting/MMCA.Common.Aspire/packages.lock.json
@@ -2,6 +2,54 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Aspire.StackExchange.Redis": {
+        "type": "Direct",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "B0mJpW8715pp8ecZ5RXh3pG78ncg8EKMM1pOZO2X10z0RLqTLerhyW4i2RrxOZMkx00BDRrZT+43e6GHmvdjUQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Aspire.StackExchange.Redis.DistributedCaching": {
+        "type": "Direct",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EBkcHLElw38oWRbBlY/TRY1OEWOE+zMptWlPidsCY3lKhj3v0usGrH18BdB5JPRQKdJDA7fjJd7eqsvAOIJlNw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Aspire.StackExchange.Redis": "13.5.3",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
       "AspNetCore.HealthChecks.Rabbitmq": {
         "type": "Direct",
         "requested": "[9.0.0, )",
@@ -10,16 +58,6 @@
         "dependencies": {
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "RabbitMQ.Client": "7.0.0"
-        }
-      },
-      "AspNetCore.HealthChecks.Redis": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
-          "StackExchange.Redis": "2.7.4"
         }
       },
       "AspNetCore.HealthChecks.Sqlite": {
@@ -112,6 +150,17 @@
         "requested": "[3.0.200, )",
         "resolved": "3.0.200",
         "contentHash": "xDYQDG/pBdvC3r1PcqQw9d8/9dRYxh9xxljjgVydBezpxOUSABjuRjVWNoUmqNByrtWqwJ+nRdAwUuWPbU8uXQ=="
+      },
+      "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "pjjof07KoM9SvcGkfHVEYjuCxxTtO3mnXJkBJVsqGbTW6jU0hNuR/pMsgdTi8x6Xq4c2eKuaJR5c3W/uVKyY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "StackExchange.Redis": "2.7.27"
+        }
       },
       "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
         "type": "Direct",
@@ -261,6 +310,17 @@
           "SQLitePCLRaw.config.e_sqlite3": "3.0.5"
         }
       },
+      "StackExchange.Redis": {
+        "type": "Direct",
+        "requested": "[3.1.31, )",
+        "resolved": "3.1.31",
+        "contentHash": "QillloeZxgw9+IWmnowTrjrn+JV7JIMVzr1JiUpCa7pJQI48rtcqG9yy6u5UBRiTuCiKU5909aRu67Ch6gWVMg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "RESPite": "3.1.31",
+          "System.IO.Hashing": "10.0.5"
+        }
+      },
       "StyleCop.Analyzers": {
         "type": "Direct",
         "requested": "[1.2.0-beta.556, )",
@@ -277,6 +337,15 @@
         "contentHash": "TokfVsaU2fmcwvsU6ihLCkseVfwhLX6Tmbl3qh3nOBIqHSX4yqFllpslA+PuHERH/ENu3kwqo4deZiyT0Wvh3Q==",
         "dependencies": {
           "System.Security.Cryptography.Pkcs": "10.0.11"
+        }
+      },
+      "AspNetCore.HealthChecks.Redis": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
+          "StackExchange.Redis": "2.7.4"
         }
       },
       "Azure.Core": {
@@ -394,6 +463,14 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "vUl798SmruTqqlt/xH2gDk3tJlhk6k3HdOXAHirlRfbNKDym4g/kRpUL9S4sl6F6FsOTOMW+ZsDapqlZMOOiEw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
         "resolved": "10.9.0",
@@ -423,11 +500,11 @@
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "resolved": "10.0.11",
+        "contentHash": "KICyU3eVi5jvloKm01EXV69L97H/zkhISVtV98cIuzuFOxNx3xTUVcXqvWTz3aq7OvUuDB/MFlPFjmxRaKF7/A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -485,19 +562,19 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "Transitive",
-        "resolved": "8.0.11",
-        "contentHash": "zLgN22Zp9pk8RHlwssRTexw4+a6wqOnKWN+VejdPn5Yhjql4XiBhkFo35Nu8mmqHIk/UEmmCnMGLWq75aFfkOw==",
+        "resolved": "10.0.11",
+        "contentHash": "fzUGzOCLquuyIxVVvvcw9h8KaUrRZ/cGTai2gBDQ1YxbdH/8eZnSyoOu+PQJYoD+RUcgTTlVe6D4+FrcaUOR9w==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "8.0.11",
-          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Options": "8.0.2"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.11",
-        "contentHash": "So3JUdRxozRjvQ3cxU6F3nI/i4emDnjane6yMYcJhvTTTu29ltlIdoXjkFGRceIWz8yKvuEpzXItZ0x5GvN2nQ=="
+        "resolved": "10.0.11",
+        "contentHash": "5DCBP95vpklAkEfIbT2yzunianCeRtjaLrmAwoIgTf+xOJGFMmkAut/p3R2YmZL7TM1dnV81adGIg4m7Kg6wUw=="
       },
       "Microsoft.Extensions.Features": {
         "type": "Transitive",
@@ -765,14 +842,6 @@
           "OpenTelemetry.PersistentStorage.Abstractions": "1.0.3"
         }
       },
-      "Pipelines.Sockets.Unofficial": {
-        "type": "Transitive",
-        "resolved": "2.2.8",
-        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ==",
-        "dependencies": {
-          "System.IO.Pipelines": "5.0.1"
-        }
-      },
       "Polly.Extensions": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -800,6 +869,11 @@
           "System.IO.Pipelines": "8.0.0",
           "System.Threading.RateLimiting": "8.0.0"
         }
+      },
+      "RESPite": {
+        "type": "Transitive",
+        "resolved": "3.1.31",
+        "contentHash": "u+MFK6FzGWngKaY3wJ/V9vQSVe/NSqpk0IYYw6ACwmlPq5eTnsyZGlzEa3YMifJGVs3omrl5MkgigB1jZYNnGg=="
       },
       "Serilog": {
         "type": "Transitive",
@@ -919,8 +993,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
@@ -1013,6 +1087,18 @@
           "System.Runtime.Caching": "8.0.0"
         }
       },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.11",
+        "contentHash": "0SCQuU1m+BcLMjyh6q1X9j0hongN9EZx9KhgDyPgHxVa5RJ5xuHBkvcgnX95KSa5bQlkYupeQFu8IAI3NgPIUQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.0.11, )",
@@ -1041,16 +1127,6 @@
         "requested": "[8.7.0, )",
         "resolved": "8.4.2",
         "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
-      },
-      "StackExchange.Redis": {
-        "type": "CentralTransitive",
-        "requested": "[3.1.31, )",
-        "resolved": "2.7.4",
-        "contentHash": "lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Pipelines.Sockets.Unofficial": "2.2.8"
-        }
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "CentralTransitive",

--- a/Source/MMCA.Common/packages.lock.json
+++ b/Source/MMCA.Common/packages.lock.json
@@ -63,6 +63,15 @@
           "Asp.Versioning.Abstractions": "10.2.1"
         }
       },
+      "AspNetCore.HealthChecks.Redis": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
+          "StackExchange.Redis": "2.7.4"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.61.0",
@@ -323,11 +332,11 @@
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "resolved": "10.0.11",
+        "contentHash": "KICyU3eVi5jvloKm01EXV69L97H/zkhISVtV98cIuzuFOxNx3xTUVcXqvWTz3aq7OvUuDB/MFlPFjmxRaKF7/A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
@@ -397,19 +406,19 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "4x6y2Uy+g9Ou93eBCVkG/3JCwnc2AMKhrE1iuEhXT/MzNN7co/Zt6yL+q1Srt0CnOe3iLX+sVqpJI4ZGlOPfug==",
+        "resolved": "10.0.11",
+        "contentHash": "fzUGzOCLquuyIxVVvvcw9h8KaUrRZ/cGTai2gBDQ1YxbdH/8eZnSyoOu+PQJYoD+RUcgTTlVe6D4+FrcaUOR9w==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+        "resolved": "10.0.11",
+        "contentHash": "5DCBP95vpklAkEfIbT2yzunianCeRtjaLrmAwoIgTf+xOJGFMmkAut/p3R2YmZL7TM1dnV81adGIg4m7Kg6wUw=="
       },
       "Microsoft.Extensions.Features": {
         "type": "Transitive",
@@ -851,8 +860,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8IBJWcCT9+e4Bmevm4T7+fQEiAh133KGiz4oiVTgJckd3Q76OFdR1falgn9lpz7+C4HJvogCDJeAa2QmvbeVtg=="
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -909,9 +918,10 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
-          "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "AspNetCore.HealthChecks.Sqlite": "[9.0.0, )",
+          "Aspire.StackExchange.Redis": "[13.5.3, )",
+          "Aspire.StackExchange.Redis.DistributedCaching": "[13.5.3, )",
           "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.2, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.4, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.4, )",
@@ -919,6 +929,7 @@
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "Azure.Storage.Blobs": "[12.29.2, )",
           "MMCA.Common.Shared": "[1.0.0, )",
+          "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": "[10.0.11, )",
           "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.9.0, )",
           "OpenTelemetry.Api": "[1.18.0, )",
@@ -931,6 +942,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
           "Serilog.Sinks.File": "[7.0.0, )",
+          "StackExchange.Redis": "[3.1.31, )",
           "System.Security.Cryptography.Xml": "[10.0.11, )"
         }
       },
@@ -997,6 +1009,54 @@
           "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
+      "Aspire.StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "B0mJpW8715pp8ecZ5RXh3pG78ncg8EKMM1pOZO2X10z0RLqTLerhyW4i2RrxOZMkx00BDRrZT+43e6GHmvdjUQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Aspire.StackExchange.Redis.DistributedCaching": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EBkcHLElw38oWRbBlY/TRY1OEWOE+zMptWlPidsCY3lKhj3v0usGrH18BdB5JPRQKdJDA7fjJd7eqsvAOIJlNw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Aspire.StackExchange.Redis": "13.5.3",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.11",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
       "AspNet.Security.OAuth.Apple": {
         "type": "CentralTransitive",
         "requested": "[10.0.0, )",
@@ -1020,16 +1080,6 @@
         "dependencies": {
           "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
           "RabbitMQ.Client": "7.0.0"
-        }
-      },
-      "AspNetCore.HealthChecks.Redis": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "8.0.11",
-          "StackExchange.Redis": "2.7.4"
         }
       },
       "AspNetCore.HealthChecks.Sqlite": {
@@ -1214,6 +1264,17 @@
           "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
+      "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "pjjof07KoM9SvcGkfHVEYjuCxxTtO3mnXJkBJVsqGbTW6jU0hNuR/pMsgdTi8x6Xq4c2eKuaJR5c3W/uVKyY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
       "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
         "type": "CentralTransitive",
         "requested": "[10.0.11, )",
@@ -1306,6 +1367,18 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.11",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
           "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.11",
+        "contentHash": "0SCQuU1m+BcLMjyh6q1X9j0hongN9EZx9KhgDyPgHxVa5RJ5xuHBkvcgnX95KSa5bQlkYupeQFu8IAI3NgPIUQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "StackExchange.Redis": "2.7.27"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {

--- a/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
+++ b/Source/Presentation/MMCA.Common.UI.Web/packages.lock.json
@@ -60,6 +60,14 @@
           "Asp.Versioning.Abstractions": "10.2.1"
         }
       },
+      "AspNetCore.HealthChecks.Redis": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.4"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.61.0",
@@ -569,8 +577,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8IBJWcCT9+e4Bmevm4T7+fQEiAh133KGiz4oiVTgJckd3Q76OFdR1falgn9lpz7+C4HJvogCDJeAa2QmvbeVtg=="
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -621,9 +629,10 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
-          "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "AspNetCore.HealthChecks.Sqlite": "[9.0.0, )",
+          "Aspire.StackExchange.Redis": "[13.5.3, )",
+          "Aspire.StackExchange.Redis.DistributedCaching": "[13.5.3, )",
           "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.2, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.4, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.4, )",
@@ -631,6 +640,7 @@
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "Azure.Storage.Blobs": "[12.29.2, )",
           "MMCA.Common.Shared": "[1.0.0, )",
+          "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": "[10.0.11, )",
           "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.9.0, )",
           "OpenTelemetry.Api": "[1.18.0, )",
@@ -642,7 +652,8 @@
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
-          "Serilog.Sinks.File": "[7.0.0, )"
+          "Serilog.Sinks.File": "[7.0.0, )",
+          "StackExchange.Redis": "[3.1.31, )"
         }
       },
       "mmca.common.domain": {
@@ -721,6 +732,34 @@
           "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
+      "Aspire.StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "B0mJpW8715pp8ecZ5RXh3pG78ncg8EKMM1pOZO2X10z0RLqTLerhyW4i2RrxOZMkx00BDRrZT+43e6GHmvdjUQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Aspire.StackExchange.Redis.DistributedCaching": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EBkcHLElw38oWRbBlY/TRY1OEWOE+zMptWlPidsCY3lKhj3v0usGrH18BdB5JPRQKdJDA7fjJd7eqsvAOIJlNw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Aspire.StackExchange.Redis": "13.5.3",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
       "AspNet.Security.OAuth.Apple": {
         "type": "CentralTransitive",
         "requested": "[10.0.0, )",
@@ -743,15 +782,6 @@
         "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
         "dependencies": {
           "RabbitMQ.Client": "7.0.0"
-        }
-      },
-      "AspNetCore.HealthChecks.Redis": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
-        "dependencies": {
-          "StackExchange.Redis": "2.7.4"
         }
       },
       "AspNetCore.HealthChecks.Sqlite": {
@@ -925,6 +955,15 @@
           "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
+      "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "pjjof07KoM9SvcGkfHVEYjuCxxTtO3mnXJkBJVsqGbTW6jU0hNuR/pMsgdTi8x6Xq4c2eKuaJR5c3W/uVKyY6A==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
       "Microsoft.AspNetCore.SignalR.Client": {
         "type": "CentralTransitive",
         "requested": "[10.0.11, )",
@@ -1011,6 +1050,15 @@
         "requested": "[10.9.0, )",
         "resolved": "10.9.0",
         "contentHash": "D0tHRbUCliInxTfPgN9K6RxrCVaWu9kyIT66vbIJ/YwA6BV2xa8vTqoE3JQXA2Rf2vRdgd29+HR6Ay6KmzDslw=="
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.11",
+        "contentHash": "0SCQuU1m+BcLMjyh6q1X9j0hongN9EZx9KhgDyPgHxVa5RJ5xuHBkvcgnX95KSa5bQlkYupeQFu8IAI3NgPIUQ==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
+        }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "CentralTransitive",

--- a/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Hosting.Tests/packages.lock.json
@@ -130,6 +130,14 @@
           "Microsoft.Azure.Cosmos": "3.46.0"
         }
       },
+      "AspNetCore.HealthChecks.Redis": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.4"
+        }
+      },
       "AspNetCore.HealthChecks.Uris": {
         "type": "Transitive",
         "resolved": "9.0.0",
@@ -661,11 +669,6 @@
           "OpenTelemetry.PersistentStorage.Abstractions": "1.0.3"
         }
       },
-      "Pipelines.Sockets.Unofficial": {
-        "type": "Transitive",
-        "resolved": "2.2.8",
-        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
-      },
       "Polly.Extensions": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -691,6 +694,11 @@
         "type": "Transitive",
         "resolved": "7.2.1",
         "contentHash": "YKXEfg9fVQiTKgZlvIhAfPSFaamEgi8DsQmisCH0IAsU4FYLrtoguDrDj6JtJVGUt40QPnBLRH6fTQcAC4qsOg=="
+      },
+      "RESPite": {
+        "type": "Transitive",
+        "resolved": "3.1.31",
+        "contentHash": "u+MFK6FzGWngKaY3wJ/V9vQSVe/NSqpk0IYYw6ACwmlPq5eTnsyZGlzEa3YMifJGVs3omrl5MkgigB1jZYNnGg=="
       },
       "Semver": {
         "type": "Transitive",
@@ -898,9 +906,10 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
-          "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "AspNetCore.HealthChecks.Sqlite": "[9.0.0, )",
+          "Aspire.StackExchange.Redis": "[13.5.3, )",
+          "Aspire.StackExchange.Redis.DistributedCaching": "[13.5.3, )",
           "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.2, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.4, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.4, )",
@@ -908,6 +917,7 @@
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "Azure.Storage.Blobs": "[12.29.2, )",
           "MMCA.Common.Shared": "[1.0.0, )",
+          "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": "[10.0.11, )",
           "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.9.0, )",
           "OpenTelemetry.Api": "[1.18.0, )",
@@ -919,7 +929,8 @@
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
-          "Serilog.Sinks.File": "[7.0.0, )"
+          "Serilog.Sinks.File": "[7.0.0, )",
+          "StackExchange.Redis": "[3.1.31, )"
         }
       },
       "mmca.common.aspire.hosting": {
@@ -1063,6 +1074,34 @@
           "YamlDotNet": "16.3.0"
         }
       },
+      "Aspire.StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "B0mJpW8715pp8ecZ5RXh3pG78ncg8EKMM1pOZO2X10z0RLqTLerhyW4i2RrxOZMkx00BDRrZT+43e6GHmvdjUQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Aspire.StackExchange.Redis.DistributedCaching": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EBkcHLElw38oWRbBlY/TRY1OEWOE+zMptWlPidsCY3lKhj3v0usGrH18BdB5JPRQKdJDA7fjJd7eqsvAOIJlNw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Aspire.StackExchange.Redis": "13.5.3",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
       "AspNetCore.HealthChecks.Rabbitmq": {
         "type": "CentralTransitive",
         "requested": "[9.0.0, )",
@@ -1070,15 +1109,6 @@
         "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
         "dependencies": {
           "RabbitMQ.Client": "7.0.0"
-        }
-      },
-      "AspNetCore.HealthChecks.Redis": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
-        "dependencies": {
-          "StackExchange.Redis": "2.7.4"
         }
       },
       "AspNetCore.HealthChecks.Sqlite": {
@@ -1204,6 +1234,15 @@
           "Microsoft.NET.StringTools": "17.11.4"
         }
       },
+      "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "pjjof07KoM9SvcGkfHVEYjuCxxTtO3mnXJkBJVsqGbTW6jU0hNuR/pMsgdTi8x6Xq4c2eKuaJR5c3W/uVKyY6A==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
       "Microsoft.Data.SqlClient": {
         "type": "CentralTransitive",
         "requested": "[7.0.2, )",
@@ -1219,6 +1258,15 @@
           "Microsoft.SqlServer.Server": "1.0.0",
           "System.Configuration.ConfigurationManager": "9.0.13",
           "System.Security.Cryptography.Pkcs": "9.0.13"
+        }
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.11",
+        "contentHash": "0SCQuU1m+BcLMjyh6q1X9j0hongN9EZx9KhgDyPgHxVa5RJ5xuHBkvcgnX95KSa5bQlkYupeQFu8IAI3NgPIUQ==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -1343,10 +1391,11 @@
       "StackExchange.Redis": {
         "type": "CentralTransitive",
         "requested": "[3.1.31, )",
-        "resolved": "2.7.4",
-        "contentHash": "lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
+        "resolved": "3.1.31",
+        "contentHash": "QillloeZxgw9+IWmnowTrjrn+JV7JIMVzr1JiUpCa7pJQI48rtcqG9yy6u5UBRiTuCiKU5909aRu67Ch6gWVMg==",
         "dependencies": {
-          "Pipelines.Sockets.Unofficial": "2.2.8"
+          "RESPite": "3.1.31",
+          "System.IO.Hashing": "10.0.5"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/RedisPingHealthCheckTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/RedisPingHealthCheckTests.cs
@@ -1,0 +1,109 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using MMCA.Common.Aspire.Health;
+using Moq;
+using StackExchange.Redis;
+
+namespace MMCA.Common.Aspire.Tests.Health;
+
+/// <summary>
+/// The replacement for the AspNetCore.HealthChecks.Redis check must answer the only question a health
+/// probe has ("can this process talk to Redis?") with the only command that is always available:
+/// <c>PING</c>. The check it replaced branched on server type and issued <c>CLUSTER INFO</c>, which
+/// Azure Managed Redis refuses outside admin mode, so it reported a healthy cache as failed forever.
+/// </summary>
+public sealed class RedisPingHealthCheckTests
+{
+    private const string ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1";
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenPingSucceeds_ReportsHealthy()
+    {
+        var database = new Mock<IDatabase>(MockBehavior.Strict);
+        database.Setup(d => d.PingAsync(CommandFlags.None)).ReturnsAsync(TimeSpan.FromMilliseconds(3));
+
+        await using var check = CheckWith(database.Object);
+
+        var result = await check.CheckHealthAsync(Context(check), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        database.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_UsesPingOnly_AndNeverAnAdministrativeCommand()
+    {
+        // MockBehavior.Strict is the assertion: any call other than the configured PingAsync throws,
+        // so a future edit that reaches for CLUSTER INFO, INFO, or a server endpoint fails here.
+        var database = new Mock<IDatabase>(MockBehavior.Strict);
+        database.Setup(d => d.PingAsync(CommandFlags.None)).ReturnsAsync(TimeSpan.FromMilliseconds(1));
+
+        var multiplexer = new Mock<IConnectionMultiplexer>(MockBehavior.Strict);
+        multiplexer.Setup(m => m.GetDatabase(-1, null)).Returns(database.Object);
+
+        await using var check = new RedisPingHealthCheck(ConnectionString, Provider(multiplexer.Object));
+
+        var result = await check.CheckHealthAsync(Context(check), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        multiplexer.VerifyAll();
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenPingThrows_ReportsUnhealthyWithoutRethrowing()
+    {
+        var database = new Mock<IDatabase>();
+        database.Setup(d => d.PingAsync(It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(
+                ConnectionFailureType.UnableToConnect,
+                CommandFlags.None,
+                "no route to host",
+                innerException: null,
+                commandStatus: CommandStatus.Unknown));
+
+        await using var check = CheckWith(database.Object);
+
+        var result = await check.CheckHealthAsync(Context(check), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().BeOfType<RedisConnectionException>();
+    }
+
+    // The exact shape of the failure the incident produced: the server answering a command with
+    // "admin mode is not enabled". It must degrade the /health payload, never fault the probe.
+    [Fact]
+    public async Task CheckHealthAsync_WhenTheServerRefusesACommand_ReportsUnhealthyWithoutRethrowing()
+    {
+        var database = new Mock<IDatabase>();
+        database.Setup(d => d.PingAsync(It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisCommandException("This operation is not available unless admin mode is enabled: CLUSTER"));
+
+        await using var check = CheckWith(database.Object);
+
+        var result = await check.CheckHealthAsync(Context(check), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().BeOfType<RedisCommandException>();
+    }
+
+    private static RedisPingHealthCheck CheckWith(IDatabase database)
+    {
+        var multiplexer = new Mock<IConnectionMultiplexer>();
+        multiplexer.Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object?>())).Returns(database);
+
+        return new RedisPingHealthCheck(ConnectionString, Provider(multiplexer.Object));
+    }
+
+    private static ServiceProvider Provider(IConnectionMultiplexer multiplexer) =>
+        new ServiceCollection().AddSingleton(multiplexer).BuildServiceProvider();
+
+    private static HealthCheckContext Context(IHealthCheck check) => new()
+    {
+        Registration = new HealthCheckRegistration(
+            "redis",
+            check,
+            failureStatus: null,
+            tags: [HealthCheckTags.Optional]),
+    };
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/RedisReadinessSafetyTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Health/RedisReadinessSafetyTests.cs
@@ -1,0 +1,123 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using MMCA.Common.Aspire.Caching;
+
+namespace MMCA.Common.Aspire.Tests.Health;
+
+/// <summary>
+/// The regression gate for the 2026-09-02 readiness outage. Aspire's Redis integrations register the
+/// AspNetCore.HealthChecks.Redis check under the name <c>StackExchange.Redis</c> with NO tags, and the
+/// readiness predicate in <c>MapDefaultEndpoints()</c> admits every check that is not tagged
+/// <c>live</c> or <c>optional</c>. That untagged check therefore gated readiness, issued
+/// <c>CLUSTER INFO</c> against Azure Managed Redis (which StackExchange.Redis 3.x detects as a
+/// cluster and which refuses the command outside admin mode), and took every replica of every backend
+/// service out of rotation while the caches were perfectly healthy.
+/// <para>
+/// These assertions are deliberately phrased against the readiness CONTRACT rather than against one
+/// registration name: whatever a future Aspire version decides to register, no Redis check may reach
+/// <c>/health/ready</c>.
+/// </para>
+/// </summary>
+public sealed class RedisReadinessSafetyTests
+{
+    // abortConnect=false so nothing in this file ever tries to reach a real server.
+    private const string RedisConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1";
+
+    [Fact]
+    public void AddRedisCaching_DoesNotRegisterTheUntaggedAspireRedisCheck()
+    {
+        var builder = BuilderWithRedis();
+
+        builder.AddRedisCaching();
+        builder.AddInfrastructureHealthChecks();
+
+        Registrations(builder).Select(r => r.Name)
+            .Should().NotContain(
+                name => name.StartsWith("StackExchange.Redis", StringComparison.OrdinalIgnoreCase),
+                because: "the Aspire integration's own check is untagged, so its presence alone makes Redis readiness-fatal");
+    }
+
+    [Fact]
+    public void EveryRedisCheck_IsTaggedOptional_SoNoneOfThemGateReadiness()
+    {
+        var builder = BuilderWithRedis();
+
+        builder.AddRedisCaching();
+        builder.AddInfrastructureHealthChecks();
+
+        var redisChecks = Registrations(builder)
+            .Where(r => r.Name.Contains("redis", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        redisChecks.Should().NotBeEmpty("Redis must still be observable on /health");
+        redisChecks.Should().AllSatisfy(r => r.Tags.Should().Contain(HealthCheckTags.Optional));
+    }
+
+    [Fact]
+    public void ReadinessPredicate_AdmitsNoRedisCheck()
+    {
+        var builder = BuilderWithRedis();
+
+        builder.AddRedisCaching();
+        builder.AddRedisOutputCaching();
+        builder.AddInfrastructureHealthChecks();
+
+        // The exact predicate MapDefaultEndpoints() applies to /health/ready.
+        var readinessChecks = Registrations(builder)
+            .Where(r => !r.Tags.Contains(HealthCheckTags.Live) && !r.Tags.Contains(HealthCheckTags.Optional))
+            .Select(r => r.Name)
+            .ToList();
+
+        readinessChecks.Should().NotContain(
+            name => name.Contains("redis", StringComparison.OrdinalIgnoreCase),
+            because: "a cache the application falls back to memory without must never be able to unready every replica at once");
+    }
+
+    [Fact]
+    public void AddRedisCaching_WithoutAConnectionString_RegistersNothing()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>());
+
+        var act = () => builder.AddRedisCaching();
+
+        act.Should().NotThrow("Redis is optional per host and its absence is a valid configuration");
+        builder.Services.Should().NotContain(
+            d => d.ServiceType == typeof(StackExchange.Redis.IConnectionMultiplexer),
+            because: "a host with no Redis connection string must not acquire a client that can never connect");
+    }
+
+    [Fact]
+    public void AddRedisOutputCaching_WithoutAConnectionString_RegistersNothing()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>());
+        var before = builder.Services.Count;
+
+        builder.AddRedisOutputCaching();
+
+        builder.Services.Count.Should().Be(
+            before,
+            because: "with no Redis the built-in per-replica memory store is correct and must stay in place");
+    }
+
+    private static HostApplicationBuilder BuilderWithRedis()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:redis"] = RedisConnectionString,
+            ["ConnectionStrings:SQLServerConnectionString"] = "Server=(local);Database=Test;Integrated Security=true;TrustServerCertificate=true",
+        });
+
+        return builder;
+    }
+
+    private static IReadOnlyList<HealthCheckRegistration> Registrations(HostApplicationBuilder builder) =>
+        [.. builder.Services.BuildServiceProvider()
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<HealthCheckServiceOptions>>()
+            .Value.Registrations];
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/MMCA.Common.Aspire.Tests.csproj
@@ -14,6 +14,11 @@
   <ItemGroup>
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Moq" />
+    <!-- Proves the metrics cost knobs are authoritative: a MeterProvider built through the same
+         configuration path exports into this reader, so a dropped instrument is asserted as absent
+         rather than inferred from which Add*Instrumentation call was skipped. -->
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/MetricsInstrumentationToggleTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/MetricsInstrumentationToggleTests.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics.Metrics;
 using AwesomeAssertions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Metrics;
 
 namespace MMCA.Common.Aspire.Tests.Telemetry;
 
@@ -43,4 +47,94 @@ public sealed class MetricsInstrumentationToggleTests
     [InlineData("")] // blank
     public void FalseOrUnparseable_KeepsInstrumentation(string raw)
         => Extensions.IsInstrumentationDisabled(Config(raw), Key).Should().BeFalse();
+
+    // ── The knobs must be authoritative, not advisory ──
+    // Reading the flag correctly is only half the contract. Until 2026-09-02 the toggle merely skipped
+    // AddHttpClientInstrumentation(), and a deployed host ALSO calls UseAzureMonitor(), whose distro
+    // adds the System.Net.Http meter itself: http.client.open_connections kept flowing and stayed the
+    // single largest AppMetrics stream in both production workspaces with the toggle switched on. The
+    // fix is a metrics View, which applies to the whole MeterProvider no matter who added the meter.
+    // These tests reproduce that exact shape: a third party subscribes the meter, and the assertion is
+    // whether the instrument reaches an exporter.
+    [Theory]
+    [InlineData("System.Net.Http", "http.client.open_connections")]
+    [InlineData("System.Net.NameResolution", "dns.lookup.duration")]
+    public void HttpClientMetricsDisabled_DropsTheStream_EvenWhenAnotherComponentAddsTheMeter(
+        string meterName,
+        string instrumentName)
+    {
+        var exported = CollectFrom(
+            new() { ["Telemetry:DisableHttpClientMetrics"] = "true" },
+            meterName,
+            instrumentName);
+
+        exported.Should().NotContain(
+            instrumentName,
+            because: "a View drops the instrument regardless of which component subscribed the meter");
+    }
+
+    [Fact]
+    public void HttpClientMetricsEnabled_KeepsTheStream()
+    {
+        var exported = CollectFrom([], "System.Net.Http", "http.client.open_connections");
+
+        exported.Should().Contain(
+            "http.client.open_connections",
+            because: "an unset knob must change nothing (the default)");
+    }
+
+    [Fact]
+    public void RuntimeMetricsDisabled_DropsTheStream_EvenWhenAnotherComponentAddsTheMeter()
+    {
+        var exported = CollectFrom(
+            new() { ["Telemetry:DisableRuntimeMetrics"] = "true" },
+            "System.Runtime",
+            "dotnet.gc.collections");
+
+        exported.Should().NotContain("dotnet.gc.collections");
+    }
+
+    [Fact]
+    public void RuntimeMetricsEnabled_KeepsTheStream()
+    {
+        var exported = CollectFrom([], "System.Runtime", "dotnet.gc.collections");
+
+        exported.Should().Contain("dotnet.gc.collections");
+    }
+
+    /// <summary>
+    /// Builds a MeterProvider through the real <c>ConfigureOpenTelemetry()</c> path, has a third party
+    /// subscribe <paramref name="meterName"/> exactly the way the Azure Monitor distro does, emits one
+    /// measurement on <paramref name="instrumentName"/>, and returns the instrument names that reached
+    /// the exporter.
+    /// </summary>
+    private static IReadOnlyList<string> CollectFrom(
+        Dictionary<string, string?> settings,
+        string meterName,
+        string instrumentName)
+    {
+        // Blanked explicitly so an OTLP endpoint or Application Insights key in the developer's own
+        // environment cannot attach a second exporter to this provider.
+        settings["OTEL_EXPORTER_OTLP_ENDPOINT"] = string.Empty;
+        settings["APPLICATIONINSIGHTS_CONNECTION_STRING"] = string.Empty;
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(settings);
+        builder.ConfigureOpenTelemetry();
+
+        var exportedMetrics = new List<Metric>();
+        builder.Services.ConfigureOpenTelemetryMeterProvider(metrics => metrics
+            .AddMeter(meterName)
+            .AddInMemoryExporter(exportedMetrics));
+
+        using var host = builder.Build();
+        var provider = host.Services.GetRequiredService<MeterProvider>();
+
+        using var meter = new Meter(meterName);
+        meter.CreateCounter<long>(instrumentName).Add(1);
+
+        provider.ForceFlush();
+
+        return [.. exportedMetrics.Select(m => m.Name)];
+    }
 }

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/packages.lock.json
@@ -26,6 +26,24 @@
         "resolved": "18.7.23",
         "contentHash": "dyj6z8m+LFjpeH69hdnciCcRCmD0YgMlvuQEywiEshjqj/blgQ+PuWX8Vd5gkWQFoBN4e+TFxx6DvGNSv/gIKg=="
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.20.72, )",
+        "resolved": "4.20.72",
+        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "OpenTelemetry.Exporter.InMemory": {
+        "type": "Direct",
+        "requested": "[1.18.0, )",
+        "resolved": "1.18.0",
+        "contentHash": "ZOdDyDwE0cCED5LDicejJZekyO0p7+vsVSnAVa5GdtFg8A/wZyG3pr44Kd/j6nj6NHUQRqXx1DIDXnaPcSVIlg==",
+        "dependencies": {
+          "OpenTelemetry": "1.18.0"
+        }
+      },
       "Roslynator.Analyzers": {
         "type": "Direct",
         "requested": "[5.0.0, )",
@@ -54,6 +72,14 @@
         "contentHash": "czH4MaZ2k2eLjetuN5W1fUEnNVADsTOeYxDvrqIFh04XO6H3Y8Yu1FrSy3psF1q06DZV33wftjqZVv4acwIp9Q==",
         "dependencies": {
           "xunit.v3.mtp-v2": "[4.0.0]"
+        }
+      },
+      "AspNetCore.HealthChecks.Redis": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.4"
         }
       },
       "Azure.Core": {
@@ -102,6 +128,11 @@
           "Azure.Core": "1.55.0",
           "System.IO.Hashing": "10.0.3"
         }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -335,11 +366,6 @@
           "OpenTelemetry.PersistentStorage.Abstractions": "1.0.3"
         }
       },
-      "Pipelines.Sockets.Unofficial": {
-        "type": "Transitive",
-        "resolved": "2.2.8",
-        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
-      },
       "Polly.Extensions": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -360,6 +386,11 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "8YJz22mOSMtkbIVuVSz2HbJwbpKwRoXQ1uqbczDUt1w1Ds8dxFs6dkV/oZ8AlTmkErZjtQelHv+oBu52ud00WA=="
+      },
+      "RESPite": {
+        "type": "Transitive",
+        "resolved": "3.1.31",
+        "contentHash": "u+MFK6FzGWngKaY3wJ/V9vQSVe/NSqpk0IYYw6ACwmlPq5eTnsyZGlzEa3YMifJGVs3omrl5MkgigB1jZYNnGg=="
       },
       "Serilog": {
         "type": "Transitive",
@@ -457,8 +488,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -547,9 +578,10 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
-          "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "AspNetCore.HealthChecks.Sqlite": "[9.0.0, )",
+          "Aspire.StackExchange.Redis": "[13.5.3, )",
+          "Aspire.StackExchange.Redis.DistributedCaching": "[13.5.3, )",
           "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.2, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.4, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.4, )",
@@ -557,6 +589,7 @@
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "Azure.Storage.Blobs": "[12.29.2, )",
           "MMCA.Common.Shared": "[1.0.0, )",
+          "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": "[10.0.11, )",
           "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.9.0, )",
           "OpenTelemetry.Api": "[1.18.0, )",
@@ -568,11 +601,40 @@
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
-          "Serilog.Sinks.File": "[7.0.0, )"
+          "Serilog.Sinks.File": "[7.0.0, )",
+          "StackExchange.Redis": "[3.1.31, )"
         }
       },
       "mmca.common.shared": {
         "type": "Project"
+      },
+      "Aspire.StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "B0mJpW8715pp8ecZ5RXh3pG78ncg8EKMM1pOZO2X10z0RLqTLerhyW4i2RrxOZMkx00BDRrZT+43e6GHmvdjUQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Aspire.StackExchange.Redis.DistributedCaching": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EBkcHLElw38oWRbBlY/TRY1OEWOE+zMptWlPidsCY3lKhj3v0usGrH18BdB5JPRQKdJDA7fjJd7eqsvAOIJlNw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Aspire.StackExchange.Redis": "13.5.3",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
       },
       "AspNetCore.HealthChecks.Rabbitmq": {
         "type": "CentralTransitive",
@@ -581,15 +643,6 @@
         "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
         "dependencies": {
           "RabbitMQ.Client": "7.0.0"
-        }
-      },
-      "AspNetCore.HealthChecks.Redis": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
-        "dependencies": {
-          "StackExchange.Redis": "2.7.4"
         }
       },
       "AspNetCore.HealthChecks.Sqlite": {
@@ -672,6 +725,15 @@
           "Azure.Storage.Common": "12.28.0"
         }
       },
+      "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "pjjof07KoM9SvcGkfHVEYjuCxxTtO3mnXJkBJVsqGbTW6jU0hNuR/pMsgdTi8x6Xq4c2eKuaJR5c3W/uVKyY6A==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
       "Microsoft.Data.SqlClient": {
         "type": "CentralTransitive",
         "requested": "[7.0.2, )",
@@ -686,6 +748,15 @@
           "Microsoft.SqlServer.Server": "1.0.0",
           "System.Configuration.ConfigurationManager": "8.0.0",
           "System.Runtime.Caching": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.11",
+        "contentHash": "0SCQuU1m+BcLMjyh6q1X9j0hongN9EZx9KhgDyPgHxVa5RJ5xuHBkvcgnX95KSa5bQlkYupeQFu8IAI3NgPIUQ==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -810,10 +881,11 @@
       "StackExchange.Redis": {
         "type": "CentralTransitive",
         "requested": "[3.1.31, )",
-        "resolved": "2.7.4",
-        "contentHash": "lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
+        "resolved": "3.1.31",
+        "contentHash": "QillloeZxgw9+IWmnowTrjrn+JV7JIMVzr1JiUpCa7pJQI48rtcqG9yy6u5UBRiTuCiKU5909aRu67Ch6gWVMg==",
         "dependencies": {
-          "Pipelines.Sockets.Unofficial": "2.2.8"
+          "RESPite": "3.1.31",
+          "System.IO.Hashing": "10.0.5"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/packages.lock.json
@@ -78,6 +78,14 @@
           "Asp.Versioning.Abstractions": "10.2.1"
         }
       },
+      "AspNetCore.HealthChecks.Redis": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.4"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.61.0",
@@ -632,8 +640,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8IBJWcCT9+e4Bmevm4T7+fQEiAh133KGiz4oiVTgJckd3Q76OFdR1falgn9lpz7+C4HJvogCDJeAa2QmvbeVtg=="
+        "resolved": "10.0.8",
+        "contentHash": "+dJsbPJ3FyUbTZNplFj0RCKePFizmv6ewDV46JE9q/IVH4c3xTCftHfHelLsAKf0jryIPqgMb5GpS0x7TAY3mg=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -749,9 +757,10 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.HealthChecks.Rabbitmq": "[9.0.0, )",
-          "AspNetCore.HealthChecks.Redis": "[9.0.0, )",
           "AspNetCore.HealthChecks.SqlServer": "[9.0.0, )",
           "AspNetCore.HealthChecks.Sqlite": "[9.0.0, )",
+          "Aspire.StackExchange.Redis": "[13.5.3, )",
+          "Aspire.StackExchange.Redis.DistributedCaching": "[13.5.3, )",
           "Azure.Extensions.AspNetCore.Configuration.Secrets": "[1.5.2, )",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.5.4, )",
           "Azure.Extensions.AspNetCore.DataProtection.Keys": "[1.6.4, )",
@@ -759,6 +768,7 @@
           "Azure.Monitor.OpenTelemetry.AspNetCore": "[1.6.0, )",
           "Azure.Storage.Blobs": "[12.29.2, )",
           "MMCA.Common.Shared": "[1.0.0, )",
+          "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": "[10.0.11, )",
           "Microsoft.Extensions.Http.Resilience": "[10.9.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.9.0, )",
           "OpenTelemetry.Api": "[1.18.0, )",
@@ -770,7 +780,8 @@
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.5, )",
           "Serilog.AspNetCore": "[10.0.0, )",
           "Serilog.Sinks.Console": "[6.1.1, )",
-          "Serilog.Sinks.File": "[7.0.0, )"
+          "Serilog.Sinks.File": "[7.0.0, )",
+          "StackExchange.Redis": "[3.1.31, )"
         }
       },
       "mmca.common.domain": {
@@ -857,6 +868,34 @@
           "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
+      "Aspire.StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "B0mJpW8715pp8ecZ5RXh3pG78ncg8EKMM1pOZO2X10z0RLqTLerhyW4i2RrxOZMkx00BDRrZT+43e6GHmvdjUQ==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
+      "Aspire.StackExchange.Redis.DistributedCaching": {
+        "type": "CentralTransitive",
+        "requested": "[13.5.3, )",
+        "resolved": "13.5.3",
+        "contentHash": "EBkcHLElw38oWRbBlY/TRY1OEWOE+zMptWlPidsCY3lKhj3v0usGrH18BdB5JPRQKdJDA7fjJd7eqsvAOIJlNw==",
+        "dependencies": {
+          "AspNetCore.HealthChecks.Redis": "9.0.0",
+          "Aspire.StackExchange.Redis": "13.5.3",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.8.0",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "StackExchange.Redis": "2.13.1",
+          "System.IO.Hashing": "10.0.8"
+        }
+      },
       "AspNet.Security.OAuth.Apple": {
         "type": "CentralTransitive",
         "requested": "[10.0.0, )",
@@ -879,15 +918,6 @@
         "contentHash": "7WSQ7EwioA5niakzzLtGVcZMEOh+42fSwrI24vnNsT7gZuVGOViNekyz38G6wBPYKcpL/lUkMdg3ZaCiZTi/Dw==",
         "dependencies": {
           "RabbitMQ.Client": "7.0.0"
-        }
-      },
-      "AspNetCore.HealthChecks.Redis": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "yNH0h8GLRbAf+PU5HNVLZ5hNeyq9mDVmRKO9xuZsme/znUYoBJlQvI0gq45gaZNlLncCHkMhR4o90MuT+gxxPw==",
-        "dependencies": {
-          "StackExchange.Redis": "2.7.4"
         }
       },
       "AspNetCore.HealthChecks.Sqlite": {
@@ -1061,6 +1091,15 @@
           "Microsoft.OpenApi": "[2.7.5, 3.0.0)"
         }
       },
+      "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "pjjof07KoM9SvcGkfHVEYjuCxxTtO3mnXJkBJVsqGbTW6jU0hNuR/pMsgdTi8x6Xq4c2eKuaJR5c3W/uVKyY6A==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
       "Microsoft.AspNetCore.SignalR.Client": {
         "type": "CentralTransitive",
         "requested": "[10.0.11, )",
@@ -1147,6 +1186,15 @@
         "requested": "[10.9.0, )",
         "resolved": "10.9.0",
         "contentHash": "D0tHRbUCliInxTfPgN9K6RxrCVaWu9kyIT66vbIJ/YwA6BV2xa8vTqoE3JQXA2Rf2vRdgd29+HR6Ay6KmzDslw=="
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.11",
+        "contentHash": "0SCQuU1m+BcLMjyh6q1X9j0hongN9EZx9KhgDyPgHxVa5RJ5xuHBkvcgnX95KSa5bQlkYupeQFu8IAI3NgPIUQ==",
+        "dependencies": {
+          "StackExchange.Redis": "2.7.27"
+        }
       },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Incident

Production `/health/ready` on every ADC and Store backend service has returned 503 since MMCA.Common v1.165.0 bumped StackExchange.Redis 2.13.17 -> 3.1.31. The service hosts call Aspire's `AddRedisDistributedCache` / `AddRedisClient` directly, and those register the AspNetCore.HealthChecks.Redis check under the name `StackExchange.Redis` with NO tags. Common's readiness predicate admits every check that is not tagged `live` or `optional`, so the untagged check silently gated readiness. Under SE.Redis 3.x, Azure Managed Redis (Enterprise tier, port 10000) is detected as `ServerType.Cluster`, the check issues `CLUSTER INFO`, and the server refuses it (`RedisCommandException: ... admin mode is not enabled: CLUSTER`). Every probe threw against a perfectly healthy cache and every replica went unready at once. Common's own `AddRedis(...)` check used the same package and threw on `/health` too, though it was correctly excluded from readiness.

## Changes

- **Redis wiring is now framework-owned** (`Caching/RedisCachingExtensions`): the wrapper registers the Aspire integrations with `DisableHealthChecks = true`, so nothing untagged can reach readiness. Both methods are a no-op when the connection string is absent.
- **PING-only health check** (`Health/RedisPingHealthCheck`, internal): resolves `IConnectionMultiplexer` from DI, or lazily creates and owns one, and issues nothing but `PING`. Still named `redis`, still tagged `optional`. `AspNetCore.HealthChecks.Redis` is removed as a direct reference and its `PackageVersion` pin is gone (this repo does not enable central transitive pinning, so the transitive it still arrives as needs no entry).
- **Metric drop views**: `Telemetry:DisableHttpClientMetrics` and `Telemetry:DisableRuntimeMetrics` only skipped an `Add*Instrumentation` call, but a deployed host also calls `UseAzureMonitor()`, whose distro adds `System.Net.Http` and `System.Runtime` itself. Each toggle now also registers a `MetricStreamConfiguration.Drop` View for its meters (plus `System.Net.NameResolution`), which applies to the whole MeterProvider regardless of who added the meter.

## New public API

```
MMCA.Common.Aspire.Caching.RedisCachingExtensions
const RedisCachingExtensions.DefaultConnectionName = "redis" -> string!
RedisCachingExtensions.extension<TBuilder>(TBuilder).AddRedisCaching(string! connectionName = "redis") -> TBuilder
RedisCachingExtensions.extension<TBuilder>(TBuilder).AddRedisOutputCaching(string! connectionName = "redis") -> TBuilder
```

(`TBuilder : IHostApplicationBuilder`.)

## Package changes

Added to `Directory.Packages.props` + `MMCA.Common.Aspire.csproj`: `Aspire.StackExchange.Redis` 13.5.3, `Aspire.StackExchange.Redis.DistributedCaching` 13.5.3, `Microsoft.AspNetCore.OutputCaching.StackExchangeRedis` 10.0.11, direct `StackExchange.Redis`. Removed: `AspNetCore.HealthChecks.Redis` (reference and pin). Test tier: `Moq` and `OpenTelemetry.Exporter.InMemory` 1.18.0 on `MMCA.Common.Aspire.Tests`. Lock files regenerated with `--force-evaluate`.

## Verification

`dotnet build MMCA.Common.slnx -c Release` warning-free; `dotnet test --solution MMCA.Common.slnx -c Release` 5278/5278 passed (Aspire tier 190, architecture tier 178); FACTS drift gate clean.

## Follow-up (not in this PR)

The seven consumer hosts still call the raw Aspire methods; they need a sweep onto `AddRedisCaching()` / `AddRedisOutputCaching()` after the next Common release. This repo has no banned-API analyzer, so nothing mechanically blocks the bypass yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFaTUw34BQJneR4auAyBH8
