### PR TITLE
§31: keep health-probe telemetry out of trace export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Added
+
+- **`Telemetry:FilterProbeTelemetry` cost knob** (`MMCA.Common.Aspire`, rubric §31). Keeps
+  health-probe traces out of Application Insights / Log Analytics: the ASP.NET Core instrumentation
+  refuses inbound `/alive`, `/health` and `/health/*` requests, the HttpClient instrumentation
+  refuses outbound calls to the same paths (YARP active health checks and the gateway's
+  `DownstreamServiceHealthCheck` probes, which have no request ancestor), and a new
+  `ProbeTelemetryFilterProcessor` un-records the dependency spans hanging off a probe request (the
+  health check's SQL `SELECT 1`, the Redis PING). Container Apps probes, gateway aggregate probes
+  and the availability web test accounted for 100% of the AppRequests rows in both production
+  workspaces, and `Telemetry:TracesSampleRatio` does not reduce them. **Defaults to `true`**, unlike
+  the metrics knobs: a host that wants to see its own probe traces sets it to `false`. Metrics are
+  deliberately untouched, so `http.server.request.duration`, Kestrel and routing instruments keep
+  feeding dashboards.
+- **`HealthEndpointPaths`** (`MMCA.Common.Aspire`). The `/health`, `/alive` and `/health/ready`
+  paths `MapDefaultEndpoints()` maps, plus an `IsProbePath` predicate, declared once so the mapping
+  and the probe telemetry filters cannot drift apart.
+
 ## [1.181.0] - 2026-09-02
 
 Readiness-safe Redis registration and authoritative metric cost toggles. One consumer action is

--- a/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Extensions.cs
@@ -28,6 +28,12 @@ namespace MMCA.Common.Aspire;
     Justification = "False positive: with multiple extension(T) blocks in one static class, CA1708 flags the compiler-generated grouping members as case-colliding. No user-visible identifier differs only by case.")]
 public static class Extensions
 {
+    /// <summary>
+    /// Configuration key of the probe-telemetry cost knob. Defaults to <see langword="true"/>; see
+    /// <see cref="IsProbeTelemetryFilterEnabled"/>.
+    /// </summary>
+    internal const string FilterProbeTelemetryConfigKey = "Telemetry:FilterProbeTelemetry";
+
     extension<TBuilder>(TBuilder builder)
         where TBuilder : IHostApplicationBuilder
     {
@@ -201,16 +207,51 @@ public static class Extensions
                 .WithTracing(tracing =>
                 {
                     tracing.AddSource(builder.Environment.ApplicationName)
-                        .AddSource("MMCA.Common.Outbox")
-                        .AddAspNetCoreInstrumentation()
-                        .AddHttpClientInstrumentation()
+                        .AddSource("MMCA.Common.Outbox");
 
-                        // Drops recurring outbox poll spans (and their SqlClient children from the
-                        // Azure Monitor distro) from export — idle polling would otherwise dominate
-                        // telemetry ingestion cost. Must be registered here, before
-                        // AddOpenTelemetryExporters() below, so its OnEnd clears the Recorded flag
-                        // before the exporters' batch processors check it.
-                        .AddProcessor(new Telemetry.OutboxPollFilterProcessor());
+                    // Cost control (rubric §31): health-probe traces. Container Apps liveness and
+                    // readiness probes, the gateway's downstream aggregate probes, YARP active
+                    // health checks and the availability web test made up 100% of the AppRequests
+                    // rows in both production workspaces, and their children (the health check's
+                    // SQL SELECT 1, the Redis PING, the gateway's HttpClient calls to each
+                    // backend's /alive) most of the AppDependencies rows. None of it carries
+                    // end-user signal and none of it is touched by Telemetry:TracesSampleRatio,
+                    // because probe spans are what the sampler is asked to keep proportionally.
+                    // On by default (this is chatter no host wants billed); a host that is
+                    // debugging its own probes sets Telemetry:FilterProbeTelemetry=false.
+                    // Metrics are deliberately untouched: http.server.request.duration, Kestrel
+                    // and routing instruments keep flowing, so probe traffic stays on dashboards.
+                    var filterProbeTelemetry = IsProbeTelemetryFilterEnabled(builder.Configuration);
+                    if (filterProbeTelemetry)
+                    {
+                        // Both filters configure the DEFAULT-named instrumentation options, so they
+                        // also apply to the instrumentation the Azure Monitor distro adds: unlike
+                        // the metrics toggles above, these are authoritative without a View.
+                        tracing.AddAspNetCoreInstrumentation(options =>
+                                options.Filter = Telemetry.ProbeTelemetryFilter.ShouldCollectRequest)
+                            .AddHttpClientInstrumentation(options =>
+                                options.FilterHttpRequestMessage = Telemetry.ProbeTelemetryFilter.ShouldCollectOutgoing);
+                    }
+                    else
+                    {
+                        tracing.AddAspNetCoreInstrumentation()
+                            .AddHttpClientInstrumentation();
+                    }
+
+                    // Drops recurring outbox poll spans (and their SqlClient children from the
+                    // Azure Monitor distro) from export — idle polling would otherwise dominate
+                    // telemetry ingestion cost. Must be registered here, before
+                    // AddOpenTelemetryExporters() below, so its OnEnd clears the Recorded flag
+                    // before the exporters' batch processors check it.
+                    tracing.AddProcessor(new Telemetry.OutboxPollFilterProcessor());
+
+                    if (filterProbeTelemetry)
+                    {
+                        // Same registration-order requirement, same reason: the inbound filter only
+                        // refuses the probe request span itself, while its dependency children are
+                        // sampled independently and need un-recording before the exporters look.
+                        tracing.AddProcessor(new Telemetry.ProbeTelemetryFilterProcessor());
+                    }
 
                     // Cost control (rubric §31): head-based trace sampling. Unset by default, so a
                     // host samples everything (no behavior change). A deployed host sets
@@ -369,11 +410,11 @@ public static class Extensions
         /// <returns>The same application instance for chaining.</returns>
         public WebApplication MapDefaultEndpoints()
         {
-            app.MapHealthChecks("/health");
+            app.MapHealthChecks(HealthEndpointPaths.Health);
 
             // Liveness: only the "self" check (tagged "live") — avoids marking the
             // process as dead when an external dependency (e.g., SQL Server) is down.
-            app.MapHealthChecks("/alive", new HealthCheckOptions
+            app.MapHealthChecks(HealthEndpointPaths.Alive, new HealthCheckOptions
             {
                 Predicate = r => r.Tags.Contains(HealthCheckTags.Live)
             });
@@ -389,7 +430,7 @@ public static class Extensions
             // into a total outage, because every replica goes unready at once and the app stops
             // serving traffic it was perfectly capable of serving. Those checks still surface on
             // /health, so the degradation is visible without being self-inflicted.
-            app.MapHealthChecks("/health/ready", new HealthCheckOptions
+            app.MapHealthChecks(HealthEndpointPaths.Ready, new HealthCheckOptions
             {
                 Predicate = r => !r.Tags.Contains(HealthCheckTags.Live) && !r.Tags.Contains(HealthCheckTags.Optional)
             });
@@ -429,6 +470,18 @@ public static class Extensions
     /// </summary>
     internal static bool IsInstrumentationDisabled(IConfiguration configuration, string configKey)
         => bool.TryParse(configuration[configKey], out var disabled) && disabled;
+
+    /// <summary>
+    /// Reads the <c>Telemetry:FilterProbeTelemetry</c> cost knob (rubric §31), which keeps health-probe
+    /// requests and their dependency children out of trace export. Unlike the metrics knobs this one
+    /// defaults to <see langword="true"/>: probe chatter is ingestion no host wants billed, so absent,
+    /// blank or unparseable all mean "filter", and only an explicit boolean <see langword="false"/>
+    /// turns the filtering off (for a host debugging its own probes).
+    /// </summary>
+    /// <param name="configuration">Configuration carrying the knob.</param>
+    /// <returns><see langword="true"/> when probe telemetry must be filtered.</returns>
+    internal static bool IsProbeTelemetryFilterEnabled(IConfiguration configuration)
+        => !bool.TryParse(configuration[FilterProbeTelemetryConfigKey], out var enabled) || enabled;
 
     /// <summary>
     /// Registers the relational database checks and enforces the "the database must be there" rule

--- a/Source/Hosting/MMCA.Common.Aspire/Gateway/DownstreamServiceHealthCheck.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Gateway/DownstreamServiceHealthCheck.cs
@@ -43,7 +43,7 @@ internal sealed class DownstreamServiceHealthCheck(
     DownstreamProbeVersion probeVersion) : IHealthCheck
 {
     /// <summary>The relative path probed on the downstream service.</summary>
-    internal static readonly Uri ProbePath = new("/alive", UriKind.Relative);
+    internal static readonly Uri ProbePath = new(HealthEndpointPaths.Alive, UriKind.Relative);
 
     /// <summary>
     /// The version <see cref="DownstreamProbeVersion.Auto"/> has settled on, held as the underlying

--- a/Source/Hosting/MMCA.Common.Aspire/HealthEndpointPaths.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/HealthEndpointPaths.cs
@@ -1,0 +1,34 @@
+namespace MMCA.Common.Aspire;
+
+/// <summary>
+/// The health-probe endpoint paths mapped by <c>MapDefaultEndpoints()</c>. Declared once so the
+/// mapping, the probe telemetry filters and any host bypass list cannot drift apart: a new probe
+/// route added to the mapping is automatically a probe route everywhere else.
+/// </summary>
+public static class HealthEndpointPaths
+{
+    /// <summary>Full health report: every registered check must pass.</summary>
+    public const string Health = "/health";
+
+    /// <summary>Liveness probe: only checks tagged <see cref="HealthCheckTags.Live"/> run.</summary>
+    public const string Alive = "/alive";
+
+    /// <summary>Readiness probe: everything except live-only and optional checks.</summary>
+    public const string Ready = "/health/ready";
+
+    private const string HealthPrefix = Health + "/";
+
+    /// <summary>
+    /// Whether <paramref name="path"/> addresses one of the health-probe endpoints: <c>/alive</c>,
+    /// <c>/health</c>, or anything below <c>/health/</c> (which covers <c>/health/ready</c> and any
+    /// sub-route a host adds later). The comparison is case-insensitive because ASP.NET Core
+    /// routing is.
+    /// </summary>
+    /// <param name="path">An absolute request path without query string, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when the path addresses a probe endpoint.</returns>
+    public static bool IsProbePath(string? path)
+        => !string.IsNullOrEmpty(path)
+            && (string.Equals(path, Alive, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(path, Health, StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith(HealthPrefix, StringComparison.OrdinalIgnoreCase));
+}

--- a/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Aspire/PublicAPI.Unshipped.txt
@@ -32,3 +32,12 @@ MMCA.Common.Aspire.Caching.RedisCachingExtensions.extension<TBuilder>(TBuilder).
 const MMCA.Common.Aspire.Caching.RedisCachingExtensions.DefaultConnectionName = "redis" -> string!
 static MMCA.Common.Aspire.Caching.RedisCachingExtensions.AddRedisCaching<TBuilder>(this TBuilder builder, string! connectionName = "redis") -> TBuilder
 static MMCA.Common.Aspire.Caching.RedisCachingExtensions.AddRedisOutputCaching<TBuilder>(this TBuilder builder, string! connectionName = "redis") -> TBuilder
+MMCA.Common.Aspire.HealthEndpointPaths
+const MMCA.Common.Aspire.HealthEndpointPaths.Alive = "/alive" -> string!
+const MMCA.Common.Aspire.HealthEndpointPaths.Health = "/health" -> string!
+const MMCA.Common.Aspire.HealthEndpointPaths.Ready = "/health/ready" -> string!
+static MMCA.Common.Aspire.HealthEndpointPaths.IsProbePath(string? path) -> bool
+MMCA.Common.Aspire.Telemetry.ProbeTelemetryFilterProcessor
+MMCA.Common.Aspire.Telemetry.ProbeTelemetryFilterProcessor.ProbeTelemetryFilterProcessor() -> void
+override MMCA.Common.Aspire.Telemetry.ProbeTelemetryFilterProcessor.OnEnd(System.Diagnostics.Activity! data) -> void
+override MMCA.Common.Aspire.Telemetry.ProbeTelemetryFilterProcessor.OnStart(System.Diagnostics.Activity! data) -> void

--- a/Source/Hosting/MMCA.Common.Aspire/Telemetry/ProbeTelemetryFilter.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Telemetry/ProbeTelemetryFilter.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+
+namespace MMCA.Common.Aspire.Telemetry;
+
+/// <summary>
+/// The two instrumentation predicates behind the <c>Telemetry:FilterProbeTelemetry</c> cost knob
+/// (rubric §31). Health probes are pure infrastructure chatter: Container Apps liveness and
+/// readiness probes, the gateway's downstream aggregate probes, YARP active health checks and the
+/// availability web test together accounted for every AppRequests row in both production
+/// workspaces, and none of them carries end-user signal.
+/// <para>
+/// <see cref="ShouldCollectRequest"/> drops the inbound probe request span, and stamps
+/// <see cref="ProbeMarkerTagName"/> on the request activity on its way out. The marker is what
+/// <see cref="ProbeTelemetryFilterProcessor"/> matches on: when this predicate refuses a request the
+/// ASP.NET Core instrumentation returns before it writes <c>url.path</c>, so the descendants of that
+/// request (the SQL <c>SELECT 1</c>, the Redis PING) would otherwise have no way to recognize their
+/// own probe ancestor.
+/// </para>
+/// <para>
+/// <see cref="ShouldCollectOutgoing"/> drops outbound probe calls that are NOT descendants of an
+/// inbound request and therefore never reach the processor at all: the gateway's
+/// <c>DownstreamServiceHealthCheck</c> calls to each backend's <c>/alive</c> and YARP's active
+/// health checks, both driven by background timers.
+/// </para>
+/// </summary>
+internal static class ProbeTelemetryFilter
+{
+    /// <summary>
+    /// Tag stamped on an inbound probe request activity so descendant spans can recognize it. Never
+    /// exported: the activity carrying it is unrecorded by the same pass that stamps it.
+    /// </summary>
+    internal const string ProbeMarkerTagName = "mmca.probe";
+
+    /// <summary>
+    /// Whether an inbound request should be traced. Probe endpoints are refused (and marked).
+    /// </summary>
+    /// <param name="context">The request being started.</param>
+    /// <returns><see langword="false"/> for a health-probe request, otherwise <see langword="true"/>.</returns>
+    internal static bool ShouldCollectRequest(HttpContext context)
+    {
+        if (context is null || !HealthEndpointPaths.IsProbePath(context.Request.Path.Value))
+        {
+            return true;
+        }
+
+        // Activity.Current is the request activity here: the instrumentation invokes this filter
+        // from its start callback, after ASP.NET Core has started and made it current.
+        if (Activity.Current is { Kind: ActivityKind.Server } request)
+        {
+            request.SetTag(ProbeMarkerTagName, true);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether an outbound HTTP call should be traced. Calls to a probe endpoint are refused.
+    /// </summary>
+    /// <param name="request">The outgoing request.</param>
+    /// <returns><see langword="false"/> for a health-probe call, otherwise <see langword="true"/>.</returns>
+    internal static bool ShouldCollectOutgoing(HttpRequestMessage request)
+        => request?.RequestUri is not { } uri || !HealthEndpointPaths.IsProbePath(PathOf(uri));
+
+    /// <summary>
+    /// The path portion of an outgoing request URI. Service discovery hands the client an absolute
+    /// URI, but a relative one is legal on a client with a BaseAddress, so both shapes are handled
+    /// without allocating a combined URI on every outbound call.
+    /// </summary>
+    /// <param name="uri">The request URI.</param>
+    /// <returns>The path, with any query or fragment removed.</returns>
+    private static string PathOf(Uri uri)
+    {
+        if (uri.IsAbsoluteUri)
+        {
+            return uri.AbsolutePath;
+        }
+
+        var raw = uri.OriginalString;
+        var cut = raw.AsSpan().IndexOfAny('?', '#');
+        return cut < 0 ? raw : raw[..cut];
+    }
+}

--- a/Source/Hosting/MMCA.Common.Aspire/Telemetry/ProbeTelemetryFilterProcessor.cs
+++ b/Source/Hosting/MMCA.Common.Aspire/Telemetry/ProbeTelemetryFilterProcessor.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace MMCA.Common.Aspire.Telemetry;
+
+/// <summary>
+/// Suppresses the descendants of a health-probe request from telemetry export: the SQL
+/// <c>SELECT 1</c> of the database health check, the Redis PING, and the gateway's HttpClient call
+/// to each backend's <c>/alive</c>. The probe request span itself is refused by
+/// <see cref="ProbeTelemetryFilter.ShouldCollectRequest"/>, but its children are sampled
+/// independently and would otherwise still be exported, which is how they came to make up most of
+/// the AppDependencies volume in both production workspaces (rubric §31).
+/// <para>
+/// Registered only when <c>Telemetry:FilterProbeTelemetry</c> is left at its default of
+/// <see langword="true"/>, and always before the exporters so the cleared Recorded flag is what
+/// their batch processors see. Metrics are untouched: <c>http.server.request.duration</c>, Kestrel
+/// and routing instruments keep flowing, so probe traffic stays visible on dashboards.
+/// </para>
+/// </summary>
+public sealed class ProbeTelemetryFilterProcessor : BaseProcessor<Activity>
+{
+    // Set by the ASP.NET Core instrumentation on the server span at request start, before any child
+    // span exists. Names, not the semantic-convention constants, because this package deliberately
+    // takes no dependency on the instrumentation's internal attribute class.
+    private const string UrlPathTagName = "url.path";
+    private const string HttpRouteTagName = "http.route";
+
+    /// <inheritdoc />
+    public override void OnStart(Activity data) => SuppressWhenUnderProbe(data);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The same pass runs again at end because a span's identifying tags do not all exist at start:
+    /// a client span is started before its instrumentation has written any attribute, so an
+    /// OnStart-only filter would depend on callback ordering it does not control. Clearing Recorded
+    /// at end is what actually keeps the span out of the exporters (the pattern
+    /// <see cref="OutboxPollFilterProcessor"/> uses), while the OnStart pass additionally stops the
+    /// instrumentation from collecting data it will never export.
+    /// </remarks>
+    public override void OnEnd(Activity data) => SuppressWhenUnderProbe(data);
+
+    private static void SuppressWhenUnderProbe(Activity data)
+    {
+        if (data is null)
+        {
+            // Never throw from a telemetry callback.
+            return;
+        }
+
+        // Walk the in-process parent chain: a probe's dependency spans can sit several levels below
+        // the request span (HttpClient handler -> connection -> DNS).
+        for (var current = data; current is not null; current = current.Parent)
+        {
+            if (IsProbeRequest(current))
+            {
+                // Clearing Recorded makes the batch export processors (Azure Monitor, OTLP) skip
+                // this activity; dropping IsAllDataRequested stops instrumentation from enriching
+                // it in the first place.
+                data.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                data.IsAllDataRequested = false;
+                return;
+            }
+        }
+    }
+
+    private static bool IsProbeRequest(Activity activity)
+    {
+        if (activity.GetTagItem(ProbeTelemetryFilter.ProbeMarkerTagName) is not null)
+        {
+            return true;
+        }
+
+        // Server kind only: an outgoing call to a probe endpoint is the gateway's own health check,
+        // and is filtered at the instrumentation instead, so a normal request never loses its whole
+        // subtree because one dependency happened to be a probe.
+        return activity.Kind == ActivityKind.Server
+            && (HealthEndpointPaths.IsProbePath(activity.GetTagItem(UrlPathTagName) as string)
+                || HealthEndpointPaths.IsProbePath(activity.GetTagItem(HttpRouteTagName) as string)
+                || HealthEndpointPaths.IsProbePath(RouteOfDisplayName(activity.DisplayName)));
+    }
+
+    /// <summary>
+    /// The route portion of a server span's display name. Once the route is resolved the ASP.NET
+    /// Core instrumentation renames the span to <c>"{method} {route}"</c>, which is the only probe
+    /// evidence left on a span whose tags an exporter-side enricher has already consumed.
+    /// </summary>
+    /// <param name="displayName">The activity display name.</param>
+    /// <returns>The trailing route segment, or the whole name when there is no method prefix.</returns>
+    private static string RouteOfDisplayName(string displayName)
+    {
+        var lastSpace = displayName.LastIndexOf(' ');
+        return lastSpace < 0 ? displayName : displayName[(lastSpace + 1)..];
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/ProbeTelemetryFilterProcessorTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/ProbeTelemetryFilterProcessorTests.cs
@@ -1,0 +1,208 @@
+using System.Diagnostics;
+using AwesomeAssertions;
+using MMCA.Common.Aspire.Telemetry;
+
+namespace MMCA.Common.Aspire.Tests.Telemetry;
+
+/// <summary>
+/// Unit tests for <see cref="ProbeTelemetryFilterProcessor"/>: the dependency spans hanging off a
+/// health-probe request (the health check's SQL <c>SELECT 1</c>, the Redis PING, the gateway's
+/// HttpClient call to a backend's <c>/alive</c>) must be unrecorded so exporters skip them, while
+/// the children of a real request keep flowing.
+/// </summary>
+public sealed class ProbeTelemetryFilterProcessorTests : IDisposable
+{
+    private const string SourceName = "Test.ProbeTelemetry";
+    private const string DependencySourceName = "Test.ProbeTelemetry.Dependency";
+
+    private readonly ActivitySource _source = new(SourceName);
+    private readonly ActivitySource _dependencySource = new(DependencySourceName);
+    private readonly ActivityListener _listener;
+    private readonly ProbeTelemetryFilterProcessor _sut = new();
+
+    public ProbeTelemetryFilterProcessorTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+                string.Equals(source.Name, SourceName, StringComparison.Ordinal)
+                || string.Equals(source.Name, DependencySourceName, StringComparison.Ordinal),
+
+            // Always sample, so what the processor does to the Recorded flag is the only thing the
+            // assertions can be reading.
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _source.Dispose();
+        _dependencySource.Dispose();
+        _sut.Dispose();
+    }
+
+    private static bool IsRecorded(Activity activity) =>
+        activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded);
+
+    private Activity StartProbeRequest(string urlPath = "/alive")
+        => _source.StartActivity(
+            "GET",
+            ActivityKind.Server,
+            default(ActivityContext),
+            [new KeyValuePair<string, object?>("url.path", urlPath)])!;
+
+    [Theory]
+    [InlineData("/alive")]
+    [InlineData("/health")]
+    [InlineData("/health/ready")]
+    public void ChildOfProbeRequest_IsUnrecorded(string urlPath)
+    {
+        using var request = StartProbeRequest(urlPath);
+        using var sqlChild = _dependencySource.StartActivity("SELECT 1", ActivityKind.Client);
+        sqlChild.Should().NotBeNull();
+
+        _sut.OnStart(sqlChild);
+
+        IsRecorded(sqlChild).Should().BeFalse("probe dependency spans must be suppressed from export");
+        sqlChild.IsAllDataRequested.Should().BeFalse("nothing should enrich a span that is not exported");
+    }
+
+    [Fact]
+    public void ChildOfNormalRequest_StaysRecorded()
+    {
+        using var request = StartProbeRequest("/api/tickets");
+        using var sqlChild = _dependencySource.StartActivity("SELECT Tickets", ActivityKind.Client);
+        sqlChild.Should().NotBeNull();
+
+        _sut.OnStart(sqlChild);
+
+        IsRecorded(sqlChild).Should().BeTrue("real request dependencies keep flowing");
+        sqlChild.IsAllDataRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GrandchildOfProbeRequest_IsUnrecorded()
+    {
+        using var request = StartProbeRequest();
+        using var handler = _dependencySource.StartActivity("HTTP GET", ActivityKind.Client);
+        using var dns = _dependencySource.StartActivity("DNS", ActivityKind.Internal);
+        dns.Should().NotBeNull();
+
+        _sut.OnStart(dns);
+
+        IsRecorded(dns).Should().BeFalse("the full parent chain is walked");
+    }
+
+    [Fact]
+    public void ProbeRequestItself_IsUnrecorded()
+    {
+        using var request = StartProbeRequest();
+
+        _sut.OnStart(request);
+
+        IsRecorded(request).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ChildOfMarkedProbeRequest_IsUnrecorded()
+    {
+        // The shape a live host actually produces: the inbound filter refuses the request before the
+        // instrumentation writes url.path, and leaves only its marker tag behind.
+        using var request = _source.StartActivity("GET", ActivityKind.Server);
+        request.Should().NotBeNull();
+        request.SetTag(ProbeTelemetryFilter.ProbeMarkerTagName, true);
+
+        using var redisChild = _dependencySource.StartActivity("PING", ActivityKind.Client);
+        redisChild.Should().NotBeNull();
+
+        _sut.OnStart(redisChild);
+
+        IsRecorded(redisChild).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ChildOfProbeRequestKnownOnlyByRoute_IsUnrecorded()
+    {
+        using var request = _source.StartActivity(
+            "GET /alive",
+            ActivityKind.Server,
+            default(ActivityContext),
+            [new KeyValuePair<string, object?>("http.route", "/alive")]);
+        using var sqlChild = _dependencySource.StartActivity("SELECT 1", ActivityKind.Client);
+        sqlChild.Should().NotBeNull();
+
+        _sut.OnStart(sqlChild);
+
+        IsRecorded(sqlChild).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ChildOfProbeRequestKnownOnlyByDisplayName_IsUnrecorded()
+    {
+        using var request = _source.StartActivity("GET /health/ready", ActivityKind.Server);
+        using var sqlChild = _dependencySource.StartActivity("SELECT 1", ActivityKind.Client);
+        sqlChild.Should().NotBeNull();
+
+        _sut.OnStart(sqlChild);
+
+        IsRecorded(sqlChild).Should().BeFalse("the renamed span is the last probe evidence left");
+    }
+
+    [Fact]
+    public void ClientSpanToAProbeEndpoint_StaysRecorded()
+    {
+        // Outgoing probe calls are dropped by the instrumentation filter instead. Matching them here
+        // too would cost a real request its whole subtree the moment one dependency looked probe-like.
+        using var client = _dependencySource.StartActivity(
+            "GET",
+            ActivityKind.Client,
+            default(ActivityContext),
+            [new KeyValuePair<string, object?>("url.path", "/alive")]);
+        client.Should().NotBeNull();
+
+        _sut.OnStart(client);
+
+        IsRecorded(client).Should().BeTrue("only server spans identify a probe request");
+    }
+
+    [Fact]
+    public void UnrelatedRootSpan_StaysRecorded()
+    {
+        using var unrelated = _dependencySource.StartActivity("BackgroundWork");
+        unrelated.Should().NotBeNull();
+
+        _sut.OnStart(unrelated);
+        _sut.OnEnd(unrelated);
+
+        IsRecorded(unrelated).Should().BeTrue();
+    }
+
+    [Fact]
+    public void OnEnd_SuppressesASpanWhoseTagsArrivedAfterStart()
+    {
+        using var request = _source.StartActivity("GET", ActivityKind.Server);
+        using var sqlChild = _dependencySource.StartActivity("SELECT 1", ActivityKind.Client);
+        sqlChild.Should().NotBeNull();
+
+        // Nothing identifies the parent as a probe yet, so the start pass leaves the child alone.
+        _sut.OnStart(sqlChild);
+        IsRecorded(sqlChild).Should().BeTrue();
+
+        request!.SetTag("url.path", "/health");
+        _sut.OnEnd(sqlChild);
+
+        IsRecorded(sqlChild).Should().BeFalse("the end pass is the backstop for late tags");
+    }
+
+    [Fact]
+    public void NullActivity_DoesNotThrow()
+    {
+        Action start = () => _sut.OnStart(null!);
+        Action end = () => _sut.OnEnd(null!);
+
+        start.Should().NotThrow("telemetry callbacks must never throw");
+        end.Should().NotThrow("telemetry callbacks must never throw");
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/ProbeTelemetryFilterTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/ProbeTelemetryFilterTests.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using MMCA.Common.Aspire.Telemetry;
+
+namespace MMCA.Common.Aspire.Tests.Telemetry;
+
+/// <summary>
+/// The <c>Telemetry:FilterProbeTelemetry</c> cost knob (rubric §31) and the two instrumentation
+/// predicates it installs. Health probes (Container Apps liveness/readiness, the gateway's
+/// downstream aggregate probes, YARP active health checks, the availability web test) are pure
+/// infrastructure chatter and made up every AppRequests row in both production workspaces. The knob
+/// defaults to ON, the opposite of the metrics knobs, so an unset key filters.
+/// </summary>
+public sealed class ProbeTelemetryFilterTests
+{
+    private static IConfiguration Config(string? value)
+    {
+        var values = new Dictionary<string, string?>();
+        if (value is not null)
+        {
+            values["Telemetry:FilterProbeTelemetry"] = value;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void Absent_FiltersProbeTelemetry()
+        => Extensions.IsProbeTelemetryFilterEnabled(Config(null))
+            .Should().BeTrue("an unset knob must filter probe telemetry (the default)");
+
+    [Theory]
+    [InlineData("false")]
+    [InlineData("False")]
+    [InlineData("FALSE")]
+    public void ExplicitFalse_KeepsProbeTelemetry(string raw)
+        => Extensions.IsProbeTelemetryFilterEnabled(Config(raw)).Should().BeFalse();
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("0")] // not a bool literal, so it cannot turn filtering off
+    [InlineData("no")] // unparseable
+    [InlineData("")] // blank
+    public void TrueOrUnparseable_FiltersProbeTelemetry(string raw)
+        => Extensions.IsProbeTelemetryFilterEnabled(Config(raw))
+            .Should().BeTrue("only an explicit boolean false turns the filter off");
+
+    // ── Inbound requests ──
+    [Theory]
+    [InlineData("/alive")]
+    [InlineData("/health")]
+    [InlineData("/health/ready")]
+    [InlineData("/health/anything-added-later")]
+    [InlineData("/Health/Ready")] // routing is case-insensitive
+    public void ProbeRequest_IsNotCollected(string path)
+        => ProbeTelemetryFilter.ShouldCollectRequest(RequestFor(path)).Should().BeFalse();
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/api/tickets")]
+    [InlineData("/healthcare")] // shares the prefix but is not a probe route
+    [InlineData("/alive-check")]
+    [InlineData("")]
+    public void NormalRequest_IsCollected(string path)
+        => ProbeTelemetryFilter.ShouldCollectRequest(RequestFor(path)).Should().BeTrue();
+
+    [Fact]
+    public void NullContext_IsCollected()
+        => ProbeTelemetryFilter.ShouldCollectRequest(null!)
+            .Should().BeTrue("telemetry callbacks must never throw or over-filter");
+
+    [Fact]
+    public void ProbeRequest_MarksTheCurrentServerActivity()
+    {
+        using var source = new ActivitySource("Test.ProbeFilter.Marker");
+        using var listener = ListenTo(source.Name);
+
+        using var request = source.StartActivity("GET", ActivityKind.Server);
+        request.Should().NotBeNull();
+
+        ProbeTelemetryFilter.ShouldCollectRequest(RequestFor("/alive")).Should().BeFalse();
+
+        request.GetTagItem(ProbeTelemetryFilter.ProbeMarkerTagName)
+            .Should().NotBeNull("descendant spans recognize their probe ancestor by this marker, "
+                + "because a filtered request never gets a url.path tag");
+    }
+
+    [Fact]
+    public void NormalRequest_DoesNotMarkTheCurrentServerActivity()
+    {
+        using var source = new ActivitySource("Test.ProbeFilter.NoMarker");
+        using var listener = ListenTo(source.Name);
+
+        using var request = source.StartActivity("GET", ActivityKind.Server);
+        request.Should().NotBeNull();
+
+        ProbeTelemetryFilter.ShouldCollectRequest(RequestFor("/api/tickets")).Should().BeTrue();
+
+        request.GetTagItem(ProbeTelemetryFilter.ProbeMarkerTagName).Should().BeNull();
+    }
+
+    // ── Outbound calls (YARP active health checks, the gateway's downstream probes) ──
+    [Theory]
+    [InlineData("http://identity/alive")]
+    [InlineData("https://conference.internal/health")]
+    [InlineData("http://engagement/health/ready")]
+    [InlineData("http://identity/alive?probe=1")]
+    public void OutgoingProbeCall_IsNotCollected(string url)
+        => ProbeTelemetryFilter.ShouldCollectOutgoing(new HttpRequestMessage(HttpMethod.Get, url))
+            .Should().BeFalse();
+
+    [Theory]
+    [InlineData("/alive")]
+    [InlineData("/health/ready?x=1")]
+    public void OutgoingProbeCall_OnARelativeUri_IsNotCollected(string url)
+        => ProbeTelemetryFilter.ShouldCollectOutgoing(
+                new HttpRequestMessage(HttpMethod.Get, new Uri(url, UriKind.Relative)))
+            .Should().BeFalse();
+
+    [Theory]
+    [InlineData("http://identity/api/users")]
+    [InlineData("https://gateway/")]
+    [InlineData("http://identity/healthcare")]
+    public void NormalOutgoingCall_IsCollected(string url)
+        => ProbeTelemetryFilter.ShouldCollectOutgoing(new HttpRequestMessage(HttpMethod.Get, url))
+            .Should().BeTrue();
+
+    [Fact]
+    public void OutgoingCallWithoutUri_IsCollected()
+        => ProbeTelemetryFilter.ShouldCollectOutgoing(new HttpRequestMessage())
+            .Should().BeTrue("a request with no URI cannot be identified as a probe");
+
+    private static DefaultHttpContext RequestFor(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        return context;
+    }
+
+    private static ActivityListener ListenTo(string sourceName)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, sourceName, StringComparison.Ordinal),
+            Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}

--- a/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/ProbeTelemetryToggleTests.cs
+++ b/Tests/Hosting/MMCA.Common.Aspire.Tests/Telemetry/ProbeTelemetryToggleTests.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics;
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Instrumentation.AspNetCore;
+using OpenTelemetry.Instrumentation.Http;
+using OpenTelemetry.Trace;
+
+namespace MMCA.Common.Aspire.Tests.Telemetry;
+
+/// <summary>
+/// The <c>Telemetry:FilterProbeTelemetry</c> knob asserted through the real
+/// <c>ConfigureOpenTelemetry()</c> path rather than inferred from the flag reader: all three pieces
+/// (the inbound request filter, the outbound HttpClient filter, and the descendant-suppressing
+/// processor) must appear together when the knob is left at its default and disappear together when
+/// a host sets it to <see langword="false"/>.
+/// </summary>
+public sealed class ProbeTelemetryToggleTests
+{
+    [Fact]
+    public void Default_InstallsBothInstrumentationFilters()
+    {
+        using var host = BuildHost(knob: null, out _, out var sourceName);
+        var (aspNetFilter, httpClientFilter) = InstrumentationFilters(host);
+
+        aspNetFilter.Should().NotBeNull("probe requests must be refused before a span is exported");
+        httpClientFilter.Should().NotBeNull("YARP and gateway probe calls have no request ancestor");
+        sourceName.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Disabled_InstallsNeitherInstrumentationFilter()
+    {
+        using var host = BuildHost(knob: "false", out _, out _);
+        var (aspNetFilter, httpClientFilter) = InstrumentationFilters(host);
+
+        aspNetFilter.Should().BeNull("an opted-out host keeps its probe traces");
+        httpClientFilter.Should().BeNull("an opted-out host keeps its probe traces");
+    }
+
+    [Fact]
+    public void Default_DropsAProbeRequestAndItsDependency()
+    {
+        var exported = Trace(knob: null);
+
+        exported.Should().BeEmpty(
+            "the probe span and the SELECT 1 hanging off it are the AppRequests / AppDependencies volume this knob exists to remove");
+    }
+
+    [Fact]
+    public void Disabled_KeepsAProbeRequestAndItsDependency()
+    {
+        var exported = Trace(knob: "false");
+
+        exported.Should().HaveCount(2, "with the knob off nothing suppresses probe traces");
+    }
+
+    /// <summary>
+    /// Emits a probe server span with one dependency child through a TracerProvider built by the
+    /// real service defaults, and returns the display names that reached an exporter.
+    /// </summary>
+    private static IReadOnlyList<string> Trace(string? knob)
+    {
+        using var host = BuildHost(knob, out var exported, out var sourceName);
+        var provider = host.Services.GetRequiredService<TracerProvider>();
+
+        using (var source = new ActivitySource(sourceName))
+        {
+            using var request = source.StartActivity(
+                "GET",
+                ActivityKind.Server,
+                default(ActivityContext),
+                [new KeyValuePair<string, object?>("url.path", "/alive")]);
+            using var dependency = source.StartActivity("SELECT 1", ActivityKind.Client);
+        }
+
+        provider.ForceFlush();
+
+        return [.. exported.Select(activity => activity.DisplayName)];
+    }
+
+    private static (Delegate? AspNetCore, Delegate? HttpClient) InstrumentationFilters(IHost host)
+    {
+        // Building the provider is what runs the deferred tracer-builder callbacks that configure
+        // the instrumentation options.
+        _ = host.Services.GetRequiredService<TracerProvider>();
+
+        var aspNetCore = host.Services
+            .GetRequiredService<IOptionsMonitor<AspNetCoreTraceInstrumentationOptions>>()
+            .Get(Options.DefaultName);
+        var httpClient = host.Services
+            .GetRequiredService<IOptionsMonitor<HttpClientTraceInstrumentationOptions>>()
+            .Get(Options.DefaultName);
+
+        return (aspNetCore.Filter, httpClient.FilterHttpRequestMessage);
+    }
+
+    private static IHost BuildHost(string? knob, out List<Activity> exported, out string sourceName)
+    {
+        sourceName = "Test.ProbeToggle." + Guid.NewGuid().ToString("N");
+
+        var settings = new Dictionary<string, string?>
+        {
+            // Blanked explicitly so an OTLP endpoint or Application Insights key in the developer's
+            // own environment cannot attach a second exporter to this provider.
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = string.Empty,
+            ["APPLICATIONINSIGHTS_CONNECTION_STRING"] = string.Empty,
+        };
+
+        if (knob is not null)
+        {
+            settings["Telemetry:FilterProbeTelemetry"] = knob;
+        }
+
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration.AddInMemoryCollection(settings);
+        builder.ConfigureOpenTelemetry();
+
+        var collected = new List<Activity>();
+        exported = collected;
+
+        var registeredSource = sourceName;
+        builder.Services.ConfigureOpenTelemetryTracerProvider(tracing => tracing
+            .AddSource(registeredSource)
+            .AddInMemoryExporter(collected));
+
+        return builder.Build();
+    }
+}


### PR DESCRIPTION
## Why

Measured in production today: 100% of the `AppRequests` rows in both the ADC and Store workspaces are `GET /alive`, `GET /health/ready` and `GET /health` (Container Apps probes, the gateway's downstream aggregate probes, YARP active health checks, the availability web test), and most `AppDependencies` rows are the children of those probe requests: the SQL health check's `SELECT 1`, the Redis PING, and the gateway's HttpClient calls to each backend's `/alive`.

None of it is reduced by `Telemetry:TracesSampleRatio`, because probe spans are exactly what a ratio sampler keeps proportionally. Cost of the noise: about $24/month across the two apps.

## What

New knob **`Telemetry:FilterProbeTelemetry`**, read the same way as the existing `Telemetry:Disable*` knobs but **defaulting to `true`** (probe chatter is ingestion no host wants billed; a host debugging its own probes sets it to `false`). When on, three pieces are installed together:

1. `AddAspNetCoreInstrumentation(options => options.Filter = ...)` refuses inbound `/alive`, `/health` and `/health/*` requests. On its way out it stamps a marker tag on the request activity, because a refused request never receives the `url.path` tag its descendants would otherwise use to recognize their probe ancestor.
2. `AddHttpClientInstrumentation(options => options.FilterHttpRequestMessage = ...)` refuses outbound calls to the same paths. This is what catches the probes that are not children of a request at all: YARP active health checks and the gateway's `DownstreamServiceHealthCheck`.
3. `ProbeTelemetryFilterProcessor` (`BaseProcessor<Activity>`, modelled on `OutboxPollFilterProcessor` and registered next to it, before the exporters) walks the parent chain and un-records every descendant of a probe request. It runs at start and again at end, because a span's identifying tags do not all exist at start.

Both filters configure the **default-named** instrumentation options, so they also apply to the instrumentation the Azure Monitor distro adds: unlike the metrics toggles, these are authoritative without a metrics View.

**Metrics are deliberately untouched.** `http.server.request.duration`, Kestrel and routing instruments keep flowing, so probe traffic stays visible on dashboards.

The three probe paths now live in one place, `HealthEndpointPaths`, used by `MapDefaultEndpoints`, both filters, the processor and the gateway probe, so the mapping and the filters cannot drift apart.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: succeeded, 0 warnings, 0 errors.
- `MMCA.Common.Aspire.Tests`: 238 passed, 0 failed (48 of them new: 31 filter + knob, 13 processor, 4 end-to-end toggle).
- `MMCA.Common.Architecture.Tests`: 178 passed, 0 failed.
- `dotnet format --verify-no-changes` clean on the two touched projects (except one pre-existing IDE0290 on an untouched file).

No consumer action is required at bump time: the filtering is on by default and only removes telemetry the apps do not use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFaTUw34BQJneR4auAyBH8
