### PR TITLE
release: v1.184.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.184.0] - 2026-09-03
+
 **Breaking:** second feature-by-folder pass (rubric §5), this time over the eight flat public
 namespaces the first pass left alone because every consumer imports them. Namespaces follow folders
 (IDE0130), so each bucket below was split by concern; no type, member, signature, configuration key,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,7 +32,7 @@ grep -rl --include='*.cs' --include='*.razor' 'using MMCA.Common.Application.Use
 The first-party consumers (MMCA.ADC, MMCA.Store, MMCA.Helpdesk) are swept by the workspace script
 `Tools/Scripts/move-namespace.ps1` in the same release, which does exactly the three steps above.
 
-## [Unreleased]
+## [1.184.0] - 2026-09-03
 
 **Breaking: namespace moves only.** No type, member, signature, configuration key, database object
 or runtime behavior changed. Eight flat public namespaces that each held 17 to 23 types were split


### PR DESCRIPTION
Release docs for v1.184.0: the **Breaking** namespace split (#352) rolled from Unreleased into the 1.184.0 headings of CHANGELOG.md and UPGRADING.md. No source change. Tag follows on merged main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFaTUw34BQJneR4auAyBH8