### PR TITLE
release: v1.186.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.186.0] - 2026-09-05
+
 ### Changed
 
 - **The gRPC typed-client convention now names its patterns.** `AddTypedGrpcClient<TClient>` and the


### PR DESCRIPTION
Rolls the CHANGELOG Unreleased section into 1.186.0.

Ships: ACL + Strangler Fig naming in the MMCA.Common.Grpc docs (#358), the samples/deployment sql-conn Key Vault secret fix (#358), and E2ETestBase.SignOutAsync for the Firefox NS_BINDING_ABORTED logout race (#358). No source changes beyond #358, already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFaTUw34BQJneR4auAyBH8