### PR TITLE
fix(ui): clip .page horizontal overflow at every width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.187.0] - 2026-09-06
+
 ### Fixed
 
 - **`MainLayout` clips horizontal page overflow at every width** (`MMCA.Common.UI`). `.page` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Fixed
+
+- **`MainLayout` clips horizontal page overflow at every width** (`MMCA.Common.UI`). `.page` now
+  carries `overflow-x: clip` in its base rule instead of only inside the desktop breakpoint. An
+  absolutely positioned descendant parked off-screen to the right (an app's closed temporary
+  drawer, 100vw wide on phones) otherwise extends the document's scrollable width, and mobile
+  Chrome widens the layout viewport to match while the visual viewport stays at device width, so
+  every viewport-fixed element centered with `left: 50%` (the MudBlazor snackbar and dialog
+  containers) lands at the right screen edge, clipped. Reproduced and verified against MMCA.Store
+  production in Pixel 7 emulation (`window.innerWidth` 824 to 412 with the rule in place).
+  `clip`, not `hidden`, so `.page` never becomes a scroll container.
+
 ## [1.186.0] - 2026-09-05
 
 ### Changed

--- a/Source/Presentation/MMCA.Common.UI/Layout/MainLayout.razor.css
+++ b/Source/Presentation/MMCA.Common.UI/Layout/MainLayout.razor.css
@@ -24,6 +24,19 @@
     flex-direction: column;
     min-height: 100vh;
     min-height: 100dvh;
+    /* Clip horizontal overflow at EVERY width, not only on desktop. Any absolutely positioned
+       descendant parked off-screen to the right (an app's closed temporary drawer at
+       right: calc(-1 * var(--mud-drawer-width)), 100vw wide on phones) otherwise extends the
+       document's scrollable width, and mobile Chrome widens the LAYOUT viewport to that content
+       width while the visual viewport stays at device width. Every viewport-fixed element centered
+       with left: 50% (MudBlazor's snackbar container, the dialog container) is then centered
+       against the doubled width and lands at the right screen edge, clipped. Clipping the
+       containing block keeps the overflow out of the document, so the layout viewport stays at
+       device width. Root-level overflow-x on html/body does not change that calculation; this
+       does. clip, NOT hidden: a non-visible overflow-x forces the computed overflow-y from visible
+       to auto, which would turn .page into a scroll container (see the desktop block below for
+       what that does to the sticky sidebar). */
+    overflow-x: clip;
 }
 
 main {
@@ -127,14 +140,14 @@ main {
         flex-wrap: wrap;
         width: 100%;
         max-width: 100vw;
-        /* clip, NOT hidden: per spec a non-visible overflow-x forces the computed overflow-y
-           from visible to auto, which turns .page into a scroll container. The sticky sidebar
-           below then resolves against .page's scrollport instead of the viewport, and since
-           .page grows with its content and never scrolls itself, the sidebar never sticks: it
-           scrolled off with the document and its background stopped one viewport down. clip
+        /* overflow-x: clip is inherited from the base .page rule above and must stay clip, NOT
+           hidden, here of all places: per spec a non-visible overflow-x forces the computed
+           overflow-y from visible to auto, which turns .page into a scroll container. The sticky
+           sidebar below then resolves against .page's scrollport instead of the viewport, and
+           since .page grows with its content and never scrolls itself, the sidebar never sticks:
+           it scrolled off with the document and its background stopped one viewport down. clip
            bounds the horizontal overflow the same way without creating a scrollport. Same
            reasoning as main's overflow-x below. */
-        overflow-x: clip;
     }
 
     /* Force the footer onto the next flex line so it spans full width instead of


### PR DESCRIPTION
## Problem

On phones, MudBlazor snackbars are clipped at the right screen edge and dialogs render off-screen (seen on MMCA.Store production, Android Chrome). Every affected element is a viewport-fixed container centered with `left: 50%`.

## Root cause

An absolutely positioned descendant of `.page` parked off-screen to the right (Store's closed cart drawer: 100vw wide below 600px, at `right: calc(-1 * var(--mud-drawer-width))`) extends the document's scrollable width to 2x. Mobile Chrome widens the **layout** viewport to that content width while the **visual** viewport stays at device width, so `left: 50%` resolves to the right edge of the screen.

Reproduced with Playwright Pixel 7 emulation: `window.innerWidth` 824 vs `visualViewport.width` 412 on Store prod; 412/412 on ADC prod (no drawer).

## Fix

`MainLayout.razor.css` already applied `overflow-x: clip` to `.page` inside the desktop breakpoint (for the sticky-sidebar reason documented there). This PR hoists the declaration into the base `.page` rule so it applies at every width, keeps the desktop block's sticky-sidebar rationale as a pointer, and documents why `clip` rather than `hidden` (a non-visible `overflow-x` would force `overflow-y: auto` and make `.page` a scroll container).

Verified in emulation with the rule injected: innerWidth 824 to 412, snackbar container recentered at x=206. Root-level `overflow-x` on `html`/`body`, `transform`, and `clip-path` on the drawer were tested and do NOT change Chromium's mobile layout-viewport calculation; clipping the containing block does.

Companion: MMCA.Store PR #130 carries the same rule app-side in `store.css` as the immediate fix; it becomes redundant once this ships and can be dropped in Store's version-bump PR.

## Checklist

- [x] `dotnet build MMCA.Common.UI -c Release` clean
- [x] CHANGELOG `[Unreleased]` entry
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LACV6nojAfoDbfwUWAN6U5
