### PR TITLE
release: v1.189.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.189.0] - 2026-09-08
+
 ### Changed
 
 - Dependency sweep (2026-09-08 NuGet audit): AngleSharp 1.8.0, bunit 2.10.3, Google.Protobuf 3.36.1,


### PR DESCRIPTION
Rolls the CHANGELOG Unreleased entries under 1.189.0. Dependency-only release: AngleSharp 1.8.0, bunit 2.10.3, Google.Protobuf 3.36.1, Grpc.Tools 2.83.0, Meziantou.Analyzer 3.0.228, MAUI 10.0.101, Microsoft.Extensions.Caching.StackExchangeRedis 10.0.11, MinVer 8.0.0, Scalar.AspNetCore 2.17.3, Testcontainers 4.15.0 (#370). No behavioral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LACV6nojAfoDbfwUWAN6U5