### PR TITLE
release: v1.190.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,8 +141,9 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
   the tier against an in-repo sample AppHost with `MMCA_APPHOST_TESTS=1`. The sample AppHost, its
   sample service and the AppHost-backed test project sit outside `MMCA.Common.slnx`, so the
   solution-wide unit loop neither builds nor discovers them.
-- Consumer step for the stored permission grants: `EFPermissionGrantStore` hard-deletes a revoked grant, so a
-  consumer that runs the shared `SoftDeleteEnforcementTests` adds that type to its `AllowedHardDeleteTypes`
+- Consumer step: `EFPermissionGrantStore` hard-deletes a revoked grant, and `InternalCommandCleanupService` plus
+  `InternalCommandAdministration` purge processed and dead-lettered rows, so a
+  consumer that runs the shared `SoftDeleteEnforcementTests` adds those three types to its `AllowedHardDeleteTypes`
   when it takes this release (Common's own allowlist already carries it).
 
 ## [1.189.0] - 2026-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.190.0] - 2026-09-10
+
 ### Added
 
 - **Strongly typed identifiers, opt in** (ADR-115). `IStronglyTypedId<TSelf, TValue>` in
@@ -139,6 +141,9 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
   the tier against an in-repo sample AppHost with `MMCA_APPHOST_TESTS=1`. The sample AppHost, its
   sample service and the AppHost-backed test project sit outside `MMCA.Common.slnx`, so the
   solution-wide unit loop neither builds nor discovers them.
+- Consumer step for the stored permission grants: `EFPermissionGrantStore` hard-deletes a revoked grant, so a
+  consumer that runs the shared `SoftDeleteEnforcementTests` adds that type to its `AllowedHardDeleteTypes`
+  when it takes this release (Common's own allowlist already carries it).
 
 ## [1.189.0] - 2026-09-08
 


### PR DESCRIPTION
Rolls the Unreleased CHANGELOG block onto the 1.190.0 header. Ships the framework gap wave: PostgreSQL engine (#373, ADR-113), internal commands job queue (#374, ADR-114), strongly typed identifiers (#377, ADR-115), identity completions (#375, ADR-116), MMCA.Common.Testing.Aspire (#376, ADR-117). Adds the consumer note that EFPermissionGrantStore must join each consumer's AllowedHardDeleteTypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXs5HjPgxuutXc7ymo2FnM