### PR TITLE
feat(ui.web): AddTrustedCallerHeader, the client half of the gateway trusted-caller exemption (v1.191.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.191.0] - 2026-09-10
+
+### Added
+
+- **The client half of the gateway trusted-caller exemption.**
+  `services.AddTrustedCallerHeader(configuration)` (MMCA.Common.UI.Web) presents the deployment's
+  trusted-internal-caller secret on a server-rendered host's server-to-server calls, so they take
+  the gateway's no-limiter partition instead of collapsing every visitor into one client-IP window.
+  The gateway edge limiter already read `GatewayRateLimiting:TrustedCallerHeaderName` and
+  `GatewayRateLimiting:TrustedCallerSecret`; the same section now configures both ends, and each
+  host stopped needing its own copy of the client side.
+- **Narrow by construction.** The public `TrustedCallerHandler` (a `DelegatingHandler` in
+  `MMCA.Common.UI.Web.Security`) is composed onto every `HttpClient` the host creates, because the
+  call that suffers most from the per-IP collapse is the cookie-session token refresh, whose client
+  the framework creates under a name a host has no supported way to reach. Breadth costs nothing
+  because the handler stamps only a request whose scheme, host and port match the gateway origin
+  (`Api:ApiEndpoint`), as exactly one header value: a client later pointed at a third party cannot
+  be handed the bypass by accident.
+- **Opt in, and server side only.** With no secret configured (the local and CI default) the call
+  registers nothing at all and every request stays rate limited exactly as it is today; the same is
+  true when the header name is blank or the API endpoint is not an absolute URI. The secret exempts
+  a component the deployment ships, never a visitor's browser, so it must reach the SSR host alone,
+  from a secret store or the environment (`GatewayRateLimiting__TrustedCallerSecret`), never a
+  checked-in `appsettings` file and never client-side code.
+- **Consumer note.** A host that hand-rolled this can delete its local copy and call
+  `AddTrustedCallerHeader(builder.Configuration)` instead. MMCA.Store's settings move from its own
+  `TrustedCaller:*` section to `GatewayRateLimiting:*` (`TrustedCaller:Secret` becomes
+  `GatewayRateLimiting:TrustedCallerSecret`, `TrustedCaller:HeaderName` becomes
+  `GatewayRateLimiting:TrustedCallerHeaderName`), which is a deployment-configuration rename:
+  the environment variable `TrustedCaller__Secret` becomes
+  `GatewayRateLimiting__TrustedCallerSecret`.
+
 ## [1.190.0] - 2026-09-10
 
 ### Added

--- a/Source/Presentation/MMCA.Common.UI.Web/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI.Web/DependencyInjection.cs
@@ -1,5 +1,9 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using MMCA.Common.Aspire.Gateway;
 using MMCA.Common.Aspire.Security;
+using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Services;
 using MMCA.Common.UI.Services.Auth.Tokens;
 using MMCA.Common.UI.Web.Security;
@@ -46,5 +50,68 @@ public static class DependencyInjection
         /// </summary>
         public IServiceCollection AddCommonWebFormFactor() =>
             services.AddSingleton<IFormFactor, WebFormFactor>();
+
+        /// <summary>
+        /// Presents the deployment's trusted-internal-caller secret on this host's server-to-server
+        /// calls to the gateway, so they take the gateway's no-limiter partition instead of
+        /// collapsing every visitor into one client-IP window. Composes
+        /// <see cref="TrustedCallerHandler"/> onto every <c>HttpClient</c> the host creates; the
+        /// handler stamps only requests whose origin is the gateway.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Opt in.</b> The whole feature is off unless
+        /// <c>GatewayRateLimiting:TrustedCallerSecret</c> is set: with no secret (the local and CI
+        /// default) this registers nothing at all and every call stays rate limited exactly as it is
+        /// today. The gateway must be configured from the SAME
+        /// <c>GatewayRateLimiting</c> section, so one section configures both ends
+        /// (<see cref="GatewayRateLimitingSettings"/>).
+        /// </para>
+        /// <para>
+        /// <b>Server only.</b> The secret exempts a component this deployment ships, never a
+        /// visitor's browser, so it must never reach client-side code: supply it from a secret store
+        /// or the environment (<c>GatewayRateLimiting__TrustedCallerSecret</c>) to the SSR host
+        /// alone, never to the WebAssembly client or a rendered page.
+        /// </para>
+        /// <para>
+        /// <b>Why every client.</b> The call that suffers most from the per-IP collapse is the
+        /// cookie-session token refresh, whose client the framework creates under a name a host has
+        /// no supported way to reach, so there is no single name to configure. The gateway origin
+        /// comes from <c>Api:ApiEndpoint</c> (<see cref="ApiSettings"/>), the endpoint this host's
+        /// server-side calls already target; a host whose endpoint is missing or not an absolute URI
+        /// registers nothing.
+        /// </para>
+        /// </remarks>
+        /// <param name="configuration">The host's configuration.</param>
+        /// <returns>The service collection, for chaining.</returns>
+        public IServiceCollection AddTrustedCallerHeader(IConfiguration configuration)
+        {
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            var settings = configuration.GetSection(GatewayRateLimitingSettings.SectionName)
+                .Get<GatewayRateLimitingSettings>() ?? new GatewayRateLimitingSettings();
+
+            // ApiEndpoint, not WasmApiEndpoint: this stamps SERVER-side calls, and the browser-facing
+            // endpoint the CSP pins is a different question.
+            var apiEndpoint = configuration.GetSection(ApiSettings.SectionName)
+                .Get<ApiSettings>()?.ApiEndpoint;
+
+            if (string.IsNullOrWhiteSpace(settings.TrustedCallerSecret)
+                || string.IsNullOrWhiteSpace(settings.TrustedCallerHeaderName)
+                || !Uri.TryCreate(apiEndpoint, UriKind.Absolute, out var gatewayOrigin))
+            {
+                return services;
+            }
+
+            var headerName = settings.TrustedCallerHeaderName;
+            var secret = settings.TrustedCallerSecret;
+
+            services.ConfigureAll<HttpClientFactoryOptions>(options =>
+                options.HttpMessageHandlerBuilderActions.Add(builder =>
+                    builder.AdditionalHandlers.Add(
+                        new TrustedCallerHandler(headerName, secret, gatewayOrigin))));
+
+            return services;
+        }
     }
 }

--- a/Source/Presentation/MMCA.Common.UI.Web/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI.Web/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+MMCA.Common.UI.Web.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddTrustedCallerHeader(Microsoft.Extensions.Configuration.IConfiguration! configuration) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.UI.Web.Security.TrustedCallerHandler
+MMCA.Common.UI.Web.Security.TrustedCallerHandler.TrustedCallerHandler(string! headerName, string! secret, System.Uri! gatewayOrigin) -> void
+static MMCA.Common.UI.Web.DependencyInjection.AddTrustedCallerHeader(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/Source/Presentation/MMCA.Common.UI.Web/Security/TrustedCallerHandler.cs
+++ b/Source/Presentation/MMCA.Common.UI.Web/Security/TrustedCallerHandler.cs
@@ -1,0 +1,83 @@
+namespace MMCA.Common.UI.Web.Security;
+
+/// <summary>
+/// Stamps the trusted-internal-caller header on the outbound requests a server-rendered host sends
+/// to its gateway, so those calls take the gateway's no-limiter partition instead of collapsing
+/// every visitor into one client-IP window.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The problem.</b> The gateway's edge limiter partitions on the connecting address, and an SSR
+/// host makes all of its back-end calls from ONE address on behalf of every visitor: the render of a
+/// page, and above all the cookie-session token refresh that runs whenever an access cookie has
+/// expired. Those calls collapse into a single per-IP window, so the limiter starts throttling the
+/// APPLICATION as soon as the site is busy rather than throttling a caller. A request proving
+/// <c>GatewayRateLimiting:TrustedCallerSecret</c> in
+/// <c>GatewayRateLimiting:TrustedCallerHeaderName</c> takes the no-limiter partition instead
+/// (<see cref="MMCA.Common.Aspire.Gateway.GatewayRateLimitingSettings.TrustedCallerSecret"/>,
+/// compared in constant time, single-valued header only).
+/// </para>
+/// <para>
+/// <b>Why the breadth is safe.</b> The registration composes this handler onto EVERY client the host
+/// creates, because the call that suffers most from the per-IP collapse is created by the framework
+/// under a name a host cannot reach. Breadth costs nothing here because the handler itself is
+/// narrow: it attaches the secret only to a request whose scheme, host and port match the gateway
+/// origin, so a client later pointed at a third party (a telemetry exporter, an identity provider)
+/// can never be handed the bypass by accident.
+/// </para>
+/// <para>
+/// <b>Where the value belongs.</b> The secret exempts a component of the deployment, never an end
+/// user's browser, so it must never reach client-side code: read it on the server from a secret
+/// store or the environment (<c>GatewayRateLimiting__TrustedCallerSecret</c>), never from a
+/// checked-in <c>appsettings</c> file.
+/// </para>
+/// </remarks>
+public sealed class TrustedCallerHandler : DelegatingHandler
+{
+    private readonly string _headerName;
+    private readonly string _secret;
+    private readonly Uri _gatewayOrigin;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TrustedCallerHandler"/> class.
+    /// </summary>
+    /// <param name="headerName">The header the gateway reads.</param>
+    /// <param name="secret">The shared secret the gateway compares.</param>
+    /// <param name="gatewayOrigin">
+    /// The gateway origin. Only a request whose scheme, host and port match it is stamped.
+    /// </param>
+    public TrustedCallerHandler(string headerName, string secret, Uri gatewayOrigin)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(headerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(secret);
+        ArgumentNullException.ThrowIfNull(gatewayOrigin);
+
+        _headerName = headerName;
+        _secret = secret;
+        _gatewayOrigin = gatewayOrigin;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.RequestUri is { IsAbsoluteUri: true } uri
+            && Uri.Compare(
+                uri,
+                _gatewayOrigin,
+                UriComponents.Scheme | UriComponents.HostAndPort,
+                UriFormat.UriEscaped,
+                StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            // Single-valued and replaced rather than appended: the gateway compares one header value
+            // in constant time, so a second value would silently fail the comparison.
+            request.Headers.Remove(_headerName);
+            request.Headers.TryAddWithoutValidation(_headerName, _secret);
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/TrustedCallerHandlerTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/TrustedCallerHandlerTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using AwesomeAssertions;
+using MMCA.Common.UI.Web.Security;
+
+namespace MMCA.Common.UI.Web.Tests.Security;
+
+/// <summary>
+/// Pins <see cref="TrustedCallerHandler"/>: the secret rides a request whose scheme, host and port
+/// match the gateway origin, as exactly one header value, and rides nothing else. A client later
+/// pointed at a third party (a different host, or the same host on a different port) must never be
+/// handed the bypass.
+/// </summary>
+public sealed class TrustedCallerHandlerTests
+{
+    private const string HeaderName = "X-Internal-Caller-Key";
+    private const string Secret = "0123456789abcdef0123456789abcdef";
+    private const string GatewayOrigin = "https://gateway.example.com:6001";
+
+    [Fact]
+    public async Task SendAsync_ToTheGatewayOrigin_AddsExactlyOneHeaderValue()
+    {
+        var (client, inner) = CreateClient();
+
+        await client.GetAsync(new Uri(GatewayOrigin + "/Auth/refresh"), TestContext.Current.CancellationToken);
+
+        inner.LastRequest.Should().NotBeNull();
+        inner.LastRequest!.Headers.GetValues(HeaderName).Should().ContainSingle().Which.Should().Be(Secret);
+    }
+
+    [Fact]
+    public async Task SendAsync_ToAnotherPathOnTheGatewayOrigin_StillAddsTheHeader()
+    {
+        var (client, inner) = CreateClient();
+
+        await client.GetAsync(new Uri(GatewayOrigin + "/Events?page=2"), TestContext.Current.CancellationToken);
+
+        inner.LastRequest!.Headers.Contains(HeaderName).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://telemetry.example.com/ingest")] // different host
+    [InlineData("https://gateway.example.com/Auth/refresh")] // same host, default port
+    [InlineData("https://gateway.example.com:6002/Auth")] // same host, different port
+    [InlineData("http://gateway.example.com:6001/Auth")] // same host and port, different scheme
+    public async Task SendAsync_ToAnyOtherOrigin_AddsNoHeader(string requestUri)
+    {
+        var (client, inner) = CreateClient();
+
+        await client.GetAsync(new Uri(requestUri), TestContext.Current.CancellationToken);
+
+        inner.LastRequest!.Headers.Contains(HeaderName).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenTheRequestAlreadyCarriesTheHeader_ReplacesItRatherThanAppending()
+    {
+        var (client, inner) = CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(GatewayOrigin + "/Auth/refresh"));
+        request.Headers.TryAddWithoutValidation(HeaderName, "a-forged-value");
+
+        await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        inner.LastRequest!.Headers.GetValues(HeaderName).Should().ContainSingle().Which.Should().Be(Secret);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WithABlankHeaderNameOrSecret_Throws(string? blank)
+    {
+        var origin = new Uri(GatewayOrigin);
+
+        FluentActions.Invoking(() => new TrustedCallerHandler(blank!, Secret, origin))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => new TrustedCallerHandler(HeaderName, blank!, origin))
+            .Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNoGatewayOrigin_Throws() =>
+        FluentActions.Invoking(() => new TrustedCallerHandler(HeaderName, Secret, null!))
+            .Should().Throw<ArgumentNullException>();
+
+    private static (HttpClient Client, CapturingHandler Inner) CreateClient()
+    {
+        var inner = new CapturingHandler();
+        var handler = new TrustedCallerHandler(HeaderName, Secret, new Uri(GatewayOrigin))
+        {
+            InnerHandler = inner,
+        };
+
+        return (new HttpClient(handler), inner);
+    }
+
+    /// <summary>Stub inner handler that records the request the pipeline produced.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request });
+        }
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/TrustedCallerHeaderRegistrationTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/TrustedCallerHeaderRegistrationTests.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MMCA.Common.UI.Web.Tests.Security;
+
+/// <summary>
+/// Pins <c>AddTrustedCallerHeader(IConfiguration)</c>: it is opt in (nothing at all is registered
+/// without a secret), it reads the same <c>GatewayRateLimiting</c> section the gateway edge limiter
+/// reads, it defaults the header name from that settings type, and it applies to EVERY named client
+/// the host creates (the cookie-session refresh client is created under a name a host cannot reach).
+/// </summary>
+public sealed class TrustedCallerHeaderRegistrationTests
+{
+    private const string DefaultHeaderName = "X-Internal-Caller-Key";
+    private const string Secret = "0123456789abcdef0123456789abcdef";
+    private const string GatewayOrigin = "https://gateway.example.com:6001";
+
+    [Fact]
+    public void AddTrustedCallerHeader_WithNoSecret_RegistersNothing()
+    {
+        var services = new ServiceCollection();
+        var before = services.Count;
+
+        services.AddTrustedCallerHeader(BuildConfiguration(secret: null));
+
+        services.Count.Should().Be(before);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AddTrustedCallerHeader_WithNoSecret_SendsNoHeader(string? secret)
+    {
+        var (request, _) = await SendThroughNamedClientAsync(
+            BuildConfiguration(secret), "AnyClient", GatewayOrigin + "/Auth/refresh");
+
+        request.Headers.Contains(DefaultHeaderName).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-an-absolute-uri")]
+    public void AddTrustedCallerHeader_WithoutAnAbsoluteGatewayOrigin_RegistersNothing(string? apiEndpoint)
+    {
+        var services = new ServiceCollection();
+        var before = services.Count;
+
+        services.AddTrustedCallerHeader(BuildConfiguration(Secret, apiEndpoint));
+
+        services.Count.Should().Be(before);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddTrustedCallerHeader_WithABlankHeaderName_RegistersNothing(string headerName)
+    {
+        var services = new ServiceCollection();
+        var before = services.Count;
+
+        services.AddTrustedCallerHeader(BuildConfiguration(Secret, GatewayOrigin, headerName));
+
+        services.Count.Should().Be(before);
+    }
+
+    [Fact]
+    public async Task AddTrustedCallerHeader_WithASecret_StampsRequestsToTheGatewayOrigin()
+    {
+        var (request, _) = await SendThroughNamedClientAsync(
+            BuildConfiguration(Secret), "AnyClient", GatewayOrigin + "/Auth/refresh");
+
+        request.Headers.GetValues(DefaultHeaderName).Should().ContainSingle().Which.Should().Be(Secret);
+    }
+
+    [Theory]
+    [InlineData("https://telemetry.example.com/ingest")]
+    [InlineData("https://gateway.example.com:6002/Auth/refresh")]
+    public async Task AddTrustedCallerHeader_WithASecret_StampsNothingBoundElsewhere(string requestUri)
+    {
+        var (request, _) = await SendThroughNamedClientAsync(
+            BuildConfiguration(Secret), "ThirdPartyClient", requestUri);
+
+        request.Headers.Contains(DefaultHeaderName).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("SessionCookieRefreshClient")]
+    [InlineData("SomeAppSpecificClient")]
+    [InlineData("")]
+    public async Task AddTrustedCallerHeader_AppliesToEveryNamedClient(string clientName)
+    {
+        var (request, _) = await SendThroughNamedClientAsync(
+            BuildConfiguration(Secret), clientName, GatewayOrigin + "/Events");
+
+        request.Headers.Contains(DefaultHeaderName).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AddTrustedCallerHeader_WithOnlyASecret_UsesTheGatewaySettingsDefaultHeaderName()
+    {
+        var (request, _) = await SendThroughNamedClientAsync(
+            BuildConfiguration(Secret), "AnyClient", GatewayOrigin + "/Events");
+
+        request.Headers.Contains(DefaultHeaderName).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AddTrustedCallerHeader_WithAConfiguredHeaderName_UsesIt()
+    {
+        var configuration = BuildConfiguration(Secret, GatewayOrigin, headerName: "X-Deployment-Caller");
+
+        var (request, _) = await SendThroughNamedClientAsync(configuration, "AnyClient", GatewayOrigin + "/Events");
+
+        request.Headers.Contains(DefaultHeaderName).Should().BeFalse();
+        request.Headers.GetValues("X-Deployment-Caller").Should().ContainSingle().Which.Should().Be(Secret);
+    }
+
+    private static IConfiguration BuildConfiguration(
+        string? secret,
+        string? apiEndpoint = GatewayOrigin,
+        string? headerName = null)
+    {
+        // A null argument means the key is ABSENT, the way a real appsettings file omits it: an
+        // in-memory entry whose value is null is a present-but-null key, which binds over the
+        // settings type's own default rather than leaving it in place.
+        var values = new Dictionary<string, string?>(StringComparer.Ordinal);
+        if (apiEndpoint is not null)
+        {
+            values["Api:ApiEndpoint"] = apiEndpoint;
+        }
+
+        if (secret is not null)
+        {
+            values["GatewayRateLimiting:TrustedCallerSecret"] = secret;
+        }
+
+        if (headerName is not null)
+        {
+            values["GatewayRateLimiting:TrustedCallerHeaderName"] = headerName;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    // Registers the handler through the extension, resolves the named client from the factory (so
+    // the ConfigureAll breadth is what is under test, not a hand-composed pipeline), and returns the
+    // request as it left the pipeline.
+    private static async Task<(HttpRequestMessage Request, HttpResponseMessage Response)> SendThroughNamedClientAsync(
+        IConfiguration configuration,
+        string clientName,
+        string requestUri)
+    {
+        var inner = new CapturingHandler();
+        var services = new ServiceCollection();
+        services.AddTrustedCallerHeader(configuration);
+        services.AddHttpClient(clientName).ConfigurePrimaryHttpMessageHandler(() => inner);
+
+        await using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient(clientName);
+
+        var response = await client.GetAsync(new Uri(requestUri), TestContext.Current.CancellationToken);
+
+        inner.LastRequest.Should().NotBeNull();
+        return (inner.LastRequest, response);
+    }
+
+    /// <summary>Stub primary handler that records the request the client pipeline produced.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request });
+        }
+    }
+}


### PR DESCRIPTION
## What

Ships the **client half** of the gateway trusted-caller exemption in `MMCA.Common.UI.Web`, and rolls the CHANGELOG release header to `1.191.0`.

Common already shipped the SERVER half: the gateway edge limiter puts a request carrying `GatewayRateLimiting:TrustedCallerHeaderName` + `GatewayRateLimiting:TrustedCallerSecret` into the no-limiter partition (`GatewayRateLimitingSettings`). Both consumers hand-rolled the client side, differently: one attaches the header to a single named client by repeating the framework's internal client name as a literal (which silently stops applying if that name ever changes), the other runs an origin-gated `DelegatingHandler` over every client but reads its own `TrustedCaller:*` section.

This lifts the origin-gated handler shape into the framework and points it at the `GatewayRateLimiting` section, so **one section configures both ends**.

## The change

- `Source/Presentation/MMCA.Common.UI.Web/Security/TrustedCallerHandler.cs`: public sealed `DelegatingHandler`. It stamps the secret only on a request whose scheme, host and port match the gateway origin, and as exactly ONE header value (the gateway compares one value in constant time, so an appended second value would silently fail the comparison). A client later pointed at a third party (a telemetry exporter, an identity provider) can never be handed the bypass.
- `DependencyInjection.cs`: `services.AddTrustedCallerHeader(configuration)` binds `GatewayRateLimitingSettings` from its own `SectionName`, resolves the gateway origin from `ApiSettings` (`Api:ApiEndpoint`, the endpoint the host's server-side calls already target: `WasmApiEndpoint` is the browser-facing one the CSP pins and is deliberately not used here), and composes the handler onto every client via `ConfigureAll<HttpClientFactoryOptions>`.

## Config contract

| Key | Meaning |
| --- | --- |
| `GatewayRateLimiting:TrustedCallerSecret` | The shared secret. Blank (the default) means the whole feature is off. |
| `GatewayRateLimiting:TrustedCallerHeaderName` | Header the gateway reads; defaults to `X-Internal-Caller-Key`. |
| `Api:ApiEndpoint` | The gateway origin. Only requests to this scheme/host/port are stamped. |

The call is a **no-op** (returns the collection unchanged, registers nothing) when the secret is blank, the header name is blank, or the endpoint is not an absolute URI, so local runs and CI stay rate limited exactly as they are today. The gateway must hold the same secret in the same section or nothing changes on its side either.

The secret exempts a component the deployment ships, never a visitor's browser: it must reach the SSR host alone, from a secret store or the environment (`GatewayRateLimiting__TrustedCallerSecret`), never a checked-in `appsettings` file and never client-side code. The XML docs state this at both the handler and the registration.

Why every client rather than one named client: the call that suffers most from the per-IP collapse is the cookie-session token refresh, whose client the framework creates under a name a host has no supported way to reach, so there is no single name to configure. Breadth is safe because the handler is narrow.

## Tests

`Tests/Presentation/MMCA.Common.UI.Web.Tests/Security/` (59 tests in the project, all green):

- `TrustedCallerHandlerTests`: the header rides a request to the gateway origin as exactly one value; nothing rides a different host, the same host on a different port, the same host on the default port, or a different scheme; a forged pre-existing header value is replaced rather than appended; the constructor refuses a blank header name or secret and a null origin.
- `TrustedCallerHeaderRegistrationTests`: with no secret nothing is registered at all (service count unchanged) and no header is sent; a blank header name and a missing or non-absolute `Api:ApiEndpoint` are the same no-op; with a secret, a request resolved through `IHttpClientFactory` carries the header; requests bound elsewhere do not; the header name defaults from `GatewayRateLimitingSettings` and a configured name is honored; and it applies to an arbitrary named client (including the framework's `SessionCookieRefreshClient` name and the default unnamed client), which is what proves the `ConfigureAll` breadth. A stub inner handler captures the outgoing request.

## Consumer note

Additive to Common's public API, so no `UPGRADING.md` entry. A host that hand-rolled this can delete its local copy and call `AddTrustedCallerHeader(builder.Configuration)`. For MMCA.Store the settings section moves from `TrustedCaller:*` to `GatewayRateLimiting:*`, which is a deployment-configuration rename (`TrustedCaller__Secret` becomes `GatewayRateLimiting__TrustedCallerSecret`).

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors.
- `dotnet test --project Tests/Presentation/MMCA.Common.UI.Web.Tests/MMCA.Common.UI.Web.Tests.csproj -c Release`: 59/59 passed.
- `dotnet test --project Tests/Architecture/MMCA.Common.Architecture.Tests -c Release`: 196/196 passed.
- `dotnet run --project build/facts -- . --check`: FACTS.md up to date (untouched; it is regenerated post-tag).
- No new package reference, so no lock-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXs5HjPgxuutXc7ymo2FnM
