### PR TITLE
release: v1.193.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.193.0] - 2026-09-11
+
 ### Added
 
 - **`ClickableCard`** (`MMCA.Common.UI.Components.Lists`): the card body shared by `MobileCardList`


### PR DESCRIPTION
Promotes the CHANGELOG Unreleased section to 1.193.0.

Ships the WCAG 2.1 AA sweep merged in #384: ClickableCard keyboard-operable mobile lists, screen-reader toast announcements, role=alert/status on conditional alerts, h1 on every shipped page, mobile nav focus fixes, and the palette contrast changes consumers inherit (light Warning #A85D00 + white contrast text; dark Secondary/Tertiary/Info/Success contrast text; dark Error #FF8A80; LinesInputs overrides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXs5HjPgxuutXc7ymo2FnM