### PR TITLE
fix(ui): host toasts in a live region instead of mirroring their text; fix Forbidden heading locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.194.0] - 2026-09-11
+
+Two regressions from the 1.193.0 accessibility sweep.
+
+### Changed
+
+- **Breaking (direct callers only): `MudToastService` no longer takes an `IAccessibilityAnnouncer`.**
+  The optional second constructor parameter introduced in 1.193.0 is gone, along with the text
+  mirroring it drove. The type is `internal` and is resolved through `IToastService`, so a host that
+  registers it the normal way (`AddUIShared`) needs no change at all. The mechanical fix for anyone
+  who constructed it explicitly is to drop the second argument:
+  `new MudToastService(snackbar, announcer)` becomes `new MudToastService(snackbar)`. See
+  [UPGRADING.md](UPGRADING.md). `IAccessibilityAnnouncer` is unchanged and stays registered
+  (`NullAccessibilityAnnouncer` by default, `BrowserAccessibilityAnnouncer` with the device
+  capabilities, `MauiAccessibilityAnnouncer` on MAUI): it remains available to any caller that wants
+  to announce something of its own.
+
+### Fixed
+
+- **Toasts are announced by their HOST rather than by a copy of their text.** `MmcaThemeProviders`
+  now renders `MudSnackbarProvider` inside a `role="status" aria-live="polite"` element, so a
+  snackbar is announced by the act of being inserted into the live region. Mirroring the text
+  through `IAccessibilityAnnouncer` (1.193.0) put the same sentence in the DOM twice: the visible
+  `.mud-snackbar-content-message` and the visually hidden live region. That read the message twice
+  to anyone using a screen reader alongside the visible toast, and it made every Playwright text
+  locator in a consumer's E2E suite ambiguous, so an assertion as ordinary as
+  `GetByText("Item added to cart!")` failed with a strict-mode violation on two matching elements.
+  The wrapper carries no styles and the provider's own container is `position: fixed`, so nothing
+  about where a toast appears changes.
+- **`AuthorizationTestsBase` locates the Forbidden page heading as a heading.** The shared
+  Playwright base looked the denial up with `h1[role='alert']`, which the same sweep had made
+  unmatchable: `role="alert"` moved OFF the `h1` in `Forbidden.razor` (an explicit role replaces the
+  implicit one, so the page had announced an alert and offered no level-1 heading). The locator is
+  now `GetByRole(AriaRole.Heading, Level = 1)`.
+
 ## [1.193.0] - 2026-09-11
 
 ### Added
@@ -14,11 +49,14 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
   and `MobileInfiniteScrollList`. A card wired to a click callback now renders as a real control
   (`tabindex="0"`, `role="button"`, Enter/Space activation); a card with no callback renders exactly
   as before, with no `tabindex` and no `role`, so a read-only list does not fill the tab order.
-- **Toasts are announced to screen readers.** `MudToastService` takes an optional
-  `IAccessibilityAnnouncer` and pushes every toast's text into the visually hidden `aria-live`
-  region alongside the snackbar. MudBlazor's snackbar host emits no live region of its own, so
-  toasts (push notifications included) previously reached sighted users only. The dependency is
-  optional: a host that never registered the device capabilities is unaffected.
+- **Toasts are announced to screen readers.** MudBlazor's snackbar host emits no `aria-live` region
+  of its own, so toasts (push notifications included) previously reached sighted users only. The
+  framework now makes the snackbar host itself the live region: `MmcaThemeProviders` renders
+  `MudSnackbarProvider` inside a `role="status" aria-live="polite"` element, so an inserted toast is
+  announced by being rendered. Nothing is required of the host beyond the provider block it already
+  renders. (This release delivered the announcement by mirroring the text through
+  `IAccessibilityAnnouncer` instead; that produced a duplicate DOM node and was replaced by the
+  live-region host in 1.194.0, described above. The live-region host is the mechanism to build on.)
 - **E2E gates**: axe WCAG 2.1 AA scans of the home, 404 and 403 pages and of the mobile hamburger
   menu in its OPEN state (every previous scan ran at 1280px), plus the suite's first
   keyboard-navigation test (Tab reaches the hamburger, Enter opens it, Escape closes it and returns

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Workflows/Identity/AuthorizationTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Workflows/Identity/AuthorizationTestsBase.cs
@@ -111,10 +111,13 @@ public abstract class AuthorizationTestsBase : E2ETestBase
             // load would bounce to /login and never exercise the ROLE check this test exists for.
             await Page.GotoProtectedAsync(path).ConfigureAwait(false);
 
-            // Assert — the shared Forbidden page renders (its h1 carries role="alert" and the localized
-            // "Access Denied" title). Role denial is not a redirect: the URL stays on the requested
-            // path, so the page CONTENT is the only reliable denial signal.
-            await Expect(Page.Locator("h1[role='alert']"))
+            // Assert: the shared Forbidden page renders (its h1 carries the localized "Access
+            // Denied" title). Role denial is not a redirect: the URL stays on the requested path, so
+            // the page CONTENT is the only reliable denial signal. The heading is located as a plain
+            // h1: role="alert" used to sit ON the heading, where the explicit role replaced the
+            // implicit heading one and left the page with no level-1 heading at all; it now sits on
+            // the message beneath.
+            await Expect(Page.GetByRole(AriaRole.Heading, new() { Level = 1 }))
                 .ToContainTextAsync("Access Denied", new() { Timeout = 15_000 }).ConfigureAwait(false);
         }
     }

--- a/Source/Presentation/MMCA.Common.UI/Services/MudToastService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/MudToastService.cs
@@ -1,6 +1,4 @@
-using Microsoft.JSInterop;
 using MMCA.Common.UI.Common.Interfaces;
-using MMCA.Common.UI.Services.Capabilities.Accessibility;
 using MudBlazor;
 
 namespace MMCA.Common.UI.Services;
@@ -11,49 +9,36 @@ namespace MMCA.Common.UI.Services;
 /// by <c>AddUIShared</c>, so every host that calls it gets toasts without any page having to know
 /// which library renders them.
 /// <para>
-/// Every toast is ALSO pushed through <see cref="IAccessibilityAnnouncer"/>. MudBlazor's snackbar
-/// host emits no <c>aria-live</c> region of any kind, so a toast is invisible to a screen reader:
-/// the one channel the framework uses to tell the user that something happened (a save succeeded, a
-/// push notification arrived) reached sighted users only. The announcer writes into the visually
-/// hidden live region owned by <c>capabilities-interop.js</c>, which every screen reader monitors.
+/// Screen-reader announcement is NOT this service's job: <c>MmcaThemeProviders</c> hosts
+/// <c>MudSnackbarProvider</c> inside a <c>role="status" aria-live="polite"</c> element, so the
+/// rendered toast IS the live-region content. Pushing the text through a second channel would put
+/// the same sentence in the DOM twice, which reads the message twice and makes every text locator
+/// ambiguous.
 /// </para>
 /// </summary>
 internal sealed class MudToastService : IToastService
 {
     private readonly ISnackbar _snackbar;
-    private readonly IAccessibilityAnnouncer? _announcer;
 
-    /// <summary>
-    /// Initializes the service. The announcer is OPTIONAL on purpose: <c>AddCommonUiFacades</c> is
-    /// called on its own by the shipped bUnit base and by hosts that never register the device
-    /// capabilities, and a toast facade must not become the reason a container fails to resolve.
-    /// When it is absent, toasts behave exactly as they did before, so the announcement is a pure
-    /// addition rather than a new requirement on the host DI sequence.
-    /// </summary>
-    public MudToastService(ISnackbar snackbar, IAccessibilityAnnouncer? announcer = null)
-    {
-        _snackbar = snackbar;
-        _announcer = announcer;
-    }
+    public MudToastService(ISnackbar snackbar) => _snackbar = snackbar;
 
     /// <inheritdoc />
-    public void Success(string message) => Raise(message, Severity.Success);
+    public void Success(string message) => _snackbar.Add(message, Severity.Success);
 
     /// <inheritdoc />
-    public void Info(string message) => Raise(message, Severity.Info);
+    public void Info(string message) => _snackbar.Add(message, Severity.Info);
 
     /// <inheritdoc />
-    public void Warning(string message) => Raise(message, Severity.Warning);
+    public void Warning(string message) => _snackbar.Add(message, Severity.Warning);
 
     /// <inheritdoc />
-    public void Error(string message) => Raise(message, Severity.Error);
+    public void Error(string message) => _snackbar.Add(message, Severity.Error);
 
     /// <inheritdoc />
-    public void Show(string message, ToastSeverity severity) => Raise(message, Map(severity));
+    public void Show(string message, ToastSeverity severity) => _snackbar.Add(message, Map(severity));
 
     /// <inheritdoc />
-    public void ShowPersistent(string title, string body, ToastSeverity severity = ToastSeverity.Info)
-    {
+    public void ShowPersistent(string title, string body, ToastSeverity severity = ToastSeverity.Info) =>
         _snackbar.Add(
             builder =>
             {
@@ -73,19 +58,13 @@ internal sealed class MudToastService : IToastService
                 options.SnackbarVariant = Variant.Filled;
             });
 
-        // The rendered toast is two elements; the announcement is one sentence, which is how a
-        // screen reader would read the title and body anyway.
-        Announce($"{title}. {body}");
-    }
-
     /// <inheritdoc />
     public void ShowAction(
         string message,
         string actionText,
         Func<Task> onAction,
         ToastSeverity severity = ToastSeverity.Info,
-        bool requireInteraction = false)
-    {
+        bool requireInteraction = false) =>
         _snackbar.Add(
             message,
             Map(severity),
@@ -108,54 +87,6 @@ internal sealed class MudToastService : IToastService
                     options.SnackbarVariant = Variant.Filled;
                 }
             });
-
-        // The action label is part of what was offered, so it is part of what is announced.
-        Announce($"{message}. {actionText}");
-    }
-
-    private void Raise(string message, Severity severity)
-    {
-        _snackbar.Add(message, severity);
-        Announce(message);
-    }
-
-    /// <summary>
-    /// Pushes the toast text into the screen-reader live region without making the caller wait:
-    /// <see cref="IToastService"/> is deliberately synchronous (a page raises a toast and carries
-    /// on), so the announcement is fire-and-forget. Every failure is swallowed by design: the
-    /// browser announcer is a JS-interop call, which throws during prerendering and while a circuit
-    /// is tearing down, and a toast must never fail because the announcement could not be delivered.
-    /// </summary>
-    private void Announce(string message)
-    {
-        if (_announcer is null || string.IsNullOrWhiteSpace(message))
-        {
-            return;
-        }
-
-        _ = AnnounceCoreAsync(message);
-    }
-
-    private async Task AnnounceCoreAsync(string message)
-    {
-        try
-        {
-            await _announcer!.AnnounceAsync(message).ConfigureAwait(false);
-        }
-        catch (JSDisconnectedException)
-        {
-            // Circuit already gone; there is no live region left to write into.
-        }
-        catch (JSException)
-        {
-            // The browser rejected the call (no DOM yet, a head with no live region).
-        }
-        catch (InvalidOperationException)
-        {
-            // JS interop unavailable (SSR prerender, before hydration), and, through its derived
-            // ObjectDisposedException, a scope torn down between the toast and the announcement.
-        }
-    }
 
     /// <summary>
     /// Projects the vendor-neutral level onto MudBlazor's own. Written out rather than cast: the

--- a/Source/Presentation/MMCA.Common.UI/Theme/MmcaThemeProviders.razor
+++ b/Source/Presentation/MMCA.Common.UI/Theme/MmcaThemeProviders.razor
@@ -12,7 +12,18 @@
 <MudThemeProvider Theme="@Theme" @bind-IsDarkMode="_isDarkMode" />
 <MudPopoverProvider />
 <MudDialogProvider />
-<MudSnackbarProvider />
+
+@* The snackbar HOST is the live region, so a toast is announced by the act of being rendered.
+   MudBlazor's provider emits no aria-live region of its own and renders its container inline here,
+   so every snackbar insertion lands inside this element and a screen reader picks the text up from
+   the rendered toast itself. Announcing by hosting rather than by mirroring the text through
+   IAccessibilityAnnouncer is deliberate: a mirror produces a SECOND node carrying identical text,
+   which breaks every consumer's Playwright strict-mode text locator and reads the message twice to
+   anyone using both a screen reader and the visible toast. The wrapper carries no styles; the
+   provider's own container is position:fixed, so it still positions against the viewport. *@
+<div role="status" aria-live="polite">
+    <MudSnackbarProvider />
+</div>
 
 @code {
     /// <summary>

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Services/MudToastServiceTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Services/MudToastServiceTests.cs
@@ -1,7 +1,6 @@
 using AwesomeAssertions;
 using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Services;
-using MMCA.Common.UI.Services.Capabilities.Accessibility;
 using Moq;
 using MudBlazor;
 
@@ -17,14 +16,8 @@ namespace MMCA.Common.UI.Tests.Services;
 public sealed class MudToastServiceTests
 {
     private readonly Mock<ISnackbar> _snackbar = new();
-    private readonly Mock<IAccessibilityAnnouncer> _announcer = new();
 
-    public MudToastServiceTests() =>
-        _announcer
-            .Setup(a => a.AnnounceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-    private MudToastService Toast => new(_snackbar.Object, _announcer.Object);
+    private MudToastService Toast => new(_snackbar.Object);
 
     [Fact]
     public void ShowAction_RendersALabelledActionButtonOnThePrimaryColour()
@@ -114,25 +107,31 @@ public sealed class MudToastServiceTests
     }
 
     /// <summary>
-    /// The screen-reader half of the contract. MudBlazor's snackbar host emits no aria-live region,
-    /// so a toast that is only rendered is a toast only sighted users receive; every entry point
-    /// therefore pushes its text through <see cref="IAccessibilityAnnouncer"/> as well.
+    /// The screen-reader half of the contract is NOT this service's: the toast text reaches a screen
+    /// reader because <c>MmcaThemeProviders</c> hosts the snackbar provider inside a
+    /// <c>role="status" aria-live="polite"</c> element (asserted by
+    /// <c>MmcaThemeProvidersTests.Render_HostsTheSnackbarProviderInsideAPoliteLiveRegion</c>). This
+    /// service must therefore raise the snackbar and nothing else: a second copy of the text would
+    /// be announced twice and would make every text locator ambiguous.
     /// </summary>
     [Theory]
-    [InlineData(ToastSeverity.Normal)]
-    [InlineData(ToastSeverity.Info)]
-    [InlineData(ToastSeverity.Success)]
-    [InlineData(ToastSeverity.Warning)]
-    [InlineData(ToastSeverity.Error)]
-    public void Show_AnnouncesTheMessageToTheScreenReader(ToastSeverity severity)
+    [InlineData(ToastSeverity.Normal, Severity.Normal)]
+    [InlineData(ToastSeverity.Info, Severity.Info)]
+    [InlineData(ToastSeverity.Success, Severity.Success)]
+    [InlineData(ToastSeverity.Warning, Severity.Warning)]
+    [InlineData(ToastSeverity.Error, Severity.Error)]
+    public void Show_RaisesExactlyOneSnackbarAndNothingElse(ToastSeverity severity, Severity expected)
     {
         Toast.Show("Saved", severity);
 
-        _announcer.Verify(a => a.AnnounceAsync("Saved", It.IsAny<CancellationToken>()), Times.Once);
+        _snackbar.Verify(
+            s => s.Add("Saved", expected, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            Times.Once);
+        _snackbar.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public void SeverityShorthands_EachAnnounceTheirMessage()
+    public void SeverityShorthands_EachRaiseTheirOwnLevel()
     {
         var toast = Toast;
 
@@ -141,77 +140,19 @@ public sealed class MudToastServiceTests
         toast.Warning("Careful");
         toast.Error("Broken");
 
-        _announcer.Verify(a => a.AnnounceAsync("Created", It.IsAny<CancellationToken>()), Times.Once);
-        _announcer.Verify(a => a.AnnounceAsync("Heads up", It.IsAny<CancellationToken>()), Times.Once);
-        _announcer.Verify(a => a.AnnounceAsync("Careful", It.IsAny<CancellationToken>()), Times.Once);
-        _announcer.Verify(a => a.AnnounceAsync("Broken", It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public void Success_StillRaisesTheSnackbar_AsWellAsAnnouncing()
-    {
-        // "Alongside", not "instead of": the announcement is additive, so the visible toast must be
-        // unchanged.
-        Toast.Success("Saved");
-
         _snackbar.Verify(
-            s => s.Add("Saved", Severity.Success, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            s => s.Add("Created", Severity.Success, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
             Times.Once);
-        _announcer.Verify(a => a.AnnounceAsync("Saved", It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public void ShowPersistent_AnnouncesTheTitleAndBodyAsOneSentence()
-    {
-        // The rendered push toast is a bold title and a body on two lines; a screen reader would read
-        // them as one utterance either way, and the live region takes text, not a render fragment.
-        Toast.ShowPersistent("New message", "Ada replied to your comment.");
-
-        _announcer.Verify(
-            a => a.AnnounceAsync("New message. Ada replied to your comment.", It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public void ShowAction_AnnouncesTheMessageAndTheActionLabel()
-    {
-        // The action is part of what was offered, so a non-sighted user has to hear that it exists.
-        Toast.ShowAction("Item deleted", "Undo", () => Task.CompletedTask);
-
-        _announcer.Verify(
-            a => a.AnnounceAsync("Item deleted. Undo", It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public void Toast_StillWorks_WhenNoAnnouncerIsRegistered()
-    {
-        // AddCommonUiFacades is called on its own by the shipped bUnit base and by hosts that never
-        // register the device capabilities, so the dependency is optional by design.
-        var withoutAnnouncer = new MudToastService(_snackbar.Object);
-
-        withoutAnnouncer.Success("Saved");
-
         _snackbar.Verify(
-            s => s.Add("Saved", Severity.Success, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            s => s.Add("Heads up", Severity.Info, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
             Times.Once);
-    }
-
-    [Fact]
-    public void Toast_IsNotAffected_WhenTheAnnouncementFails()
-    {
-        // A prerender pass has no JS runtime, so the browser announcer throws. A toast must never
-        // fail because the announcement could not be delivered.
-        _announcer
-            .Setup(a => a.AnnounceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("JS interop unavailable during prerendering"));
-
-        var act = () => Toast.Error("Broken");
-
-        act.Should().NotThrow();
+        _snackbar.Verify(
+            s => s.Add("Careful", Severity.Warning, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
+            Times.Once);
         _snackbar.Verify(
             s => s.Add("Broken", Severity.Error, It.IsAny<Action<SnackbarOptions>>(), It.IsAny<string>()),
             Times.Once);
+        _snackbar.VerifyNoOtherCalls();
     }
 
     /// <summary>

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Theme/MmcaThemeProvidersTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Theme/MmcaThemeProvidersTests.cs
@@ -49,6 +49,24 @@ public sealed class MmcaThemeProvidersTests : BunitTestBase
     }
 
     [Fact]
+    public void Render_HostsTheSnackbarProviderInsideAPoliteLiveRegion()
+    {
+        // How a toast reaches a screen reader: the snackbar HOST is the live region, so an inserted
+        // toast is announced by being rendered. Mirroring the text through IAccessibilityAnnouncer
+        // instead put the same sentence in the DOM twice, which read it twice and made every
+        // Playwright text locator in the consumers ambiguous (strict-mode violation). MudBlazor's
+        // provider renders its container inline here, so insertions land inside this element.
+        var cut = RenderUnderTest<MmcaThemeProviders>(_ => { });
+
+        var liveRegion = cut.Find("div[role='status'][aria-live='polite']");
+
+        var providerMarkup = cut.FindComponent<MudSnackbarProvider>().Markup;
+        liveRegion.InnerHtml.Should().Contain(
+            providerMarkup,
+            "the snackbar provider's own container must sit INSIDE the live region, not beside it");
+    }
+
+    [Fact]
     public void Render_HonoursAnAppSuppliedThemeOverride()
     {
         // The Theme parameter is the extension point for a downstream brand: an app passes its own

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,29 @@ grep -rl --include='*.cs' --include='*.razor' 'using MMCA.Common.Application.Use
 The first-party consumers (MMCA.ADC, MMCA.Store, MMCA.Helpdesk) are swept by the workspace script
 `Tools/Scripts/move-namespace.ps1` in the same release, which does exactly the three steps above.
 
+## [1.194.0] - 2026-09-11
+
+**`MudToastService` no longer takes an `IAccessibilityAnnouncer`: nothing to do unless you construct
+it yourself.** The optional second constructor parameter added in 1.193.0 is removed together with
+the toast-text mirroring it drove. Toasts are now announced because `MmcaThemeProviders` hosts
+`MudSnackbarProvider` inside a `role="status" aria-live="polite"` element, so the rendered toast is
+the live-region content and a second copy of the text is neither needed nor wanted (it announced
+every message twice and made `GetByText("...")` match two elements in Playwright).
+
+The type is `internal` and is resolved through `IToastService`, so a host that registers it the
+normal way (`AddUIShared`, or the `AddCommonUiFacades` bUnit base) is unaffected. Only code that
+newed it up explicitly, inside this framework's own test assemblies or through `InternalsVisibleTo`,
+sees a compile error, and the fix is one argument:
+
+| Old | New |
+| --- | --- |
+| `new MudToastService(snackbar, announcer)` | `new MudToastService(snackbar)` |
+
+`IAccessibilityAnnouncer` itself is unchanged and stays registered (`NullAccessibilityAnnouncer` by
+default, `BrowserAccessibilityAnnouncer` once the device capabilities are added,
+`MauiAccessibilityAnnouncer` on MAUI). Inject it wherever you want to announce something of your
+own; just do not use it to repeat text that is already in the DOM.
+
 ## [1.192.0] - 2026-09-11
 
 **`MMCA.Common.AI` is a new optional package: no action unless you adopt it.** Nothing in the


### PR DESCRIPTION
Two regressions from the v1.193.0 accessibility sweep (#384), plus the `1.194.0` release header so no separate release PR is needed.

## Regression 1: every toast's text was in the DOM twice

`MudToastService` mirrored each toast's text into the visually hidden `aria-live` region through `IAccessibilityAnnouncer`, alongside the snackbar MudBlazor already rendered. Two consequences:

- A screen reader used alongside the visible toast heard the message twice.
- Every Playwright text locator in a consumer's E2E suite became ambiguous: `GetByText("Item added to cart!")` matched both `.mud-snackbar-content-message` and the `<div role="status" aria-live="polite">` region and threw a strict-mode violation. The shipped shared bases hit the same wall (`ProfileManagementTestsBase.cs:97`, "Password changed successfully.").

**Fix: announce by HOSTING, not by copying.** `MmcaThemeProviders` now renders `<MudSnackbarProvider />` inside a `role="status" aria-live="polite"` element, so a snackbar is announced by the act of being inserted into the live region and there is only ever one node carrying the text. MudBlazor renders its snackbar container inline as a child of the provider, so insertions land inside the region (asserted by a new bUnit test). The wrapper carries no styles and the provider's container is `position: fixed`, so nothing about where a toast appears changes.

The mirroring and its optional `IAccessibilityAnnouncer` constructor parameter are removed. The announce-focused unit tests are replaced by tests asserting `MudToastService` raises the snackbar and does nothing else (`VerifyNoOtherCalls`).

## Regression 2: the Forbidden heading locator no longer matched

`AuthorizationTestsBase` (`MMCA.Common.Testing.E2E`) located the role-denial page with `h1[role='alert']`. The same sweep correctly moved `role="alert"` OFF the `h1` in `Pages/Forbidden.razor` (an explicit role replaces the implicit heading one, so the page had been announcing an alert and offering no level-1 heading at all), which left the shipped locator permanently unmatchable. It is now `GetByRole(AriaRole.Heading, new() { Level = 1 })`.

Swept the whole `MMCA.Common.Testing.E2E` package and `MMCA.Common.UI.E2E.Tests` for any other locator depending on `role='alert'` on a heading or on the toast-mirror text: this was the only one. The gallery suite's `ForbiddenPage_KeepsTheHeadingRole_AndAlertsOnTheMessage` already asserts the corrected markup.

## Breaking (direct callers only)

`MudToastService` no longer takes an `IAccessibilityAnnouncer`. The optional second constructor parameter shipped in 1.193.0 only. The type is `internal` and is resolved through `IToastService`, so a host registering it the normal way (`AddUIShared`) needs no change; anyone who constructed it explicitly drops the second argument: `new MudToastService(snackbar, announcer)` becomes `new MudToastService(snackbar)`. Recorded under **Breaking** in `CHANGELOG.md` and as a section of `UPGRADING.md`.

`IAccessibilityAnnouncer` itself is untouched and stays registered (`NullAccessibilityAnnouncer` / `BrowserAccessibilityAnnouncer` / `MauiAccessibilityAnnouncer`): it remains available to any other caller. `MudToastService` is internal, so no `PublicAPI.*.txt` entry moves.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors.
- `MMCA.Common.UI.Tests.exe`: 921 passed, 0 failed (includes the new `Render_HostsTheSnackbarProviderInsideAPoliteLiveRegion` bUnit test, which is what empirically confirms MudBlazor renders its snackbar container inside the wrapper).
- `MMCA.Common.UI.E2E.Tests.exe` (gallery, chromium): 69 passed, 0 failed, matching the baseline. The axe WCAG 2.1 AA scans pass with the new wrapper.
- `dotnet run --project build/facts -- . --check`: up to date (FACTS.md untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXs5HjPgxuutXc7ymo2FnM
