### PR TITLE
release: v1.195.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+## [1.195.0] - 2026-09-11
+
 ### Added
 
 - **The outbox and the broker carry the request context across the hop.** An event delivered by the

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,6 +34,8 @@ The first-party consumers (MMCA.ADC, MMCA.Store, MMCA.Helpdesk) are swept by the
 
 ## [Unreleased]
 
+## [1.195.0] - 2026-09-11
+
 **The outbox table gains four nullable columns: add one migration per relational outbox source.**
 `OutboxMessage` now carries the ambient context of the request that raised the event, so the
 delivery can restore it. The columns are:


### PR DESCRIPTION
Release docs for v1.195.0: tenant/user/correlation propagation across the outbox and broker (consumers add one expand-only outbox migration per relational source), log-once exception boundaries, the Polly meter exported by AddServiceDefaults, Smtp:TimeoutSeconds, and the feature-flag lifecycle attribute plus fitness gate (from PR #389).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK