### PR TITLE
fix(ui): explicit already-registered message on Register + account section first in the mobile menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and are derived from git tags by MinVer (see [the published versioning policy](h
 
 ## [Unreleased]
 
+### Added
+
+- `MMCA.Common.Shared.Auth.AuthErrorCodes`, one place to name the authentication error codes a
+  caller reacts to rather than only displays. It carries `EmailAlreadyExists`, the code
+  `AuthenticationServiceBase` returns from both the up-front registration check and the
+  unique-index race recovery, so the UI matches a constant instead of a repeated literal. The code
+  and its message are unchanged.
+
+### Fixed
+
+- **Registering with an address that already has an account says so, and offers the way out**
+  (`MMCA.Common.UI`). The duplicate-address conflict rendered as a generic red alert carrying the
+  server's sentence, which invited the user to retry the form. The Register page now recognises the
+  `Auth.EmailAlreadyExists` code and shows a warning alert naming the typed address, with links to
+  sign in and to reset the password (`Auth.Register.EmailAlreadyRegistered` /
+  `Auth.Register.ResetPassword`, English and Spanish). Every other failure keeps the generic alert.
+- **The account section leads the mobile nav menu** (`MMCA.Common.UI`). `NavMenu` renders
+  `.nav-auth-section` (the signed-in identity, Signed-in devices and Logout, or Login and Register
+  when anonymous) above the module navigation list instead of below it. The section exists below
+  1024px only, where the menu is a scrolling column: on a phone a long organizer or admin menu put
+  Logout under the browser chrome. The safe-area bottom clearance moves with it, onto the expanded
+  `.nav-scrollable`, so the last nav item keeps the same breathing room.
+
 ## [1.195.0] - 2026-09-11
 
 ### Added

--- a/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
+++ b/Source/Core/MMCA.Common.Application/Auth/AuthenticationServiceBase.cs
@@ -914,7 +914,7 @@ public abstract class AuthenticationServiceBase<TUser>(
     /// </summary>
     private static Result<AuthenticationResponse> EmailAlreadyExistsFailure() =>
         Result.Failure<AuthenticationResponse>(
-            Error.Conflict("Auth.EmailAlreadyExists", "An account with this email already exists.", nameof(RegisterAsync)));
+            Error.Conflict(AuthErrorCodes.EmailAlreadyExists, "An account with this email already exists.", nameof(RegisterAsync)));
 
     /// <summary>
     /// What opening or rotating a session produces: the plaintext token the client is handed (which

--- a/Source/Core/MMCA.Common.Shared/Auth/AuthErrorCodes.cs
+++ b/Source/Core/MMCA.Common.Shared/Auth/AuthErrorCodes.cs
@@ -1,0 +1,20 @@
+namespace MMCA.Common.Shared.Auth;
+
+/// <summary>
+/// Error codes the framework's authentication surface returns, named once so a caller that has to
+/// react to a specific outcome (rather than only display its message) compares against a constant
+/// instead of repeating the literal.
+/// </summary>
+/// <remarks>
+/// The code, not the message, is the contract: messages are localized and may be reworded, while a
+/// code is matched with <see cref="System.StringComparison.Ordinal"/> by UI and API callers alike.
+/// </remarks>
+public static class AuthErrorCodes
+{
+    /// <summary>
+    /// Registration was refused because the address already belongs to an account. Both the up-front
+    /// check and the unique-index race recovery return it, so the two paths stay indistinguishable to
+    /// the caller. The registration UI keys its "sign in instead" guidance on this code.
+    /// </summary>
+    public const string EmailAlreadyExists = "Auth.EmailAlreadyExists";
+}

--- a/Source/Core/MMCA.Common.Shared/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Shared/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ MMCA.Common.Shared.Abstractions.Result<T>.Ensure(System.Func<T, bool>! predicate
 MMCA.Common.Shared.Abstractions.Result<T>.MatchAsync<TResult>(System.Func<T, System.Threading.Tasks.Task<TResult>!>! onSuccess, System.Func<System.Collections.Generic.IEnumerable<MMCA.Common.Shared.Abstractions.Error!>!, System.Threading.Tasks.Task<TResult>!>! onFailure) -> System.Threading.Tasks.Task<TResult>!
 MMCA.Common.Shared.Abstractions.Result<T>.Tap(System.Action<T>! action) -> MMCA.Common.Shared.Abstractions.Result<T>!
 MMCA.Common.Shared.Abstractions.ResultExtensions
+MMCA.Common.Shared.Auth.AuthErrorCodes
 MMCA.Common.Shared.Auth.ClaimsPrincipalExtensions
 MMCA.Common.Shared.Auth.Requests.ForgotPasswordRequest
 MMCA.Common.Shared.Auth.Requests.ForgotPasswordRequest.Deconstruct(out string! Email) -> void
@@ -161,6 +162,7 @@ static MMCA.Common.Shared.Identifiers.StronglyTypedIdMappings<TSelf, TValue>.ToV
 const MMCA.Common.Shared.Auth.AuthClaimTypes.MultiFactor = "mfa" -> string!
 const MMCA.Common.Shared.Auth.AuthClaimTypes.MultiFactorMethodRecoveryCode = "recovery" -> string!
 const MMCA.Common.Shared.Auth.AuthClaimTypes.MultiFactorMethodTotp = "otp" -> string!
+const MMCA.Common.Shared.Auth.AuthErrorCodes.EmailAlreadyExists = "Auth.EmailAlreadyExists" -> string!
 const MMCA.Common.Shared.Auth.Permissions.AdministrationPermissions.ManageRoles = "roles:manage" -> string!
 const MMCA.Common.Shared.Auth.Permissions.AdministrationPermissions.ManageUsers = "users:manage" -> string!
 MMCA.Common.Shared.Auth.Permissions.AdministrationPermissions

--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
@@ -30,9 +30,9 @@
        app bar itself is hidden below 1024px). Culture + theme must be available to everyone here,
        authenticated or not (ADR-027/028); only the module app-bar components are gated on
        authentication. The signed-in user name deliberately does NOT repeat here: this row only ever
-       renders below 1024px, which is exactly where .nav-auth-section shows the name above Logout in
-       the hamburger menu, so a copy on the top row was pure duplication competing for the narrowest
-       row in the layout. *@
+       renders below 1024px, which is exactly where .nav-auth-section opens the hamburger menu with
+       the name above Logout, so a copy on the top row is pure duplication competing for the
+       narrowest row in the layout. *@
     @* role="group": aria-label is prohibited on a generic div (WCAG 4.1.2 / axe aria-prohibited-attr),
        and the row is a labelled set of related controls, which is exactly what group means. *@
     <div class="toprow-actions" role="group" aria-label="@L["Nav.QuickActions.Aria"]">
@@ -62,6 +62,33 @@
 <div class="nav-backdrop" aria-hidden="true"></div>
 
 <nav id="nav-menu" class="nav-scrollable" aria-label="@L["Nav.SiteNavigation.Aria"]">
+    @* The account block leads the menu (CSS renders it below 1024px only, where the MudAppBar that
+       carries Logout on desktop is hidden). It sits above the navigation list because the menu is a
+       scrolling column on a phone and an organizer or admin menu is long: at the top, the signed-in
+       name and the way out are both reachable the moment the hamburger opens, with no scroll. *@
+    <div class="nav-auth-section">
+        <AuthorizeView>
+            <Authorized>
+                <div class="nav-user-identity">
+                    <MudIcon Icon="@Icons.Material.Filled.AccountCircle" Size="Size.Small" />
+                    <MudText Typo="Typo.body2">@context.User.Identity?.Name</MudText>
+                </div>
+                <MudNavMenu Color="Color.Default">
+                    @* Framework-owned account page: every host that renders this menu gets the
+                       signed-in devices list without wiring a NavItem of its own. *@
+                    <MudNavLink Href="@RoutePaths.Sessions" Icon="@Icons.Material.Filled.Devices">@L["Auth.Sessions.NavLabel"]</MudNavLink>
+                    <MudNavLink Icon="@Icons.Material.Filled.Logout" OnClick="HandleLogoutAsync">@L["Common.Button.Logout"]</MudNavLink>
+                </MudNavMenu>
+            </Authorized>
+            <NotAuthorized>
+                <MudNavMenu Color="Color.Default">
+                    <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">@L["Common.Button.Login"]</MudNavLink>
+                    <MudNavLink Href="/register" Icon="@Icons.Material.Filled.PersonAdd">@L["Common.Button.Register"]</MudNavLink>
+                </MudNavMenu>
+            </NotAuthorized>
+        </AuthorizeView>
+    </div>
+
     <MudNavMenu Color="Color.Default">
         <MudNavLink Href="@RoutePaths.Home" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">@L["Nav.Home"]</MudNavLink>
 
@@ -136,29 +163,6 @@
             }
         }
     </MudNavMenu>
-
-    <div class="nav-auth-section">
-        <AuthorizeView>
-            <Authorized>
-                <div class="nav-user-identity">
-                    <MudIcon Icon="@Icons.Material.Filled.AccountCircle" Size="Size.Small" />
-                    <MudText Typo="Typo.body2">@context.User.Identity?.Name</MudText>
-                </div>
-                <MudNavMenu Color="Color.Default">
-                    @* Framework-owned account page: every host that renders this menu gets the
-                       signed-in devices list without wiring a NavItem of its own. *@
-                    <MudNavLink Href="@RoutePaths.Sessions" Icon="@Icons.Material.Filled.Devices">@L["Auth.Sessions.NavLabel"]</MudNavLink>
-                    <MudNavLink Icon="@Icons.Material.Filled.Logout" OnClick="HandleLogoutAsync">@L["Common.Button.Logout"]</MudNavLink>
-                </MudNavMenu>
-            </Authorized>
-            <NotAuthorized>
-                <MudNavMenu Color="Color.Default">
-                    <MudNavLink Href="/login" Icon="@Icons.Material.Filled.Login">@L["Common.Button.Login"]</MudNavLink>
-                    <MudNavLink Href="/register" Icon="@Icons.Material.Filled.PersonAdd">@L["Common.Button.Register"]</MudNavLink>
-                </MudNavMenu>
-            </NotAuthorized>
-        </AuthorizeView>
-    </div>
 </nav>
 
 @code {

--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor.css
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor.css
@@ -132,6 +132,11 @@
     opacity: 1;
     visibility: visible;
     transition: max-height 0.3s ease-in-out, opacity 0.2s ease-in-out, visibility 0s linear 0s;
+    /* Bottom clearance for the last nav item in the open mobile menu. Without it the final row sits
+       flush on the container edge, and on phones with a bottom browser bar or home indicator it
+       lands under the chrome; env() adds the device inset where one exists (0 elsewhere), the
+       0.75rem is the breathing room on every phone. */
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
 }
 
 /* ── Mobile Nav Backdrop ── */
@@ -223,15 +228,13 @@
         padding-top: 0.875rem;
     }
 
+/* This section only renders below 1024px, and it is the FIRST block of the mobile menu: the account
+   row and Logout are in reach the moment the hamburger opens, however long the module navigation
+   below them runs. The separator therefore closes the block rather than opening it. */
 .nav-auth-section {
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     padding-top: 0.5rem;
-    margin-top: auto;
-    /* This section only renders below 1024px, where Logout is the last row of the mobile menu.
-       Without bottom clearance it sits flush on the container edge, and on phones with a bottom
-       browser bar or home indicator it lands under the chrome; env() adds the device inset where
-       one exists (0 elsewhere), the 0.75rem is the breathing room on every phone. */
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+    padding-bottom: 0.5rem;
 }
 
 .nav-user-identity {
@@ -256,9 +259,9 @@
        the absolutely positioned .navbar-toggler, but a shrinkable actions box (the previous
        min-width: 0 plus the default flex-shrink: 1) gets squeezed by the width:100% brand
        container and spills its nowrap, overflow-visible contents right into that reserve,
-       painting the theme icon over the hamburger. The row now holds only fixed-width icon buttons
-       in every auth state (the ellipsizing user name that used to absorb the squeeze when signed
-       in has moved to the hamburger menu's .nav-auth-section), so nothing here can give way and
+       painting the theme icon over the hamburger. The row holds only fixed-width icon buttons in
+       every auth state (the signed-in user name lives in the hamburger menu's .nav-auth-section,
+       so no ellipsizing text is here to absorb the squeeze), so nothing here can give way and
        this must stay. The brand is the element meant to give way instead: .top-row
        .container-fluid is min-width: 0 and .navbar-brand already ellipsizes. */
     flex: 0 0 auto;

--- a/Source/Presentation/MMCA.Common.UI/Pages/Auth/Register.razor
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Auth/Register.razor
@@ -1,5 +1,6 @@
 ﻿@page "/register"
 @using MMCA.Common.Shared.Abstractions
+@using MMCA.Common.Shared.Auth
 @using MMCA.Common.Shared.Auth.Requests
 @using MMCA.Common.Shared.ValueObjects.Contact
 @using MMCA.Common.UI.Common
@@ -30,7 +31,24 @@
         <EditForm Model="_model" OnValidSubmit="HandleRegisterAsync">
             <DataAnnotationsValidator />
             <MudCardContent Class="pa-6">
-                @if (!string.IsNullOrWhiteSpace(_errorMessage))
+                @if (_emailAlreadyRegistered)
+                {
+                    @* The address already has an account, so the way forward is signing in rather than
+                       resubmitting the form: Severity.Warning plus the two routes out of the dead end.
+                       role="alert": the alert only enters the DOM after a failed submit, so nothing
+                       announces it unless it arrives as a live region. *@
+                    <MudAlert Severity="Severity.Warning" Class="mb-4" Dense="true" role="alert"
+                              data-testid="email-already-registered">
+                        @L["Auth.Register.EmailAlreadyRegistered", _model.Email]
+                        @* Underline.Always: an in-text link must be distinguishable without relying on
+                           colour alone (WCAG 2.1 AA / axe link-in-text-block). *@
+                        <div class="d-flex flex-wrap mt-1" style="gap: 1rem;">
+                            <MudLink Href="/login" Typo="Typo.body2" Underline="Underline.Always">@L["Auth.Register.SignIn"]</MudLink>
+                            <MudLink Href="/forgot-password" Typo="Typo.body2" Underline="Underline.Always">@L["Auth.Register.ResetPassword"]</MudLink>
+                        </div>
+                    </MudAlert>
+                }
+                else if (!string.IsNullOrWhiteSpace(_errorMessage))
                 {
                     @* role="alert": the alert only enters the DOM after a failed submit, so nothing
                        announces it unless it arrives as a live region. *@
@@ -128,6 +146,7 @@
 @code {
     private readonly RegisterModel _model = new();
     private string? _errorMessage;
+    private bool _emailAlreadyRegistered;
     private bool _isLoading;
 
     // Null means "no address entered", which is legitimate: the address block is optional. Anything
@@ -152,6 +171,7 @@
         // EditForm + DataAnnotations before OnValidSubmit fires; this method only handles the call and
         // any server-side failure, surfaced in the form-level MudAlert.
         _errorMessage = null;
+        _emailAlreadyRegistered = false;
 
         var addressResult = BuildAddressResult();
         if (addressResult is { IsFailure: true } failedAddress)
@@ -168,6 +188,15 @@
                 new RegisterRequest(_model.Email, _model.Password, _model.FirstName, _model.LastName, addressResult?.Value));
             if (result.IsFailure)
             {
+                // The duplicate-address conflict is the one failure with a next step of its own: the
+                // account exists, so the user is pointed at sign-in or password reset rather than at a
+                // red alert that invites a retry. Matched on the code, never on the wording.
+                if (result.Errors.Any(e => string.Equals(e.Code, AuthErrorCodes.EmailAlreadyExists, StringComparison.Ordinal)))
+                {
+                    _emailAlreadyRegistered = true;
+                    return;
+                }
+
                 _errorMessage = result.LocalizedErrorMessage(L) ?? L["Auth.Register.Failed"];
                 return;
             }

--- a/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.es.resx
@@ -346,6 +346,12 @@
   <data name="Auth.Register.SignIn" xml:space="preserve">
     <value>Iniciar sesión</value>
   </data>
+  <data name="Auth.Register.ResetPassword" xml:space="preserve">
+    <value>Restablecer contraseña</value>
+  </data>
+  <data name="Auth.Register.EmailAlreadyRegistered" xml:space="preserve">
+    <value>Ya existe una cuenta registrada para {0}. Inicie sesión con ella o restablezca su contraseña si la olvidó.</value>
+  </data>
   <data name="Notif.List.Col.Title" xml:space="preserve">
     <value>Título</value>
   </data>

--- a/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.resx
+++ b/Source/Presentation/MMCA.Common.UI/Resources/SharedResource.resx
@@ -346,6 +346,12 @@
   <data name="Auth.Register.SignIn" xml:space="preserve">
     <value>Sign In</value>
   </data>
+  <data name="Auth.Register.ResetPassword" xml:space="preserve">
+    <value>Reset password</value>
+  </data>
+  <data name="Auth.Register.EmailAlreadyRegistered" xml:space="preserve">
+    <value>An account for {0} is already registered. Sign in with it instead, or reset your password if you have forgotten it.</value>
+  </data>
   <data name="Notif.List.Col.Title" xml:space="preserve">
     <value>Title</value>
   </data>

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
@@ -80,6 +80,26 @@ public sealed class NavMenuTests : BunitTestBase
     }
 
     [Fact]
+    public void TheAccountSectionLeadsTheMenu_AheadOfTheNavigationList()
+    {
+        // The auth section renders below 1024px only, where the menu is a scrolling column: an
+        // organizer or admin menu is long enough to push a trailing Logout under the browser chrome,
+        // so the account row and the way out come first.
+        RenderMudProviders();
+        var cut = RenderAs<NavMenu>(TestPrincipal.AuthenticatedUser(name: "Ada Lovelace"), _ => { });
+
+        var blocks = cut.Find("#nav-menu").Children.ToList();
+        var authIndex = blocks.FindIndex(e => e.ClassList.Contains("nav-auth-section"));
+        var navListIndex = blocks.FindIndex(e => e.ClassList.Contains("mud-navmenu"));
+
+        authIndex.Should().BeGreaterThanOrEqualTo(0);
+        navListIndex.Should().BeGreaterThanOrEqualTo(0, "the module navigation list is still rendered");
+        authIndex.Should().BeLessThan(
+            navListIndex,
+            "the account section is the first thing visible when the hamburger opens");
+    }
+
+    [Fact]
     public void WhenAnonymous_HidesTheSignedInDevicesLink()
     {
         RenderMudProviders();

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Auth/RegisterFormTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Auth/RegisterFormTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
 using MMCA.Common.Shared.Auth.Requests;
 using MMCA.Common.Shared.Auth.Responses;
 using MMCA.Common.Testing.UI;
@@ -135,6 +136,55 @@ public sealed class RegisterFormTests : BunitTestBase
 
         cut.WaitForAssertion(() => cut.Markup.Should().Contain("Registration failed. Please try again."));
         cut.Markup.Should().NotContain("Auth.Register.Failed");
+    }
+
+    [Fact]
+    public void WhenTheEmailIsAlreadyRegistered_PointsTheUserAtSignInAndPasswordReset()
+    {
+        // The duplicate-address conflict is the one registration failure with a next step of its own,
+        // and it is recognised by its CODE, never by the server's wording.
+        RegistrationReturns(Result.Failure<AuthenticationResponse>(
+            Error.Conflict(AuthErrorCodes.EmailAlreadyExists, "An account with this email already exists.")));
+        var cut = RenderUnderTest<Register>(_ => { });
+        FillRequiredFields(cut);
+
+        cut.ClickButtonByText("Create Account");
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-testid='email-already-registered']").Should().ContainSingle());
+
+        var alert = cut.Find("[data-testid='email-already-registered']");
+        alert.GetAttribute("role").Should().Be("alert", "the block only enters the DOM after a failed submit");
+        alert.ClassList.Should().Contain(
+            c => c.Contains("warning", StringComparison.Ordinal),
+            "an existing account is guidance, not an error to retry past");
+        alert.TextContent.Should().Contain("ada@example.com", "the user must see WHICH address is taken");
+        alert.TextContent.Should().Contain("is already registered");
+
+        var hrefs = alert.QuerySelectorAll("a").Select(a => a.GetAttribute("href")).ToList();
+        hrefs.Should().Contain("/login").And.Contain("/forgot-password");
+
+        cut.FindAll(".mud-alert").Should().ContainSingle(
+            "the generic error alert is replaced by this one, not shown beside it");
+        cut.Markup.Should().NotContain("An account with this email already exists.",
+            "the server's generic wording gives the user nowhere to go");
+    }
+
+    [Fact]
+    public void WhenTheFailureIsNotADuplicateEmail_ShowsOnlyTheGenericAlert()
+    {
+        RegistrationReturns(Result.Failure<AuthenticationResponse>(
+            Error.Failure("Auth.Register.Unavailable", "Registration is temporarily unavailable.")));
+        var cut = RenderUnderTest<Register>(_ => { });
+        FillRequiredFields(cut);
+
+        cut.ClickButtonByText("Create Account");
+
+        cut.WaitForAssertion(() =>
+            cut.Markup.Should().Contain("Registration is temporarily unavailable."));
+        cut.FindAll("[data-testid='email-already-registered']").Should().BeEmpty(
+            "only the duplicate-address code earns the sign-in guidance");
+        cut.FindAll(".mud-alert").Should().ContainSingle();
     }
 
     private static void FillRequiredFields(IRenderedComponent<Register> cut)


### PR DESCRIPTION
## Summary
- **Register page**: when the address already has an account (`Auth.EmailAlreadyExists`), the page now shows a warning alert naming the typed address with links to sign in and to reset the password, instead of the generic red alert. The code is matched via the new `MMCA.Common.Shared.Auth.AuthErrorCodes` constant; server message unchanged. English + Spanish resources.
- **Mobile nav menu**: the account section (signed-in name, Signed-in devices, Logout, or Login/Register when anonymous) now leads the hamburger menu instead of trailing a long scrolling list, so Logout is reachable the moment the menu opens on a phone. Safe-area bottom clearance moves onto the expanded `.nav-scrollable`.

## Test plan
- [x] `dotnet build MMCA.Common.slnx` warning-free
- [x] UI.Tests 924/924 (new: `RegisterFormTests` duplicate-email + generic-path cases, `NavMenuTests` ordering gate), Application.Tests 1149/1149, Architecture.Tests 220/220
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK