### PR TITLE
feat(ui): shared user-administration list (UserAdminList) + generic Admin/Users client

### DIFF
--- a/Source/Core/MMCA.Common.Shared/Auth/Administration/IUserAdminDTO.cs
+++ b/Source/Core/MMCA.Common.Shared/Auth/Administration/IUserAdminDTO.cs
@@ -1,0 +1,31 @@
+namespace MMCA.Common.Shared.Auth.Administration;
+
+/// <summary>
+/// The projection the framework's user-administration UI reads from an app's own user DTO. ADR-116
+/// keeps that DTO app-owned (the columns an operator needs differ per app), so the shared list
+/// component states only the four values it renders itself and the app's DTO declares how it
+/// answers them.
+/// </summary>
+/// <remarks>
+/// Implement it on the administration DTO the app already serves from its <c>Admin/Users</c>
+/// endpoints. An explicit implementation is fine and is usually the right one: the component reads
+/// through the interface, so a DTO that spells the lock state its own way (ADC's <c>LockedOn</c>
+/// timestamp, Store's <c>IsActive</c> flag) maps it here instead of renaming its wire contract.
+/// </remarks>
+public interface IUserAdminDTO
+{
+    /// <summary>Gets the account identifier, used for the detail route and for every administration call.</summary>
+    UserIdentifierType UserId { get; }
+
+    /// <summary>Gets the account's email address, which the list renders as the row's primary label.</summary>
+    string Email { get; }
+
+    /// <summary>Gets the single role the account holds.</summary>
+    string Role { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the account is shut out of sign-in (ADC: <c>LockedOn</c> is
+    /// not null; Store: <c>!IsActive</c>).
+    /// </summary>
+    bool IsLocked { get; }
+}

--- a/Source/Core/MMCA.Common.Shared/PublicAPI.Unshipped.txt
+++ b/Source/Core/MMCA.Common.Shared/PublicAPI.Unshipped.txt
@@ -9,6 +9,11 @@ MMCA.Common.Shared.Abstractions.Result<T>.Ensure(System.Func<T, bool>! predicate
 MMCA.Common.Shared.Abstractions.Result<T>.MatchAsync<TResult>(System.Func<T, System.Threading.Tasks.Task<TResult>!>! onSuccess, System.Func<System.Collections.Generic.IEnumerable<MMCA.Common.Shared.Abstractions.Error!>!, System.Threading.Tasks.Task<TResult>!>! onFailure) -> System.Threading.Tasks.Task<TResult>!
 MMCA.Common.Shared.Abstractions.Result<T>.Tap(System.Action<T>! action) -> MMCA.Common.Shared.Abstractions.Result<T>!
 MMCA.Common.Shared.Abstractions.ResultExtensions
+MMCA.Common.Shared.Auth.Administration.IUserAdminDTO
+MMCA.Common.Shared.Auth.Administration.IUserAdminDTO.Email.get -> string!
+MMCA.Common.Shared.Auth.Administration.IUserAdminDTO.IsLocked.get -> bool
+MMCA.Common.Shared.Auth.Administration.IUserAdminDTO.Role.get -> string!
+MMCA.Common.Shared.Auth.Administration.IUserAdminDTO.UserId.get -> int
 MMCA.Common.Shared.Auth.AuthErrorCodes
 MMCA.Common.Shared.Auth.ClaimsPrincipalExtensions
 MMCA.Common.Shared.Auth.Requests.ForgotPasswordRequest

--- a/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
+++ b/Source/Presentation/MMCA.Common.UI/DependencyInjection.cs
@@ -8,6 +8,7 @@ using MMCA.Common.UI.Common.Interfaces;
 using MMCA.Common.UI.Common.Settings;
 using MMCA.Common.UI.Globalization;
 using MMCA.Common.UI.Services;
+using MMCA.Common.UI.Services.Administration;
 using MMCA.Common.UI.Services.Auth;
 using MMCA.Common.UI.Services.Auth.OAuth;
 using MMCA.Common.UI.Services.Caching;
@@ -189,6 +190,32 @@ public static class DependencyInjection
         /// </summary>
         public IServiceCollection AddWasmFormFactor() =>
             services.AddSingleton<IFormFactor, WasmFormFactor>();
+
+        /// <summary>
+        /// The UI opt-in of ADR-116's user administration: registers the HTTP client for the app's
+        /// <c>Admin/Users</c> endpoints, which is what
+        /// <c>MMCA.Common.UI.Pages.Administration.UserAdminList&lt;TUser&gt;</c> lists and acts
+        /// through. Call it once per app, after <c>AddUIShared</c>, with the app's own
+        /// administration DTO (the DTO stays app-owned; it only has to implement
+        /// <c>IUserAdminDTO</c> for the shared component to render it).
+        /// <para>
+        /// Nothing else in the framework calls this: an app that serves no administration endpoints
+        /// registers nothing and the component is simply never rendered.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TUserDto">The app's administration-facing user DTO.</typeparam>
+        /// <returns>The service collection, for chaining.</returns>
+        public IServiceCollection AddUserAdministrationUI<TUserDto>()
+        {
+            services.TryAddScoped<IUserAdminUIService<TUserDto>, UserAdminService<TUserDto>>();
+
+            // Forwarded rather than registered a second time, so the actions the component performs
+            // and the page it lists go through ONE instance (and one substitute, in a test).
+            services.TryAddScoped<IUserAdminActionsUIService>(
+                sp => sp.GetRequiredService<IUserAdminUIService<TUserDto>>());
+
+            return services;
+        }
 
         /// <summary>
         /// Registers one UI module: the Scrutor scan that picks up every

--- a/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminList.razor
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminList.razor
@@ -1,0 +1,194 @@
+@using MMCA.Common.Shared.Auth.Administration
+@using MMCA.Common.UI.Components.PageState
+@typeparam TUser where TUser : IUserAdminDTO
+@inherits MMCA.Common.UI.Pages.Common.DataGridListPageBase<TUser>
+
+<PageTitle>@Title</PageTitle>
+
+<PageHeader Title="@Title">
+    @if (IsLoading)
+    {
+        <MudButton Color="Color.Error" OnClick="CancelLoading" StartIcon="@Icons.Material.Filled.Cancel"
+                   aria-label="@T("Aria.CancelLoading")">
+            @T("Button.Cancel")
+        </MudButton>
+    }
+</PageHeader>
+
+@if (ShowSearch)
+{
+    <MudTextField T="string" Value="_searchString" ValueChanged="OnSearchChanged"
+                  Placeholder="@T("Placeholder.Search")"
+                  Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true" DebounceInterval="300" Clearable="true"
+                  Variant="Variant.Outlined" Class="mb-2" Style="max-width: min(400px, 100%);" />
+}
+
+@if (IsMobile)
+{
+    <MobileInfiniteScrollList TItem="TUser"
+                              @ref="_infiniteList"
+                              FetchPageResult="FetchMobilePage"
+                              EmptyMessage="@T("Empty.NoUsers")">
+        <CardTemplate Context="item">
+            @* The card itself binds no OnCardClick, so it renders as plain content: a card carrying
+               role="button" with these controls inside it would be axe nested-interactive. That
+               leaves the affordances to be explicit, which is why the details link below is a
+               labelled button of its own rather than a whole-card tap an operator has to guess at. *@
+            <div style="min-width: 0;">
+                <MudLink Href="@DetailHref(item)">
+                    <MudText Typo="Typo.subtitle2">@item.Email</MudText>
+                </MudLink>
+                @CardContent?.Invoke(item)
+                <MudChip T="string" Color="Color.Primary" Size="Size.Small" Variant="Variant.Outlined">@RoleText(item.Role)</MudChip>
+                @if (item.IsLocked)
+                {
+                    <MudChip T="string" Color="Color.Error" Size="Size.Small" Variant="Variant.Filled">@T("Status.Locked")</MudChip>
+                }
+            </div>
+            <div class="d-flex flex-wrap align-center justify-end gap-1 mt-2">
+                <MudButton Variant="Variant.Text" Size="Size.Small" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.OpenInNew"
+                           Href="@DetailHref(item)"
+                           aria-label="@T("Aria.ViewDetails", item.Email)">
+                    @T("Action.ViewDetails")
+                </MudButton>
+                @if (CanAdminister(item))
+                {
+                    @* Label + EndIcon, not a bare kebab: the built-in activator IS the button (custom
+                       ActivatorContent would wrap it in a div carrying role="button", the axe
+                       nested-interactive violation), and on a phone a labelled "Actions" button is
+                       the only thing that reads as one. AriaLabel still names it per account. *@
+                    <MudMenu Dense="true"
+                             Label="@T("Menu.Actions")"
+                             EndIcon="@Icons.Material.Filled.ArrowDropDown"
+                             Variant="Variant.Text"
+                             Size="Size.Small"
+                             AriaLabel="@T("Aria.Actions", item.Email)">
+                        <MudMenuItem OnClick="@(() => ToggleLockAsync(item))" data-testid="toggle-lock">
+                            @(item.IsLocked ? T("Action.Unlock") : T("Action.Lock"))
+                        </MudMenuItem>
+                        @foreach (var role in AssignableRoles)
+                        {
+                            <MudMenuItem Disabled="@(string.Equals(role, item.Role, StringComparison.Ordinal))"
+                                         OnClick="@(() => ChangeRoleAsync(item, role))"
+                                         data-testid="set-role">
+                                @T("Action.SetRole", RoleText(role))
+                            </MudMenuItem>
+                        }
+                    </MudMenu>
+                }
+                @if (OnDelete is not null)
+                {
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                                   OnClick="@(() => DeleteUserAsync(item))"
+                                   aria-label="@T("Aria.Delete", item.Email)" />
+                }
+            </div>
+        </CardTemplate>
+    </MobileInfiniteScrollList>
+}
+else
+{
+    <MudDataGrid T="TUser"
+                 @ref="_dataGrid"
+                 @bind-CurrentPage="CurrentPageState"
+                 ServerData="LoadServerData"
+                 Loading="IsLoading"
+                 AllowUnsorted="false"
+                 Dense="true"
+                 Elevation="1"
+                 Filterable="true"
+                 FilterCaseSensitivity="DataGridFilterCaseSensitivity.CaseInsensitive"
+                 HorizontalScrollbar="true"
+                 Hover="true"
+                 RowsPerPage="@RowsPerPageState"
+                 Striped="true">
+        <Columns>
+            @* The email cell carries a real link, and it is the ONLY path to the account: the grid
+               binds no RowClick. A whole-row click is mouse-only, and it also forces the row's action
+               menu to be built out of an activator wrapper that stops propagation, which is the
+               nested-interactive violation axe reports. Keyboard, pointer and screen-reader users all
+               take the link. *@
+            <PropertyColumn Property="x => x.Email" Title="@T("Column.Email")" Sortable="@Sortable" Filterable="true"
+                            InitialDirection="@(Sortable ? SortDirection.Ascending : SortDirection.None)">
+                <CellTemplate>
+                    <MudLink Href="@DetailHref(context.Item)"
+                             Color="Color.Inherit" Underline="Underline.None">
+                        @context.Item.Email
+                    </MudLink>
+                </CellTemplate>
+            </PropertyColumn>
+            @Columns
+            <PropertyColumn Property="x => x.Role" Title="@T("Column.Role")" Sortable="@Sortable" Filterable="true">
+                <CellTemplate>
+                    @RoleText(context.Item.Role)
+                </CellTemplate>
+            </PropertyColumn>
+            <TemplateColumn Title="@T("Column.Status")" Sortable="false" Filterable="false">
+                <CellTemplate>
+                    @if (context.Item.IsLocked)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Error" Variant="Variant.Filled">@T("Status.Locked")</MudChip>
+                    }
+                    else
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">@T("Status.Active")</MudChip>
+                    }
+                </CellTemplate>
+            </TemplateColumn>
+            @TrailingColumns
+            @* The cell's context is named so the row actions read as row.Item rather than the bare
+               "context" the nested MudMenu templates also bind. *@
+            <TemplateColumn Sortable="false" Filterable="false" CellStyle="width: 110px; text-align: center;">
+                <CellTemplate Context="row">
+                    @if (CanAdminister(row.Item))
+                    {
+                        @* Icon + AriaLabel, not ActivatorContent: MudBlazor wraps custom activator
+                           content in its own div carrying role="button" and tabindex="0", so an icon
+                           button placed inside it is a control nested in a control (axe
+                           nested-interactive). The built-in icon activator IS the button, and
+                           AriaLabel names it per account. *@
+                        <MudMenu Dense="true"
+                                 Icon="@Icons.Material.Filled.MoreVert"
+                                 Size="Size.Small"
+                                 AriaLabel="@T("Aria.Actions", row.Item.Email)">
+                            <MudMenuItem OnClick="@(() => ToggleLockAsync(row.Item))" data-testid="toggle-lock">
+                                @(row.Item.IsLocked ? T("Action.Unlock") : T("Action.Lock"))
+                            </MudMenuItem>
+                            @foreach (var role in AssignableRoles)
+                            {
+                                <MudMenuItem Disabled="@(string.Equals(role, row.Item.Role, StringComparison.Ordinal))"
+                                             OnClick="@(() => ChangeRoleAsync(row.Item, role))"
+                                             data-testid="set-role">
+                                    @T("Action.SetRole", RoleText(role))
+                                </MudMenuItem>
+                            }
+                        </MudMenu>
+                    }
+                    @if (OnDelete is not null)
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                       Color="Color.Error"
+                                       Size="Size.Small"
+                                       OnClick="@(() => DeleteUserAsync(row.Item))"
+                                       aria-label="@T("Aria.Delete", row.Item.Email)" />
+                    }
+                </CellTemplate>
+            </TemplateColumn>
+        </Columns>
+        <NoRecordsContent>
+            <ListNoRecordsContent LoadFailed="LoadFailed" EmptyMessage="@T("Empty.NoUsers")" OnRetry="RetryLoadAsync" />
+        </NoRecordsContent>
+        <PagerContent>
+            <MudStack Row AlignItems="AlignItems.Center">
+                <MudDataGridPager T="TUser" PageSizeOptions=@(new int[] { 5, 10, 25, 50, 100 }) />
+            </MudStack>
+        </PagerContent>
+    </MudDataGrid>
+}
+
+@if (OnDelete is not null)
+{
+    <DeleteConfirmation @ref="_deleteConfirm" EntityType="@T("EntityName")" />
+}

--- a/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminList.razor.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminList.razor.cs
@@ -1,0 +1,359 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+using MMCA.Common.Shared.Auth.Administration;
+using MMCA.Common.UI.Common.Interfaces;
+using MMCA.Common.UI.Components.Forms;
+using MMCA.Common.UI.Components.Lists;
+using MMCA.Common.UI.Pages.Common;
+using MMCA.Common.UI.Services.Administration;
+using MudBlazor;
+
+namespace MMCA.Common.UI.Pages.Administration;
+
+/// <summary>
+/// The UI half of ADR-116's user administration: a drop-in account roster with the operator actions
+/// the framework's <c>Admin/Users</c> endpoints expose (lock, unlock, change role), plus an optional
+/// delete. It is a COMPONENT, not a page: the app supplies the route, the authorization attribute
+/// and the detail link, so the role that may reach it stays the app's decision.
+/// </summary>
+/// <remarks>
+/// <para>
+/// What the app supplies: a DTO implementing <see cref="IUserAdminDTO"/>, the required
+/// <see cref="DetailHref"/> route builder, and optionally the roles an operator may assign, extra
+/// columns or card lines, a delete callback, and its own <see cref="Localizer"/> for wording. Every
+/// string this component renders is looked up in that localizer FIRST and falls back to
+/// <see cref="UserAdminListResources"/>, so an app keeps its own vocabulary ("Deactivate" rather
+/// than "Lock") without a parameter per word.
+/// </para>
+/// <para>
+/// Two data paths. By default the list reads through
+/// <see cref="IUserAdminUIService{TUserDto}"/> (registered by <c>AddUserAdministrationUI</c>),
+/// whose endpoint takes a search term and a role. An app whose roster lives on its own endpoint,
+/// with per-column filters and server sort, passes <see cref="FetchPage"/> instead and the service
+/// is never resolved for reads. The three account ACTIONS always go through
+/// <see cref="IUserAdminActionsUIService"/>, because they are the framework's endpoints either way.
+/// </para>
+/// <para>
+/// The administration actions are hidden on the signed-in operator's own row. An operator who
+/// locked or demoted themselves would lose the very capability needed to undo it, and the API has
+/// no notion of "the caller", so the guard belongs here.
+/// </para>
+/// </remarks>
+/// <typeparam name="TUser">The app's administration-facing user DTO.</typeparam>
+public partial class UserAdminList<TUser>
+    where TUser : IUserAdminDTO
+{
+    /// <summary>
+    /// The filter-bag key the search box is injected under when <see cref="FetchPage"/> owns the
+    /// fetch. The app's delegate reads it to map the free-text box onto whatever its own endpoint
+    /// calls that filter.
+    /// </summary>
+    public const string SearchFilterKey = "Search";
+
+    /// <summary>The page title. Defaults to the localized "Users" when not supplied.</summary>
+    [Parameter] public string? Heading { get; set; }
+
+    /// <summary>Builds the route to one account's detail page. Required.</summary>
+    [Parameter]
+    [EditorRequired]
+    public Func<TUser, string> DetailHref { get; set; } = default!;
+
+    /// <summary>
+    /// The roles an operator may assign, offered in the row menu as "Set role to X". Order them
+    /// least to most privileged so the menu reads as a ladder. An empty list offers only
+    /// lock and unlock.
+    /// </summary>
+    [Parameter] public IReadOnlyList<string> AssignableRoles { get; set; } = [];
+
+    /// <summary>
+    /// Maps a role value to its display name (Store shows "Administrator" for "Admin"). When null
+    /// the raw value is shown. Used in the Role column, the mobile chip, and the set-role menu items
+    /// and confirmations.
+    /// </summary>
+    [Parameter] public Func<string, string>? RoleLabel { get; set; }
+
+    /// <summary>Extra grid columns rendered directly after the Email column.</summary>
+    [Parameter] public RenderFragment? Columns { get; set; }
+
+    /// <summary>Extra grid columns rendered after the status column, before the actions column.</summary>
+    [Parameter] public RenderFragment? TrailingColumns { get; set; }
+
+    /// <summary>Extra lines on the mobile card, rendered between the email link and the role/status chips.</summary>
+    [Parameter] public RenderFragment<TUser>? CardContent { get; set; }
+
+    /// <summary>
+    /// Overrides the data source with the app's own paged endpoint (per-column filters and server
+    /// sort included). When null the list reads through
+    /// <see cref="IUserAdminUIService{TUserDto}"/>; the account actions always go through
+    /// <see cref="IUserAdminActionsUIService"/> either way. The free-text search box is passed
+    /// through the filter bag under <see cref="SearchFilterKey"/>.
+    /// </summary>
+    [Parameter]
+    public Func<
+        Dictionary<string, (string Operator, string Value)>,
+        int,
+        int,
+        string?,
+        string?,
+        CancellationToken,
+        Task<Result<(IReadOnlyList<TUser> Items, int TotalItems)>>>? FetchPage
+    { get; set; }
+
+    /// <summary>
+    /// Whether the Email and Role columns are sortable. Defaults to <see langword="false"/>, because
+    /// the framework's administration endpoint ignores sort and a sortable header would lie; an app
+    /// listing through <see cref="FetchPage"/> from a sorting endpoint turns it on.
+    /// </summary>
+    [Parameter] public bool Sortable { get; set; }
+
+    /// <summary>Whether the debounced search box is rendered above the list.</summary>
+    [Parameter] public bool ShowSearch { get; set; } = true;
+
+    /// <summary>
+    /// The app's own delete call. When set, every row and card offers a Delete button behind the
+    /// shared confirmation dialog; when null no delete is offered at all (account erasure is its own
+    /// endpoint under its own authorization rule, so the framework does not assume one exists).
+    /// </summary>
+    [Parameter] public Func<TUser, Task<Result>>? OnDelete { get; set; }
+
+    /// <summary>
+    /// An app localizer consulted FIRST for every key this component renders; a key it does not
+    /// carry falls back to <see cref="UserAdminListResources"/>. This is how an app keeps its own
+    /// wording without a parameter per word.
+    /// </summary>
+    [Parameter] public IStringLocalizer? Localizer { get; set; }
+
+    [Inject] private IUserAdminActionsUIService Actions { get; set; } = default!;
+
+    [Inject] private IAppDialogService Dialogs { get; set; } = default!;
+
+    [Inject] private AuthenticationStateProvider AuthStateProvider { get; set; } = default!;
+
+    [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
+
+    [Inject] private IStringLocalizer<UserAdminListResources> L { get; set; } = default!;
+
+    private UserIdentifierType? _currentUserId;
+
+    private MudDataGrid<TUser>? _dataGrid;
+    private MobileInfiniteScrollList<TUser>? _infiniteList;
+    private DeleteConfirmation _deleteConfirm = default!;
+    private string _searchString = string.Empty;
+
+    /// <inheritdoc />
+    protected override string Title => Heading ?? T("Title");
+
+    /// <inheritdoc />
+    protected override MudDataGrid<TUser>? GridRef => _dataGrid;
+
+    /// <summary>
+    /// The reading service, resolved on demand rather than injected so an app that supplies
+    /// <see cref="FetchPage"/> never needs it registered at all.
+    /// </summary>
+    private IUserAdminUIService<TUser> Users =>
+        ServiceProvider.GetService<IUserAdminUIService<TUser>>()
+            ?? throw new InvalidOperationException(
+                $"UserAdminList<{typeof(TUser).Name}> lists through IUserAdminUIService<{typeof(TUser).Name}>, which is not registered. "
+                + $"Call services.AddUserAdministrationUI<{typeof(TUser).Name}>() after AddUIShared, or supply the FetchPage parameter to list from your own endpoint.");
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        _currentUserId = authState.User.GetUserId();
+    }
+
+    /// <summary>
+    /// Resolves one key: the app's own localizer when it carries the key, otherwise this
+    /// component's resources. Arguments go through the localizer's indexer rather than
+    /// <c>string.Format</c>, so a translation is free to reorder its placeholders.
+    /// </summary>
+    /// <param name="key">The resource key.</param>
+    /// <param name="args">Format arguments, if the string takes any.</param>
+    private string T(string key, params object[] args)
+    {
+        if (Localizer is not null)
+        {
+            var overridden = args.Length == 0 ? Localizer[key] : Localizer[key, args];
+            if (!overridden.ResourceNotFound)
+            {
+                return overridden.Value;
+            }
+        }
+
+        return (args.Length == 0 ? L[key] : L[key, args]).Value;
+    }
+
+    /// <summary>The display name of a role value, or the raw value when the app supplied no map.</summary>
+    /// <param name="role">The role value as the API states it.</param>
+    private string RoleText(string role) => RoleLabel?.Invoke(role) ?? role;
+
+    /// <summary>
+    /// Whether the administration actions are offered for <paramref name="user"/>. They are hidden
+    /// on the operator's own row: locking or demoting yourself removes the capability to undo it.
+    /// </summary>
+    /// <param name="user">The row.</param>
+    private bool CanAdminister(TUser user) =>
+        _currentUserId is null || !EqualityComparer<UserIdentifierType>.Default.Equals(user.UserId, _currentUserId.Value);
+
+    /// <inheritdoc />
+    protected override void SaveFilters(Dictionary<string, string> filters) =>
+        filters["search"] = _searchString;
+
+    /// <inheritdoc />
+    protected override void RestoreFilters(IReadOnlyDictionary<string, string> filters) =>
+        _searchString = filters.GetValueOrDefault("search") ?? string.Empty;
+
+    private Task ReloadActiveLayoutAsync()
+        => ListPageActions.ReloadActiveLayoutAsync(IsMobile, _infiniteList, _dataGrid);
+
+    /// <summary>Retries a failed grid fetch from the inline error state (<c>LoadFailed</c>).</summary>
+    private Task RetryLoadAsync() => GridRef?.ReloadServerData() ?? Task.CompletedTask;
+
+    private async Task OnSearchChanged(string value)
+    {
+        _searchString = value;
+        await ReloadActiveLayoutAsync();
+    }
+
+    private Task<GridData<TUser>> LoadServerData(GridState<TUser> state, CancellationToken cancellationToken)
+    {
+        if (FetchPage is { } fetch)
+        {
+            return LoadServerDataAsync(state, fetch, InjectSearchFilter);
+        }
+
+        return LoadServerDataAsync(
+            state,
+            (filters, page, size, _, _, ct) => Users.GetPagedAsync(
+                page,
+                size,
+                SearchTermFrom(filters),
+                FilterValue(filters, nameof(IUserAdminDTO.Role)),
+                ct));
+    }
+
+    // ── Mobile ──
+    private Task<Result<(IReadOnlyList<TUser> Items, int TotalItems)>> FetchMobilePage(int page, int pageSize, CancellationToken ct)
+    {
+        if (FetchPage is { } fetch)
+        {
+            var filters = new Dictionary<string, (string Operator, string Value)>(StringComparer.Ordinal);
+            InjectSearchFilter(filters);
+            return fetch(filters, page, pageSize, "Email", "asc", ct);
+        }
+
+        var searchTerm = !string.IsNullOrWhiteSpace(_searchString) ? _searchString : null;
+        return Users.GetPagedAsync(page, pageSize, searchTerm, role: null, ct);
+    }
+
+    /// <summary>
+    /// Adds the free-text box to the filter bag the app's own fetch delegate reads, under the
+    /// documented <see cref="SearchFilterKey"/>. A blank box adds nothing, so the delegate never has
+    /// to distinguish "empty" from "absent".
+    /// </summary>
+    /// <param name="filters">The grid's filter bag.</param>
+    private void InjectSearchFilter(Dictionary<string, (string Operator, string Value)> filters)
+    {
+        if (!string.IsNullOrWhiteSpace(_searchString))
+        {
+            filters[SearchFilterKey] = ("contains", _searchString);
+        }
+    }
+
+    /// <summary>
+    /// The search term the administration endpoint is called with: the free-text box when it holds
+    /// anything, otherwise the Email column's own filter, so both affordances reach the one
+    /// parameter the endpoint takes.
+    /// </summary>
+    /// <param name="filters">The grid's filter bag.</param>
+    private string? SearchTermFrom(Dictionary<string, (string Operator, string Value)> filters) =>
+        !string.IsNullOrWhiteSpace(_searchString)
+            ? _searchString
+            : FilterValue(filters, nameof(IUserAdminDTO.Email));
+
+    /// <summary>
+    /// Reads one column filter's value out of the grid's filter bag. The operator is ignored: the
+    /// administration endpoint takes a search term and a role, not a per-column comparison, so the
+    /// value is all it can honor.
+    /// </summary>
+    /// <param name="filters">The grid's filter bag.</param>
+    /// <param name="property">The column's property name.</param>
+    private static string? FilterValue(Dictionary<string, (string Operator, string Value)> filters, string property) =>
+        filters is not null && filters.TryGetValue(property, out var filter) && !string.IsNullOrWhiteSpace(filter.Value)
+            ? filter.Value
+            : null;
+
+    // ── Administration (ADR-116) ──
+    private async Task ToggleLockAsync(TUser user)
+    {
+        var locking = !user.IsLocked;
+
+        var confirmed = await Dialogs.ConfirmAsync(
+            locking ? T("Confirm.Lock.Title") : T("Confirm.Unlock.Title"),
+            locking ? T("Confirm.Lock.Message", user.Email) : T("Confirm.Unlock.Message", user.Email),
+            locking ? T("Action.Lock") : T("Action.Unlock"),
+            T("Button.Cancel"));
+
+        if (!confirmed)
+        {
+            return;
+        }
+
+        var result = locking
+            ? await Actions.LockAsync(user.UserId)
+            : await Actions.UnlockAsync(user.UserId);
+
+        if (result.IsFailure)
+        {
+            Toast.Error(locking ? T("Snackbar.LockFailed") : T("Snackbar.UnlockFailed"));
+            return;
+        }
+
+        Toast.Success(locking ? T("Snackbar.Locked") : T("Snackbar.Unlocked"));
+        await ReloadActiveLayoutAsync();
+    }
+
+    private async Task ChangeRoleAsync(TUser user, string role)
+    {
+        var label = RoleText(role);
+
+        var confirmed = await Dialogs.ConfirmAsync(
+            T("Confirm.Role.Title"),
+            T("Confirm.Role.Message", user.Email, label),
+            T("Confirm.Role.Confirm"),
+            T("Button.Cancel"));
+
+        if (!confirmed)
+        {
+            return;
+        }
+
+        var result = await Actions.SetRoleAsync(user.UserId, role);
+        if (result.IsFailure)
+        {
+            Toast.Error(T("Snackbar.RoleChangeFailed"));
+            return;
+        }
+
+        Toast.Success(T("Snackbar.RoleChanged", label));
+        await ReloadActiveLayoutAsync();
+    }
+
+    // ── Common ──
+    private Task DeleteUserAsync(TUser user)
+        => ListPageActions.DeleteWithConfirmationAsync(
+            _deleteConfirm,
+            user.Email,
+            () => OnDelete!(user),
+            Toast,
+            T("Snackbar.UserDeleted"),
+            _ => T("Snackbar.DeleteUserFailed"),
+            ReloadActiveLayoutAsync);
+}

--- a/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminListResources.cs
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminListResources.cs
@@ -1,0 +1,14 @@
+namespace MMCA.Common.UI.Pages.Administration;
+
+/// <summary>
+/// Resource anchor type for the user-administration list's strings (ADR-027). A generic component
+/// cannot own a <c>.resx</c> by its own type name, so <c>UserAdminList&lt;TUser&gt;</c> injects
+/// <c>IStringLocalizer&lt;UserAdminListResources&gt;</c> and this non-generic marker is what the
+/// <c>UserAdminListResources.resx</c> / <c>UserAdminListResources.es.resx</c> pair binds to.
+/// </summary>
+/// <remarks>
+/// An app that wants different wording does NOT edit these resources: it passes its own
+/// <c>IStringLocalizer</c> as the component's <c>Localizer</c> parameter, and any key that localizer
+/// carries wins over the key of the same name here.
+/// </remarks>
+public sealed class UserAdminListResources;

--- a/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminListResources.es.resx
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminListResources.es.resx
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Usuarios</value>
+  </data>
+  <data name="EntityName" xml:space="preserve">
+    <value>usuario</value>
+  </data>
+  <data name="Placeholder.Search" xml:space="preserve">
+    <value>Buscar por correo electronico...</value>
+  </data>
+  <data name="Aria.CancelLoading" xml:space="preserve">
+    <value>Cancelar la carga de usuarios</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="Empty.NoUsers" xml:space="preserve">
+    <value>No se encontraron usuarios.</value>
+  </data>
+  <data name="Column.Email" xml:space="preserve">
+    <value>Correo electronico</value>
+  </data>
+  <data name="Column.Role" xml:space="preserve">
+    <value>Rol</value>
+  </data>
+  <data name="Column.Status" xml:space="preserve">
+    <value>Estado</value>
+  </data>
+  <data name="Status.Active" xml:space="preserve">
+    <value>Activa</value>
+  </data>
+  <data name="Status.Locked" xml:space="preserve">
+    <value>Bloqueada</value>
+  </data>
+  <data name="Action.ViewDetails" xml:space="preserve">
+    <value>Ver detalles</value>
+  </data>
+  <data name="Aria.ViewDetails" xml:space="preserve">
+    <value>Ver detalles de {0}</value>
+  </data>
+  <data name="Menu.Actions" xml:space="preserve">
+    <value>Acciones</value>
+  </data>
+  <data name="Aria.Actions" xml:space="preserve">
+    <value>Acciones de administracion para {0}</value>
+  </data>
+  <data name="Action.Lock" xml:space="preserve">
+    <value>Bloquear cuenta</value>
+  </data>
+  <data name="Action.Unlock" xml:space="preserve">
+    <value>Desbloquear cuenta</value>
+  </data>
+  <data name="Action.SetRole" xml:space="preserve">
+    <value>Asignar el rol {0}</value>
+  </data>
+  <data name="Aria.Delete" xml:space="preserve">
+    <value>Eliminar {0}</value>
+  </data>
+  <data name="Confirm.Lock.Title" xml:space="preserve">
+    <value>Bloquear cuenta</value>
+  </data>
+  <data name="Confirm.Lock.Message" xml:space="preserve">
+    <value>Bloquear a {0}? Se cerrara su sesion y no podra iniciar sesion hasta que la cuenta se desbloquee.</value>
+  </data>
+  <data name="Confirm.Unlock.Title" xml:space="preserve">
+    <value>Desbloquear cuenta</value>
+  </data>
+  <data name="Confirm.Unlock.Message" xml:space="preserve">
+    <value>Desbloquear a {0}? Podra iniciar sesion de nuevo.</value>
+  </data>
+  <data name="Confirm.Role.Title" xml:space="preserve">
+    <value>Cambiar rol</value>
+  </data>
+  <data name="Confirm.Role.Message" xml:space="preserve">
+    <value>Cambiar el rol de {0} a {1}? Se cerrara su sesion y volvera a entrar con los nuevos permisos.</value>
+  </data>
+  <data name="Confirm.Role.Confirm" xml:space="preserve">
+    <value>Cambiar rol</value>
+  </data>
+  <data name="Snackbar.Locked" xml:space="preserve">
+    <value>Cuenta bloqueada.</value>
+  </data>
+  <data name="Snackbar.Unlocked" xml:space="preserve">
+    <value>Cuenta desbloqueada.</value>
+  </data>
+  <data name="Snackbar.LockFailed" xml:space="preserve">
+    <value>No se pudo bloquear la cuenta.</value>
+  </data>
+  <data name="Snackbar.UnlockFailed" xml:space="preserve">
+    <value>No se pudo desbloquear la cuenta.</value>
+  </data>
+  <data name="Snackbar.RoleChanged" xml:space="preserve">
+    <value>Rol cambiado a {0}.</value>
+  </data>
+  <data name="Snackbar.RoleChangeFailed" xml:space="preserve">
+    <value>No se pudo cambiar el rol.</value>
+  </data>
+  <data name="Snackbar.UserDeleted" xml:space="preserve">
+    <value>El usuario se elimino correctamente.</value>
+  </data>
+  <data name="Snackbar.DeleteUserFailed" xml:space="preserve">
+    <value>No se pudo eliminar el usuario.</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminListResources.resx
+++ b/Source/Presentation/MMCA.Common.UI/Pages/Administration/UserAdminListResources.resx
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Users</value>
+  </data>
+  <data name="EntityName" xml:space="preserve">
+    <value>User</value>
+  </data>
+  <data name="Placeholder.Search" xml:space="preserve">
+    <value>Search by email...</value>
+  </data>
+  <data name="Aria.CancelLoading" xml:space="preserve">
+    <value>Cancel loading users</value>
+  </data>
+  <data name="Button.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Empty.NoUsers" xml:space="preserve">
+    <value>No users found.</value>
+  </data>
+  <data name="Column.Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Column.Role" xml:space="preserve">
+    <value>Role</value>
+  </data>
+  <data name="Column.Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Status.Active" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="Status.Locked" xml:space="preserve">
+    <value>Locked</value>
+  </data>
+  <data name="Action.ViewDetails" xml:space="preserve">
+    <value>View details</value>
+  </data>
+  <data name="Aria.ViewDetails" xml:space="preserve">
+    <value>View details for {0}</value>
+  </data>
+  <data name="Menu.Actions" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="Aria.Actions" xml:space="preserve">
+    <value>Administration actions for {0}</value>
+  </data>
+  <data name="Action.Lock" xml:space="preserve">
+    <value>Lock account</value>
+  </data>
+  <data name="Action.Unlock" xml:space="preserve">
+    <value>Unlock account</value>
+  </data>
+  <data name="Action.SetRole" xml:space="preserve">
+    <value>Set role to {0}</value>
+  </data>
+  <data name="Aria.Delete" xml:space="preserve">
+    <value>Delete {0}</value>
+  </data>
+  <data name="Confirm.Lock.Title" xml:space="preserve">
+    <value>Lock account</value>
+  </data>
+  <data name="Confirm.Lock.Message" xml:space="preserve">
+    <value>Lock {0}? They will be signed out and cannot sign in again until the account is unlocked.</value>
+  </data>
+  <data name="Confirm.Unlock.Title" xml:space="preserve">
+    <value>Unlock account</value>
+  </data>
+  <data name="Confirm.Unlock.Message" xml:space="preserve">
+    <value>Unlock {0}? They will be able to sign in again.</value>
+  </data>
+  <data name="Confirm.Role.Title" xml:space="preserve">
+    <value>Change role</value>
+  </data>
+  <data name="Confirm.Role.Message" xml:space="preserve">
+    <value>Change the role of {0} to {1}? They will be signed out and will sign back in with the new permissions.</value>
+  </data>
+  <data name="Confirm.Role.Confirm" xml:space="preserve">
+    <value>Change role</value>
+  </data>
+  <data name="Snackbar.Locked" xml:space="preserve">
+    <value>Account locked.</value>
+  </data>
+  <data name="Snackbar.Unlocked" xml:space="preserve">
+    <value>Account unlocked.</value>
+  </data>
+  <data name="Snackbar.LockFailed" xml:space="preserve">
+    <value>Failed to lock the account.</value>
+  </data>
+  <data name="Snackbar.UnlockFailed" xml:space="preserve">
+    <value>Failed to unlock the account.</value>
+  </data>
+  <data name="Snackbar.RoleChanged" xml:space="preserve">
+    <value>Role changed to {0}.</value>
+  </data>
+  <data name="Snackbar.RoleChangeFailed" xml:space="preserve">
+    <value>Failed to change the role.</value>
+  </data>
+  <data name="Snackbar.UserDeleted" xml:space="preserve">
+    <value>User deleted successfully.</value>
+  </data>
+  <data name="Snackbar.DeleteUserFailed" xml:space="preserve">
+    <value>Failed to delete user.</value>
+  </data>
+</root>

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -371,6 +371,7 @@ virtual MMCA.Common.UI.Services.Api.EntityServiceBase<TEntityDTO, TIdentifierTyp
 ~override MMCA.Common.UI.Pages.Auth.ForgotPassword.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
 ~override MMCA.Common.UI.Pages.Auth.ResetPassword.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
 ~override MMCA.Common.UI.Pages.Auth.Sessions.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
+~override MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder) -> void
 MMCA.Common.UI.Components.Capabilities.BiometricGate.Dispose() -> void
 MMCA.Common.UI.Components.Capabilities.BiometricGate.ReLockAfter.get -> System.TimeSpan
 MMCA.Common.UI.Components.Capabilities.BiometricGate.ReLockAfter.set -> void
@@ -398,7 +399,59 @@ MMCA.Common.UI.Services.Capabilities.DeviceStatus.IAppLifecycleNotifier.Resumed 
 MMCA.Common.UI.Services.Capabilities.DeviceStorage.BrowserLocalCacheStore.ClearAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 MMCA.Common.UI.Services.Capabilities.DeviceStorage.ILocalCacheStore.ClearAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 MMCA.Common.UI.Services.Capabilities.DeviceStorage.NullLocalCacheStore.ClearAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.AssignableRoles.get -> System.Collections.Generic.IReadOnlyList<string!>!
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.AssignableRoles.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.CardContent.get -> Microsoft.AspNetCore.Components.RenderFragment<TUser>?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.CardContent.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Columns.get -> Microsoft.AspNetCore.Components.RenderFragment?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Columns.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.DetailHref.get -> System.Func<TUser, string!>!
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.DetailHref.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.FetchPage.get -> System.Func<System.Collections.Generic.Dictionary<string!, (string! Operator, string! Value)>!, int, int, string?, string?, System.Threading.CancellationToken, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TUser>! Items, int TotalItems)>!>!>?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.FetchPage.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Heading.get -> string?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Heading.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Localizer.get -> Microsoft.Extensions.Localization.IStringLocalizer?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Localizer.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.OnDelete.get -> System.Func<TUser, System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!>?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.OnDelete.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.RoleLabel.get -> System.Func<string!, string!>?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.RoleLabel.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.ShowSearch.get -> bool
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.ShowSearch.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Sortable.get -> bool
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Sortable.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.TrailingColumns.get -> Microsoft.AspNetCore.Components.RenderFragment?
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.TrailingColumns.set -> void
+MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.UserAdminList() -> void
+MMCA.Common.UI.Pages.Administration.UserAdminListResources
+MMCA.Common.UI.Pages.Administration.UserAdminListResources.UserAdminListResources() -> void
+MMCA.Common.UI.DependencyInjection.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection!).AddUserAdministrationUI<TUserDto>() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+MMCA.Common.UI.Services.Administration.IUserAdminActionsUIService
+MMCA.Common.UI.Services.Administration.IUserAdminActionsUIService.LockAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.IUserAdminActionsUIService.SetRoleAsync(int userId, string! role, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.IUserAdminActionsUIService.SetRolesAsync(int userId, System.Collections.Generic.IReadOnlyList<string!>! roles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.IUserAdminActionsUIService.UnlockAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.IUserAdminUIService<TUserDto>
+MMCA.Common.UI.Services.Administration.IUserAdminUIService<TUserDto>.GetAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TUserDto>!>!
+MMCA.Common.UI.Services.Administration.IUserAdminUIService<TUserDto>.GetPagedAsync(int pageNumber, int pageSize, string? searchTerm, string? role, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TUserDto>! Items, int TotalItems)>!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.GetAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<TUserDto>!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.GetPagedAsync(int pageNumber, int pageSize, string? searchTerm, string? role, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result<(System.Collections.Generic.IReadOnlyList<TUserDto>! Items, int TotalItems)>!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.LockAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.SetRoleAsync(int userId, string! role, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.SetRolesAsync(int userId, System.Collections.Generic.IReadOnlyList<string!>! roles, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.UnlockAsync(int userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<MMCA.Common.Shared.Abstractions.Result!>!
+MMCA.Common.UI.Services.Administration.UserAdminService<TUserDto>.UserAdminService(System.Net.Http.IHttpClientFactory! httpClientFactory, MMCA.Common.UI.Services.Auth.Tokens.ITokenStorageService! tokenStorageService) -> void
 const MMCA.Common.UI.Services.Auth.OAuth.OAuthFlowStateStore.StorageKey = "auth.oauth-flow" -> string!
+const MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.SearchFilterKey = "Search" -> string!
 override MMCA.Common.UI.Pages.Auth.Login.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
 override MMCA.Common.UI.Pages.Auth.ResetPassword.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.GridRef.get -> MudBlazor.MudDataGrid<TUser>?
+override MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.OnInitializedAsync() -> System.Threading.Tasks.Task!
+override MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.RestoreFilters(System.Collections.Generic.IReadOnlyDictionary<string!, string!>! filters) -> void
+override MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.SaveFilters(System.Collections.Generic.Dictionary<string!, string!>! filters) -> void
+override MMCA.Common.UI.Pages.Administration.UserAdminList<TUser>.Title.get -> string!
 static MMCA.Common.UI.Services.Capabilities.Navigation.DeepLinkDispatcher.IsAppRelativeRoute(string? route) -> bool
+static MMCA.Common.UI.DependencyInjection.AddUserAdministrationUI<TUserDto>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/Source/Presentation/MMCA.Common.UI/Services/Administration/IUserAdminActionsUIService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Administration/IUserAdminActionsUIService.cs
@@ -1,0 +1,55 @@
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.UI.Services.Administration;
+
+/// <summary>
+/// The three account actions the framework's <c>Admin/Users</c> endpoints expose (ADR-116): lock an
+/// account out of sign-in, unlock it, and replace the roles it holds. Non-generic on purpose, so a
+/// component that only acts on an account never has to name the app's DTO.
+/// </summary>
+/// <remarks>
+/// Every member answers with a <see cref="Result"/> carrying the API's own errors and their
+/// <see cref="ErrorType"/> intact, so a page branches on the outcome instead of catching. The
+/// framework registers one implementation for both this contract and
+/// <see cref="IUserAdminUIService{TUserDto}"/>; see <c>AddUserAdministrationUI</c>.
+/// </remarks>
+public interface IUserAdminActionsUIService
+{
+    /// <summary>Locks an account out of sign-in and revokes its live sessions.</summary>
+    /// <param name="userId">The account to lock.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success, or the API's own refusal.</returns>
+    Task<Result> LockAsync(UserIdentifierType userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Unlocks an account so it can sign in again.</summary>
+    /// <param name="userId">The account to unlock.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success, or the API's own refusal.</returns>
+    Task<Result> UnlockAsync(UserIdentifierType userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Replaces the set of roles an account holds.</summary>
+    /// <param name="userId">The account to re-role.</param>
+    /// <param name="roles">The roles the account should hold afterwards.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success, or the API's own refusal.</returns>
+    Task<Result> SetRolesAsync(
+        UserIdentifierType userId,
+        IReadOnlyList<string> roles,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the single role an account holds, by sending a one-element set to the role-replacement
+    /// endpoint. Both shipped consumers hold exactly one role per account, so this is the shape
+    /// their pages call.
+    /// </summary>
+    /// <remarks>
+    /// Declared as its own member rather than a default interface implementation over
+    /// <see cref="SetRolesAsync"/>: a default implementation is not virtual on the interface a mock
+    /// proxies, so a test could neither stub nor verify it.
+    /// </remarks>
+    /// <param name="userId">The account to re-role.</param>
+    /// <param name="role">The role the account should hold afterwards.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Success, or the API's own refusal.</returns>
+    Task<Result> SetRoleAsync(UserIdentifierType userId, string role, CancellationToken cancellationToken = default);
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Administration/IUserAdminUIService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Administration/IUserAdminUIService.cs
@@ -1,0 +1,39 @@
+using MMCA.Common.Shared.Abstractions;
+
+namespace MMCA.Common.UI.Services.Administration;
+
+/// <summary>
+/// The reading half of user administration (ADR-116) over the app's own administration DTO: one
+/// page of accounts and one account, from the <c>Admin/Users</c> endpoints the framework's
+/// <c>UsersAdminControllerBase</c> serves. Inherits the three account actions from
+/// <see cref="IUserAdminActionsUIService"/>.
+/// </summary>
+/// <remarks>
+/// The listing is its own member rather than the generic entity-service <c>GetPagedAsync</c>: the
+/// administration endpoint takes a search term and a role, not the grid's per-column filter syntax,
+/// and it carries the pagination metadata in the body (the <c>X-Pagination</c> header repeats it),
+/// so the flattening to <c>(Items, TotalItems)</c> happens here either way.
+/// </remarks>
+/// <typeparam name="TUserDto">The app's administration-facing user DTO.</typeparam>
+public interface IUserAdminUIService<TUserDto> : IUserAdminActionsUIService
+{
+    /// <summary>Reads one page of accounts from <c>GET Admin/Users/paged</c>.</summary>
+    /// <param name="pageNumber">The 1-based page.</param>
+    /// <param name="pageSize">Accounts per page.</param>
+    /// <param name="searchTerm">Optional free-text filter; the server decides which fields it covers.</param>
+    /// <param name="role">Optional role filter.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The page and the total count, or the API's own refusal.</returns>
+    Task<Result<(IReadOnlyList<TUserDto> Items, int TotalItems)>> GetPagedAsync(
+        int pageNumber,
+        int pageSize,
+        string? searchTerm,
+        string? role,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Reads one account, including its lock state, from <c>GET Admin/Users/{userId}</c>.</summary>
+    /// <param name="userId">The account to read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The account, or the API's own refusal.</returns>
+    Task<Result<TUserDto>> GetAsync(UserIdentifierType userId, CancellationToken cancellationToken = default);
+}

--- a/Source/Presentation/MMCA.Common.UI/Services/Administration/UserAdminService.cs
+++ b/Source/Presentation/MMCA.Common.UI/Services/Administration/UserAdminService.cs
@@ -1,0 +1,160 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth.Requests;
+using MMCA.Common.Shared.Http;
+using MMCA.Common.UI.Services.Api;
+using MMCA.Common.UI.Services.Auth.Tokens;
+
+namespace MMCA.Common.UI.Services.Administration;
+
+/// <summary>
+/// HTTP client for the <c>Admin/Users</c> resource (ADR-116), generic over the app's own
+/// administration DTO. Registered by <c>AddUserAdministrationUI</c>.
+/// </summary>
+/// <remarks>
+/// Nothing here throws for a server answer: the response is read back through
+/// <see cref="ProblemDetailsResultReader"/> with the API's own <see cref="ErrorType"/> intact, and
+/// transport faults become failures through <see cref="HttpResultExecutor"/>. Only the caller's own
+/// cancellation still propagates. It follows the shape of the shipped authenticated services rather
+/// than the generic entity-service base, because these endpoints are not CRUD over an entity
+/// resource.
+/// </remarks>
+/// <typeparam name="TUserDto">The app's administration-facing user DTO.</typeparam>
+/// <param name="httpClientFactory">Creates the API client.</param>
+/// <param name="tokenStorageService">Supplies the caller's bearer token.</param>
+public sealed class UserAdminService<TUserDto>(
+    IHttpClientFactory httpClientFactory,
+    ITokenStorageService tokenStorageService)
+    : AuthenticatedServiceBase(httpClientFactory, tokenStorageService), IUserAdminUIService<TUserDto>
+{
+    private const string Endpoint = "Admin/Users";
+
+    /// <inheritdoc />
+    public async Task<Result<(IReadOnlyList<TUserDto> Items, int TotalItems)>> GetPagedAsync(
+        int pageNumber,
+        int pageSize,
+        string? searchTerm,
+        string? role,
+        CancellationToken cancellationToken = default)
+    {
+        var queryParams = new List<string>
+        {
+            string.Create(CultureInfo.InvariantCulture, $"pageNumber={pageNumber}"),
+            string.Create(CultureInfo.InvariantCulture, $"pageSize={pageSize}"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            queryParams.Add($"searchTerm={Uri.EscapeDataString(searchTerm)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(role))
+        {
+            queryParams.Add($"role={Uri.EscapeDataString(role)}");
+        }
+
+        var url = $"{Endpoint}/paged?{string.Join("&", queryParams)}";
+
+        var page = await HttpResultExecutor.ExecuteAsync(
+            async () =>
+            {
+                using var httpClient = await CreateAuthenticatedClientAsync();
+                using var response = await RetryPolicy.ExecuteAsync(
+                    _ => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
+                    cancellationToken);
+
+                return await ProblemDetailsResultReader.ReadAsync<PagedCollectionResult<TUserDto>>(
+                    response, cancellationToken: cancellationToken);
+            },
+            cancellationToken);
+
+        return page.Map<(IReadOnlyList<TUserDto> Items, int TotalItems)>(
+            value => ([.. value.Items], value.PaginationMetadata.TotalItemCount));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<TUserDto>> GetAsync(
+        UserIdentifierType userId,
+        CancellationToken cancellationToken = default)
+    {
+        var url = string.Create(CultureInfo.InvariantCulture, $"{Endpoint}/{userId}");
+
+        return await HttpResultExecutor.ExecuteAsync(
+            async () =>
+            {
+                using var httpClient = await CreateAuthenticatedClientAsync();
+                using var response = await RetryPolicy.ExecuteAsync(
+                    _ => httpClient.GetAsync(new Uri(url, UriKind.Relative), cancellationToken),
+                    cancellationToken);
+
+                return await ProblemDetailsResultReader.ReadAsync<TUserDto>(
+                    response, cancellationToken: cancellationToken);
+            },
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> LockAsync(UserIdentifierType userId, CancellationToken cancellationToken = default) =>
+        PostLockChangeAsync(userId, "lock", cancellationToken);
+
+    /// <inheritdoc />
+    public Task<Result> UnlockAsync(UserIdentifierType userId, CancellationToken cancellationToken = default) =>
+        PostLockChangeAsync(userId, "unlock", cancellationToken);
+
+    /// <inheritdoc />
+    public Task<Result> SetRoleAsync(
+        UserIdentifierType userId,
+        string role,
+        CancellationToken cancellationToken = default) =>
+        SetRolesAsync(userId, [role], cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<Result> SetRolesAsync(
+        UserIdentifierType userId,
+        IReadOnlyList<string> roles,
+        CancellationToken cancellationToken = default)
+    {
+        var url = string.Create(CultureInfo.InvariantCulture, $"{Endpoint}/{userId}/roles");
+
+        return await HttpResultExecutor.ExecuteAsync(
+            async () =>
+            {
+                using var httpClient = await CreateAuthenticatedClientAsync();
+                using var response = await RetryPolicy.ExecuteAsync(
+                    _ => httpClient.PutAsJsonAsync(
+                        new Uri(url, UriKind.Relative),
+                        new SetUserRolesRequest(roles),
+                        cancellationToken),
+                    cancellationToken);
+
+                return await ProblemDetailsResultReader.ReadAsync(response, cancellationToken);
+            },
+            cancellationToken);
+    }
+
+    private async Task<Result> PostLockChangeAsync(
+        UserIdentifierType userId,
+        string action,
+        CancellationToken cancellationToken)
+    {
+        var url = string.Create(CultureInfo.InvariantCulture, $"{Endpoint}/{userId}/{action}");
+
+        return await HttpResultExecutor.ExecuteAsync(
+            async () =>
+            {
+                using var httpClient = await CreateAuthenticatedClientAsync();
+
+                // No retry: the endpoint is declared non-idempotent, so a retried POST is a second
+                // request rather than a replayed response. Both actions are idempotent in the
+                // domain, but the client should not decide that on the endpoint's behalf.
+                using var response = await httpClient.PostAsync(
+                    new Uri(url, UriKind.Relative),
+                    content: null,
+                    cancellationToken);
+
+                return await ProblemDetailsResultReader.ReadAsync(response, cancellationToken);
+            },
+            cancellationToken);
+    }
+}

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Administration/UserAdminListTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Pages/Administration/UserAdminListTests.cs
@@ -1,0 +1,552 @@
+using System.Globalization;
+using System.Security.Claims;
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using MMCA.Common.Shared.Abstractions;
+using MMCA.Common.Shared.Auth;
+using MMCA.Common.Shared.Auth.Administration;
+using MMCA.Common.UI.Common.Interfaces;
+using MMCA.Common.UI.Pages.Administration;
+using MMCA.Common.UI.Services.Administration;
+using Moq;
+using MudBlazor;
+using MudBlazor.Services;
+
+namespace MMCA.Common.UI.Tests.Pages.Administration;
+
+/// <summary>
+/// bUnit tests for the shared <see cref="UserAdminList{TUser}"/> component (the UI half of
+/// ADR-116): rows and the empty/failed states, the debounced search box and the Email column filter
+/// both mapping onto the administration endpoint's one search parameter, the accessible shape of the
+/// row action menu, the confirm-then-act flows for lock and role change, the own-row guard, the
+/// opt-in delete, the <c>FetchPage</c> data-source override, the app-localizer override, and the
+/// mobile card layout.
+/// </summary>
+public sealed class UserAdminListTests : BunitTestBase
+{
+    /// <summary>
+    /// A principal carrying the id of the first seeded row, used to prove the administration
+    /// actions are hidden on the operator's OWN row (self-lock and self-demotion are one-way doors).
+    /// </summary>
+    private static readonly ClaimsPrincipal SignedInAsAda = new(new ClaimsIdentity(
+        [new Claim(AuthClaimTypes.Subject, "1")],
+        authenticationType: "TestAuth"));
+
+    private static readonly BrowserWindowSize PhoneViewport = new() { Width = 390, Height = 844 };
+
+    private readonly Mock<IUserAdminUIService<TestUser>> _admin = new();
+    private readonly Mock<IAppDialogService> _dialogs = new();
+
+    public UserAdminListTests()
+    {
+        // One mock answers both contracts: the component reads through the generic service and acts
+        // through the non-generic one, exactly as AddUserAdministrationUI forwards them in a host.
+        Services.AddSingleton(_admin.Object);
+        Services.AddSingleton<IUserAdminActionsUIService>(_admin.Object);
+        Services.AddSingleton(_dialogs.Object);
+
+        // Wires the list-page state services, the inert IBrowserViewportService stub (keeping
+        // IsMobile deterministically false so the component stays on the desktop grid branch) and
+        // the persistent-state double, then sets the interactive renderer info LoadServerDataAsync
+        // consults. Must be last: it freezes the service provider.
+        ConfigureDataGridListPageHost();
+
+        SetupUsers(Ada, Grace);
+
+        _admin.Setup(x => x.LockAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _admin.Setup(x => x.UnlockAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _admin.Setup(x => x.SetRoleAsync(It.IsAny<UserIdentifierType>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
+
+    /// <summary>
+    /// The app's own administration DTO. Public so Moq can proxy a generic service closed over it,
+    /// and it maps its own spelling of the identifier and lock state onto
+    /// <see cref="IUserAdminDTO"/> explicitly, which is the adoption path a consumer takes.
+    /// </summary>
+    public sealed record TestUser(int Id, string Email, string Role, bool Locked) : IUserAdminDTO
+    {
+        UserIdentifierType IUserAdminDTO.UserId => Id;
+
+        bool IUserAdminDTO.IsLocked => Locked;
+    }
+
+    private static TestUser Ada => new(1, "ada@example.com", "Admin", Locked: false);
+
+    private static TestUser Grace => new(2, "grace@example.com", "Member", Locked: false);
+
+    // Every Result-returning member needs an explicit setup: an unstubbed Task<Result<T>> hands
+    // back null rather than a success, which the component would dereference.
+    private void SetupUsers(params TestUser[] users) =>
+        _admin
+            .Setup(x => x.GetPagedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success<(IReadOnlyList<TestUser> Items, int TotalItems)>((users, users.Length)));
+
+    private IRenderedComponent<UserAdminList<TestUser>> RenderList(
+        ClaimsPrincipal? principal = null,
+        Action<ComponentParameterCollectionBuilder<UserAdminList<TestUser>>>? extra = null) =>
+        RenderAs<UserAdminList<TestUser>>(
+            principal ?? Anonymous,
+            p =>
+            {
+                p.Add(x => x.DetailHref, u => string.Create(CultureInfo.InvariantCulture, $"/users/{u.Id}"));
+                p.Add(x => x.AssignableRoles, ["Member", "Admin"]);
+                extra?.Invoke(p);
+            });
+
+    // ── Rows and states ──
+    [Fact]
+    public void RendersRowsFromTheAdministrationService()
+    {
+        RenderMudProviders();
+
+        var cut = RenderList();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("ada@example.com");
+            cut.Markup.Should().Contain("grace@example.com");
+            cut.Markup.Should().Contain("Member");
+        });
+    }
+
+    [Fact]
+    public void WithNoAccounts_RendersTheEmptyState()
+    {
+        SetupUsers();
+        RenderMudProviders();
+
+        var cut = RenderList();
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("No users found."));
+    }
+
+    /// <summary>
+    /// A failed fetch renders zero rows, which is visually identical to a genuinely empty list, so
+    /// the shared <c>ListNoRecordsContent</c> must take over with its inline error and Retry.
+    /// </summary>
+    [Fact]
+    public void WhenTheFetchFails_RendersTheInlineLoadFailureInsteadOfTheEmptyState()
+    {
+        _admin
+            .Setup(x => x.GetPagedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<(IReadOnlyList<TestUser> Items, int TotalItems)>(
+                Error.Failure("Users.LoadFailed", "boom")));
+        RenderMudProviders();
+
+        var cut = RenderList();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("Could not load this list");
+            cut.Markup.Should().NotContain("No users found.");
+        });
+    }
+
+    [Fact]
+    public void ALockedAccount_RendersTheLockedChip()
+    {
+        SetupUsers(Grace with { Locked = true });
+        RenderMudProviders();
+
+        var cut = RenderList();
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("Locked"));
+    }
+
+    // ── Search and filtering ──
+    [Fact]
+    public void TypingSearch_RequeriesWithTheSearchTerm()
+    {
+        RenderMudProviders();
+        var cut = RenderList();
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("ada@example.com"));
+
+        cut.Find("input[placeholder='Search by email...']").Input("smith");
+
+        // The search box debounces for 300ms before reloading the grid.
+        cut.WaitForAssertion(
+            () => _admin.Verify(
+                x => x.GetPagedAsync(
+                    It.IsAny<int>(), It.IsAny<int>(), "smith", null, It.IsAny<CancellationToken>()),
+                Times.AtLeastOnce()),
+            TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// The endpoint takes ONE search parameter, so the Email column filter has to reach it too;
+    /// the free-text box wins only while it holds something.
+    /// </summary>
+    [Fact]
+    public async Task AnEmailColumnFilter_MapsToTheSearchTerm_WhenTheSearchBoxIsBlank()
+    {
+        RenderMudProviders();
+        var cut = RenderList();
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("ada@example.com"));
+
+        var grid = cut.FindComponent<MudDataGrid<TestUser>>();
+        await cut.InvokeAsync(() =>
+        {
+            grid.Instance.FilterDefinitions.Add(Filter("Email", "contains", "grace"));
+            return grid.Instance.ReloadServerData();
+        });
+
+        _admin.Verify(
+            x => x.GetPagedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), "grace", null, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce());
+    }
+
+    private static IFilterDefinition<TestUser> Filter(string propertyName, string @operator, string value)
+    {
+        var column = new Mock<Column<TestUser>>();
+        column.Setup(c => c.PropertyName).Returns(propertyName);
+
+        var definition = new Mock<IFilterDefinition<TestUser>>();
+        definition.SetupGet(f => f.Column).Returns(column.Object);
+        definition.SetupGet(f => f.Operator).Returns(@operator);
+        definition.SetupGet(f => f.Value).Returns(value);
+        return definition.Object;
+    }
+
+    // ── The action menu's accessible shape ──
+    /// <summary>
+    /// The row's action menu must be one button, not a button inside a button: MudBlazor wraps
+    /// custom <c>ActivatorContent</c> in its own div carrying <c>role="button"</c>, so an icon
+    /// button placed inside it is a control nested in a control (axe nested-interactive). The
+    /// built-in icon activator IS the button.
+    /// </summary>
+    [Fact]
+    public void TheActionMenuActivator_IsTheButtonItselfNotAWrapperAroundOne()
+    {
+        RenderMudProviders();
+
+        var cut = RenderList();
+        cut.WaitForAssertion(() =>
+            cut.Find("button[aria-label='Administration actions for grace@example.com']"));
+
+        cut.FindAll(".mud-menu-activator").Should().BeEmpty();
+        cut.FindAll("[role='button'] button").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Clicking the activator must OPEN the menu. A custom activator that never calls
+    /// <c>MenuContext.ToggleAsync</c> renders a button that does nothing, which is how the lock and
+    /// set-role actions once shipped unreachable.
+    /// </summary>
+    [Fact]
+    public void ClickingTheActivator_OpensTheAdministrationMenu()
+    {
+        var providers = RenderMudProviders();
+
+        var cut = RenderList();
+        cut.WaitForAssertion(() =>
+            cut.Find("button[aria-label='Administration actions for grace@example.com']"));
+
+        cut.Find("button[aria-label='Administration actions for grace@example.com']").Click();
+
+        providers.Popover.WaitForAssertion(
+            () => providers.Popover.FindAll("[data-testid=toggle-lock]").Should().NotBeEmpty(),
+            TimeSpan.FromSeconds(5));
+    }
+
+    // ── Lock and role, behind a confirmation ──
+    [Fact]
+    public void ConfirmingTheLockDialog_CallsLockAsync()
+    {
+        SetupUsers(Grace);
+        Confirms(true);
+        var providers = RenderMudProviders();
+
+        var cut = OpenTheActionsMenu(providers);
+        providers.Popover.Find("[data-testid=toggle-lock]").Click();
+
+        cut.WaitForAssertion(() => _admin.Verify(x => x.LockAsync(2, It.IsAny<CancellationToken>()), Times.Once()));
+    }
+
+    [Fact]
+    public void DecliningTheLockDialog_CallsNothing()
+    {
+        SetupUsers(Grace);
+        Confirms(false);
+        var providers = RenderMudProviders();
+
+        var cut = OpenTheActionsMenu(providers);
+        providers.Popover.Find("[data-testid=toggle-lock]").Click();
+
+        cut.WaitForAssertion(() => _dialogs.Verify(
+            x => x.ConfirmAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Once()));
+        _admin.Verify(x => x.LockAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()), Times.Never());
+        _admin.Verify(x => x.UnlockAsync(It.IsAny<UserIdentifierType>(), It.IsAny<CancellationToken>()), Times.Never());
+    }
+
+    /// <summary>
+    /// The set-role items carry the account's own role as a disabled entry, so the enabled one is
+    /// the move the operator can actually make.
+    /// </summary>
+    [Fact]
+    public void ConfirmingASetRoleItem_CallsSetRoleAsyncWithThatRole()
+    {
+        SetupUsers(Grace);
+        Confirms(true);
+        var providers = RenderMudProviders();
+
+        var cut = OpenTheActionsMenu(providers);
+        var roleItems = providers.Popover.FindAll("[data-testid=set-role]");
+        roleItems.Should().HaveCount(2, "the account's own role is offered as a disabled entry beside the move it can make");
+        roleItems[1].Click();
+
+        cut.WaitForAssertion(() => _admin.Verify(
+            x => x.SetRoleAsync(2, "Admin", It.IsAny<CancellationToken>()), Times.Once()));
+    }
+
+    /// <summary>
+    /// The operator's own row offers no lock or role action. Locking or demoting yourself removes
+    /// the very capability needed to undo it, and the API has no notion of "the caller".
+    /// </summary>
+    [Fact]
+    public void TheSignedInOperatorsOwnRow_OffersNoAdministrationMenu()
+    {
+        RenderMudProviders();
+
+        var cut = RenderList(SignedInAsAda);
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("button[aria-label='Administration actions for grace@example.com']")
+                .Should().NotBeEmpty();
+            cut.FindAll("button[aria-label='Administration actions for ada@example.com']")
+                .Should().BeEmpty();
+        });
+    }
+
+    // ── Delete is opt-in ──
+    [Fact]
+    public void WithoutOnDelete_NoRowOffersADeleteButton()
+    {
+        RenderMudProviders();
+
+        var cut = RenderList();
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("grace@example.com"));
+
+        cut.FindAll("button[aria-label='Delete grace@example.com']").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithOnDelete_ConfirmingTheDialog_InvokesTheCallback()
+    {
+        SetupUsers(Grace);
+        var deleted = new List<TestUser>();
+        var providers = RenderMudProviders();
+
+        var cut = RenderList(extra: p => p.Add(
+            x => x.OnDelete,
+            user =>
+            {
+                deleted.Add(user);
+                return Task.FromResult(Result.Success());
+            }));
+        cut.WaitForAssertion(() => cut.Find("button[aria-label='Delete grace@example.com']"));
+
+        cut.Find("button[aria-label='Delete grace@example.com']").Click();
+
+        providers.Dialog.WaitForAssertion(() => providers.Dialog.Find("[data-testid=confirm-delete]"));
+        providers.Dialog.Find("[data-testid=confirm-delete]").Click();
+
+        cut.WaitForAssertion(() => deleted.Should().ContainSingle(u => u.Id == 2));
+    }
+
+    // ── The FetchPage data-source override ──
+    [Fact]
+    public void FetchPageOverride_FeedsTheGrid_AndIsGivenTheSearchFilter()
+    {
+        Dictionary<string, (string Operator, string Value)>? seenFilters = null;
+        RenderMudProviders();
+
+        var cut = RenderList(extra: p => p.Add(x => x.FetchPage, (filters, _, _, _, _, _) =>
+        {
+            seenFilters = filters;
+            return Task.FromResult(Result.Success<(IReadOnlyList<TestUser> Items, int TotalItems)>(
+                ([new TestUser(7, "own@example.com", "Member", Locked: false)], 1)));
+        }));
+
+        cut.WaitForAssertion(() => cut.Markup.Should().Contain("own@example.com"));
+
+        cut.Find("input[placeholder='Search by email...']").Input("smith");
+
+        cut.WaitForAssertion(
+            () => seenFilters.Should().ContainKey(UserAdminList<TestUser>.SearchFilterKey)
+                .WhoseValue.Should().Be(("contains", "smith")),
+            TimeSpan.FromSeconds(5));
+
+        _admin.Verify(
+            x => x.GetPagedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never(),
+            "a component given its own data source must never resolve the administration read service");
+    }
+
+    [Fact]
+    public async Task FetchPageOverride_AlsoFeedsTheMobileList()
+    {
+        var calls = 0;
+        RenderMudProviders();
+
+        var cut = RenderList(extra: p => p.Add(x => x.FetchPage, (_, _, _, _, _, _) =>
+        {
+            calls++;
+            return Task.FromResult(Result.Success<(IReadOnlyList<TestUser> Items, int TotalItems)>(
+                ([new TestUser(7, "own@example.com", "Member", Locked: false)], 1)));
+        }));
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("own@example.com"));
+
+        var before = calls;
+        await GoToPhoneAsync(cut);
+
+        calls.Should().BeGreaterThan(before, "the mobile card list fetches through the same override");
+        _admin.Verify(
+            x => x.GetPagedAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
+    }
+
+    // ── Wording override ──
+    /// <summary>
+    /// An app keeps its own vocabulary by passing its localizer, without a parameter per word: a key
+    /// it carries wins, and one it does not carry falls through to the component's own resources.
+    /// </summary>
+    [Fact]
+    public void TheAppLocalizer_WinsForAKeyItCarries_AndFallsBackOtherwise()
+    {
+        RenderMudProviders();
+
+        var cut = RenderList(extra: p => p.Add(
+            x => x.Localizer,
+            (IStringLocalizer?)new StubLocalizer(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["Title"] = "User accounts",
+                ["Action.Lock"] = "Deactivate account",
+            })));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("User accounts");
+            cut.Markup.Should().NotContain(">Users<");
+
+            // Not in the app localizer, so the component's own resources answer it.
+            cut.Markup.Should().Contain("Search by email...");
+        });
+    }
+
+    // ── Mobile card layout ──
+    // Nothing in bUnit drives the breakpoint: the harness stubs IBrowserViewportService inert (so
+    // IsMobile is deterministically false) and the component is itself the viewport observer, so the
+    // switch is a direct call to the observer callback with an Xs breakpoint.
+    private static async Task GoToPhoneAsync(IRenderedComponent<UserAdminList<TestUser>> cut)
+    {
+        await cut.InvokeAsync(() => cut.Instance.NotifyBrowserViewportChangeAsync(
+            new BrowserViewportEventArgs(Guid.NewGuid(), PhoneViewport, Breakpoint.Xs)));
+
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("View details"));
+    }
+
+    private async Task<IRenderedComponent<UserAdminList<TestUser>>> RenderOnAPhoneAsync(ClaimsPrincipal principal)
+    {
+        var cut = RenderList(principal);
+        await cut.WaitForAssertionAsync(() => cut.Markup.Should().Contain("grace@example.com"));
+        await GoToPhoneAsync(cut);
+        return cut;
+    }
+
+    /// <summary>
+    /// Every card carries an explicit, labelled link into the account. The card itself is
+    /// deliberately non-interactive (controls inside a card carrying <c>role="button"</c> are an axe
+    /// nested-interactive violation), so without this button there is nothing on a phone that reads
+    /// as "open this account".
+    /// </summary>
+    [Fact]
+    public async Task OnAPhone_EveryCard_OffersAnExplicitDetailsLink()
+    {
+        RenderMudProviders();
+
+        var cut = await RenderOnAPhoneAsync(Anonymous);
+
+        cut.Find("a[aria-label='View details for grace@example.com']")
+            .GetAttribute("href").Should().Be("/users/2");
+    }
+
+    [Fact]
+    public async Task OnAPhone_ACardForAnotherAccount_OffersTheLabelledActionsMenu()
+    {
+        RenderMudProviders();
+
+        var cut = await RenderOnAPhoneAsync(SignedInAsAda);
+
+        cut.Find("button[aria-label='Administration actions for grace@example.com']")
+            .TextContent.Should().Contain("Actions");
+    }
+
+    [Fact]
+    public async Task OnAPhone_TheOperatorsOwnCard_OffersNoActionsMenu_AndNoCardIsAButton()
+    {
+        RenderMudProviders();
+
+        var cut = await RenderOnAPhoneAsync(SignedInAsAda);
+
+        cut.FindAll("button[aria-label='Administration actions for ada@example.com']").Should().BeEmpty();
+        cut.FindAll("a[aria-label='View details for ada@example.com']").Should().NotBeEmpty();
+        cut.FindAll(".mud-card[role='button']").Should().BeEmpty();
+    }
+
+    // ── Helpers ──
+    private void Confirms(bool answer) =>
+        _dialogs
+            .Setup(x => x.ConfirmAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(answer);
+
+    private IRenderedComponent<UserAdminList<TestUser>> OpenTheActionsMenu(MudProviderHandles providers)
+    {
+        var cut = RenderList();
+        cut.WaitForAssertion(() =>
+            cut.Find("button[aria-label='Administration actions for grace@example.com']"));
+
+        cut.Find("button[aria-label='Administration actions for grace@example.com']").Click();
+
+        providers.Popover.WaitForAssertion(
+            () => providers.Popover.FindAll("[data-testid=toggle-lock]").Should().NotBeEmpty(),
+            TimeSpan.FromSeconds(5));
+
+        return cut;
+    }
+
+    /// <summary>
+    /// A minimal app localizer: it answers only the keys it was given and reports every other key as
+    /// <c>ResourceNotFound</c>, which is the signal the component falls back on.
+    /// </summary>
+    private sealed class StubLocalizer(Dictionary<string, string> values) : IStringLocalizer
+    {
+        public LocalizedString this[string name] =>
+            values.TryGetValue(name, out var value)
+                ? new LocalizedString(name, value, resourceNotFound: false)
+                : new LocalizedString(name, name, resourceNotFound: true);
+
+        public LocalizedString this[string name, params object[] arguments] =>
+            values.TryGetValue(name, out var value)
+                ? new LocalizedString(name, string.Format(CultureInfo.CurrentCulture, value, arguments), resourceNotFound: false)
+                : new LocalizedString(name, name, resourceNotFound: true);
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) =>
+            values.Select(pair => new LocalizedString(pair.Key, pair.Value));
+    }
+}


### PR DESCRIPTION
## Summary

The UI half of ADR-116. ADC and Store each carried their own Organizer/Admin user list page and their own HTTP client for the framework's `Admin/Users` endpoints. This lifts both into the framework as an opt-in, following the ADR-116 rule that the user DTO stays app-owned.

- **MMCA.Common.Shared**: `IUserAdminDTO`, the four-value projection (`UserId`, `Email`, `Role`, `IsLocked`) the shared list reads from an app's DTO (explicit implementation is fine, e.g. `IsLocked => LockedOn is not null` / `!IsActive`).
- **MMCA.Common.UI services**: `IUserAdminActionsUIService` (lock, unlock, set roles) and `IUserAdminUIService<TUserDto>` (paged list, get one) over a sealed `UserAdminService<TUserDto>` HTTP client for `Admin/Users`; `AddUserAdministrationUI<TUserDto>()` registers both over one scoped instance.
- **MMCA.Common.UI component**: `UserAdminList<TUser>` (under `Pages/Administration`, a component with no route: the app supplies `@page`, `[Authorize]`, `DetailHref`, `AssignableRoles`, extra `Columns` / `TrailingColumns` / `CardContent`, optional `OnDelete`, optional `FetchPage` for an app whose roster lives on its own sorting/filtering endpoint, and an optional `Localizer` whose keys override the shipped wording). Ports the accessibility shape already shipped in both apps: no RowClick, the built-in menu activator is the button, mobile cards are not interactive themselves, own-row guard on the actions.
- 20 bUnit tests, en + es resources, PublicAPI.Unshipped entries.

## Consumers

ADC #198 and Store #149 (already open) will adopt it with the v1.197.0 pin bump; Helpdesk #114 takes the pin only.

## Verification

- `dotnet build MMCA.Common.slnx -c Release`: 0 warnings, 0 errors
- Full solution test run: 6095 passed, 0 failed
- Architecture tests 220/220 (namespace-cycle rule is why the component sits under `Pages/`: it inherits `Pages.Common.DataGridListPageBase`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK
