### PR TITLE
chore: regenerate FACTS for v1.197.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.197.0] - 2026-09-12
+
+### Added
+
+- **A shared user-administration list, the UI half of ADR-116** (`MMCA.Common.UI`,
+  `MMCA.Common.Shared`). `Pages.Administration.UserAdminList<TUser>` is a routeless component an
+  app page wraps with its own `@page` and `[Authorize]`: it renders the account roster (search box,
+  desktop grid, mobile cards, status chip) with the operator actions the framework's `Admin/Users`
+  endpoints expose (lock, unlock, change role, each confirmed) and an optional delete, hides the
+  actions on the signed-in operator's own row, and takes the app's extra columns, card lines, role
+  vocabulary, detail route and, when the roster lives on the app's own endpoint, a `FetchPage`
+  delegate. Any of its strings is overridden by passing the page's own localizer, so an app keeps
+  its vocabulary ("Deactivate" rather than "Lock") by resx key alone; English and Spanish ship.
+- `MMCA.Common.Shared.Auth.Administration.IUserAdminDTO`, the four-value projection (`UserId`,
+  `Email`, `Role`, `IsLocked`) the list reads from an app-owned user DTO.
+- `IUserAdminActionsUIService` (lock, unlock, set roles) and `IUserAdminUIService<TUserDto>`
+  (paged list, get one) over a sealed `UserAdminService<TUserDto>` HTTP client for `Admin/Users`,
+  registered together by `AddUserAdministrationUI<TUserDto>()`.
+
 ## [1.196.0] - 2026-09-12
 
 ### Added

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-09-12 (framework v1.196.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-09-12 (framework v1.197.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -11,7 +11,7 @@ _As of: 2026-09-12 (framework v1.196.0) — **generated from source by `build/fa
 > facts (test totals, scorecard indices) live in that repo's published scorecard, **not** here.
 
 ## Framework version
-- **Current: `v1.196.0`** (MinVer-derived from the git tag at `main` HEAD).
+- **Current: `v1.197.0`** (MinVer-derived from the git tag at `main` HEAD).
 - All consumers (**MMCA.ADC**, **MMCA.Store**, MMCA.Helpdesk) track this version in **lockstep** — every
   `MMCA.Common.*` entry in each consumer's `Directory.Packages.props` is bumped together (ADR-016; no phased
   rollout).


### PR DESCRIPTION
Post-tag FACTS pin for v1.197.0, plus the [1.197.0] CHANGELOG entry (the shared UserAdminList + generic Admin/Users client, #394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK