### PR TITLE
fix(testing.e2e): duplicate-email registration test follows the v1.196.0 warning alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.198.0] - 2026-09-12
+
+### Fixed
+
+- **The shipped duplicate-email registration E2E test follows the v1.196.0 Register page**
+  (`MMCA.Common.Testing.E2E`). `UserRegistrationTestsBase.Register_WithDuplicateEmail_ShouldShowError`
+  still waited for the generic `.mud-alert-text-error` alert, which the Register page no longer
+  renders for an address that already has an account (v1.196.0 made that case a warning alert with
+  the sign-in and reset-password links). Every consumer's e2e gate went red on it, which skips
+  their deploy. `RegisterPage` gains `EmailAlreadyRegisteredAlert` (the `email-already-registered`
+  test id) and the base test asserts that alert, that it names the typed address, and that the
+  user stays on `/register`. `ErrorAlert` is unchanged for the other failures.
+
 ## [1.197.0] - 2026-09-12
 
 ### Added

--- a/Source/Hosting/MMCA.Common.Testing.E2E/PageObjects/RegisterPage.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/PageObjects/RegisterPage.cs
@@ -17,6 +17,13 @@ public sealed class RegisterPage
     public ILocator RegisterButton => _page.GetByRole(AriaRole.Button, new() { Name = "Create your account" });
     public ILocator ErrorAlert => _page.Locator(".mud-alert-text-error");
 
+    /// <summary>
+    /// The warning alert the page shows when the typed address already has an account (with the
+    /// sign-in and reset-password links). It is NOT <see cref="ErrorAlert"/>: since v1.196.0 the
+    /// duplicate-address conflict renders as a warning, not the generic red error alert.
+    /// </summary>
+    public ILocator EmailAlreadyRegisteredAlert => _page.GetByTestId("email-already-registered");
+
     // "Sign In" link is inside "Already have an account?" text
     public ILocator AlreadyHaveAccountLink => _page.GetByRole(AriaRole.Link, new() { Name = "Sign In" });
 

--- a/Source/Hosting/MMCA.Common.Testing.E2E/PublicAPI.Unshipped.txt
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/PublicAPI.Unshipped.txt
@@ -66,3 +66,4 @@ virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsB
 virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.Sentinel.get -> string!
 virtual MMCA.Common.Testing.E2E.Workflows.Globalization.PseudoLocalizationTestsBase.Timeout.get -> float
 MMCA.Common.Testing.E2E.Infrastructure.E2ETestBase.SignOutAsync() -> System.Threading.Tasks.Task!
+MMCA.Common.Testing.E2E.PageObjects.RegisterPage.EmailAlreadyRegisteredAlert.get -> Microsoft.Playwright.ILocator!

--- a/Source/Hosting/MMCA.Common.Testing.E2E/Workflows/Identity/UserRegistrationTestsBase.cs
+++ b/Source/Hosting/MMCA.Common.Testing.E2E/Workflows/Identity/UserRegistrationTestsBase.cs
@@ -73,9 +73,13 @@ public abstract class UserRegistrationTestsBase : E2ETestBase
         await registerPage.GotoAsync().ConfigureAwait(false);
         await registerPage.RegisterAsync("Dup", "User", email, "TestPass123!").ConfigureAwait(false);
 
-        // Assert — should show error about email already in use
+        // Assert — the duplicate address is a WARNING alert naming the way out (sign in / reset the
+        // password), not the generic red error alert the other server-side failures use, and the
+        // user stays on /register.
         await Page.WaitForLoadStateAsync(LoadState.Load).ConfigureAwait(false);
-        await Expect(registerPage.ErrorAlert).ToBeVisibleAsync(new() { Timeout = 15_000 }).ConfigureAwait(false);
+        await Expect(registerPage.EmailAlreadyRegisteredAlert).ToBeVisibleAsync(new() { Timeout = 15_000 }).ConfigureAwait(false);
+        await Expect(registerPage.EmailAlreadyRegisteredAlert).ToContainTextAsync(email).ConfigureAwait(false);
+        await Expect(Page).ToHaveURLAsync(new Regex("/register$")).ConfigureAwait(false);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`UserRegistrationTestsBase.Register_WithDuplicateEmail_ShouldShowError` (shipped in `MMCA.Common.Testing.E2E`) still waits for the generic `.mud-alert-text-error` alert. Since v1.196.0 (#392) the Register page renders an already-registered address as a **warning** alert with the sign-in and reset-password links, so the shipped test fails deterministically on every consumer (ADC and Store branch E2E runs on v1.197.0: red on chromium, firefox and webkit, same single test), which turns their post-merge e2e gate red and skips the deploy job.

- `RegisterPage.EmailAlreadyRegisteredAlert` = `GetByTestId("email-already-registered")` (the test id the page already carries). `ErrorAlert` is unchanged for the other server-side failures.
- The base test asserts that alert is visible, names the typed address, and that the user stays on `/register`.
- Rolls the `[1.198.0]` CHANGELOG header, so the tag can follow the merge directly.

## Verification

`dotnet build Source/Hosting/MMCA.Common.Testing.E2E -c Release`: 0 warnings, 0 errors. The behavior itself is exercised by the consumers' E2E suites; the v1.198.0 sweep will dispatch each repo's `e2e.yml` on its bump branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK
