### PR TITLE
chore: regenerate FACTS for v1.199.0 + CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.199.0] - 2026-09-12
+
+### Added
+
+- **Document uploads and download headers for the managed file storage layer** (ADR-045
+  extension; `MMCA.Common.Application`, `MMCA.Common.Infrastructure`). `DocumentContentSniffer`
+  accepts pdf / pptx / docx / xlsx / zip / txt / md only when the bytes AND the file extension agree
+  on an allowed `DocumentFormats` flag, never trusting a declared content type; the Office Open XML
+  check enumerates zip entry names only and bails out past 4096 entries. `BlobNames.SanitizeFileName`
+  reduces a user-supplied name to a blob-safe segment with the extension preserved.
+  `FileUploadOptions` (`Attachment` / `Inline` RFC 6266 disposition with an RFC 5987 `filename*`,
+  plus `Cache-Control`) rides a new `IFileStorageService.UploadAsync` overload shipped as a default
+  interface member, so every existing implementation and test fake keeps compiling;
+  `AzureBlobFileStorageService` stores the headers on the blob and `NullFileStorageService` keeps
+  failing with `FileStorage.NotConfigured`. First consumer: MMCA.ADC speaker session assets.
+
 ## [1.198.0] - 2026-09-12
 
 ### Fixed

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-09-12 (framework v1.198.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-09-12 (framework v1.199.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -11,7 +11,7 @@ _As of: 2026-09-12 (framework v1.198.0) — **generated from source by `build/fa
 > facts (test totals, scorecard indices) live in that repo's published scorecard, **not** here.
 
 ## Framework version
-- **Current: `v1.198.0`** (MinVer-derived from the git tag at `main` HEAD).
+- **Current: `v1.199.0`** (MinVer-derived from the git tag at `main` HEAD).
 - All consumers (**MMCA.ADC**, **MMCA.Store**, MMCA.Helpdesk) track this version in **lockstep** — every
   `MMCA.Common.*` entry in each consumer's `Directory.Packages.props` is bumped together (ADR-016; no phased
   rollout).


### PR DESCRIPTION
Post-tag FACTS pin for v1.199.0, plus the CHANGELOG entry for the document upload guards and download headers shipped in #398 (same shape as the v1.197.0 cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXs5HjPgxuutXc7ymo2FnM
