### PR TITLE
feat(ui): Layout:SessionsNavRequiredRole gates the Signed-in devices nav link

### DIFF
--- a/Source/Presentation/MMCA.Common.UI/Common/Settings/LayoutSettings.cs
+++ b/Source/Presentation/MMCA.Common.UI/Common/Settings/LayoutSettings.cs
@@ -28,4 +28,13 @@ public sealed class LayoutSettings
         "CA1056:URI-like properties should not be strings",
         Justification = "Bound from configuration and emitted straight into an img src, which is normally a host-relative path (e.g. /img/logo.svg). System.Uri cannot represent that without RelativeOrAbsolute round-tripping, and the other endpoint settings in this namespace are strings for the same reason.")]
     public string BrandLogoUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional role name that gates the framework-owned "Signed-in devices" entry in the
+    /// navigation menu. Null or whitespace (the default) shows the link to every signed-in user;
+    /// a role name (for example <c>RoleNames.Admin</c>) shows it only to users in that role.
+    /// This gates the menu entry alone, not the <c>/profile/sessions</c> page itself, which stays
+    /// available to any signed-in account.
+    /// </summary>
+    public string? SessionsNavRequiredRole { get; init; }
 }

--- a/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
+++ b/Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor
@@ -75,8 +75,14 @@
                 </div>
                 <MudNavMenu Color="Color.Default">
                     @* Framework-owned account page: every host that renders this menu gets the
-                       signed-in devices list without wiring a NavItem of its own. *@
-                    <MudNavLink Href="@RoutePaths.Sessions" Icon="@Icons.Material.Filled.Devices">@L["Auth.Sessions.NavLabel"]</MudNavLink>
+                       signed-in devices list without wiring a NavItem of its own. A host that sets
+                       Layout:SessionsNavRequiredRole narrows the entry to that role; the default
+                       (unset) keeps it visible to every signed-in user. The gate covers the menu
+                       entry only: the page itself stays reachable for any signed-in account. *@
+                    @if (_showSessionsLink)
+                    {
+                        <MudNavLink Href="@RoutePaths.Sessions" Icon="@Icons.Material.Filled.Devices">@L["Auth.Sessions.NavLabel"]</MudNavLink>
+                    }
                     <MudNavLink Icon="@Icons.Material.Filled.Logout" OnClick="HandleLogoutAsync">@L["Common.Button.Logout"]</MudNavLink>
                 </MudNavMenu>
             </Authorized>
@@ -171,6 +177,7 @@
     private List<NavItem> _generalItems = [];
     private List<NavItem> _userItems = [];
     private List<NavItem> _adminItems = [];
+    private bool _showSessionsLink;
 
     // ADR-027: Title and Group are resource keys resolved at render time against the item's
     // TitleResource resx pair, so the menu follows the active culture; a key the resource type does
@@ -202,6 +209,9 @@
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         _user = authState.User;
+
+        var sessionsRole = LayoutSettingsOptions.Value.SessionsNavRequiredRole;
+        _showSessionsLink = string.IsNullOrWhiteSpace(sessionsRole) || _user?.IsInRole(sessionsRole) == true;
 
         _appBarComponents = UIModules.SelectMany(m => m.AppBarComponentTypes).ToList();
 

--- a/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
+++ b/Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt
@@ -85,6 +85,8 @@ MMCA.Common.UI.Common.NavItem.TitleResource.get -> System.Type!
 MMCA.Common.UI.Common.ResultUiExtensions
 MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.get -> string!
 MMCA.Common.UI.Common.Settings.LayoutSettings.BrandLogoUrl.init -> void
+MMCA.Common.UI.Common.Settings.LayoutSettings.SessionsNavRequiredRole.get -> string?
+MMCA.Common.UI.Common.Settings.LayoutSettings.SessionsNavRequiredRole.init -> void
 MMCA.Common.UI.Common.Settings.NotificationBellOptions
 MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.get -> System.TimeSpan
 MMCA.Common.UI.Common.Settings.NotificationBellOptions.NavigationRefreshMaxAge.init -> void

--- a/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
+++ b/Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs
@@ -4,6 +4,7 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using MMCA.Common.Shared.Auth;
 using MMCA.Common.Testing.UI;
 using MMCA.Common.UI.Common;
 using MMCA.Common.UI.Common.Interfaces;
@@ -108,6 +109,38 @@ public sealed class NavMenuTests : BunitTestBase
         cut.FindAll($"a[href='{RoutePaths.Sessions}']").Should().BeEmpty(
             "the sessions page belongs to a signed-in account");
         cut.Markup.Should().NotContain("Signed-in devices");
+    }
+
+    [Fact]
+    public void WithSessionsNavRequiredRole_HidesTheLinkFromAUserWithoutThatRole()
+    {
+        // Last registration wins, so this replaces the ungated settings from the constructor.
+        Services.AddSingleton<IOptions<LayoutSettings>>(Options.Create(
+            new LayoutSettings { BrandName = "TestBrand", SessionsNavRequiredRole = RoleNames.Admin }));
+
+        RenderMudProviders();
+        var cut = RenderAs<NavMenu>(TestPrincipal.AuthenticatedUser(), _ => { });
+
+        cut.FindAll($"a[href='{RoutePaths.Sessions}']").Should().BeEmpty(
+            "the host gated the menu entry on a role this user does not hold");
+        cut.Markup.Should().NotContain("Signed-in devices");
+
+        // The gate covers the sessions entry alone: the way out is still there.
+        cut.Markup.Should().Contain("Logout");
+    }
+
+    [Fact]
+    public void WithSessionsNavRequiredRole_ShowsTheLinkToAUserInThatRole()
+    {
+        Services.AddSingleton<IOptions<LayoutSettings>>(Options.Create(
+            new LayoutSettings { BrandName = "TestBrand", SessionsNavRequiredRole = RoleNames.Admin }));
+
+        RenderMudProviders();
+        var cut = RenderAs<NavMenu>(
+            TestPrincipal.AuthenticatedUser("1", "Ada Lovelace", RoleNames.Admin), _ => { });
+
+        var sessions = cut.Find($".nav-auth-section a[href='{RoutePaths.Sessions}']");
+        sessions.TextContent.Should().Contain("Signed-in devices");
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds `LayoutSettings.SessionsNavRequiredRole` (config key `Layout:SessionsNavRequiredRole`) and uses it in `NavMenu.razor` to gate the framework-owned "Signed-in devices" link in the mobile hamburger menu.

- Null or whitespace (the default): every signed-in user sees the link, exactly as today.
- Set to a role name (for example `RoleNames.Admin`): only users in that role see it.

The gate covers the menu entry alone. The `/profile/sessions` page itself is unchanged and stays reachable for any signed-in account.

## Why

A consumer wants the signed-in devices list to be an admin-only entry in the navigation, without forking the framework's `NavMenu`. Making it a `Layout` config key keeps the change opt-in: hosts that configure nothing get identical behavior.

## Changes

- `Source/Presentation/MMCA.Common.UI/Common/Settings/LayoutSettings.cs`: new `string? SessionsNavRequiredRole { get; init; }`.
- `Source/Presentation/MMCA.Common.UI/Layout/NavMenu.razor`: `_showSessionsLink` computed in `OnInitializedAsync` right after `_user`, and the `MudNavLink` rendered behind it; the razor comment above the link now explains the gate.
- `Source/Presentation/MMCA.Common.UI/PublicAPI.Unshipped.txt`: the two new public API entries (RS0016).
- `Tests/Presentation/MMCA.Common.UI.Tests/Layout/NavMenuTests.cs`: two new tests.

No CHANGELOG.md / FACTS.md edits (the release process regenerates them). No doc file in this repo documents the `Layout` keys, so there was no doc row to add.

## Test evidence

- `dotnet build MMCA.Common.slnx -c Release`: succeeded, 0 warnings, 0 errors.
- `dotnet test --project Tests/Presentation/MMCA.Common.UI.Tests/... -- --filter-class "*NavMenuTests*"`: 14/14 passed (12 existing + 2 new).
- Full `MMCA.Common.UI.Tests`: 946/946 passed.
- `MMCA.Common.Architecture.Tests` (includes `FolderWidthTests`): 220/220 passed.

The two new tests both register a `LayoutSettings` with `SessionsNavRequiredRole = RoleNames.Admin` after the base registration (last registration wins), then render as an authenticated principal: without the role the sessions anchor is absent and the markup does not contain "Signed-in devices" while Logout still renders; with the `Admin` role the link renders inside `.nav-auth-section`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK
