### PR TITLE
chore: regenerate FACTS for v1.200.0 + CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the MMCA.Common packages are documented here. The format 
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow [Semantic Versioning](https://semver.org/)
 and are derived from git tags by MinVer (see [the published versioning policy](https://ivanball.github.io/docs/guides/common-VERSIONING.html)).
 
+## [1.200.0] - 2026-09-13
+
+### Added
+
+- **`Layout:SessionsNavRequiredRole`** (`MMCA.Common.UI`). New optional `LayoutSettings` key: when
+  set to a role name (for example `Admin`), the framework-owned "Signed-in devices" link in the
+  navigation menu renders only for signed-in users in that role; when unset (the default) every
+  signed-in user keeps seeing it, so existing hosts are unchanged. The setting gates the menu entry
+  only; the `/profile/sessions` page itself stays available to any signed-in account. First
+  consumer: MMCA.ADC, which shows the link to administrators only.
+
 ## [1.199.0] - 2026-09-12
 
 ### Added

--- a/FACTS.md
+++ b/FACTS.md
@@ -1,7 +1,7 @@
 # MMCA.Common — Canonical Facts
 
 **Single source of truth for the framework-wide facts that otherwise drift across dozens of docs.**
-_As of: 2026-09-12 (framework v1.199.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
+_As of: 2026-09-13 (framework v1.200.0) — **generated from source by `build/facts`; do not hand-edit the numbers below.**_
 
 > **Rule: link here, don't restate.** Other docs (scorecards, CLAUDE.md files, READMEs, the LinkedIn/Medium
 > campaigns) must **reference** these facts rather than copy the numbers inline. A "thirteen packages"
@@ -11,7 +11,7 @@ _As of: 2026-09-12 (framework v1.199.0) — **generated from source by `build/fa
 > facts (test totals, scorecard indices) live in that repo's published scorecard, **not** here.
 
 ## Framework version
-- **Current: `v1.199.0`** (MinVer-derived from the git tag at `main` HEAD).
+- **Current: `v1.200.0`** (MinVer-derived from the git tag at `main` HEAD).
 - All consumers (**MMCA.ADC**, **MMCA.Store**, MMCA.Helpdesk) track this version in **lockstep** — every
   `MMCA.Common.*` entry in each consumer's `Directory.Packages.props` is bumped together (ADR-016; no phased
   rollout).


### PR DESCRIPTION
Post-tag FACTS pin for v1.200.0, plus the v1.200.0 CHANGELOG entry (Layout:SessionsNavRequiredRole).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvovao3Xg9xgKkTNEJxzPK
